### PR TITLE
test.py: add fio to measure disk performance

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -46,6 +46,7 @@ debian_base_packages=(
     python3-pytest-timeout
     python3-pytest-sugar
     python3-pexpect
+    fio
     libsnappy-dev
     libjsoncpp-dev
     rapidjson-dev


### PR DESCRIPTION
Add fio to measure disk performance for calculation the number of thread for pytest.

Fixes: SCYLLADB-932

No backport, only adding dependency that be used in test framework.