### PR TITLE
test/alternator: fix run script

### DIFF
--- a/test/alternator/run
+++ b/test/alternator/run
@@ -65,7 +65,9 @@ def run_alternator_cmd(pid, dir):
         '--alternator-write-isolation', 'only_rmw_uses_lwt',
         '--alternator-streams-time-window-s', '0',
         '--alternator-timeout-in-ms', '30000',
-        '--alternator-ttl-period-in-seconds', '0.5',
+        # no longer needed here because it's defined in test/cqlpy/run.py
+        # now that this parameter is used also by CQL's per-row TTL.
+        #'--alternator-ttl-period-in-seconds', '0.5',
         '--alternator-allow-system-table-write=1',
         # Allow testing experimental features. Following issue #9467, we need
         # to add here specific experimental features as they are introduced.


### PR DESCRIPTION
The test/alternator/run script currently fails, Scylla fails to boot complaining that "--alternator-ttl-period-in-seconds" is specified twice (which is, unfortunately, not allowed). The problem is that recently we started to set this option in test/cqlpy/run.py, for CQL's new row-level TTL, so now it is no longer needed in test/alternator/run - and in fact not allowed and we must remove it.

This patch only affects the script test/alternator/run, and has no affect on running tests through test.py or Jenkins.

This patch fixes a very recent regression, so no need to backport it.