### PR TITLE
selection: prevent adding to result_set columns for filtering and grouping

### DIFF
--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -212,7 +212,11 @@ public:
     }
 
     virtual uint32_t add_column_for_post_processing(const column_definition& c) override {
-        auto it = std::find_if(_selectors.begin(), _selectors.end(), [&c](const expr::expression& e) {
+        return add_column(c).index;
+    }
+
+    virtual uint32_t add_column_for_ordering(const column_definition& c) override {
+        auto it = std::ranges::find_if(_selectors.begin(), _selectors.end(), [&c](const expr::expression& e) {
             auto col = expr::as_if<expr::column_value>(&e);
             return col && col->col == &c;
         });
@@ -482,10 +486,10 @@ std::vector<const column_definition*> selection::wildcard_columns(schema_ptr sch
 selection::add_column_result selection::add_column(const column_definition& c) {
     auto index = index_of(c);
     if (index != -1) {
-        return {index, false};
+        return {.index = uint32_t(index), .added = false};
     }
     _columns.push_back(&c);
-    return {_columns.size() - 1, true};
+    return {.index = uint32_t(_columns.size() - 1), .added = true};
 }
 
 uint32_t selection::add_column_for_post_processing(const column_definition& c) {

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -125,6 +125,11 @@ public:
     static ::shared_ptr<selection> for_columns(schema_ptr schema, std::vector<const column_definition*> columns);
 
     // Adds a column to the selection and result set. Returns an index within the result set row.
+    virtual uint32_t add_column_for_ordering(const column_definition& c) {
+        return add_column_for_post_processing(c);
+    }
+
+    // Adds a column to the selection. Returns an index within the query result row.
     virtual uint32_t add_column_for_post_processing(const column_definition& c);
 
     virtual std::vector<shared_ptr<functions::function>> used_functions() const { return {}; }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2757,7 +2757,7 @@ select_statement::ordering_comparator_type select_statement::get_ordering_compar
     // even if we don't
     // ultimately ship them to the client (CASSANDRA-4911).
     for (auto&& [column_def, is_descending] : orderings) {
-        auto index = selection.add_column_for_post_processing(*column_def);
+        auto index = selection.add_column_for_ordering(*column_def);
         sorters.emplace_back(index, column_def->type);
     }
 
@@ -2948,11 +2948,7 @@ std::vector<size_t> select_statement::prepare_group_by(const schema& schema, sel
             throw make_order_exception(*col);
         }
         ++expected_index;
-        auto index = selection.index_of(*def);
-        if (index == -1) {
-            selection.add_column_for_post_processing(*def);
-            index = selection.index_of(*def);
-        }
+        auto index = selection.add_column_for_post_processing(*def);
         indices.push_back(index);
     }
 

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -114,22 +114,19 @@ auto I(int32_t x) { return int32_type->decompose(x); }
 
 auto L(int64_t x) { return long_type->decompose(x); }
 
-auto T(const char* t) { return utf8_type->decompose(t); }
-
 } // anonymous namespace
 
 SEASTAR_TEST_CASE(test_group_by_aggregate_single_key) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "create table t (p int primary key, n int)");
         cquery_nofail(e, "insert into t (p, n) values (1, 10)");
-        // Rows contain GROUP BY column values (later filtered in cql_server::connection).
-        require_rows(e, "select sum(n) from t group by p", {{I(10), I(1)}});
-        require_rows(e, "select avg(n) from t group by p", {{I(10), I(1)}});
-        require_rows(e, "select count(n) from t group by p", {{L(1), I(1)}});
+        require_rows(e, "select sum(n) from t group by p", {{I(10)}});
+        require_rows(e, "select avg(n) from t group by p", {{I(10)}});
+        require_rows(e, "select count(n) from t group by p", {{L(1)}});
         cquery_nofail(e, "insert into t (p, n) values (2, 20)");
-        require_rows(e, "select sum(n) from t group by p", {{I(10), I(1)}, {I(20), I(2)}});
-        require_rows(e, "select avg(n) from t group by p", {{I(20), I(2)}, {I(10), I(1)}});
-        require_rows(e, "select count(n) from t group by p", {{L(1), I(2)}, {L(1), I(1)}});
+        require_rows(e, "select sum(n) from t group by p", {{I(10)}, {I(20)}});
+        require_rows(e, "select avg(n) from t group by p", {{I(20)}, {I(10)}});
+        require_rows(e, "select count(n) from t group by p", {{L(1)}, {L(1)}});
         return make_ready_future<>();
     });
 }
@@ -138,19 +135,18 @@ SEASTAR_TEST_CASE(test_group_by_aggregate_partition_only) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "create table t (p1 int, p2 int, p3 int, v int, primary key((p1, p2, p3)))");
         cquery_nofail(e, "insert into t (p1, p2, p3, v) values (1, 1, 1, 100)");
-        // Rows contain GROUP BY column values (later filtered in cql_server::connection).
-        require_rows(e, "select sum(v) from t group by p1, p2, p3", {{I(100), I(1), I(1), I(1)}});
-        cquery_nofail(e, "insert into t (p1, p2, p3, v) values (1, 2, 1, 100)");
+        require_rows(e, "select sum(v) from t group by p1, p2, p3", {{I(100)}});
+        cquery_nofail(e, "insert into t (p1, p2, p3, v) values (1, 2, 1, 101)");
         require_rows(e, "select sum(v) from t group by p1, p2, p3",
-                     {{I(100), I(1), I(1), I(1)}, {I(100), I(1), I(2), I(1)}});
+                     {{I(100)}, {I(101)}});
         require_rows(e, "select sum(v) from t where p2=2 group by p1, p3 allow filtering",
-                     {{I(100), I(2), I(1), I(1)}});
-        cquery_nofail(e, "insert into t (p1, p2, p3, v) values (1, 2, 2, 100)");
+                     {{I(101)}});
+        cquery_nofail(e, "insert into t (p1, p2, p3, v) values (1, 2, 2, 102)");
         require_rows(e, "select sum(v) from t group by p1, p2, p3",
-                     {{I(100), I(1), I(1), I(1)}, {I(100), I(1), I(2), I(1)}, {I(100), I(1), I(2), I(2)}});
+                     {{I(100)}, {I(101)}, {I(102)}});
         cquery_nofail(e, "delete from t where p1=1 and p2=1 and p3=1");
         require_rows(e, "select sum(v) from t group by p1, p2, p3",
-                     {{I(100), I(1), I(2), I(1)}, {I(100), I(1), I(2), I(2)}});
+                     {{I(101)}, {I(102)}});
         return make_ready_future<>();
     });
 }
@@ -158,20 +154,20 @@ SEASTAR_TEST_CASE(test_group_by_aggregate_partition_only) {
 SEASTAR_TEST_CASE(test_group_by_aggregate_clustering) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "create table t (p1 int, c1 int, c2 int, v int, primary key((p1), c1, c2))");
-        cquery_nofail(e, "insert into t (p1, c1, c2, v) values (1, 1, 1, 100)");
-        cquery_nofail(e, "insert into t (p1, c1, c2, v) values (1, 1, 2, 100)");
+        cquery_nofail(e, "insert into t (p1, c1, c2, v) values (1, 1, 1, 101)");
+        cquery_nofail(e, "insert into t (p1, c1, c2, v) values (1, 1, 2, 102)");
         cquery_nofail(e, "insert into t (p1, c1, c2, v) values (1, 1, 3, 100)");
-        cquery_nofail(e, "insert into t (p1, c1, c2, v) values (2, 1, 1, 100)");
-        cquery_nofail(e, "insert into t (p1, c1, c2, v) values (2, 2, 2, 100)");
+        cquery_nofail(e, "insert into t (p1, c1, c2, v) values (2, 1, 1, 104)");
+        cquery_nofail(e, "insert into t (p1, c1, c2, v) values (2, 2, 2, 108)");
         cquery_nofail(e, "delete from t where p1=1 and c1=1 and c2 =3");
-        require_rows(e, "select sum(v) from t group by p1", {{I(200), I(1)}, {I(200), I(2)}});
+        require_rows(e, "select sum(v) from t group by p1", {{I(203)}, {I(212)}});
         require_rows(e, "select sum(v) from t group by p1, c1",
-                     {{I(200), I(1), I(1)}, {I(100), I(2), I(1)}, {I(100), I(2), I(2)}});
+                     {{I(203)}, {I(104)}, {I(108)}});
         require_rows(e, "select sum(v) from t where p1=1 and c1=1 group by c2 allow filtering",
-                     {{I(100), I(1)}, {I(100), I(2)}});
+                     {{I(101)}, {I(102)}});
         require_rows(e, "select sum(v) from t group by p1, c1, c2",
-                     {{I(100), I(1), I(1), I(1)}, {I(100), I(1), I(1), I(2)},
-                      {I(100), I(2), I(1), I(1)}, {I(100), I(2), I(2), I(2)}});
+                     {{I(101)}, {I(102)},
+                      {I(104)}, {I(108)}});
         return make_ready_future<>();
     });
 }
@@ -179,31 +175,31 @@ SEASTAR_TEST_CASE(test_group_by_aggregate_clustering) {
 SEASTAR_TEST_CASE(test_group_by_text_key) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "create table t (p text, c text, v int, primary key(p, c))");
-        cquery_nofail(e, "insert into t (p, c, v) values ('123456789012345678901234567890123', '1', 100)");
-        cquery_nofail(e, "insert into t (p, c, v) values ('123456789012345678901234567890123', '2', 200)");
-        cquery_nofail(e, "insert into t (p, c, v) values ('123456789012345678901234567890123', '3', 300)");
+        cquery_nofail(e, "insert into t (p, c, v) values ('123456789012345678901234567890123', '1', 101)");
+        cquery_nofail(e, "insert into t (p, c, v) values ('123456789012345678901234567890123', '2', 202)");
+        cquery_nofail(e, "insert into t (p, c, v) values ('123456789012345678901234567890123', '3', 303)");
         cquery_nofail(e, "insert into t (p, c, v) values ('123456789012345678901234567890123abc', '1', 150)");
         cquery_nofail(e, "insert into t (p, c, v) values ('123456789012345678901234567890123abc', '2', 250)");
         cquery_nofail(e, "insert into t (p, c, v) values ('ab', 'cd', 310)");
         cquery_nofail(e, "insert into t (p, c, v) values ('abc', 'd', 420)");
         require_rows(e, "select sum(v) from t group by p",
-                     {{I(600), T("123456789012345678901234567890123")},
-                      {I(400), T("123456789012345678901234567890123abc")},
-                      {I(310), T("ab")},
-                      {I(420), T("abc")}});
+                     {{I(606)}, // "123456789012345678901234567890123"
+                      {I(400)}, // "123456789012345678901234567890123abc"
+                      {I(310)}, // "ab"
+                      {I(420)}}); // "abc"
         require_rows(e, "select sum(v) from t where p in ('ab','abc') group by p, c allow filtering",
-                     {{I(310), T("ab"), T("cd")}, {I(420), T("abc"), T("d")}});
+                     {{I(310)}, {I(420)}});
         require_rows(e, "select sum(v) from t where p='123456789012345678901234567890123' group by c",
-                     {{I(100), T("1")}, {I(200), T("2")}, {I(300), T("3")}});
+                     {{I(101)}, {I(202)}, {I(303)}});
         cquery_nofail(e, "create table t2 (p text, c1 text, c2 text, v int, primary key(p, c1, c2))");
         cquery_nofail(e, "insert into t2 (p, c1, c2, v) values (' ', '', '', 10)");
         cquery_nofail(e, "insert into t2 (p, c1, c2, v) values (' ', '', 'b', 20)");
         cquery_nofail(e, "insert into t2 (p, c1, c2, v) values (' ', 'a', '', 30)");
         cquery_nofail(e, "insert into t2 (p, c1, c2, v) values (' ', 'a', 'b', 40)");
-        require_rows(e, "select avg(v) from t2 group by p", {{I(25), T(" ")}});
-        require_rows(e, "select avg(v) from t2 group by p, c1", {{I(15), T(" "), T("")}, {I(35), T(" "), T("a")}});
+        require_rows(e, "select avg(v) from t2 group by p", {{I(25)}});
+        require_rows(e, "select avg(v) from t2 group by p, c1", {{I(15)}, {I(35)}});
         require_rows(e, "select sum(v) from t2 where c1='' group by p, c2 allow filtering",
-                     {{I(10), T(" "), T("")}, {I(20), T(" "), T("b")}});
+                     {{I(10)}, {I(20)}});
         return make_ready_future<>();
     });
 }
@@ -212,15 +208,15 @@ SEASTAR_TEST_CASE(test_group_by_non_aggregate) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "create table t (p int, c int, n int, primary key(p, c))");
         cquery_nofail(e, "insert into t (p, c, n) values (1, 1, 11)");
-        require_rows(e, "select n from t group by p", {{I(11), I(1)}});
+        require_rows(e, "select n from t group by p", {{I(11)}});
         cquery_nofail(e, "insert into t (p, c, n) values (2, 1, 21)");
-        require_rows(e, "select n from t group by p", {{I(11), I(1)}, {I(21), I(2)}});
+        require_rows(e, "select n from t group by p", {{I(11)}, {I(21)}});
         cquery_nofail(e, "delete from t where p=1");
-        require_rows(e, "select n from t group by p", {{I(21), I(2)}});
+        require_rows(e, "select n from t group by p", {{I(21)}});
         cquery_nofail(e, "insert into t (p, c, n) values (1, 1, 11)");
         cquery_nofail(e, "insert into t (p, c, n) values (1, 2, 12)");
         cquery_nofail(e, "insert into t (p, c, n) values (1, 3, 13)");
-        require_rows(e, "select n from t group by p", {{I(11), I(1)}, {I(21), I(2)}});
+        require_rows(e, "select n from t group by p", {{I(11)}, {I(21)}});
         return make_ready_future<>();
     });
 }
@@ -229,7 +225,8 @@ SEASTAR_TEST_CASE(test_group_by_null_clustering) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "create table t (p int, c int, sv int static, primary key(p, c))");
         cquery_nofail(e, "insert into t (p, sv) values (1, 100)"); // c will be NULL.
-        require_rows(e, "select sv from t where p=1 group by c", {{I(100), std::nullopt}});
+        require_rows(e, "select sv from t where p=1 group by c", {{I(100)}});
+        require_rows(e, "select sv,c from t where p=1 group by c", {{I(100), std::nullopt}});
         return make_ready_future<>();
     });
 }

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5592,9 +5592,8 @@ SEASTAR_TEST_CASE(test_single_partition_aggregation_is_not_parallelized) {
         // and we doesn't parallelize queries which need filtering.
         // See issue #19369.
         const auto result_pk1 = e.execute_cql("SELECT COUNT(*) FROM tbl2 WHERE pk1 = 1 ALLOW FILTERING;").get();
-        // This query contains also column for pk1
         assert_that(result_pk1).is_rows().with_rows({
-            {long_type->decompose(int64_t(value_count * 2)), int32_type->decompose(int32_t(1))}
+            {long_type->decompose(int64_t(value_count * 2))}
         });
         BOOST_CHECK_EQUAL(stat_parallelized, qp.get_cql_stats().select_parallelized);
     });

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -768,9 +768,13 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
 
         eventually([&] {
             auto msg = cquery_nofail(e, "SELECT SUM(e) FROM t WHERE c = 5 AND b = 911 ALLOW FILTERING;");
-            assert_that(msg).is_rows().with_rows({{ int32_type->decompose(0), {} }});
+            assert_that(msg).is_rows().with_rows({{ int32_type->decompose(0) }});
             msg = cquery_nofail(e, "SELECT e FROM t WHERE c = 5 AND b = 3 ALLOW FILTERING;");
-            assert_that(msg).is_rows().with_rows({{ int32_type->decompose(9), int32_type->decompose(3) }});
+            // This query uses simplified processing and there is an extra column that is used for the filtering.
+            // Since we are dealing with the result set before serializing to the client, this column
+            // will not be present in the response to the client and with_serialized_columns_count() verifies exactly that.
+            assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows(
+                {{ int32_type->decompose(9), int32_type->decompose(3) }});
         });
     });
 }
@@ -1144,10 +1148,11 @@ SEASTAR_TEST_CASE(test_filtering) {
             });
         }
         //test filtering with count
+        // With aggregation function final result set is transformed and there is no extra column for filtering.
         {
             auto msg = e.execute_cql("SELECT COUNT(k) FROM cf WHERE n>3 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_serialized_columns_count(1).with_size(1).with_rows_ignore_order({
-                { long_type->decompose(4L), int32_type->decompose(5) },
+                { long_type->decompose(4L) },
             });
         }
 


### PR DESCRIPTION
The filtering and grouping requires fetching of additional columns that are not part of original SELECT clause. It is done with `add_column_for_post_processing` function and such columns are not serialized in response. However they do appear in the intermediate result_set.

This is unnecessary - filtering and grouping happens before result_set is transformed and gets its final shape. At that step only post-query ordering requires such additional columns. The most important difference between these two cases is related to interpretation of the column index (pre- and post-transformation). Confusion of these were the reason of bug solved in #28472.

This patch introduces such distinction more explicitly:
- `add_column_for_post_processing` now fetches a column from replicas, but not intended to be in the result_set and the index it returns refers to column position in replica query response.
- new `add_column_for_ordering` adds a column to the result_set and returned index refers to position in that result_set. 

Both check if the column is already added and return corresponding index.

Mind that this change applies to `selection_with_processing`. In `simple_selection` there is no transformation step, so both functions have the same effect, and even with `add_column_for_post_processing` columns can appear in the result set (but still not in the response to client).

Since boost tests are dealing with the result set before serializing to the client, they were actually expecting extra columns. This patch updates them, primarily removing these extra columns. Whenever these extra columns might better indicate correctness of the response, data values where updated to disambiguate results.

Follow-up #28472

It is just an enhancement, no need to backport.