### PR TITLE
test: Fix non-awaited coroutine in test_gossiper_empty_self_id_on_shadow_round

### DIFF
--- a/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
+++ b/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
@@ -44,7 +44,6 @@ async def test_gossiper_empty_self_id_on_shadow_round(manager: ManagerClient):
 
     logging.info("Starting cluster normally")
     node1 = await manager.server_add(cmdline=cmdline, start=False, config=cfg)
-    manager.server_add(cmdline=cmdline, start=False)
     node1_log = await manager.server_open_log(node1.server_id)
     node2 = await manager.server_add(cmdline=cmdline, start=False, seeds=[node1.ip_addr])
     node2_log = await manager.server_open_log(node2.server_id)


### PR DESCRIPTION
The line with the error was not actually needed and has therefore been removed.

Fixes: SCYLLADB-906
backport: seems this issue does not cause lots of issues. so no backporting is needed.

