### PR TITLE
Add RELENG to milestone-to-Jira sync project keys

### DIFF
--- a/.github/workflows/call_sync_milestone_to_jira.yml
+++ b/.github/workflows/call_sync_milestone_to_jira.yml
@@ -9,6 +9,6 @@ jobs:
     uses: scylladb/github-automation/.github/workflows/main_sync_milestone_to_jira_release.yml@main
     with:
       # Comma-separated list of Jira project keys
-      jira_project_keys: "SCYLLADB,CUSTOMER,SMI"
+      jira_project_keys: "SCYLLADB,CUSTOMER,SMI,RELENG"
     secrets:
       caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
Add RELENG to the comma-separated list of Jira project keys in `call_sync_milestone_to_jira.yml`, so that new milestones are also synced to the RELENG Jira project.

Fixes: PM-208