### PR TITLE
cql3/query_processor: retry prepare cache lookup on null weak ptr

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -725,7 +725,11 @@ query_processor::prepare(sstring query_string, service::query_state& query_state
 
 future<::shared_ptr<cql_transport::messages::result_message::prepared>>
 query_processor::prepare(sstring query_string, const service::client_state& client_state, cql3::dialect d) {
-        auto key = compute_id(query_string, client_state.get_raw_keyspace(), d);
+    auto key = compute_id(query_string, client_state.get_raw_keyspace(), d);
+
+    // Keep retrying until we either get a live prepared statement pointer or hit the request deadline.
+    auto deadline = db::timeout_clock::now() + client_state.get_timeout_config().other_timeout;
+    while (true) {
         prepared_statements_cache::value_type prep_ptr;
         try {
             prep_ptr = co_await _prepared_cache.get(key, [this, &query_string, &client_state, d] {
@@ -745,6 +749,15 @@ query_processor::prepare(sstring query_string, const service::client_state& clie
             throw prepared_statement_is_too_big(query_string);
         }
 
+        if (!prep_ptr) {
+            if (db::timeout_clock::now() > deadline) {
+                // The entry kept getting invalidated by concurrent schema changes until the deadline.
+                throw exceptions::server_exception("Prepared statement could not be prepared due to concurrent schema changes (timed out)");
+            }
+            // checked_weak_ptr expired after retrieval; retry within the same deadline.
+            continue;
+        }
+
         const auto& warnings = prep_ptr->warnings;
         const auto msg = ::make_shared<result_message::prepared::cql>(prepared_cache_key_type::cql_id(key), std::move(prep_ptr),
                     client_state.is_protocol_extension_set(cql_transport::cql_protocol_extension::LWT_ADD_METADATA_MARK));
@@ -752,6 +765,7 @@ query_processor::prepare(sstring query_string, const service::client_state& clie
             msg->add_warning(w);
         }
         co_return ::shared_ptr<cql_transport::messages::result_message::prepared>(std::move(msg));
+    }
 }
 
 static std::string hash_target(std::string_view query_string, std::string_view keyspace) {


### PR DESCRIPTION
When schema invalidation races with PREPARE, the cache can return an expired checked weak pointer after `get()` completes.

What happens in particular: The `checked_ptr` can get invalidated when returning from prepared cache `get()` into the `prepare()` method. This can happen because the Seastar co_await implementation might preempt after returning from the `co_awaited` method:
```cpp
    bool await_ready() const noexcept {
        return _future.available() && (!CheckPreempt || !need_preempt());
    }
```

If `need_preempt()` returns true (because for example the prepared cache value retrieval / loading took too much timeshare), the reactor might preempt a different operation before continuing the `prepare()` code. Which can invalidate the `checked_ptr` returned from the prepared cache `get()`, before the `prepare()` gets a chance to continue. This is also the reason that we must perform the retry in the `prepare()` itself, as performing retries in prepared cache `get()` would not help there (the pointer can still get invalidated during returning it back to `prepare()`).

The invalidation in particular seems to be most likely performed by the `on_update_column_family()`:

```cpp
void query_processor::migration_subscriber::on_update_column_family(
        const sstring& ks_name,
        const sstring& cf_name,
        bool columns_changed) {
    // #1255: Ignoring columns_changed deliberately.
    log.info("Column definitions for {}.{} changed, invalidating related prepared statements", ks_name, cf_name);
    remove_invalid_prepared_statements(ks_name, cf_name);
}
```

Note that the #1255 and the corresponding commit 13d8cd0ae90a1711bb782f4d93b30d1b38de831c removed the "if (columns_changed)" check, so now the prepared cache invalidation is performed on every change (not only on actual column changes) - in particular, the test does "ALTER TABLE" to modify the tablet count - it doesn't modify the columns, but still changes the schema.

Handle this by retrying in `query_processor::prepare()` until either:

- a live prepared statement pointer is obtained, or
- the request timeout deadline is reached.

On deadline expiry, return `server_exception` describing repeated invalidation due to concurrent schema changes.

The alternative would be to trigger UNPREPARED (0x2500) error. But returning UNPREPARED from a PREPARE request would be semantically wrong:

- UNPREPARED means "I don't recognize this prepared statement ID you referenced." PREPARE doesn't reference a prepared ID - it sends a query string. The error is not "unknown ID" but "I prepared it internally, then lost it before returning." UNPREPARED misrepresents what happened.
- Drivers implement reprepare logic only in the EXECUTE/BATCH response path, where a PreparedStatement context exists. For example, the python-driver's Session.prepare() creates a ResponseFuture with prepared_statement=None, so the UNPREPARED handler cannot reprepare and simply raises an error. Other drivers likely make the same assumption since the protocol defines UNPREPARED for EXECUTE/BATCH.
- A server-side retry avoids a full network round-trip, requires zero driver changes across the entire driver ecosystem, and is virtually guaranteed to succeed since two consecutive hits on this microsecond race window is practically impossible.

Fixes: scylladb/scylladb#27657

Backport to active branches recommended: No node crash, but user-visible PREPARE failures under rare schema-invalidation race; low-risk timeout-bounded retry improves robustness.