### PR TITLE
Relax test's check_mutation_replicas() argument list

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -717,7 +717,7 @@ async def test_restore_with_streaming_scopes(build_mode: str, manager: ManagerCl
         await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
 
         # validate replicas assertions hold on fresh dataset
-        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test', expected_replicas = None)
+        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
 
         snap_name, sstables = await take_snapshot(ks, servers, manager, logger)
         prefix = f'test/{snap_name}'

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -66,7 +66,7 @@ async def test_refresh_with_streaming_scopes(build_mode: str, manager: ManagerCl
     _, keys, _ = await create_dataset(manager, ks, cf, topology, logger, num_keys=10, min_tablet_count=5)
 
     # validate replicas assertions hold on fresh dataset
-    await check_mutation_replicas(cql, manager, servers, keys, topology, logger, ks, cf, expected_replicas = None)
+    await check_mutation_replicas(cql, manager, servers, keys, topology, logger, ks, cf)
 
     _, sstables = await take_snapshot(ks, servers, manager, logger)
 


### PR DESCRIPTION
The one accepts long list of arguments, some of those is not really needed. Also some callers can be relaxed not to provide default values for arguments with such.

Improving tests, not backporting