### PR TITLE
test.py add support if non_gating tests

### DIFF
--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -469,3 +469,7 @@ def modify_pytest_item(item: pytest.Item) -> None:
             __skip_test(*mark.args, **mark.kwargs)
         except TypeError as e:
             raise TypeError(f"Failed to process skip_mode mark, {mark} for test {item}, error {e}")
+
+    if (any(mark.name in ("perf", "manual", "unstable") for mark in item.iter_markers())
+            and not any(mark.name == "non_gating" for mark in item.iter_markers("non_gating"))):
+        item.add_marker(pytest.mark.non_gating)

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -23,7 +23,10 @@ markers =
     single_node: test that are mark like this, should be using only one node, and should boot much quicker (dtest only)
     exclude_errors: do not consider a logging message as an error if it contains any of the specified strings (dtest only)
     cluster_options: specify cluster options used to initialize a cluster (dtest only)
-    unstable: mark for unstable tests that may pass may fail, these tests will continue to run every night and generate up-to-date statistics with failures without failing the “Main” verification path(scylla-ci, Next)
+    perf: mark for performance tests, these tests will automatically apply non_gating marker
+    manual: to mark manual test cases, these tests will automatically apply non_gating marker
+    unstable: mark for unstable tests that may pass may fail, these tests will continue to run every night and generate up-to-date statistics with failures without failing the “Main” verification path(scylla-ci, Next), these tests will automatically apply non_gating marker
+    non_gating: tests that are not run in CI/Next/Nightly verification, but can be run manually or on special job when needed
     nightly: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification
     skip_mode: Can be used to mark a test to be skipped for a specific mode, e.g. dev. The reason to skip a test should be specified, used as a comment only.  Additionally, platform_key can be specified to limit the scope of the attribute to the specified platform. Example platform_key-s: [aarch64, x86_64]
 


### PR DESCRIPTION
Add support for non_gating, the opposite of gating in dtest terminology, tests in test.py codebase

This test will/should not be run by any current gating job (ci/next/nightly)

