### PR TITLE
test.py: enable strict_config,xfail_strict,strict-markers

### DIFF
--- a/test/cluster/dtest/scrub_test.py
+++ b/test/cluster/dtest/scrub_test.py
@@ -192,9 +192,7 @@ class TestHelper(Tester):
         return self.get_sstables(table, indexes)
 
 
-@pytest.mark.dtest_full
 @pytest.mark.single_node
-@pytest.mark.next_gating
 class TestScrubIndexes(TestHelper):
     """
     Test that we scrub indexes as well as their parent tables
@@ -338,9 +336,7 @@ class TestScrubIndexes(TestHelper):
         assert initial_users == users, "List of users before and after scrub are different"
 
 
-@pytest.mark.dtest_full
 @pytest.mark.single_node
-@pytest.mark.next_gating
 class TestScrub(TestHelper):
     """
     Generic tests for scrubbing

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -172,7 +172,7 @@ async def test_move_tablet(manager: ManagerClient, move_table: str):
     "with_merge",
     [
         pytest.param(False, id="no_merge"),
-        pytest.param(True, id="with_merge", marks=pytest.mark.xfail(reason="issue #17265")),
+        pytest.param(True, id="with_merge"),
     ],
 )
 async def test_tablet_split_and_merge(manager: ManagerClient, with_merge: bool):

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,4 +1,9 @@
 [pytest]
+strict_config = true
+xfail_strict = true
+
+addopts = --strict-markers
+
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 


### PR DESCRIPTION
this commit enables 3 strict pytest options:

strict_config - if any warnings encountered while parsing the pytest section of the configuration file will raise errors. xfail_strict - if markers not registered in the markers section of the configuration file will raise errors. strict-markers - if tests marked with @pytest.mark.xfail that actually succeed will by default fail the test suite

and fix errors that occur after enabling these options

Fixes SCYLLADB-899

