### PR TITLE
test: decrease strain in test_startup_response

### DIFF
--- a/test/cluster/auth_cluster/test_startup_response.py
+++ b/test/cluster/auth_cluster/test_startup_response.py
@@ -44,6 +44,7 @@ async def test_startup_no_auth_response(manager: ManagerClient, build_mode):
     def attempt_bad_connection():
         c = Cluster([server.ip_addr], port=9042, auth_provider=auth_provider, connect_timeout=timeout, connection_class=NoOpConnection)
         try:
+            logging.info("Attempting bad connection")
             c.connect()
             pytest.fail("Should not connect")
         except Exception:
@@ -56,7 +57,9 @@ async def test_startup_no_auth_response(manager: ManagerClient, build_mode):
         nonlocal connections_observed
         c = Cluster([server.ip_addr], port=9042, auth_provider=auth_provider, connect_timeout=timeout/3)
         try:
+            logging.info("Attempting good connection")
             session = c.connect()
+            logging.info("Performing SELECT(*) FROM system.clients")
             res = session.execute("SELECT COUNT(*) FROM system.clients WHERE connection_stage = 'AUTHENTICATING' ALLOW FILTERING;")
             count = res[0][0]
             logging.info(f"Observed {count} AUTHENTICATING connections...")


### PR DESCRIPTION
For 2025.3 and 2025.4 this test runs order of magnitude
slower in debug mode. Potentially due to passwords::check
running in alien thread and overwhelming the CPU (this is
fixed in newer versions).

Decreasing the number of connections in test makes it fast
again, without breaking reproducibility.

As additional measure we double the timeout.

The fix is now cherry-picked to master as sometimes
test fails there too.

(cherry picked from commit 1f1fc2c2ac21cd10949c887c18e69a9dab9c111f)

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-795

backport: 2026.1, already on other stable branches