### PR TITLE
test.py: refactor test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -18,59 +18,28 @@ from random import randint
 
 import pytest
 
-from types import SimpleNamespace
-
 import colorama
-import glob
 import itertools
 import logging
 import multiprocessing
 import os
 import pathlib
 import resource
-import signal
 import subprocess
 import sys
 import time
-import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING, Any
 
 import humanfriendly
 import treelib
 
 from scripts import coverage
-from test import ALL_MODES, HOST_ID, TOP_SRC_DIR, path_to, TEST_DIR, TESTPY_PREPARED_ENVIRONMENT
+from test import ALL_MODES, HOST_ID, TOP_SRC_DIR, path_to
 from test.pylib import coverage_utils
 from test.pylib.suite.base import (
-    SUITE_CONFIG_FILENAME,
-    Test,
     TestSuite,
-    init_testsuite_globals,
-    output_is_a_tty,
     palette,
-    prepare_environment,
 )
-from test.pylib.resource_gather import run_resource_watcher
 from test.pylib.util import LogPrefixAdapter, get_configured_modes
-
-if TYPE_CHECKING:
-    from typing import List
-
-PYTEST_RUNNER_DIRECTORIES = [
-    TEST_DIR / 'boost',
-    TEST_DIR / 'ldap',
-    TEST_DIR / 'raft',
-    TEST_DIR / 'unit',
-    TEST_DIR / 'vector_search',
-    TEST_DIR / 'alternator',
-    TEST_DIR / 'broadcast_tables',
-    TEST_DIR / 'cql',
-    TEST_DIR / 'cqlpy',
-    TEST_DIR / 'rest_api',
-    TEST_DIR / 'nodetool',
-    TEST_DIR / 'scylla_gdb',
-    TEST_DIR / 'cluster',
-]
 
 launch_time = time.monotonic()
 
@@ -120,97 +89,16 @@ class ThreadsCalculator:
 
 
 
-class TabularConsoleOutput:
-    """Print test progress to the console"""
-
-    def __init__(self, verbose: bool, test_count: int) -> None:
-        self.verbose = verbose
-
-        if not output_is_a_tty:
-            self.verbose = True
-
-        self.test_count = test_count
-        self.last_test_no = 0
-
-    def print_start_blurb(self) -> None:
-        print("="*80)
-        print("{:10s} {:^8s} {:^7s} {:8s} {}".format("[N/TOTAL]", "SUITE", "MODE", "RESULT", "TEST"))
-        print("-"*78)
-        print("")
-
-    def print_end_blurb(self) -> None:
-        print("-"*78)
-
-    def print_progress(self, test: Test) -> None:
-        self.last_test_no += 1
-        status = ""
-        if test.success:
-            logging.debug("Test {} is flaky {}".format(test.uname,
-                                                       test.is_flaky_failure))
-            if test.is_flaky_failure:
-                status = palette.warn("[ FLKY ]")
-            else:
-                status = palette.ok("[ PASS ]")
-        else:
-            status = palette.fail("[ FAIL ]")
-        msg = "{:10s} {:^8s} {:^7s} {:8s} {}".format(
-            f"[{self.last_test_no}/{self.test_count}]",
-            test.suite.name, test.mode[:7],
-            status,
-            test.uname
-        )
-        if not self.verbose:
-            if test.success:
-                print("\033[A", end="\r")
-                print("\033[K", end="\r")
-                print(msg)
-            else:
-                print("\033[A", end="\r")
-                print("\033[K", end="\r")
-                print(f"{msg}\n")
-        else:
-            msg += " {:.2f}s".format(test.time_end - test.time_start)
-            print(msg)
-
-
-def setup_signal_handlers(loop, signaled) -> None:
-
-    async def shutdown(loop, signo, signaled):
-        print("\nShutdown requested... Aborting tests:"),
-        signaled.signo = signo
-        signaled.set()
-
-    # Use a lambda to avoid creating a coroutine until
-    # the signal is delivered to the loop - otherwise
-    # the coroutine will be dangling when the loop is over,
-    # since it's never going to be invoked
-    for signo in [signal.SIGINT, signal.SIGTERM]:
-        loop.add_signal_handler(signo, lambda: asyncio.create_task(shutdown(loop, signo, signaled)))
-
-
 def parse_cmd_line() -> argparse.Namespace:
     """ Print usage and process command line options. """
     parser = argparse.ArgumentParser(description='Scylla test runner', formatter_class=argparse.RawTextHelpFormatter)
 
-    directories = '\n'.join(f" - {str(item.relative_to(TOP_SRC_DIR))}" for item in PYTEST_RUNNER_DIRECTORIES)
     name_help = textwrap.dedent("""\
         Can be empty. List of test names or path to test files, to look for.
-        There are two runners: test.py and pytest.
-
-        test.py works in the following way:
-        Each name is used as a substring to look for in the path to test file,
-        e.g. "mem" will run all tests that have "mem" in their name in all
-        suites, "nodetool/test_compact" will only enable tests starting with
-        "test_compact" in "nodetool" suite, and 
-        "nodetool/test_compact::test_all_keyspaces" to narrow down to a 
-        certain test case.
-
-        pytest runner works in the following way:
+        
         provide the path to the test file for execution or path to the directory
         to narrow you can use function name 'test/boost/aggregate_fcts_test.cc::test_aggregate_avg'
-
-        Pytest directories are:
-        """) + directories + "\n\nDefault: run all tests in all suites."
+        """)
 
     parser.add_argument(
         "name",
@@ -258,8 +146,7 @@ def parse_cmd_line() -> argparse.Namespace:
                                  "DEBUG"],
                         dest="log_level")
     parser.add_argument('-k', metavar="EXPRESSION", action="store",
-                        help=f"Supported only for tests in {[str(d) for d in PYTEST_RUNNER_DIRECTORIES]} "
-                        "directories. Only run tests which match the given substring expression. An expression is a Python evaluable expression where all names are "
+                        help="Only run tests which match the given substring expression. An expression is a Python evaluable expression where all names are "
                         "substring-matched against test names and their parent classes. Example: -k 'test_method or test_other' matches all test functions and "
                         "classes whose name contains 'test_method' or 'test_other', while -k 'not test_method' matches those that don't contain 'test_method' "
                         "in their names. -k 'not test_method and not test_other' will eliminate the matches. Additionally keywords are matched to classes and "
@@ -354,35 +241,15 @@ def parse_cmd_line() -> argparse.Namespace:
     return args
 
 
-async def find_tests(options: argparse.Namespace) -> None:
-    for f in TEST_DIR.glob("*"):
-        config = pathlib.Path(f) / SUITE_CONFIG_FILENAME
-        if config.is_file():
-            for mode in options.modes:
-                suite = TestSuite.opt_create(config=config, options=options, mode=mode)
-                await suite.add_test_list()
-
-def run_pytest(options: argparse.Namespace) -> tuple[int, list[SimpleNamespace]]:
+def run_pytest(options: argparse.Namespace) -> int:
     # When tests are executed in parallel on different hosts, we need to distinguish results from them.
     # So HOST_ID needed to not overwrite results from different hosts during Jenkins will copy to one directory.
 
-    failed_tests = []
     temp_dir = pathlib.Path(options.tmpdir).absolute()
+
     report_dir =  temp_dir / 'report'
     junit_output_file = report_dir / f'pytest_cpp_{HOST_ID}.xml'
-    files_to_run = []
-    if options.name:
-        for name in options.name:
-            file_name = name
-            if '::' in name:
-                file_name, _ = name.split('::', maxsplit=1)
-            if any((TOP_SRC_DIR / file_name).is_relative_to(x) for x in PYTEST_RUNNER_DIRECTORIES):
-                files_to_run.append(name)
-    else:
-        files_to_run = [ TOP_SRC_DIR / 'test/']
-    if not files_to_run:
-        logging.info('Skipping pytest execution because no tests were selected for pytest.')
-        return 0, []
+    files_to_run = options.name or [str(TOP_SRC_DIR / 'test/')]
     args = [
         '--color=yes',
         f'--repeat={options.repeat}',
@@ -394,7 +261,6 @@ def run_pytest(options: argparse.Namespace) -> tuple[int, list[SimpleNamespace]]
         args.extend([
             f'--junit-xml={junit_output_file}',
             "-rf",
-            '--test-py-init',
             f'-n{options.jobs}',
             f'--tmpdir={temp_dir}',
             f'--maxfail={options.max_failures}',
@@ -430,201 +296,36 @@ def run_pytest(options: argparse.Namespace) -> tuple[int, list[SimpleNamespace]]
     if options.markers:
         args.append(f'-m={options.markers}')
     args.extend(files_to_run)
-    pytest.main(args=args)
+    exit_code = pytest.main(args=args)
 
-    if options.list_tests:
-        return 0, []
-
-    suite = ET.parse(junit_output_file).getroot().find('testsuite')
-    total_tests = int(suite.get('tests'))
-
-    # Find failed tests in the pytest XML output, create a SimpleNamespace for each to mimic the Test class to be able
-    # to print the summary later
-    for test_case in suite.findall('testcase'):
-        if test_case.find('error') is not None or test_case.find('failure') is not None:
-            classname = test_case.get('classname')
-            if classname.endswith('.cc'):
-                file_path, extension = test_case.get('classname').rsplit('.', 1)
-            else:
-                extension = 'py'
-                file_path = '/'.join(x for x in test_case.get('classname').split('.') if x.islower())
-            # get the test name without mode name
-            test_name = test_case.get('name').split('.')[0]
-            test = SimpleNamespace()
-
-            test.name = f"test/{file_path.replace('.', '/')}.{extension}::{test_name}"
-            # print_summary used to print additional information about the failed test that is called in verbose mode
-            # This is needed to mimic the Test class and not fail the run summary output
-            test.print_summary = Test.print_summary
-
-            failed_tests.append(test)
-
-    return total_tests, failed_tests
-
-
-
-async def run_all_tests(signaled: asyncio.Event, options: argparse.Namespace) -> tuple[int | Any, list[
-    SimpleNamespace]] | None:
-    failed_tests = []
-    console = TabularConsoleOutput(options.verbose, TestSuite.test_count())
-    signaled_task = asyncio.create_task(signaled.wait())
-    pending = {signaled_task}
-
-    async def cancel(pending, msg):
-        for task in pending:
-            task.cancel(msg)
-        await asyncio.wait(pending, return_when=asyncio.ALL_COMPLETED)
-        print("...done")
-
-    async def reap(done, pending, signaled):
-        nonlocal console
-        if signaled.is_set():
-            await cancel(pending, "Signal received")
-        failed = 0
-        for coro in done:
-            result = coro.result()
-            if isinstance(result, bool):
-                continue    # skip signaled task result
-            if not result.success:
-                failed += 1
-            if not result.did_not_run:
-                console.print_progress(result)
-        return failed
-
-    total_tests = 0
-    max_failures = options.max_failures
-    failed = 0
-    deadline = time.perf_counter() + options.session_timeout
-    try:
-        # Run pytest in an executor to avoid blocking the event loop
-        # This allows resource monitoring to run concurrently
-        loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, run_pytest, options)
-        total_tests += result[0]
-        failed_tests.extend(result[1])
-        console.print_start_blurb()
-        TestSuite.artifacts.add_exit_artifact(None, TestSuite.hosts.cleanup)
-        for test in TestSuite.all_tests():
-            # +1 for 'signaled' event
-            if len(pending) > options.jobs:
-                # Wait for some task to finish
-                done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
-                failed += await reap(done, pending, signaled)
-                if time.perf_counter() > deadline:
-                    print("Session timeout reached")
-                    await cancel(pending, "Session timeout reached")
-                if max_failures != 0 and max_failures <= failed:
-                    print("Too much failures, stopping")
-                    await cancel(pending, "Too much failures, stopping")
-            pending.add(asyncio.create_task(test.suite.run(test, options)))
-        # Wait & reap ALL tasks but signaled_task
-        # Do not use asyncio.ALL_COMPLETED to print a nice progress report
-        while len(pending) > 1:
-            done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
-            failed += await reap(done, pending, signaled)
-            if max_failures != 0 and max_failures <= failed:
-                print("Too much failures, stopping")
-                await cancel(pending, "Too much failures, stopping")
-    finally:
-        await TestSuite.artifacts.cleanup_before_exit()
-
-    console.print_end_blurb()
-    return total_tests, failed_tests
-
-
-def print_summary(failed_tests: List["Test"], cancelled_tests: int, options: argparse.Namespace, failed_pytest_tests: list[SimpleNamespace], total_tests_pytest: int) -> None:
     rusage = resource.getrusage(resource.RUSAGE_CHILDREN)
     cpu_used = rusage.ru_stime + rusage.ru_utime
     cpu_available = (time.monotonic() - launch_time) * multiprocessing.cpu_count()
-    utilization = cpu_used / cpu_available
-    print(f"CPU utilization: {utilization*100:.1f}%")
-    total_tests = TestSuite.test_count() + total_tests_pytest
-    if failed_tests or failed_pytest_tests:
-        all_fails = [*failed_tests, *failed_pytest_tests]
-        print(f'The following test(s) have failed: {" ".join(t.name for t in all_fails)}')
-        if options.verbose:
-            for test in failed_tests:
-                test.print_summary()
-                print("-"*78)
-        if cancelled_tests > 0:
-            print(f"Summary: {len(all_fails)} of the total {total_tests} tests failed, {cancelled_tests} cancelled")
-        else:
-            print(f"Summary: {len(all_fails)} of the total {total_tests} tests failed")
-    if total_tests == 0:
-        print( palette.warn(f"No tests were run, nothing to report. Please check your test selection criteria. "
-                            f"Due to the recent changes in the test.py, if you want to run a test from one of the "
-                            f"following directories: \n"
-                            f"{'\n'.join([f'{str(item.relative_to(TOP_SRC_DIR))}' for item in PYTEST_RUNNER_DIRECTORIES])}\nPlease use the path "
-                            f"to the test file with extension, e.g. 'test/boost/memtable_test.cc' instead of "
-                            f"'boost/memtable_test'"))
+    print(f"CPU utilization: {cpu_used / cpu_available * 100:.1f}%")
 
-
-def open_log(tmpdir: str, log_file_name: str, log_level: str) -> None:
-    pathlib.Path(tmpdir).mkdir(parents=True, exist_ok=True)
-    logging.basicConfig(
-        filename=os.path.join(tmpdir, log_file_name),
-        filemode="w",
-        level=log_level,
-        format="%(asctime)s.%(msecs)03d %(levelname)s> %(message)s",
-        datefmt="%H:%M:%S",
-    )
-    logging.critical("Started %s", " ".join(sys.argv))
+    return exit_code
 
 
 async def main() -> int:
 
     options = parse_cmd_line()
 
-    await find_tests(options)
     if options.list_tests:
-        print('\n'.join([f"{t.suite.mode:<8} {type(t.suite).__name__[:-9]:<11} {t.name}"
-                         for t in TestSuite.all_tests()]))
-        run_pytest(options)
-        return 0
-
-    open_log(options.tmpdir, f"test.py.{'-'.join(options.modes)}.log", options.log_level)
-    init_testsuite_globals()
-    await prepare_environment(
-        tempdir_base=pathlib.Path(options.tmpdir),
-        modes=options.modes,
-        gather_metrics=options.gather_metrics,
-        save_log_on_success=options.save_log_on_success,
-        toxiproxy_byte_limit=options.byte_limit,
-    )
-    os.environ[TESTPY_PREPARED_ENVIRONMENT] = '1'
-
-    if options.manual_execution and TestSuite.test_count() > 1:
-        print('--manual-execution only supports running a single test, but multiple selected: {}'.format(
-            [t.path for t in TestSuite.tests()][:3])) # Print whole t.path; same shortname may be in different dirs.
-        return 1
-
-    signaled = asyncio.Event()
-    stop_event = asyncio.Event()
-    resource_watcher = run_resource_watcher(options.gather_metrics, signaled, stop_event, options.tmpdir)
-
-    setup_signal_handlers(asyncio.get_running_loop(), signaled)
+        return run_pytest(options)
 
     try:
         logging.info('running all tests')
-        total_tests_pytest, failed_pytest_tests = await run_all_tests(signaled, options)
+        # Run pytest in the default thread pool executor so the event loop stays
+        # responsive (e.g. signal handlers continue to work while pytest runs).
+        loop = asyncio.get_running_loop()
+        exit_code = await loop.run_in_executor(None, run_pytest, options)
         logging.info('after running all tests')
-        stop_event.set()
-        async with asyncio.timeout(5):
-            await resource_watcher
     except asyncio.CancelledError:
         print('\ntests cancelled by signal')
         return 1
     except Exception as e:
         print(palette.fail(e))
         raise
-
-    if signaled.is_set():
-        return -signaled.signo      # type: ignore
-
-    failed_tests = [test for test in TestSuite.all_tests() if test.failed]
-    cancelled_tests = sum(1 for test in TestSuite.all_tests() if test.did_not_run)
-
-    print_summary(failed_tests, cancelled_tests, options, failed_pytest_tests, total_tests_pytest)
 
     if 'coverage' in options.modes:
         coverage.generate_coverage_report(path_to("coverage", "tests"))
@@ -634,7 +335,7 @@ async def main() -> int:
 
     # Note: failure codes must be in the ranges 0-124, 126-127,
     #       to cooperate with git bisect's expectations
-    return 0 if not failed_tests else 1
+    return exit_code
 
 
 async def process_coverage(options):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -10,14 +10,10 @@ import time
 import os
 from pathlib import Path
 
-__all__ = ["ALL_MODES", "BUILD_DIR", "DEBUG_MODES", "HOST_ID", "TEST_DIR", "TEST_RUNNER", "TOP_SRC_DIR", "path_to",
-           "TESTPY_PREPARED_ENVIRONMENT"]
+__all__ = ["ALL_MODES", "BUILD_DIR", "DEBUG_MODES", "HOST_ID", "TEST_DIR", "TEST_RUNNER", "TOP_SRC_DIR", "path_to"]
 
 
 TEST_RUNNER = os.environ.get("SCYLLA_TEST_RUNNER", "pytest")
-# This is used to mark that test.py has already prepared the environment and pytest
-# should skip the part of cleaning or starting 3rd party services
-TESTPY_PREPARED_ENVIRONMENT = "TESTPY_PREPARED_ENVIRONMENT"
 
 TOP_SRC_DIR = Path(__file__).parent.parent  # ScyllaDB's source code root directory
 TEST_DIR = TOP_SRC_DIR / "test"

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -15,9 +15,9 @@ import requests
 import re
 
 from test.alternator.util import create_test_table, is_aws, scylla_log
+from test.conftest import dynamic_scope
 from test.cqlpy.conftest import host  # add required fixtures
 from test.pylib.driver_utils import safe_driver_shutdown
-from test.pylib.runner import testpy_test_fixture_scope
 from test.pylib.suite.python import add_host_option
 from urllib.parse import urlparse
 from functools import cache
@@ -75,7 +75,7 @@ def pytest_collection_modifyitems(config, items):
 # If this function can't connect to CQL, it will return an arbitrary
 # user/secret pair, and hope it would work if alternator-enforce-authorization
 # is off.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def get_valid_alternator_role():
     from cassandra.cluster import Cluster, NoHostAvailable
     from cassandra.auth import PlainTextAuthProvider
@@ -117,7 +117,7 @@ def get_valid_alternator_role():
 # or a local Alternator installation on http://localhost:8080 - depending on the
 # existence of the "--aws" option. In the future we should provide options
 # for choosing other Amazon regions or local installations.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def dynamodb(request, get_valid_alternator_role):
     # Disable boto3's client-side validation of parameters. This validation
     # only makes it impossible for us to test various error conditions,
@@ -146,7 +146,7 @@ def dynamodb(request, get_valid_alternator_role):
     yield res
     res.meta.client.close()
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def new_dynamodb_session(request, dynamodb, get_valid_alternator_role):
     def _new_dynamodb_session(user='cassandra', password='secret_pass'):
         ses = boto3.Session()
@@ -163,7 +163,7 @@ def new_dynamodb_session(request, dynamodb, get_valid_alternator_role):
             config=conf)
     return _new_dynamodb_session
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def dynamodbstreams(request, get_valid_alternator_role):
     # Disable boto3's client-side validation of parameters. This validation
     # only makes it impossible for us to test various error conditions,
@@ -235,7 +235,7 @@ dynamodb_test_connection.scylla_crashed = False
 # time, we can also remove just tables older than a particular age. Such
 # mechanism will allow running tests in parallel, without the risk of deleting
 # a parallel run's temporary tables.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_table(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
@@ -254,7 +254,7 @@ def test_table(dynamodb):
 
 # The following fixtures test_table_* are similar to test_table but create
 # tables with different key schemas.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_table_s(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
@@ -263,35 +263,35 @@ def test_table_s(dynamodb):
     table.delete()
 # test_table_s_2 has exactly the same schema as test_table_s, and is useful
 # for tests which need two different tables with the same schema.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_table_s_2(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
         AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ])
     yield table
     table.delete()
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_table_b(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
         AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'B' } ])
     yield table
     table.delete()
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_table_sb(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
         AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'B' } ])
     yield table
     table.delete()
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_table_sn(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
         AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'N' } ])
     yield table
     table.delete()
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_table_ss(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
@@ -308,7 +308,7 @@ def test_table_ss(dynamodb):
 # This table is supposed to be read from, not updated nor overwritten.
 # This fixture returns both a table object and the description of all items
 # inserted into it.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def filled_test_table(dynamodb):
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
@@ -343,7 +343,7 @@ def filled_test_table(dynamodb):
 # The "scylla_only" fixture can be used by tests for Scylla-only features,
 # which do not exist on AWS DynamoDB. A test using this fixture will be
 # skipped if running with "--aws".
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def scylla_only(dynamodb):
     if is_aws(dynamodb):
         pytest.skip('Scylla-only feature not supported by AWS')
@@ -354,7 +354,7 @@ def scylla_only(dynamodb):
 # corect one, and DynamoDB's to be the bug. Tests using this fixture should
 # have a prominent comment explaining why we believe this to be a bug in
 # DynamoDB.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def dynamodb_bug(dynamodb):
     if is_aws(dynamodb):
         pytest.xfail('A known bug in AWS DynamoDB')
@@ -363,12 +363,12 @@ def dynamodb_bug(dynamodb):
 # If we're not testing Scylla, or the REST API port (10000) is not available,
 # the test using this fixture will be skipped with a message about the REST
 # API not being available.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def rest_api(dynamodb, optional_rest_api):
     if optional_rest_api is None:
         pytest.skip('Cannot connect to Scylla REST API')
     return optional_rest_api
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def optional_rest_api(dynamodb):
     if is_aws(dynamodb):
         return None
@@ -389,7 +389,7 @@ def optional_rest_api(dynamodb):
 # below to xfail or skip a test which is known to be failing with tablets.
 # This is a temporary measure - eventually everything in Scylla should work
 # correctly with tablets, and these fixtures can be removed.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def has_tablets(dynamodb, test_table):
     # We rely on some knowledge of Alternator internals:
     # 1. For table with name X, Scylla creates a keyspace called alternator_X
@@ -427,7 +427,7 @@ def skip_tablets(has_tablets):
 # If we're not testing Scylla, or the CQL port is not available on the same
 # IP address as the Alternator IP address, a test using this fixture will
 # be skipped with a message about the CQL API not being available.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def cql(dynamodb):
     from cassandra.auth import PlainTextAuthProvider
     from cassandra.cluster import Cluster, ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT, NoHostAvailable

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -19,7 +19,6 @@ from multiprocessing import Event
 from pathlib import Path
 from typing import TYPE_CHECKING
 from test import TOP_SRC_DIR, path_to
-from test.pylib.runner import testpy_test_fixture_scope
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
@@ -182,7 +181,7 @@ def cluster_con(hosts: list[IPAddress | EndPoint], port: int = 9042, use_ssl: bo
                    )
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 async def manager_api_sock_path(request: pytest.FixtureRequest, testpy_test: Test | None) -> AsyncGenerator[str]:
     if testpy_test is None:
         yield request.config.getoption("--manager-api")
@@ -213,7 +212,7 @@ async def manager_api_sock_path(request: pytest.FixtureRequest, testpy_test: Tes
             future.result()
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 async def manager_internal(request: pytest.FixtureRequest, manager_api_sock_path: str) -> Callable[[], ManagerClient]:
     """Session fixture to prepare client object for communicating with the Cluster API.
        Pass the Unix socket path where the Manager server API is listening.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 
+import _pytest
 import allure
 import pytest
 from test import TEST_RUNNER
@@ -13,6 +14,17 @@ from test.pylib.skip_types import SkipType
 
 
 pytest_plugins = []
+
+def dynamic_scope() -> _pytest.scope._ScopeName:
+    """Dynamic scope for fixtures which rely on a current test.py suite/test.
+
+    Even though test.py not running tests anymore, there is some logic still there that requires module scope.
+    When using runpy runner, all custom logic should be disabled and scope should be session.
+    """
+    if TEST_RUNNER == "runpy":
+        return "session"
+    return "module"
+
 
 if TEST_RUNNER == "runpy":
     @pytest.fixture(scope="session")

--- a/test/cql/conftest.py
+++ b/test/cql/conftest.py
@@ -13,7 +13,6 @@ import pytest
 
 from test.cqlpy.conftest import host, cql, this_dc  # add required fixtures
 from test.pylib.cql_repl import CQL_TEST_SUFFIX, CqlFile
-from test.pylib.runner import testpy_test_fixture_scope
 from test.pylib.suite.base import get_testpy_test
 from test.pylib.suite.python import add_host_option, add_cql_connection_options
 
@@ -61,7 +60,7 @@ def cql_test_connection(cql: Session) -> Generator[None]:
         pytest.fail(f"Scylla appears to have crashed: {exc}")
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope, autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def keyspace(cql: Session, this_dc: str) -> Generator[str]:
     """Create a random keyspace for this pytest session.
 

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -19,10 +19,10 @@ import tempfile
 import time
 import random
 
-from test.pylib.runner import testpy_test_fixture_scope
 from test.pylib.suite.python import PythonTest, add_host_option, add_cql_connection_options, add_s3_options
 from .util import unique_name, new_test_keyspace, keyspace_has_tablets, cql_session, local_process_id, is_scylla, config_value_context
 from .nodetool import scylla_log
+from ..conftest import dynamic_scope
 
 print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")
 
@@ -37,7 +37,7 @@ def pytest_addoption(parser):
     add_s3_options(parser)
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 async def host(request, testpy_test: PythonTest | None):
     if testpy_test is None:
         yield request.config.getoption("--host")
@@ -49,7 +49,7 @@ async def host(request, testpy_test: PythonTest | None):
 # "cql" fixture: set up client object for communicating with the CQL API.
 # The host/port combination of the server are determined by the --host and
 # --port options, and defaults to localhost and 9042, respectively.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def cql(request, host):
     port = request.config.getoption("--port")
     try:
@@ -95,11 +95,11 @@ cql_test_connection.scylla_crashed = False
 # syntax that needs to specify a DC name explicitly. For this, will have
 # a "this_dc" fixture to figure out the name of the current DC, so it can be
 # used in NetworkTopologyStrategy.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def this_dc(cql):
     yield cql.execute("SELECT data_center FROM system.local").one()[0]
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_keyspace_tablets(cql, this_dc, has_tablets):
     if not is_scylla(cql) or not has_tablets:
         yield None
@@ -110,7 +110,7 @@ def test_keyspace_tablets(cql, this_dc, has_tablets):
     yield name
     cql.execute("DROP KEYSPACE " + name)
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_keyspace_vnodes(cql, this_dc, has_tablets):
     name = unique_name()
     if has_tablets:
@@ -124,7 +124,7 @@ def test_keyspace_vnodes(cql, this_dc, has_tablets):
 # "test_keyspace" fixture: Creates and returns a temporary keyspace to be
 # used in tests that need a keyspace. The keyspace is created with RF=1,
 # and automatically deleted at the end.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_keyspace(request, test_keyspace_vnodes, test_keyspace_tablets, cql, this_dc):
     if hasattr(request, "param"):
         if request.param == "vnodes":
@@ -144,7 +144,7 @@ def test_keyspace(request, test_keyspace_vnodes, test_keyspace_tablets, cql, thi
 # The "scylla_only" fixture can be used by tests for Scylla-only features,
 # which do not exist on Apache Cassandra. A test using this fixture will be
 # skipped if running with "run-cassandra".
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def scylla_only(cql):
     # We recognize Scylla by checking if there is any system table whose name
     # contains the word "scylla":
@@ -155,7 +155,7 @@ def scylla_only(cql):
 # the test, it is expected to fail (xfail) on Cassandra. It should be used
 # in rare cases where we consider Scylla's behavior to be the correct one,
 # and Cassandra's to be the bug.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def cassandra_bug(cql):
     # We recognize Scylla by checking if there is any system table whose name
     # contains the word "scylla":
@@ -204,7 +204,7 @@ def random_seed():
 # If such a process exists, we verify that it is Scylla, and return the
 # executable's path. If we can't find the Scylla executable we use
 # pytest.skip() to skip tests relying on this executable.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def scylla_path(cql):
     pid = local_process_id(cql)
     if not pid:
@@ -228,7 +228,7 @@ def scylla_path(cql):
 # exists on the local machine... However, if the same test that uses this
 # fixture also uses the scylla_path fixture, the test will anyway be skipped
 # if the running Scylla is not on the local machine local.
-@pytest.fixture(scope="module")
+@pytest.fixture(scope=dynamic_scope())
 def scylla_data_dir(cql):
     try:
         dir = json.loads(cql.execute("SELECT value FROM system.config WHERE name = 'data_file_directories'").one().value)[0]
@@ -242,7 +242,7 @@ def temp_workdir():
     with tempfile.TemporaryDirectory() as workdir:
         yield workdir
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def has_tablets(cql, this_dc):
     with new_test_keyspace(cql, " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "': 1}") as keyspace:
         return keyspace_has_tablets(cql, keyspace)

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -20,7 +20,6 @@ from test import TOP_SRC_DIR, path_to
 from test.nodetool.rest_api_mock import set_expected_requests, expected_request, get_expected_requests, \
     get_unexpected_requests, expected_requests_manager
 from test.pylib.db.model import Test
-from test.pylib.runner import testpy_test_fixture_scope
 
 
 def pytest_addoption(parser):
@@ -41,7 +40,7 @@ class ServerAddress(NamedTuple):
     port: int
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 async def server_address(request, testpy_test: None|Test):
     # unshare(1) -rn drops us in a new network namespace in which the "lo" is
     # not up yet, so let's set it up first.
@@ -73,7 +72,7 @@ async def server_address(request, testpy_test: None|Test):
         await testpy_test.suite.hosts.release_host(ip)
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 def rest_api_mock_server(request, server_address):
     server_process = subprocess.Popen([sys.executable,
                                        os.path.join(os.path.dirname(__file__), "rest_api_mock.py"),
@@ -110,7 +109,7 @@ def rest_api_mock_server(request, server_address):
         server_process.wait()
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 def jmx(request, rest_api_mock_server):
     if request.config.getoption("nodetool") == "scylla":
         yield
@@ -171,7 +170,7 @@ def jmx(request, rest_api_mock_server):
     jmx_process.wait()
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 def nodetool_path(request, build_mode):
     if request.config.getoption("nodetool") == "scylla":
         return path_to(build_mode, "scylla")

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -265,8 +265,8 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
 
     if not is_xdist_worker: # If this is not an xdist worker there is no separate xdist main process and no pytest_main.log file
         if session.testsfailed == 0 and not session.config.getoption("--save-log-on-success"):
-            # Use missing_ok=True because logging.basicConfig only creates the file
-            # on first use, so it may never have been written if nothing was logged.
+            # Use missing_ok=True because the log file is only created on first write,
+            # so it may never have been written if nothing was logged.
             pathlib.Path(_pytest_config.stash[PYTEST_LOG_FILE]).unlink(missing_ok=True)
 
     # Check if this is an xdist worker - workers should not clean up (only the main process should)
@@ -294,11 +294,6 @@ def pytest_configure(config: pytest.Config) -> None:
     # If this is an xdist worker, set up logging to a separate file for this worker. Otherwise, set up logging for the main process.
     if worker_id is not None:
         _pytest_config.stash[PYTEST_LOG_FILE] = f"{pytest_log_dir}/pytest_{worker_id}_{HOST_ID}.log"
-        logging.basicConfig(
-            format=config.getini("log_file_format"),
-            filename=_pytest_config.stash[PYTEST_LOG_FILE],
-            level=config.getini("log_file_level"),
-        )
     else:
         # For the main process, we want to clean up old logs before the run, so we create the log directory and remove any existing log files.
         pytest_log_dir.mkdir(parents=True, exist_ok=True)
@@ -307,11 +302,20 @@ def pytest_configure(config: pytest.Config) -> None:
                 file.unlink()
 
         _pytest_config.stash[PYTEST_LOG_FILE] = f"{pytest_log_dir}/pytest_main_{HOST_ID}.log"
-        logging.basicConfig(
-            format=config.getini("log_file_format"),
-            filename=_pytest_config.stash[PYTEST_LOG_FILE],
-            level=config.getini("log_file_level"),
-        )
+
+    # Explicitly configure the root logger to write exclusively to a file.
+    # logging.basicConfig() is a no-op when the root logger already has handlers
+    # (e.g. added by pytest or any early import), which would leave a StreamHandler
+    # in place and cause all log records — including noisy third-party DEBUG messages
+    # like urllib3.connectionpool or asyncio — to appear on the terminal.
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        handler.close()
+    file_handler = logging.FileHandler(_pytest_config.stash[PYTEST_LOG_FILE])
+    file_handler.setFormatter(logging.Formatter(config.getini("log_file_format")))
+    root_logger.addHandler(file_handler)
+    root_logger.setLevel(config.getini("log_file_level"))
 
     if config.getoption("--exe-url") and config.getoption("--exe-path"):
         raise RuntimeError("Can't use --exe-url and exe-path simultaneously.")

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -27,7 +27,7 @@ import yaml
 from _pytest.junitxml import xml_key
 
 
-from test import ALL_MODES, DEBUG_MODES, TEST_RUNNER, TOP_SRC_DIR, TESTPY_PREPARED_ENVIRONMENT, HOST_ID
+from test import ALL_MODES, DEBUG_MODES, TEST_RUNNER, TOP_SRC_DIR, HOST_ID
 from test.pylib.scylla_cluster import merge_cmdline_options
 from test.pylib.skip_reason_plugin import skip_marker
 from test.pylib.suite.base import (
@@ -84,7 +84,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     # to run a test.py-compatible pytest session.
     #
     # TODO: remove this when we'll completely switch to bare pytest runner.
-    parser.addoption('--test-py-init', action='store_true', default=False,
+    parser.addoption('--test-py-init', action='store_true', default=False, deprecated=True,
                      help='Run pytest session in test.py-compatible mode.  I.e., start all required services, etc.')
 
     # Options for compatibility with test.py
@@ -195,21 +195,14 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     if TEST_RUNNER != "pytest" or session.config.getoption("--collect-only"):
         return
 
-    if not session.config.getoption("--test-py-init"):
-        return
-
     # Check if this is an xdist worker
     is_xdist_worker = xdist.is_xdist_worker(request_or_session=session)
 
-    # Always initialize globals in xdist workers (they run in separate processes)
-    # For the main process, only init if test.py hasn't done so already
-    if is_xdist_worker or TESTPY_PREPARED_ENVIRONMENT not in os.environ:
-        init_testsuite_globals()
-        TestSuite.artifacts.add_exit_artifact(None, TestSuite.hosts.cleanup)
+    init_testsuite_globals()
+    TestSuite.artifacts.add_exit_artifact(None, TestSuite.hosts.cleanup)
 
     # Run stuff just once for the main pytest process (not in xdist workers).
-    # Only prepare the environment if it hasn't been prepared by test.py
-    if not is_xdist_worker and TESTPY_PREPARED_ENVIRONMENT not in os.environ:
+    if not is_xdist_worker:
         temp_dir = pathlib.Path(session.config.getoption("--tmpdir")).absolute()
 
         prepare_environment(
@@ -265,21 +258,21 @@ def pytest_runtest_logreport(report):
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:
-    if not session.config.getoption("--test-py-init"):
-        return
 
     is_xdist_worker = xdist.is_xdist_worker(request_or_session=session)
     # If all tests passed, remove the log file to save space and avoid confusion with logs from failed runs.
     # We check this at the end of the session to ensure that we have the complete log available for any failed tests.
 
-    if not (not is_xdist_worker and TESTPY_PREPARED_ENVIRONMENT in os.environ): # If this is not an xdist worker and test.py has prepared the environment, there is no separate xdist main process and no pytest_main.log file
+    if not is_xdist_worker: # If this is not an xdist worker there is no separate xdist main process and no pytest_main.log file
         if session.testsfailed == 0 and not session.config.getoption("--save-log-on-success"):
-            os.remove(_pytest_config.stash[PYTEST_LOG_FILE])
+            # Use missing_ok=True because logging.basicConfig only creates the file
+            # on first use, so it may never have been written if nothing was logged.
+            pathlib.Path(_pytest_config.stash[PYTEST_LOG_FILE]).unlink(missing_ok=True)
 
     # Check if this is an xdist worker - workers should not clean up (only the main process should)
     # Check if test.py has already prepared the environment, so it should clean up
 
-    if is_xdist_worker or TESTPY_PREPARED_ENVIRONMENT in os.environ:
+    if is_xdist_worker:
         return
     # we only clean up when running with pure pytest
     if getattr(TestSuite, "artifacts", None) is not None:
@@ -296,30 +289,29 @@ def pytest_configure(config: pytest.Config) -> None:
     global _pytest_config
     _pytest_config = config
 
-    if _pytest_config.getoption("--test-py-init"):
-        pytest_log_dir = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_LOG_FOLDER
-        worker_id = os.environ.get("PYTEST_XDIST_WORKER")
-        # If this is an xdist worker, set up logging to a separate file for this worker. Otherwise, set up logging for the main process.
-        if worker_id is not None:
-            _pytest_config.stash[PYTEST_LOG_FILE] = f"{pytest_log_dir}/pytest_{worker_id}_{HOST_ID}.log"
-            logging.basicConfig(
-                format=config.getini("log_file_format"),
-                filename=_pytest_config.stash[PYTEST_LOG_FILE],
-                level=config.getini("log_file_level"),
-            )
-        else:
-            # For the main process, we want to clean up old logs before the run, so we create the log directory and remove any existing log files.
-            pytest_log_dir.mkdir(parents=True, exist_ok=True)
-            if not _pytest_config.getoption("--save-log-on-success"):
-                for file in pytest_log_dir.glob("*"):
-                    file.unlink()
+    pytest_log_dir = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_LOG_FOLDER
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    # If this is an xdist worker, set up logging to a separate file for this worker. Otherwise, set up logging for the main process.
+    if worker_id is not None:
+        _pytest_config.stash[PYTEST_LOG_FILE] = f"{pytest_log_dir}/pytest_{worker_id}_{HOST_ID}.log"
+        logging.basicConfig(
+            format=config.getini("log_file_format"),
+            filename=_pytest_config.stash[PYTEST_LOG_FILE],
+            level=config.getini("log_file_level"),
+        )
+    else:
+        # For the main process, we want to clean up old logs before the run, so we create the log directory and remove any existing log files.
+        pytest_log_dir.mkdir(parents=True, exist_ok=True)
+        if not _pytest_config.getoption("--save-log-on-success"):
+            for file in pytest_log_dir.glob("*"):
+                file.unlink()
 
-            _pytest_config.stash[PYTEST_LOG_FILE] = f"{pytest_log_dir}/pytest_main_{HOST_ID}.log"
-            logging.basicConfig(
-                format=config.getini("log_file_format"),
-                filename=_pytest_config.stash[PYTEST_LOG_FILE],
-                level=config.getini("log_file_level"),
-            )
+        _pytest_config.stash[PYTEST_LOG_FILE] = f"{pytest_log_dir}/pytest_main_{HOST_ID}.log"
+        logging.basicConfig(
+            format=config.getini("log_file_format"),
+            filename=_pytest_config.stash[PYTEST_LOG_FILE],
+            level=config.getini("log_file_level"),
+        )
 
     if config.getoption("--exe-url") and config.getoption("--exe-path"):
         raise RuntimeError("Can't use --exe-url and exe-path simultaneously.")
@@ -380,17 +372,16 @@ def pytest_runtest_makereport(item, call):
     # and we use hookwrapper=True to allow us to access the report after it has been generated by other hooks.
     outcome = yield
 
-    if _pytest_config.getoption("--test-py-init"):
-        rep = outcome.get_result()
-        # we only look at actual failing test calls, not setup/teardown
-        pytest_tests_logs = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
-        if rep.failed or (_pytest_config.getoption("--save-log-on-success") and rep.when == "teardown"):
-            mode = "a" if os.path.exists(pytest_tests_logs) else "w"
-            with open(pytest_tests_logs/ f"{item._nodeid.replace("::", "-").replace("/", "-")}-{rep.when}-{HOST_ID}.log",mode) as f:
-                f.write(rep.longreprtext + "\n")
-                for section in rep.sections:
-                    f.write(section[0] + "\n")
-                    f.write(section[1] + "\n")
+    rep = outcome.get_result()
+    # we only look at actual failing test calls, not setup/teardown
+    pytest_tests_logs = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
+    if rep.failed or (_pytest_config.getoption("--save-log-on-success") and rep.when == "teardown"):
+        mode = "a" if os.path.exists(pytest_tests_logs) else "w"
+        with open(pytest_tests_logs/ f"{item._nodeid.replace("::", "-").replace("/", "-")}-{rep.when}-{HOST_ID}.log",mode) as f:
+            f.write(rep.longreprtext + "\n")
+            for section in rep.sections:
+                f.write(section[0] + "\n")
+                f.write(section[1] + "\n")
 
 class TestSuiteConfig:
     def __init__(self, config_file: pathlib.Path):

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -133,21 +133,7 @@ def print_scylla_log_filename(request: pytest.FixtureRequest) -> Generator[None]
         logger.info("ScyllaDB log file: %s", scylla_log_filename)
 
 
-def testpy_test_fixture_scope(fixture_name: str, config: pytest.Config) -> _pytest.scope._ScopeName:
-    """Dynamic scope for fixtures which rely on a current test.py suite/test.
-
-    test.py runs tests file-by-file as separate pytest sessions, so, `session` scope is effectively close to be the
-    same as `module` (can be a difference in the order.)  In case of running tests with bare pytest command, we
-    need to use `module` scope to maintain same behavior as test.py, since we run all tests in one pytest session.
-    """
-    if getattr(config.option, "test_py_init", False):
-        return "module"
-    return "session"
-
-testpy_test_fixture_scope.__test__ = False
-
-
-@pytest.fixture(scope=testpy_test_fixture_scope, autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def build_mode(request: pytest.FixtureRequest) -> str:
     params_stash = get_params_stash(node=request.node)
     if params_stash is None:
@@ -155,7 +141,7 @@ def build_mode(request: pytest.FixtureRequest) -> str:
     return params_stash[BUILD_MODE]
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 def scale_timeout(build_mode: str) -> Callable[[int | float], int | float]:
     def scale_timeout_inner(timeout: int | float) -> int | float:
         return scale_timeout_by_mode(build_mode, timeout)
@@ -163,7 +149,7 @@ def scale_timeout(build_mode: str) -> Callable[[int | float], int | float]:
     return scale_timeout_inner
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 async def testpy_test(request: pytest.FixtureRequest, build_mode: str) -> Test | None:
     """Create an instance of Test class for the current test.py test."""
 

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -543,6 +543,22 @@ def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: b
             prepare_dir(tempdir_base / mode / "pytest", "*", save_log_on_success)
 
 
+def _make_service_logger(logger_name: str, log_file: pathlib.Path) -> logging.Logger:
+    """Return a logger that writes exclusively to *log_file*.
+
+    Disables propagation to the root logger so service start/stop messages
+    never appear on the console.
+    """
+    svc_logger = logging.getLogger(logger_name)
+    svc_logger.propagate = False
+    svc_logger.setLevel(logging.DEBUG)
+    if not svc_logger.handlers:
+        handler = logging.FileHandler(log_file)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+        svc_logger.addHandler(handler)
+    return svc_logger
+
+
 @universalasync.async_to_sync_wraps
 async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_limit: int):
     hosts = HostRegistry()
@@ -559,7 +575,10 @@ async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_li
     ms = MinioServer(
         tempdir_base=str(tempdir_base),
         address=await hosts.lease_host(),
-        logger=LogPrefixAdapter(logger=logging.getLogger("minio"), extra={"prefix": "minio"}),
+        logger=LogPrefixAdapter(
+            logger=_make_service_logger("minio", tempdir_base / "minio.log"),
+            extra={"prefix": "minio"},
+        ),
     )
     await ms.start()
     TestSuite.artifacts.add_exit_artifact(None, ms.stop)
@@ -569,7 +588,10 @@ async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_li
     mock_s3_server = MockS3Server(
         host=await hosts.lease_host(),
         port=2012,
-        logger=LogPrefixAdapter(logger=logging.getLogger("s3_mock"), extra={"prefix": "s3_mock"}),
+        logger=LogPrefixAdapter(
+            logger=_make_service_logger("s3_mock", tempdir_base / "s3_mock.log"),
+            extra={"prefix": "s3_mock"},
+        ),
     )
     await mock_s3_server.start()
     TestSuite.artifacts.add_exit_artifact(None, mock_s3_server.stop)
@@ -581,7 +603,10 @@ async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_li
         minio_uri=minio_uri,
         max_retries=3,
         seed=int(time.time()),
-        logger=LogPrefixAdapter(logger=logging.getLogger("s3_proxy"), extra={"prefix": "s3_proxy"}),
+        logger=LogPrefixAdapter(
+            logger=_make_service_logger("s3_proxy", tempdir_base / "s3_proxy.log"),
+            extra={"prefix": "s3_proxy"},
+        ),
     )
     await proxy_s3_server.start()
     TestSuite.artifacts.add_exit_artifact(None, proxy_s3_server.stop)

--- a/test/rest_api/conftest.py
+++ b/test/rest_api/conftest.py
@@ -12,9 +12,9 @@
 import pytest
 import requests
 
+from test.conftest import dynamic_scope
 from test.cqlpy.conftest import host, cql, this_dc  # add required fixtures
 from test.cqlpy.util import unique_name, new_test_keyspace, keyspace_has_tablets, is_scylla
-from test.pylib.runner import testpy_test_fixture_scope
 from test.pylib.suite.python import add_host_option, add_cql_connection_options
 
 # By default, tests run against a Scylla server listening
@@ -50,7 +50,7 @@ class RestApiSession:
 # "api" fixture: set up client object for communicating with Scylla API.
 # The host/port combination of the server are determined by the --host and
 # --port options, and defaults to localhost and 10000, respectively.
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def rest_api(request, host):
     port = request.config.getoption('api_port')
     return RestApiSession(host, port)
@@ -58,14 +58,14 @@ def rest_api(request, host):
 # The "scylla_only" fixture can be used by tests for Scylla-only features,
 # which do not exist on Apache Cassandra. A test using this fixture will be
 # skipped if running with "run-cassandra".
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def scylla_only(cql):
     # We recognize Scylla by checking if there is any system table whose name
     # contains the word "scylla":
     if not is_scylla(cql):
         pytest.skip('Scylla-only test skipped')
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def has_tablets(cql):
     with new_test_keyspace(cql, " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor': 1}") as keyspace:
         return keyspace_has_tablets(cql, keyspace)
@@ -80,7 +80,7 @@ def skip_without_tablets(scylla_only, has_tablets):
     if not has_tablets:
         pytest.skip("Test needs tablets experimental feature on")
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_keyspace_vnodes(cql, this_dc, has_tablets):
     name = unique_name()
     if has_tablets:
@@ -91,7 +91,7 @@ def test_keyspace_vnodes(cql, this_dc, has_tablets):
     yield name
     cql.execute("DROP KEYSPACE " + name)
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope=dynamic_scope())
 def test_keyspace(cql, this_dc):
     name = unique_name()
     cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")

--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -8,11 +8,10 @@ import subprocess
 
 import pytest
 
-from test.pylib.runner import testpy_test_fixture_scope
 from test.pylib.suite.python import PythonTest
 
 
-@pytest.fixture(scope=testpy_test_fixture_scope)
+@pytest.fixture(scope="module")
 async def scylla_server(testpy_test: PythonTest | None):
     """Return a running Scylla server instance from the active test cluster."""
     async with testpy_test.run_ctx(options=testpy_test.suite.options) as cluster:


### PR DESCRIPTION
With the latest changes, there are a lot of code that is redundant in the test.py. This PR just cleans this code.
Also, it narrows using dynamic scope for fixtures to test/alternator and test/cqlpy. All the rest by default will have module scope.
test.py will be a wrapper for pytest mostly for CI use. As for now test.py have important part of calculating the number of threads to start pytest with. This is not possible to do in pytest itself.

No backport needed, framework enhancement only.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-666