### PR TITLE
test: test_mv_merge_allowed: add mistakenly omitted awaits

### DIFF
--- a/test/cluster/mv/tablets/test_mv_tablets_merge.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_merge.py
@@ -33,10 +33,10 @@ async def test_mv_merge_allowed(manager):
                     if current_tablet_count == expected_tablet_count:
                         return True
                 
-                assert tablet_count_is(table, 2)
+                assert await tablet_count_is(table, 2)
                 await cql.run_async(f"ALTER TABLE {table} WITH tablets = {{'min_tablet_count': 1}}")
                 await wait_for(lambda: tablet_count_is(table, 1), time.time() + 60)
 
-                assert tablet_count_is(mv, 2)
+                assert await tablet_count_is(mv, 2)
                 await cql.run_async(f"ALTER MATERIALIZED VIEW {mv} WITH tablets = {{'min_tablet_count': 1}}")
                 await wait_for(lambda: tablet_count_is(mv, 1), time.time() + 60)


### PR DESCRIPTION
The test test_mv_merge_allowed asserts in two places that the tablet count is 2. It does so by calling an async function but, mistakenly, the returned coroutine was not awaited. The coroutine is, apparently, truthy so the assertions always passed.

Fix the test to properly await the coroutines in the assertions.

Fixes: SCYLLADB-905

Not sure if backporting is worth the effort, the affected assertions were sanity checks that are very likely to work in older versions.