### PR TITLE
Improve log when sstable load fails due to missing tablet replica

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1250,9 +1250,23 @@ compaction_group& tablet_storage_group_manager::compaction_group_for_sstable(con
     auto [first_id, first_range_side] = storage_group_of(sst->get_first_decorated_key().token());
     auto [last_id, last_range_side] = storage_group_of(sst->get_last_decorated_key().token());
 
+    auto sstable_desc = [] (const sstables::shared_sstable& sst) {
+        auto& identifier_opt = sst->sstable_identifier();
+        auto& originating_host_id_opt = sst->get_stats_metadata().originating_host_id;
+        return format("{} (originated from {} with id {} on host {})",
+                      sst->get_filename(), sst->get_origin(),
+                      identifier_opt ? identifier_opt->to_sstring() : "unknown",
+                      originating_host_id_opt ? originating_host_id_opt->to_sstring() : "unknown");
+    };
+    auto tablet_desc = [this] (locator::tablet_id id) {
+        return format("{} (replica set: {})", id, tablet_map().get_tablet_info(id).replicas);
+    };
+
     if (first_id != last_id) {
         on_internal_error(tlogger, format("Unable to load SSTable {} that belongs to tablets {} and {}",
-                                          sst->get_filename(), first_id, last_id));
+                                          sstable_desc(sst),
+                                          tablet_desc(locator::tablet_id(first_id)),
+                                          tablet_desc(locator::tablet_id(last_id))));
     }
 
     try {
@@ -1264,7 +1278,10 @@ compaction_group& tablet_storage_group_manager::compaction_group_for_sstable(con
 
         return *sg.select_compaction_group(first_range_side);
     } catch (std::out_of_range& e) {
-        on_internal_error(tlogger, format("Unable to load SSTable {} : {}", sst->get_filename(), e.what()));
+        on_internal_error(tlogger, format("Unable to load SSTable {} of tablet {}, due to {}",
+                                          sstable_desc(sst),
+                                          tablet_desc(locator::tablet_id(first_id)),
+                                          e.what()));
     }
 }
 


### PR DESCRIPTION
A bug or some bad operator intervention can lead to a sstable existing in a node after the tablet replica was moved to a different node.

This will result sstable loading during boot failing, requiring operator intervention.
The log today just dumps the name of the "orphaned" sstable, but one investigating it might want to know which process (repair, memtable, whatever) generated that sstable, if the sstable was created locally or remotely, and the current replica set of the underlying tablet. From the original identifier, we can know the exact time the sstable was created on its original node. From the current id, we know the time it was created on the current node.
All this info can help the investigator to correlate with events in other nodes (includes actions from the coordinator) to get closer to the root cause.

The new log will look like this:

"Unable to load SSTable .../me-3gyg_1fsw_2u0u826b00b71vc46o-big-Data.db (originated from compaction with id 913f41c0-18c2-11f1-8f08-cb8521b3f330 on host e483238c-2287-4022-8bc4-b4f1c4cb2b0d)
of tablet 6 (replica set: [e483238c-2287-4022-8bc4-b4f1c4cb2b0d:0])"

Refs https://scylladb.atlassian.net/browse/SCYLLADB-788.

Not backporting since it's just adding diagnostics.