### PR TITLE
test: fix `testJsonOrdering`

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -1264,7 +1264,6 @@ def testEmptyStringJsonSerialization(cql, test_keyspace):
 
 # CASSANDRA-14286
 # Reproduces #8100
-@pytest.mark.xfail(reason="issue #28467")
 def testJsonOrdering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a INT, b INT, PRIMARY KEY(a, b))") as table:
         execute(cql, table, "INSERT INTO %s(a, b) VALUES (20, 30);")
@@ -1296,13 +1295,14 @@ def testJsonOrdering(cql, test_keyspace):
                    ["{\"a\": 20, \"c\": 30}"])
 
         # Check ordering with CAST
+        # Cassandra prints "30.0" and "200.0", Scylla prints "30" and "200". Both are fine.
         assert_rows(execute_without_paging(cql, table, "SELECT JSON a, CAST(b AS FLOAT) FROM %s WHERE a IN (20, 100) ORDER BY b"),
-                   ["{\"a\": 20, \"cast(b as float)\": 30.0}"],
-                   ["{\"a\": 100, \"cast(b as float)\": 200.0}"])
+                   [EquivalentJson("{\"a\": 20, \"cast(b as float)\": 30.0}")],
+                   [EquivalentJson("{\"a\": 100, \"cast(b as float)\": 200.0}")])
 
         assert_rows(execute_without_paging(cql, table, "SELECT JSON a, CAST(b AS FLOAT) FROM %s WHERE a IN (20, 100) ORDER BY b DESC"),
-                   ["{\"a\": 100, \"cast(b as float)\": 200.0}"],
-                   ["{\"a\": 20, \"cast(b as float)\": 30.0}"])
+                   [EquivalentJson("{\"a\": 100, \"cast(b as float)\": 200.0}")],
+                   [EquivalentJson("{\"a\": 20, \"cast(b as float)\": 30.0}")])
 
 def testInsertAndSelectJsonSyntaxWithEmptyAndNullValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id INT, name TEXT, name_asc ASCII, bytes BLOB, PRIMARY KEY(id))") as table:


### PR DESCRIPTION
The `test/cqlpy/cassandra_tests/validation/entities/json_test.py::testJsonOrdering` was failing because of differences between Cassandra and Scylla in printing JSON floating point values - e.g. Cassandra prints 30.0, where Scylla prints 30. Both are valid, so in this patch, instead of comparing strings, we compare parsed JSON using `EquivalentJson`.

Fixes #28467

Minor test fix, no need to backport.