### PR TITLE
test.py disable XFail tests on CI run

### DIFF
--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -469,3 +469,7 @@ def modify_pytest_item(item: pytest.Item) -> None:
             __skip_test(*mark.args, **mark.kwargs)
         except TypeError as e:
             raise TypeError(f"Failed to process skip_mode mark, {mark} for test {item}, error {e}")
+
+    if (any(mark.name == "xfail" for mark in item.iter_markers("xfail"))
+            and not any(mark.name == "nightly" for mark in item.iter_markers("nightly"))):
+        item.add_marker(pytest.mark.nightly)


### PR DESCRIPTION
This PR disables running FXAIL tests on ci run to speed it up.

tests will continue run on "nightly" job and FAIL on unexpected pass 
and will continue run on "NEXT" job and NOT FAIL on unexpected pass

should be merged after: 
https://github.com/scylladb/scylladb/pull/28859
https://github.com/scylladb/scylla-pkg/pull/5942