### PR TITLE
Await async calls in test tablets migration

### DIFF
--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -409,8 +409,7 @@ async def test_staging_backlog_is_preserved_with_file_based_streaming(manager: M
         logger.info(f"SSTable count in staging dir of server 1: {s1_sstables_in_staging}")
 
         logger.info("Allowing view update generator to progress again")
-        for server in servers:
-            manager.api.disable_injection(server.ip_addr, 'view_update_generator_consume_staging_sstable')
+        await asyncio.gather(*[manager.api.disable_injection(server.ip_addr, 'view_update_generator_consume_staging_sstable') for server in servers])
 
         assert s0_sstables_in_staging > 0
         assert s0_sstables_in_staging == s1_sstables_in_staging


### PR DESCRIPTION
Fix several test cases that did not await async tasks:
- test_restart_leaving_replica_during_cleanup
- test_restart_in_cleanup_stage_after_cleanup
- test_tablet_back_and_forth_migration
- test_staging_backlog_is_preserved_with_file_based_streaming

Fixes SCYLLADB-910

* Minor fixes, no backport needed