### PR TITLE
counters: reuse counter IDs by rack

### DIFF
--- a/docs/dev/counters.md
+++ b/docs/dev/counters.md
@@ -1,0 +1,81 @@
+# Counters
+
+Counters are special kinds of cells which value can only be incremented, decremented, read and (with some limitations) deleted. In particular, once deleted, that counter cannot be used again. For example:
+
+```cql
+> UPDATE cf SET my_counter = my_counter + 6 WHERE pk = 0
+> SELECT * FROM cf;
+ pk | my_counter
+----+------------
+  0 |          6
+
+(1 rows)
+> UPDATE cf SET my_counter = my_counter - 1 WHERE pk = 0
+> SELECT * FROM cf;
+ pk | my_counter
+----+------------
+  0 |          5
+
+(1 rows)
+> DELETE my_counter FROM cf WHERE pk = 0;
+> SELECT * FROM cf;
+ pk | my_counter
+----+------------
+
+(0 rows)
+> UPDATE cf SET my_counter = my_counter + 3 WHERE pk = 0
+> SELECT * FROM cf;
+ pk | my_counter
+----+------------
+
+(0 rows)
+```
+
+## Counters representation
+Counters are represented as sets of, so called, shards which are triples containing:
+* counter id – uuid identifying the writer owning that shard (see below)
+* logical clock – incremented each time the owning writer modifies the shard value
+* current value – sum of increments and decrements done by the owning writer
+
+During each write operation one of the replicas is chosen as a leader. The leader reads its shard, increments logical clock, updates current value and then sends the new version of its shard to the other replicas.
+
+Shards owned by the same writer are merged (see below) so that each counter cell contains only one shard per counter id. Reading the actual counter value requires summing values of all shards.
+
+### Counter id
+
+The counter id is a 128-bit UUID that identifies which writer owns a shard. How it is assigned depends on whether the table uses vnodes or tablets.
+
+**Vnodes:** the counter id is the host id of the node that owns the shard. Each node in the cluster gets a unique counter id, so the number of shards in a counter cell grows with the number of distinct nodes that have ever written to it.
+
+**Tablets:** the counter id is rack-based rather than node-based. It is a deterministic type-3 (name-based) UUID derived from the string `"<datacenter>:<rack>"`. All nodes in the same rack share the same counter id.
+
+During tablet migration, since there are two active replicas in a rack and in order to avoid conflicts, the node that is a *pending replica* uses the **negated** rack UUID as its counter id.
+
+This bounds the number of shards in a counter cell to at most `2 × (number of racks)` regardless of node replacements.
+
+### Merging and reconciliation
+Reconciliation of two counters requires merging all shards belonging to the same counter id. The rule is: the shard with the highest logical clock wins.
+
+Since support of deleting counters is limited so that once deleted they cannot be used again, during reconciliation tombstones win with live counter cell regardless of their timestamps.
+
+### Digest
+Computing a digest of counter cells needs to be done based solely on the shard contents (counter id, value, logical clock) rather than any structural metadata.
+
+## Writes
+1. Counter update starts with a client sending counter delta as a long (CQL3 `bigint`) to the coordinator.
+2. CQL3 creates a `CounterMutation` containing a `counter_update` cell which is just a delta.
+3. Coordinator chooses the leader of the counter update and sends it the mutation. The leader is always one of the replicas owning the partition the modified counter belongs to.
+4. Now, the leader needs to transform counter deltas into shards. To do that it reads the current value of the shard it owns, and produces a new shard with the value modified by the delta and the logical clock incremented.
+5. The mutation with the newly created shard is both used to update the memtable on the leader as well as sent to the other nodes for replication.
+
+### Choosing leader
+Choosing a replica which becomes a leader for a counter update is completely at the coordinator discretion. It is not a static role in any way and any concurrent update could be forwarded to a different leader. This means that all problems related to leader election are avoided.
+
+The coordinator chooses the leader using the following algorithm:
+
+1. If the coordinator can be a leader it chooses itself.
+2. Otherwise, a random replica from the local DC is chosen.
+3. If there is no eligible node available in the local DC the replica closest to the coordinator (according to the snitch) is chosen.
+
+## Reads
+Querying counter values is much simpler than updating it. First part of the read operation is performed as for all other cell types. When counter cells from different sources are being reconciled their shards are merged. Once the final counter cell value is known and the `CounterCell` is serialised, current values of all shards are summed up and the output of serialisation is a long integer.

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -490,6 +490,10 @@ const endpoint_dc_rack& topology::get_location_slow(host_id id) const {
     throw std::runtime_error(format("Requested location for node {} not in topology. backtrace {}", id, lazy_backtrace()));
 }
 
+utils::UUID topology::get_rack_uuid() const {
+    return utils::UUID_gen::get_name_UUID(format("{}:{}", get_location().dc, get_location().rack));
+}
+
 void topology::sort_by_proximity(locator::host_id address, host_id_vector_replica_set& addresses) const {
     if (can_sort_by_proximity()) {
         do_sort_by_proximity(address, addresses);

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -344,6 +344,8 @@ public:
         return get_location(id).rack;
     }
 
+    utils::UUID get_rack_uuid() const;
+
     auto get_local_dc_filter() const noexcept {
         return [ this, local_dc = get_datacenter() ] (auto ep) {
             return get_datacenter(ep) == local_dc;

--- a/mutation/counters.cc
+++ b/mutation/counters.cc
@@ -175,10 +175,8 @@ std::optional<atomic_cell> counter_cell_view::difference(atomic_cell_view a, ato
 }
 
 
-void transform_counter_updates_to_shards(mutation& m, const mutation* current_state, uint64_t clock_offset, locator::host_id local_host_id) {
+void transform_counter_updates_to_shards(mutation& m, const mutation* current_state, uint64_t clock_offset, counter_id local_id) {
     // FIXME: allow current_state to be frozen_mutation
-
-    utils::UUID local_id = local_host_id.uuid();
 
     auto transform_new_row_to_shards = [&s = *m.schema(), clock_offset, local_id] (column_kind kind, auto& cells) {
         cells.for_each_cell([&] (column_id id, atomic_cell_or_collection& ac_o_c) {
@@ -188,7 +186,7 @@ void transform_counter_updates_to_shards(mutation& m, const mutation* current_st
                 return; // continue -- we are in lambda
             }
             auto delta = acv.counter_update_value();
-            auto cs = counter_shard(counter_id(local_id), delta, clock_offset + 1);
+            auto cs = counter_shard(local_id, delta, clock_offset + 1);
             ac_o_c = counter_cell_builder::from_single_shard(acv.timestamp(), cs);
         });
     };
@@ -212,7 +210,7 @@ void transform_counter_updates_to_shards(mutation& m, const mutation* current_st
                 return; // continue -- we are in lambda
             }
             auto ccv = counter_cell_view(acv);
-            auto cs = ccv.get_shard(counter_id(local_id));
+            auto cs = ccv.get_shard(local_id);
             if (!cs) {
                 return; // continue
             }
@@ -232,7 +230,7 @@ void transform_counter_updates_to_shards(mutation& m, const mutation* current_st
             auto delta = acv.counter_update_value();
 
             if (shards.empty() || shards.front().first > id) {
-                auto cs = counter_shard(counter_id(local_id), delta, clock_offset + 1);
+                auto cs = counter_shard(local_id, delta, clock_offset + 1);
                 ac_o_c = counter_cell_builder::from_single_shard(acv.timestamp(), cs);
             } else {
                 auto& cs = shards.front().second;

--- a/mutation/counters.hh
+++ b/mutation/counters.hh
@@ -370,7 +370,7 @@ struct counter_cell_mutable_view : basic_counter_cell_view<mutable_view::yes> {
 // Transforms mutation dst from counter updates to counter shards using state
 // stored in current_state.
 // If current_state is present it has to be in the same schema as dst.
-void transform_counter_updates_to_shards(mutation& dst, const mutation* current_state, uint64_t clock_offset, locator::host_id local_id);
+void transform_counter_updates_to_shards(mutation& dst, const mutation* current_state, uint64_t clock_offset, counter_id local_id);
 
 template<>
 struct appending_hash<counter_shard_view> {

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -97,6 +97,8 @@ class compaction_group {
     std::optional<compaction::compaction_backlog_tracker> _backlog_tracker;
     repair_classifier_func _repair_sstable_classifier;
 
+    counter_id _counter_id;
+
     lw_shared_ptr<logstor::segment_set> _logstor_segments;
     std::optional<logstor::separator_buffer> _logstor_separator;
     std::vector<future<>> _separator_flushes;
@@ -190,6 +192,14 @@ public:
     int64_t get_sstables_repaired_at() const noexcept;
 
     future<> update_repaired_at_for_merge();
+
+    void set_counter_id(counter_id cid) noexcept {
+        _counter_id = cid;
+    }
+
+    counter_id get_counter_id() const noexcept {
+        return _counter_id;
+    }
 
     void set_compaction_strategy_state(compaction::compaction_strategy_state compaction_strategy_state) noexcept;
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2044,10 +2044,12 @@ future<mutation> database::read_and_transform_counter_mutation_to_shards(mutatio
         co_await seastar::sleep(std::chrono::milliseconds(100));
     }
 
+    counter_id my_counter_id = cf.get_counter_id(m);
+
     // ...now, that we got existing state of all affected counter
     // cells we can look for our shard in each of them, increment
     // its clock and apply the delta.
-    transform_counter_updates_to_shards(m, mopt ? &*mopt : nullptr, cf.failed_counter_applies_to_memtable(), get_token_metadata().get_my_id());
+    transform_counter_updates_to_shards(m, mopt ? &*mopt : nullptr, cf.failed_counter_applies_to_memtable(), my_counter_id);
 
     co_return std::move(m);
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -700,6 +700,10 @@ public:
     future<> maybe_split_compaction_group_of(locator::tablet_id);
 
     dht::token_range get_token_range_after_split(const dht::token&) const noexcept;
+
+    // Returns a counter_id for use in local counter updates.
+    counter_id get_counter_id(const mutation&) const;
+
 private:
     // If SSTable doesn't need split, the same input SSTable is returned as output.
     // If SSTable needs split, then output SSTables are returned and the input SSTable is deleted.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1266,6 +1266,14 @@ dht::token_range table::get_token_range_after_split(const dht::token& token) con
     return _sg_manager->get_token_range_after_split(token);
 }
 
+counter_id table::get_counter_id(const mutation& m) const {
+    if (uses_tablets()) {
+        return storage_group_for_token(m.token()).main_compaction_group()->get_counter_id();
+    } else {
+        return counter_id(_erm->get_token_metadata().get_my_id().uuid());
+    }
+}
+
 std::unique_ptr<storage_group_manager> table::make_storage_group_manager() {
     std::unique_ptr<storage_group_manager> ret;
     if (uses_tablets()) {
@@ -3482,10 +3490,22 @@ void tablet_storage_group_manager::update_effective_replication_map(
     for_each_storage_group([&] (size_t group_id, storage_group& sg) {
         const locator::tablet_id tid = static_cast<locator::tablet_id>(group_id);
         const locator::tablet_info& tinfo = new_tablet_map->get_tablet_info(tid);
-        const bool tombstone_gc_enabled = std::ranges::contains(tinfo.replicas, this_replica);
+        const bool is_pending_replica = !std::ranges::contains(tinfo.replicas, this_replica);
+        const bool tombstone_gc_enabled = !is_pending_replica;
 
-        sg.for_each_compaction_group([tombstone_gc_enabled] (const compaction_group_ptr& cg_ptr) {
+        // construct a counter id for use in local counter updates.
+        // there is a single replica in a rack, so we can reuse a single counter id for all replicas
+        // in a rack. replicas in different racks use different counter ids.
+        // during migration there are two active counter replicas in a rack, then the pending
+        // replica uses a variation of the rack's counter id, so there are at most two distinct
+        // counter ids per rack.
+        auto rack_uuid = erm.get_topology().get_rack_uuid();
+        auto my_counter_uuid = is_pending_replica ? utils::UUID_gen::negate(rack_uuid) : rack_uuid;
+        counter_id my_counter_id(my_counter_uuid);
+
+        sg.for_each_compaction_group([tombstone_gc_enabled, my_counter_id] (const compaction_group_ptr& cg_ptr) {
             cg_ptr->set_tombstone_gc_enabled(tombstone_gc_enabled);
+            cg_ptr->set_counter_id(my_counter_id);
         });
     });
 

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -391,6 +391,7 @@ SEASTAR_TEST_CASE(test_counter_update_mutations) {
 SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
     return seastar::async([] {
         auto s = get_schema();
+        counter_id default_counter_id(locator::host_id::create_null_id().uuid());
 
         auto pk = partition_key::from_single_value(*s, int32_type->decompose(0));
         auto ck = clustering_key::from_single_value(*s, int32_type->decompose(0));
@@ -415,11 +416,11 @@ SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
         m3.set_static_cell(scol, std::move(c3));
 
         auto m0 = m1;
-        transform_counter_updates_to_shards(m0, nullptr, 0, locator::host_id::create_null_id());
+        transform_counter_updates_to_shards(m0, nullptr, 0, default_counter_id);
 
         auto empty = mutation(s, pk);
         auto m = m1;
-        transform_counter_updates_to_shards(m, &empty, 0, locator::host_id::create_null_id());
+        transform_counter_updates_to_shards(m, &empty, 0, default_counter_id);
         BOOST_REQUIRE_EQUAL(m, m0);
 
         auto ac = get_counter_cell(m);
@@ -439,7 +440,7 @@ SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
       }
 
         m = m2;
-        transform_counter_updates_to_shards(m, &m0, 0, locator::host_id::create_null_id());
+        transform_counter_updates_to_shards(m, &m0, 0, default_counter_id);
 
         ac = get_counter_cell(m);
         BOOST_REQUIRE(ac.is_live());
@@ -458,7 +459,7 @@ SEASTAR_TEST_CASE(test_transfer_updates_to_shards) {
       }
 
         m = m3;
-        transform_counter_updates_to_shards(m, &m0, 0, locator::host_id::create_null_id());
+        transform_counter_updates_to_shards(m, &m0, 0, default_counter_id);
         ac = get_counter_cell(m);
         BOOST_REQUIRE(!ac.is_live());
         ac = get_static_counter_cell(m);

--- a/test/cluster/test_counters_with_tablets.py
+++ b/test/cluster/test_counters_with_tablets.py
@@ -7,8 +7,10 @@
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace
 from test.pylib.tablets import get_tablet_replica
+from test.pylib.rest_client import read_barrier
 
 import asyncio
+import json
 import logging
 import pytest
 
@@ -91,3 +93,122 @@ async def test_counter_updates_during_tablet_migration(manager: ManagerClient, m
         actual_count = result[0].c
 
         assert actual_count == total_updates, f"Counter value mismatch: expected {total_updates}, got {actual_count}"
+
+@pytest.mark.asyncio
+async def test_counter_ids_reuse_in_single_rack(manager: ManagerClient):
+    """
+    Migrate a single counter tablet between 3 nodes in a single rack, performing counter updates on each node,
+    and verify the updates use at most 2 different counter IDs.
+    The counter ID should be reused when migrated to another node, except in the transition stage where 2 counter IDs
+    may be used.
+    """
+    cmdline = ['--smp', '1', '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'storage_service=debug']
+    servers = await manager.servers_add(3, cmdline=cmdline, property_file=[
+        {'dc': 'dc1', 'rack': 'rack1'},
+        {'dc': 'dc1', 'rack': 'rack1'},
+        {'dc': 'dc1', 'rack': 'rack1'}
+    ])
+    cql, hosts = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.counters (pk int PRIMARY KEY, c counter)")
+
+        pk = 1  # Single partition key for all updates
+        tablet_token = 0  # single tablet
+        total_updates = 0
+
+        # Get all host IDs
+        all_host_ids = [await manager.get_host_id(server.server_id) for server in servers]
+
+        # Migrate the tablet between all 3 nodes
+        for _ in range(3):
+            await cql.run_async(f"UPDATE {ks}.counters SET c = c + 1 WHERE pk = {pk}")
+            total_updates += 1
+
+            # Get current tablet location
+            replica = await get_tablet_replica(manager, servers[0], ks, 'counters', tablet_token)
+            src_host = replica[0]
+            src_shard = replica[1]
+
+            # Migrate to the next node
+            src_node_idx = all_host_ids.index(src_host)
+            dst_node_idx = (src_node_idx + 1) % 3
+            dst_host = all_host_ids[dst_node_idx]
+            dst_shard = 0
+
+            logger.info(f"Migrating tablet from node {src_node_idx} to node {dst_node_idx}")
+            await manager.api.move_tablet(servers[0].ip_addr, ks, "counters", src_host, src_shard, dst_host, dst_shard, tablet_token)
+
+        # Perform final counter updates after the last migration
+        await cql.run_async(f"UPDATE {ks}.counters SET c = c + 1 WHERE pk = {pk}")
+        total_updates += 1
+
+        # Verify no counter updates were lost
+        result = await cql.run_async(f"SELECT c FROM {ks}.counters WHERE pk = {pk}")
+        actual_count = result[0].c
+        assert actual_count == total_updates, f"Counter value mismatch: expected {total_updates}, got {actual_count}"
+
+        # Ensure all tablet transitions are fully completed and committed on all nodes
+        await manager.api.quiesce_topology(servers[0].ip_addr)
+        await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
+
+        await asyncio.gather(*[manager.api.flush_keyspace(s.ip_addr, ks) for s in servers])
+
+        # Get all counter IDs that were used
+        counter_ids = set()
+        for h in hosts:
+            res = await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({ks}.counters)", host=h)
+            for row in res:
+                if row.value:
+                    value_dict = json.loads(row.value)
+                    counter_ids.update({counter_shard["id"] for counter_shard in value_dict["c"]})
+
+        logger.info(f"Unique counter IDs found: {counter_ids}")
+        assert len(counter_ids) >= 1, f"Expected at least 1 counter ID, but found none"
+        assert len(counter_ids) <= 2, f"Expected at most 2 counter IDs, but found {len(counter_ids)}: {counter_ids}"
+
+@pytest.mark.asyncio
+async def test_counter_ids_multi_rack(manager: ManagerClient):
+    """
+    Test counter IDs with 3 nodes in 3 different racks with RF=3.
+    Each rack should use a different counter ID.
+    """
+    cmdline = ['--smp', '1', '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'storage_service=debug']
+    servers = await manager.servers_add(3, cmdline=cmdline, property_file=[
+        {'dc': 'dc1', 'rack': 'rack1'},
+        {'dc': 'dc1', 'rack': 'rack2'},
+        {'dc': 'dc1', 'rack': 'rack3'}
+    ])
+    cql, hosts = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets={'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.counters (pk int PRIMARY KEY, c counter)")
+
+        pk = 1  # Single partition key for all updates
+        total_updates = 0
+
+        # Perform counter updates on each node
+        for host in hosts:
+            await cql.run_async(f"UPDATE {ks}.counters SET c = c + 1 WHERE pk = {pk}", host=host)
+            total_updates += 1
+
+        # Verify counter value
+        result = await cql.run_async(f"SELECT c FROM {ks}.counters WHERE pk = {pk}")
+        actual_count = result[0].c
+        assert actual_count == total_updates, f"Counter value mismatch: expected {total_updates}, got {actual_count}"
+
+        await asyncio.gather(*[manager.api.flush_keyspace(s.ip_addr, ks) for s in servers])
+
+        # Collect counter IDs from all nodes
+        counter_ids = set()
+        for h in hosts:
+            res = await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({ks}.counters)", host=h)
+            for row in res:
+                if row.value:
+                    value_dict = json.loads(row.value)
+                    counter_ids.update({counter_shard["id"] for counter_shard in value_dict["c"]})
+
+        logger.info(f"Unique counter IDs found: {counter_ids}")
+        assert len(counter_ids) == 3, f"Expected exactly 3 counter IDs (one per rack), but found {len(counter_ids)}: {counter_ids}"


### PR DESCRIPTION
For counter updates, use a counter ID that is constructed from the
node's rack instead of the node's host ID.

A rack can have at most two active tablet replicas at a time: a single
normal tablet replica, and during tablet migration there are two active
replicas, the normal and pending replica. Therefore we can have two
unique counter IDs per rack that are reused by all replicas in the rack.

We construct the counter ID from the rack UUID, which is constructed
from the name "dc:rack". The pending replica uses a deterministic
variation of the rack's counter ID by negating it.

This improves the performance and size of counter cells by having less
unique counter IDs and less counter shards in a counter cell.

Previously the number of counter shards was the number of different
host_id's that updated the counter, which can be typically the number of
nodes in the cluster and continue growing indefinitely when nodes are
replaced. with the rack-based counter id the number of counter shards
will be at most twice the number of different racks (including removed
racks, which should not be significant).

Fixes SCYLLADB-356

backport not needed - an enhancement