### PR TITLE
doc: fix the upgrage guide to 2026.1

### DIFF
--- a/docs/upgrade/upgrade-guides/upgrade-guide-from-2025.x-to-2026.1/upgrade-guide-from-2025.x-to-2026.1.rst
+++ b/docs/upgrade/upgrade-guides/upgrade-guide-from-2025.x-to-2026.1/upgrade-guide-from-2025.x-to-2026.1.rst
@@ -17,16 +17,10 @@ This document describes a step-by-step procedure for upgrading from |SCYLLA_NAME
 to |SCYLLA_NAME| |NEW_VERSION| and rollback to version |SRC_VERSION| if necessary.
 
 This guide covers upgrading ScyllaDB on Red Hat Enterprise Linux (RHEL), CentOS, Debian, 
-<<<<<<< HEAD:docs/upgrade/upgrade-guides/upgrade-guide-from-2025.x-to-2025.4/upgrade-guide-from-2025.x-to-2025.4.rst
-and Ubuntu. See :doc:`OS Support by Platform and Version </getting-started/os-support>` 
-for information about supported versions.
-||||||| parent of dfd46ad3fb (doc: add the upgrade guide from 2025.x to 2026.1):docs/upgrade/upgrade-guides/upgrade-guide-from-2025.x-to-2025.4/upgrade-guide-from-2025.x-to-2025.4.rst
-and Ubuntu. See `OS Support by Platform and Version <https://docs.scylladb.com/stable/versioning/os-support-per-version.html>`_ 
-for information about supported versions.
-=======
-and Ubuntu. See `OS Support by Platform and Version <https://docs.scylladb.com/stable/versioning/os-support-per-version.html>`_ 
-for information about supported versions. It also applies when using the ScyllaDB official image on EC2, GCP, or Azure.
->>>>>>> dfd46ad3fb (doc: add the upgrade guide from 2025.x to 2026.1):docs/upgrade/upgrade-guides/upgrade-guide-from-2025.x-to-2026.1/upgrade-guide-from-2025.x-to-2026.1.rst
+and Ubuntu.
+See `OS Support by Platform and Version <https://docs.scylladb.com/stable/versioning/os-support-per-version.html>`_ 
+for information about supported versions. It also applies when using
+the ScyllaDB official image on EC2, GCP, or Azure.
 
 See :doc:`About Upgrade </upgrade/about-upgrade/>` for the ScyllaDB upgrade policy.
 
@@ -208,14 +202,6 @@ You should take note of the current version in case you want to |ROLLBACK|_ the 
       #. Run ``scylla_setup`` without ``running io_setup``.
       #. Run ``sudo /opt/scylladb/scylla-machine-image/scylla_cloud_io_setup``.
 
-<<<<<<< HEAD:docs/upgrade/upgrade-guides/upgrade-guide-from-2025.x-to-2025.4/upgrade-guide-from-2025.x-to-2025.4.rst
-
-
-||||||| parent of dfd46ad3fb (doc: add the upgrade guide from 2025.x to 2026.1):docs/upgrade/upgrade-guides/upgrade-guide-from-2025.x-to-2025.4/upgrade-guide-from-2025.x-to-2025.4.rst
-
-
-=======
->>>>>>> dfd46ad3fb (doc: add the upgrade guide from 2025.x to 2026.1):docs/upgrade/upgrade-guides/upgrade-guide-from-2025.x-to-2026.1/upgrade-guide-from-2025.x-to-2026.1.rst
 Start the node
 --------------
 


### PR DESCRIPTION
The upgrade guide on branch-2026.1 has bugs caused by incorrectly resolved conflicts in the backport PR: https://github.com/scylladb/scylladb/pull/28835.

This PR fixes the issue.
The fix only applies to branch-2026.1.

Fixes https://github.com/scylladb/scylladb/issues/28871

No backport. This PR should be merged directly to branch-2026.1.