### PR TITLE
build: add slirp4netns to dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -154,6 +154,7 @@ fedora_packages=(
 
     podman
     buildah
+    slirp4netns
 
     # for cassandra-stress
     java-openjdk-headless

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-43-20260223
+docker.io/scylladb/scylla-toolchain:fedora-43-20260304


### PR DESCRIPTION
Needed for port forwarded podman-in-podman containers

[avi:
  - move from Dockerfile to install-dependencies.sh so non-container builds also get it
  - regenerate frozen toolchain with optimized clang from

    https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-aarch64.tar.gz https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-x86_64.tar.gz ]

No backport, preparing for new tooling.