### PR TITLE
test: remove test_view_building_with_tablet_move

### DIFF
--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -81,61 +81,6 @@ async def test_start_scylla_with_view_building_disabled(manager: ManagerClient):
     res = await log.grep(r"ERROR.*\[shard [0-9]+:[a-z]+\]")
     assert len(res) == 0
 
-# Build multiple views of one base table, and while view building is running move
-# some of the base tablets to another node. Verify the view build is completed.
-# More specifically, we move all tablets except the first one to reproduce issue #21829.
-# The issue happens when we start building a view at a token F and then all partitions
-# with tokens >=F are moved, and it causes the view builder to enter an infinite loop
-# building the same token ranges repeatedly because it doesn't reach F.
-@pytest.mark.asyncio
-async def test_view_building_with_tablet_move(manager: ManagerClient, build_mode: str):
-    servers = [await manager.server_add()]
-
-    await manager.disable_tablet_balancing()
-
-    table = 'test'
-
-    view_count = 4
-    views = [f"{table}_view_{i}" for i in range(view_count)]
-
-    cql = manager.get_cql()
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{table} (pk int PRIMARY KEY, c int)")
-
-        # prefill the base table with enough rows so that view building takes some time
-        # and runs during the tablet move
-        keys = 200000 if build_mode != 'debug' else 10000
-        batch_size = 50
-        for k in range(0, keys, batch_size):
-            inserts = [f"INSERT INTO {ks}.{table}(pk, c) VALUES ({i}, {i})" for i in range(k, k+batch_size)]
-            batch = "BEGIN UNLOGGED BATCH\n" + "\n".join(inserts) + "\nAPPLY BATCH\n"
-            await manager.cql.run_async(batch)
-
-        logger.info("Adding new server")
-        servers.append(await manager.server_add())
-
-        # create some views so they are built together but starting at different tokens
-        for view in views:
-            await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.{view} AS SELECT * FROM {ks}.{table} WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk)")
-            await asyncio.sleep(1)
-
-        s0_host_id = await manager.get_host_id(servers[0].server_id)
-        s1_host_id = await manager.get_host_id(servers[1].server_id)
-        dst_shard = 0
-
-        # move all tablets except the first one (with lowest token range) to the other node.
-        table_id = await manager.get_table_id(ks, table)
-        rows = await manager.cql.run_async(f"SELECT last_token FROM system.tablets where table_id = {table_id}")
-        move_tablets_tasks = []
-        for r in rows[1:]:
-            tablet_token = r.last_token
-            replica = await get_tablet_replica(manager, servers[0], ks, table, tablet_token)
-            move_tablets_tasks.append(asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, ks, table, replica[0], replica[1], s1_host_id, dst_shard, tablet_token)))
-        await asyncio.gather(*move_tablets_tasks)
-
-        for view in views:
-            await wait_for_view(cql, view, len(servers))
-
 # While view building is in progress, drop the index (which changes the schema
 # of the base table). The state of the view table corresponding to the index
 # may become inconsistent with the base table because they got detached.


### PR DESCRIPTION
remove the test since it's not relevant anymore, it's not testing what it's supposed to test and it's unstable.

the purpose of the test was to reproduce an issue in the legacy view builder where a view starts to build at token T2 and then all tokens [T1, end) with T1<T2 migrate to another node while it's still building, exposing an issue when the view builder wraparounds the token ring.

this is not relevant anymore because now view building with tablets is done via the view building coordinator for tablets, and all views start to build from the first token with no wraparound.

besides, the test is unstable due to relying too much on specific timing, which was useful for investigating and fixing the original issue but not anymore.

Fixes SCYLLADB-842

no backport -  minor CI stability improvement