### PR TITLE
test: replace uninformative xfail/skip reason strings with GitHub iss…

### DIFF
--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -25,6 +25,7 @@ from .util import unique_table_name, random_string, new_test_table
 from .test_gsi_updatetable import wait_for_gsi, wait_for_gsi_gone
 from .test_gsi import assert_index_query
 
+
 # new_role() is a context manager for temporarily creating a new role with
 # a unique name and returning its name and the secret key needed to connect
 # to it with the DynamoDB API.
@@ -38,13 +39,17 @@ def new_role(cql, login=True, superuser=False):
     # The password set for the new role is identical to the user name (not
     # very secure ;-)) - but we later need to retrieve the "salted hash" of
     # this password, which serves in Alternator as the secret key of the role.
-    cql.execute(f"CREATE ROLE \"{role}\" WITH PASSWORD = '{role}' AND SUPERUSER = {superuser} AND LOGIN = {login}")
+    cql.execute(
+        f"CREATE ROLE \"{role}\" WITH PASSWORD = '{role}' AND SUPERUSER = {superuser} AND LOGIN = {login}"
+    )
     # Newer Scylla places the "roles" table in the "system" keyspace, but
     # older versions used "system_auth_v2" or "system_auth"
     key = None
-    for ks in ['system', 'system_auth_v2', 'system_auth']:
+    for ks in ["system", "system_auth_v2", "system_auth"]:
         try:
-            e = list(cql.execute(f"SELECT salted_hash FROM {ks}.roles WHERE role = '{role}'"))
+            e = list(
+                cql.execute(f"SELECT salted_hash FROM {ks}.roles WHERE role = '{role}'")
+            )
             if e != []:
                 key = e[0].salted_hash
                 if key is not None:
@@ -57,6 +62,7 @@ def new_role(cql, login=True, superuser=False):
     finally:
         cql.execute(f'DROP ROLE "{role}"')
 
+
 # Create a new DynamoDB API resource (connection object) similar to the
 # existing "dynamodb" resource - but authenticating with the given role
 # and key.
@@ -65,28 +71,42 @@ def new_dynamodb(dynamodb, role, key):
     url = dynamodb.meta.client._endpoint.host
     config = dynamodb.meta.client._client_config
     region_name = dynamodb.meta.client.meta.region_name
-    verify = not url.startswith('https')
-    ret = boto3.resource('dynamodb', endpoint_url=url, verify=verify,
-        aws_access_key_id=role, aws_secret_access_key=key,
-        region_name=region_name, config=config)
+    verify = not url.startswith("https")
+    ret = boto3.resource(
+        "dynamodb",
+        endpoint_url=url,
+        verify=verify,
+        aws_access_key_id=role,
+        aws_secret_access_key=key,
+        region_name=region_name,
+        config=config,
+    )
     try:
         yield ret
     finally:
         ret.meta.client.close()
+
 
 @contextmanager
 def new_dynamodb_streams(dynamodb, role, key):
     url = dynamodb.meta.client._endpoint.host
     config = dynamodb.meta.client._client_config
     region_name = dynamodb.meta.client.meta.region_name
-    verify = not url.startswith('https')
-    ret = boto3.client('dynamodbstreams', endpoint_url=url, verify=verify,
-        aws_access_key_id=role, aws_secret_access_key=key,
-        region_name=region_name, config=config)
+    verify = not url.startswith("https")
+    ret = boto3.client(
+        "dynamodbstreams",
+        endpoint_url=url,
+        verify=verify,
+        aws_access_key_id=role,
+        aws_secret_access_key=key,
+        region_name=region_name,
+        config=config,
+    )
     try:
         yield ret
     finally:
         ret.close()
+
 
 # A basic test for creating a new role. The ListTables operation is allowed
 # to any role, so it should work in the new role when given the right password
@@ -99,25 +119,30 @@ def test_new_role(dynamodb, cql):
         # Trying to use the wrong key for the new role should fail to perform
         # any request. The new_dynamodb() function can't detect the error,
         # it is detected when attempting to perform a request with it.
-        with new_dynamodb(dynamodb, role, 'wrongkey') as d:
-            with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        with new_dynamodb(dynamodb, role, "wrongkey") as d:
+            with pytest.raises(ClientError, match="UnrecognizedClientException"):
                 d.meta.client.list_tables()
+
 
 # A role without "login" permissions cannot be used to authenticate requests.
 # Reproduces #19735.
 def test_login_false(dynamodb, cql):
     with new_role(cql, login=False) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
-            with pytest.raises(ClientError, match='UnrecognizedClientException.*login=false'):
+            with pytest.raises(
+                ClientError, match="UnrecognizedClientException.*login=false"
+            ):
                 d.meta.client.list_tables()
+
 
 # Quote an identifier if it needs to be double-quoted in CQL. Quoting is
 # *not* needed if the identifier matches [a-z][a-z0-9_]*, otherwise it does.
 # double-quotes ('"') in the string are doubled.
 def maybe_quote(identifier):
-    if re.match('^[a-z][a-z0-9_]*$', identifier):
+    if re.match("^[a-z][a-z0-9_]*$", identifier):
         return identifier
     return '"' + identifier.replace('"', '""') + '"'
+
 
 # Currently, some time may pass after calling GRANT or REVOKE until this
 # change actually takes affect: There can be group0 delays as well as caching
@@ -140,11 +165,12 @@ def authorized(fun, timeout=10):
         try:
             return fun()
         except ClientError as e:
-            if e.response['Error']['Code'] != 'AccessDeniedException':
+            if e.response["Error"]["Code"] != "AccessDeniedException":
                 raise
             time.sleep(sleep)
             sleep *= 1.5
     return fun()
+
 
 def unauthorized(fun, timeout=10):
     deadline = time.time() + timeout
@@ -155,20 +181,28 @@ def unauthorized(fun, timeout=10):
             time.sleep(sleep)
             sleep *= 1.5
         except ClientError as e:
-            if e.response['Error']['Code'] == 'AccessDeniedException':
+            if e.response["Error"]["Code"] == "AccessDeniedException":
                 return
             raise
     try:
         fun()
-        pytest.fail(f'No AccessDeniedException until timeout of {timeout}')
+        pytest.fail(f"No AccessDeniedException until timeout of {timeout}")
     except ClientError as e:
-        if e.response['Error']['Code'] == 'AccessDeniedException':
+        if e.response["Error"]["Code"] == "AccessDeniedException":
             return
         raise
 
+
 @cache
 def permissions_validity_in_ms(cql):
-    return 0.001 * int(list(cql.execute("SELECT value FROM system.config WHERE name = 'permissions_validity_in_ms'"))[0][0])
+    return 0.001 * int(
+        list(
+            cql.execute(
+                "SELECT value FROM system.config WHERE name = 'permissions_validity_in_ms'"
+            )
+        )[0][0]
+    )
+
 
 # Convenience context manager for temporarily GRANTing some permission and
 # then revoking it.
@@ -181,6 +215,7 @@ def temporary_grant(cql, permission, resource, role):
     finally:
         cql.execute(f"REVOKE {permission} ON {resource} FROM {role}")
 
+
 @contextmanager
 def temporary_grant_role(cql, role_src, role_dst):
     role_src = maybe_quote(role_src)
@@ -191,21 +226,32 @@ def temporary_grant_role(cql, role_src, role_dst):
     finally:
         cql.execute(f"REVOKE {role_src} FROM {role_dst}")
 
+
 # Convenience function for getting the full CQL table name (ksname.cfname)
 # for the given Alternator table. This uses our insider knowledge that
 # table named "x" is stored in keyspace called "alternator_x", and if we
 # ever change this we'll need to change this function too.
 def cql_table_name(tab):
-    return maybe_quote('alternator_' + tab.name) + '.' + maybe_quote(tab.name)
+    return maybe_quote("alternator_" + tab.name) + "." + maybe_quote(tab.name)
+
 
 def cql_gsi_name(tab, gsi):
-    return maybe_quote('alternator_' + tab.name) + '.' + maybe_quote(tab.name + ":" + gsi)
+    return (
+        maybe_quote("alternator_" + tab.name) + "." + maybe_quote(tab.name + ":" + gsi)
+    )
+
 
 def cql_cdclog_name(tab):
-    return maybe_quote('alternator_' + tab.name) + '.' + maybe_quote(tab.name + "_scylla_cdc_log")
+    return (
+        maybe_quote("alternator_" + tab.name)
+        + "."
+        + maybe_quote(tab.name + "_scylla_cdc_log")
+    )
+
 
 def cql_keyspace_name(tab):
-    return maybe_quote('alternator_' + tab.name)
+    return maybe_quote("alternator_" + tab.name)
+
 
 # Test GetItem's support of permissions.
 # A fresh new role has no permissions to read a table, and we can allow it
@@ -219,40 +265,53 @@ def cql_keyspace_name(tab):
 def test_rbac_getitem(dynamodb, cql, test_table_s):
     p = random_string()
     v = random_string()
-    item = {'p': p, 'v': v}
+    item = {"p": p, "v": v}
     test_table_s.put_item(Item=item)
     # Sanity check: we can read the item we just wrote using the superuser
     # role.
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
     # If we now create a fresh new role, it can't read the item:
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
-            unauthorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True))
+            unauthorized(lambda: tab.get_item(Key={"p": p}, ConsistentRead=True))
             # If we now add the permissions to read this table, GetItem
             # will work:
-            with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
-                assert item == authorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True)['Item'])
+            with temporary_grant(cql, "SELECT", cql_table_name(tab), role):
+                assert item == authorized(
+                    lambda: tab.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+                )
             # After revoking the temporary permission grant, we get access
             # denied again:
-            unauthorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True))
+            unauthorized(lambda: tab.get_item(Key={"p": p}, ConsistentRead=True))
             # Check that granting permissions to the entire keyspace also works:
-            with temporary_grant(cql, 'SELECT', 'KEYSPACE ' + cql_keyspace_name(tab), role):
-                assert item == authorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True)['Item'])
-            unauthorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True))
+            with temporary_grant(
+                cql, "SELECT", "KEYSPACE " + cql_keyspace_name(tab), role
+            ):
+                assert item == authorized(
+                    lambda: tab.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+                )
+            unauthorized(lambda: tab.get_item(Key={"p": p}, ConsistentRead=True))
             # check that granting permissions to all keyspaces also works:
-            with temporary_grant(cql, 'SELECT', 'ALL KEYSPACES', role):
-                assert item == authorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True)['Item'])
-            unauthorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True))
+            with temporary_grant(cql, "SELECT", "ALL KEYSPACES", role):
+                assert item == authorized(
+                    lambda: tab.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+                )
+            unauthorized(lambda: tab.get_item(Key={"p": p}, ConsistentRead=True))
             # Test an inherited role: Create a second role, give that
             # second role permission to read this table, give the first
             # role the permissions of the second role - and see that the
             # first role can read the table.
             with new_role(cql, login=False) as (role2, _):
-                with temporary_grant(cql, 'SELECT', cql_table_name(tab), role2):
+                with temporary_grant(cql, "SELECT", cql_table_name(tab), role2):
                     with temporary_grant_role(cql, role2, role):
-                        assert item == authorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True)['Item'])
-            unauthorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True))
+                        assert item == authorized(
+                            lambda: tab.get_item(Key={"p": p}, ConsistentRead=True)[
+                                "Item"
+                            ]
+                        )
+            unauthorized(lambda: tab.get_item(Key={"p": p}, ConsistentRead=True))
+
 
 # Test PutItem's support of permissions.
 # PutItem, and other data-modifying operations (DeleteItem, UpdateItem, etc.)
@@ -267,12 +326,12 @@ def test_rbac_putitem_write(dynamodb, cql, test_table_s):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
             v = random_string()
-            unauthorized(lambda: tab.put_item(Item={'p': p, 'v': v}))
+            unauthorized(lambda: tab.put_item(Item={"p": p, "v": v}))
             # If we now add the permissions to MODIFY this table, PutItem
             # will work:
-            with temporary_grant(cql, 'MODIFY', cql_table_name(tab), role):
+            with temporary_grant(cql, "MODIFY", cql_table_name(tab), role):
                 v = random_string()
-                authorized(lambda: tab.put_item(Item={'p': p, 'v': v}))
+                authorized(lambda: tab.put_item(Item={"p": p, "v": v}))
                 # Let's verify that put_item not only didn't fail, it actually
                 # did the right thing. This check is quite redundant - we
                 # already know from many other tests that if we have
@@ -280,13 +339,16 @@ def test_rbac_putitem_write(dynamodb, cql, test_table_s):
                 # check it just once here but not do it again in other
                 # tests for other operations below.
                 # We don't yet have permissions to read the item back:
-                unauthorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True))
+                unauthorized(lambda: tab.get_item(Key={"p": p}, ConsistentRead=True))
                 # Let's also add SELECT permissions to read the item back:
-                with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
-                    assert {'p': p, 'v': v} == authorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True)['Item'])
+                with temporary_grant(cql, "SELECT", cql_table_name(tab), role):
+                    assert {"p": p, "v": v} == authorized(
+                        lambda: tab.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+                    )
             # After revoking the temporary permission grant of MODIFY, we get
             # access denied again on PutItem:
-            unauthorized(lambda: tab.put_item(Item={'p': p, 'v': v}))
+            unauthorized(lambda: tab.put_item(Item={"p": p, "v": v}))
+
 
 # As explained above, this test confirms that even when PutItem *reads*
 # an item (by using ReturnValues=ALL_OLD), it still requires only the MODIFY
@@ -294,18 +356,23 @@ def test_rbac_putitem_write(dynamodb, cql, test_table_s):
 def test_rbac_putitem_read(dynamodb, cql, test_table_s):
     p = random_string()
     v1 = random_string()
-    test_table_s.put_item(Item={'p': p, 'v': v1})
+    test_table_s.put_item(Item={"p": p, "v": v1})
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
             v2 = random_string()
-            unauthorized(lambda: tab.put_item(Item={'p': p, 'v': v2}))
+            unauthorized(lambda: tab.put_item(Item={"p": p, "v": v2}))
             # With just the MODIFY permission, not SELECT permission, we
             # can PutItem with ReturnValues=ALL_OLD and read the item:
-            with temporary_grant(cql, 'MODIFY', cql_table_name(tab), role):
-                ret = authorized(lambda: tab.put_item(Item={'p': p, 'v': v2}, ReturnValues='ALL_OLD'))
-                assert ret['Attributes'] == {'p': p, 'v': v1}
-    assert {'p': p, 'v': v2} == authorized(lambda: test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'])
+            with temporary_grant(cql, "MODIFY", cql_table_name(tab), role):
+                ret = authorized(
+                    lambda: tab.put_item(Item={"p": p, "v": v2}, ReturnValues="ALL_OLD")
+                )
+                assert ret["Attributes"] == {"p": p, "v": v1}
+    assert {"p": p, "v": v2} == authorized(
+        lambda: test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+    )
+
 
 # Test DeleteItem's support of permissions.
 # As PutItem above, DeleteItem requires the "MODIFY" permission, both for
@@ -313,29 +380,33 @@ def test_rbac_putitem_read(dynamodb, cql, test_table_s):
 def test_rbac_deleteitem_write(dynamodb, cql, test_table_s):
     p = random_string()
     v = random_string()
-    test_table_s.put_item(Item={'p': p, 'v': v})
+    test_table_s.put_item(Item={"p": p, "v": v})
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
-            unauthorized(lambda: tab.delete_item(Key={'p': p}))
-            with temporary_grant(cql, 'MODIFY', cql_table_name(tab), role):
-                authorized(lambda: tab.delete_item(Key={'p': p}))
-    assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+            unauthorized(lambda: tab.delete_item(Key={"p": p}))
+            with temporary_grant(cql, "MODIFY", cql_table_name(tab), role):
+                authorized(lambda: tab.delete_item(Key={"p": p}))
+    assert not "Item" in test_table_s.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 def test_rbac_deleteitem_read(dynamodb, cql, test_table_s):
     p = random_string()
     v = random_string()
-    test_table_s.put_item(Item={'p': p, 'v': v})
+    test_table_s.put_item(Item={"p": p, "v": v})
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
-            unauthorized(lambda: tab.delete_item(Key={'p': p}))
+            unauthorized(lambda: tab.delete_item(Key={"p": p}))
             # With just the MODIFY permission, not SELECT permission, we
             # can DeleteItem with ReturnValues=ALL_OLD and read the item:
-            with temporary_grant(cql, 'MODIFY', cql_table_name(tab), role):
-                ret = authorized(lambda: tab.delete_item(Key={'p': p}, ReturnValues='ALL_OLD'))
-                assert ret['Attributes'] == {'p': p, 'v': v}
-    assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+            with temporary_grant(cql, "MODIFY", cql_table_name(tab), role):
+                ret = authorized(
+                    lambda: tab.delete_item(Key={"p": p}, ReturnValues="ALL_OLD")
+                )
+                assert ret["Attributes"] == {"p": p, "v": v}
+    assert not "Item" in test_table_s.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 # Test UpdateItem's support of permissions.
 # As PutItem above, UpdateItem requires the "MODIFY" permission, both for
@@ -347,58 +418,97 @@ def test_rbac_updateitem_write(dynamodb, cql, test_table_s):
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
-            unauthorized(lambda: tab.update_item(Key={'p': p},
-                UpdateExpression='SET v = :val',
-                ExpressionAttributeValues={':val': v}))
-            with temporary_grant(cql, 'MODIFY', cql_table_name(tab), role):
-                authorized(lambda: tab.update_item(Key={'p': p},
-                    UpdateExpression='SET v = :val',
-                    ExpressionAttributeValues={':val': v}))
-    assert {'p': p, 'v': v} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+            unauthorized(
+                lambda: tab.update_item(
+                    Key={"p": p},
+                    UpdateExpression="SET v = :val",
+                    ExpressionAttributeValues={":val": v},
+                )
+            )
+            with temporary_grant(cql, "MODIFY", cql_table_name(tab), role):
+                authorized(
+                    lambda: tab.update_item(
+                        Key={"p": p},
+                        UpdateExpression="SET v = :val",
+                        ExpressionAttributeValues={":val": v},
+                    )
+                )
+    assert {"p": p, "v": v} == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)[
+        "Item"
+    ]
+
 
 def test_rbac_updateitem_read(dynamodb, cql, test_table_s):
     p = random_string()
     v1 = random_string()
-    test_table_s.put_item(Item={'p': p, 'v': v1})
+    test_table_s.put_item(Item={"p": p, "v": v1})
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
             v2 = 42
-            unauthorized(lambda: tab.update_item(Key={'p': p},
-                UpdateExpression='SET v = :val',
-                ExpressionAttributeValues={':val': v2},
-                ReturnValues='ALL_OLD'))
+            unauthorized(
+                lambda: tab.update_item(
+                    Key={"p": p},
+                    UpdateExpression="SET v = :val",
+                    ExpressionAttributeValues={":val": v2},
+                    ReturnValues="ALL_OLD",
+                )
+            )
             # With just the MODIFY permission, not SELECT permission, we
             # can UpdateItem with ReturnValues=ALL_OLD and read the item:
-            with temporary_grant(cql, 'MODIFY', cql_table_name(tab), role):
-                ret = authorized(lambda: tab.update_item(Key={'p': p},
-                    UpdateExpression='SET v = :val',
-                    ExpressionAttributeValues={':val': v2},
-                    ReturnValues='ALL_OLD'))
-                assert ret['Attributes'] == {'p': p, 'v': v1}
+            with temporary_grant(cql, "MODIFY", cql_table_name(tab), role):
+                ret = authorized(
+                    lambda: tab.update_item(
+                        Key={"p": p},
+                        UpdateExpression="SET v = :val",
+                        ExpressionAttributeValues={":val": v2},
+                        ReturnValues="ALL_OLD",
+                    )
+                )
+                assert ret["Attributes"] == {"p": p, "v": v1}
                 # Just MODIFY permission, not SELECT permission, also allows
                 # us to do a read-modify-write expression:
-                authorized(lambda: tab.update_item(Key={'p': p},
-                    UpdateExpression='SET v =  v + :val',
-                    ExpressionAttributeValues={':val': 1}))
-    assert {'p': p, 'v': v2 + 1} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+                authorized(
+                    lambda: tab.update_item(
+                        Key={"p": p},
+                        UpdateExpression="SET v =  v + :val",
+                        ExpressionAttributeValues={":val": 1},
+                    )
+                )
+    assert {"p": p, "v": v2 + 1} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+
 
 # Test Query's support of permissions - the "SELECT" permission is needed.
 def test_rbac_query(dynamodb, cql, test_table):
     p = random_string()
     c = random_string()
-    item = {'p': p, 'c': c}
+    item = {"p": p, "c": c}
     test_table.put_item(Item=item)
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table.name)
             # Without SELECT permissions, the Query will fail:
-            unauthorized(lambda: tab.query(ConsistentRead=True,
-                KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}}))
+            unauthorized(
+                lambda: tab.query(
+                    ConsistentRead=True,
+                    KeyConditions={
+                        "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}
+                    },
+                )
+            )
             # Adding SELECT permissions, the Query will succeed:
-            with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
-                assert [item] == authorized(lambda: tab.query(ConsistentRead=True,
-                        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}})['Items'])
+            with temporary_grant(cql, "SELECT", cql_table_name(tab), role):
+                assert [item] == authorized(
+                    lambda: tab.query(
+                        ConsistentRead=True,
+                        KeyConditions={
+                            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}
+                        },
+                    )["Items"]
+                )
+
 
 # When reading with Query (or Scan), the IndexName option can ask to read
 # from a view (GSI or LSI) instead of from the base table. We decided that
@@ -411,17 +521,20 @@ def test_rbac_query(dynamodb, cql, test_table):
 # and the permissions are granted explicitly to the role on a specific table.
 def test_rbac_query_separate_index_permissions(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' } ],
-        'GlobalSecondaryIndexes': [
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
+        ],
+        "GlobalSecondaryIndexes": [
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
-            } ]
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
     }
     with new_test_table(dynamodb, **schema) as table:
         with new_role(cql) as (role, key):
@@ -429,18 +542,76 @@ def test_rbac_query_separate_index_permissions(dynamodb, cql):
                 tab = d.Table(table.name)
                 # Without extra permissions, the new role can read neither
                 # the base table nore the view:
-                unauthorized(lambda: tab.query(KeyConditions={'p': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
-                unauthorized(lambda: tab.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                unauthorized(
+                    lambda: tab.query(
+                        KeyConditions={
+                            "p": {
+                                "AttributeValueList": ["hi"],
+                                "ComparisonOperator": "EQ",
+                            }
+                        }
+                    )
+                )
+                unauthorized(
+                    lambda: tab.query(
+                        IndexName="hello",
+                        KeyConditions={
+                            "x": {
+                                "AttributeValueList": ["hi"],
+                                "ComparisonOperator": "EQ",
+                            }
+                        },
+                    )
+                )
                 # Granting permissions on the base table we can read the
                 # base table but NOT the view:
-                with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
-                    authorized(lambda: tab.query(KeyConditions={'p': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
-                    unauthorized(lambda: tab.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                with temporary_grant(cql, "SELECT", cql_table_name(tab), role):
+                    authorized(
+                        lambda: tab.query(
+                            KeyConditions={
+                                "p": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            }
+                        )
+                    )
+                    unauthorized(
+                        lambda: tab.query(
+                            IndexName="hello",
+                            KeyConditions={
+                                "x": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            },
+                        )
+                    )
                 # Granting permissions on the GSI we can read the GSI but not
                 # the base table:
-                with temporary_grant(cql, 'SELECT', cql_gsi_name(tab, 'hello'), role):
-                    unauthorized(lambda: tab.query(KeyConditions={'p': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
-                    authorized(lambda: tab.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                with temporary_grant(cql, "SELECT", cql_gsi_name(tab, "hello"), role):
+                    unauthorized(
+                        lambda: tab.query(
+                            KeyConditions={
+                                "p": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            }
+                        )
+                    )
+                    authorized(
+                        lambda: tab.query(
+                            IndexName="hello",
+                            KeyConditions={
+                                "x": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            },
+                        )
+                    )
+
 
 # Test Scan's support of permissions - the "SELECT" permission is needed.
 def test_rbac_scan(dynamodb, cql, test_table):
@@ -453,16 +624,17 @@ def test_rbac_scan(dynamodb, cql, test_table):
             # Without SELECT permissions, the Scan will fail:
             unauthorized(lambda: tab.scan(ConsistentRead=True, Limit=1))
             # Adding SELECT permissions, the Scan will succeed:
-            with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
+            with temporary_grant(cql, "SELECT", cql_table_name(tab), role):
                 authorized(lambda: tab.scan(ConsistentRead=True, Limit=1))
+
 
 # Test DeleteTable's permissions checks. The DeleteTable operation requires
 # a DROP permission on the specific table (or on something which contains it -
 # the keyspace or ALL KEYSPACES).
 def test_rbac_deletetable(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }]
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
     }
     with new_test_table(dynamodb, **schema) as table:
         with new_role(cql) as (role, key):
@@ -475,39 +647,50 @@ def test_rbac_deletetable(dynamodb, cql):
                 # keyspace, on ALL KEYSPACES, or on an inherited role, but
                 # we already have other tests above for this kind of
                 # inheritence so don't need to test it again for DeleteTable.
-                with temporary_grant(cql, 'DROP', cql_table_name(tab), role):
+                with temporary_grant(cql, "DROP", cql_table_name(tab), role):
                     tabname = tab.name
                     authorized(lambda: tab.delete())
                     # officially, the DynamoDB API requires waiting for
                     # delete to be done, although it's not currently
                     # necessary in Alternator.
-                    tab.meta.client.get_waiter('table_not_exists').wait(TableName=tabname)
+                    tab.meta.client.get_waiter("table_not_exists").wait(
+                        TableName=tabname
+                    )
                     # When we'll go out of scope on temporary_grant() and
                     # new_test_table(), they expect the table to exist and
                     # complain that it doesn't. So let's recreate the table,
                     # using our original, super-user, role.
-                    table = dynamodb.create_table(TableName=tabname,
-                        BillingMode='PAY_PER_REQUEST', **schema)
-                    table.meta.client.get_waiter('table_exists').wait(TableName=tabname)
+                    table = dynamodb.create_table(
+                        TableName=tabname, BillingMode="PAY_PER_REQUEST", **schema
+                    )
+                    table.meta.client.get_waiter("table_exists").wait(TableName=tabname)
+
 
 @contextmanager
 def new_named_table(dynamodb, tabname, **kwargs):
-    table = authorized(lambda: dynamodb.create_table(TableName=tabname,
-                BillingMode='PAY_PER_REQUEST', **kwargs))
-    table.meta.client.get_waiter('table_exists').wait(TableName=tabname)
+    table = authorized(
+        lambda: dynamodb.create_table(
+            TableName=tabname, BillingMode="PAY_PER_REQUEST", **kwargs
+        )
+    )
+    table.meta.client.get_waiter("table_exists").wait(TableName=tabname)
     try:
         yield table
     finally:
         table.delete()
 
+
 def new_named_table_unauthorized(dynamodb, tabname, **kwargs):
     try:
-        unauthorized(lambda: dynamodb.create_table(TableName=tabname,
-                BillingMode='PAY_PER_REQUEST', **kwargs))
+        unauthorized(
+            lambda: dynamodb.create_table(
+                TableName=tabname, BillingMode="PAY_PER_REQUEST", **kwargs
+            )
+        )
     except:
         # Oops, if the table creation *was* authorized, delete the
-        # table 
-        dynamodb.meta.client.get_waiter('table_exists').wait(TableName=tabname)
+        # table
+        dynamodb.meta.client.get_waiter("table_exists").wait(TableName=tabname)
         dynamodb.meta.client.delete_table(TableName=tabname)
 
 
@@ -523,45 +706,78 @@ def test_rbac_deletetable_autorevoke(dynamodb, cql):
     # An example table schema, with a GSI to allow us to also test the
     # permissions on the view.
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' } ],
-        'GlobalSecondaryIndexes': [
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
+        ],
+        "GlobalSecondaryIndexes": [
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
-            } ]
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
     }
     # Table name to use throughout the test below (role1 will create it,
     # delete it, and then role2 will re-create it).
     table_name = unique_table_name()
     # Create two roles and two DynamoDB sessions for them (d1, d2):
     with new_role(cql) as (role1, key1), new_role(cql) as (role2, key2):
-        with new_dynamodb(dynamodb, role1, key1) as d1, new_dynamodb(dynamodb, role2, key2) as d2:
+        with (
+            new_dynamodb(dynamodb, role1, key1) as d1,
+            new_dynamodb(dynamodb, role2, key2) as d2,
+        ):
             # Allow role1 to create a table, create it and immediately
             # delete it:
-            with temporary_grant(cql, 'CREATE', 'ALL KEYSPACES', role1):
+            with temporary_grant(cql, "CREATE", "ALL KEYSPACES", role1):
                 with new_named_table(d1, table_name, **schema) as tab:
                     pass
             # Allow role2 to re-create a table with the same name that
             # role1 just deleted, and create it:
-            with temporary_grant(cql, 'CREATE', 'ALL KEYSPACES', role2):
+            with temporary_grant(cql, "CREATE", "ALL KEYSPACES", role2):
                 with new_named_table(d2, table_name, **schema) as tab:
                     # At this point, role2 should have permissions to use
                     # this table, but role1 should not!
-                    authorized(lambda: d2.Table(table_name).get_item(Key={'p': 'dog'}, ConsistentRead=True))
-                    unauthorized(lambda: d1.Table(table_name).get_item(Key={'p': 'dog'}, ConsistentRead=True))
+                    authorized(
+                        lambda: d2.Table(table_name).get_item(
+                            Key={"p": "dog"}, ConsistentRead=True
+                        )
+                    )
+                    unauthorized(
+                        lambda: d1.Table(table_name).get_item(
+                            Key={"p": "dog"}, ConsistentRead=True
+                        )
+                    )
                     # Same for the view - it should be usable by role2,
                     # but not by role1!
-                    authorized(lambda: d2.Table(table_name).query(IndexName='hello',
-                        Select='ALL_PROJECTED_ATTRIBUTES',
-                        KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
-                    unauthorized(lambda: d1.Table(table_name).query(IndexName='hello',
-                        Select='ALL_PROJECTED_ATTRIBUTES',
-                        KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                    authorized(
+                        lambda: d2.Table(table_name).query(
+                            IndexName="hello",
+                            Select="ALL_PROJECTED_ATTRIBUTES",
+                            KeyConditions={
+                                "x": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            },
+                        )
+                    )
+                    unauthorized(
+                        lambda: d1.Table(table_name).query(
+                            IndexName="hello",
+                            Select="ALL_PROJECTED_ATTRIBUTES",
+                            KeyConditions={
+                                "x": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            },
+                        )
+                    )
+
 
 # Test CreateTable's support for permissions. Because a CreateTable operation
 # creates a keyspace and a table, it requires the "CREATE" permission on
@@ -573,17 +789,20 @@ def test_rbac_createtable(dynamodb, cql):
     # An example table schema, with a GSI to make the example even more
     # interesting (it needs to create a table and a view)
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' } ],
-        'GlobalSecondaryIndexes': [
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
+        ],
+        "GlobalSecondaryIndexes": [
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
-            } ]
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
     }
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
@@ -591,7 +810,7 @@ def test_rbac_createtable(dynamodb, cql):
             table_name = unique_table_name()
             new_named_table_unauthorized(d, table_name, **schema)
             # Adding CREATE permissions, it should work
-            with temporary_grant(cql, 'CREATE', 'ALL KEYSPACES', role):
+            with temporary_grant(cql, "CREATE", "ALL KEYSPACES", role):
                 with new_named_table(d, table_name, **schema) as tab:
                     # After being allowed to create the table, this role
                     # is automatically granted permissions to SELECT or MODIFY
@@ -599,32 +818,47 @@ def test_rbac_createtable(dynamodb, cql):
                     p = random_string()
                     x = random_string()
                     v = random_string()
-                    authorized(lambda: tab.put_item(Item={'p': p, 'x': x, 'v': v}))
-                    assert {'p': p, 'x': x, 'v': v} == authorized(lambda: tab.get_item(Key={'p': p}, ConsistentRead=True)['Item'])
+                    authorized(lambda: tab.put_item(Item={"p": p, "x": x, "v": v}))
+                    assert {"p": p, "x": x, "v": v} == authorized(
+                        lambda: tab.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+                    )
                     # Check this role can also read from the view. We don't
                     # check the data itself (maybe the view wasn't yet updated)
                     # just that we have permissions.
-                    authorized(lambda: tab.query(IndexName='hello',
-                        Select='ALL_PROJECTED_ATTRIBUTES',
-                        KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                    authorized(
+                        lambda: tab.query(
+                            IndexName="hello",
+                            Select="ALL_PROJECTED_ATTRIBUTES",
+                            KeyConditions={
+                                "x": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            },
+                        )
+                    )
                     # Check that ALTER permissions were auto-granted too.
                     # The UpdateTable below doesn't actually change anything
                     # (it just sets BillingMode to what it was), but the
                     # access check is done even if there's nothing to do.
-                    authorized(lambda: tab.meta.client.update_table(TableName=tab.name,
-                        BillingMode='PAY_PER_REQUEST'))
+                    authorized(
+                        lambda: tab.meta.client.update_table(
+                            TableName=tab.name, BillingMode="PAY_PER_REQUEST"
+                        )
+                    )
                     # Note that when we now go out of scope, the new table
                     # will be deleted under the new role, so this test also
                     # verifies that the role was correctly auto-granted the
                     # DROP permission.
+
 
 # Test UpdateTable's support for permissions. It requires the "ALTER"
 # permission permission on the given table (or, as usual, something
 # containing it - like a keyspace, all keyspaces, or another role).
 def test_rbac_updatetable(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }]
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
     }
     with new_test_table(dynamodb, **schema) as table:
         with new_role(cql) as (role, key):
@@ -634,12 +868,19 @@ def test_rbac_updatetable(dynamodb, cql):
                 # The "update" doesn't actually change anything (it just
                 # sets BillingMode to what it was), but the access check is
                 # done even if there's nothing to do
-                unauthorized(lambda: tab.meta.client.update_table(TableName=tab.name,
-                    BillingMode='PAY_PER_REQUEST'))
+                unauthorized(
+                    lambda: tab.meta.client.update_table(
+                        TableName=tab.name, BillingMode="PAY_PER_REQUEST"
+                    )
+                )
                 # With ALTER permissions, it works.
-                with temporary_grant(cql, 'ALTER', cql_table_name(tab), role):
-                    authorized(lambda: tab.meta.client.update_table(TableName=tab.name,
-                        BillingMode='PAY_PER_REQUEST'))
+                with temporary_grant(cql, "ALTER", cql_table_name(tab), role):
+                    authorized(
+                        lambda: tab.meta.client.update_table(
+                            TableName=tab.name, BillingMode="PAY_PER_REQUEST"
+                        )
+                    )
+
 
 # Above in test_rbac_updatetable() we checked UpdateTable's operation to
 # change BillingMode, and that it requires the ALTER permissions. But
@@ -659,35 +900,40 @@ def test_rbac_updatetable(dynamodb, cql):
 # and auto-revoke when deleting it.
 def test_rbac_updatetable_gsi(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }]
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
     }
     create_gsi = {
-        'AttributeDefinitions': [{ 'AttributeName': 'x', 'AttributeType': 'S' }],
-        'GlobalSecondaryIndexUpdates': [
-            {  'Create':
-                {  'IndexName': 'hello',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
+        "AttributeDefinitions": [{"AttributeName": "x", "AttributeType": "S"}],
+        "GlobalSecondaryIndexUpdates": [
+            {
+                "Create": {
+                    "IndexName": "hello",
+                    "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
                 }
             }
-        ]}
-    delete_gsi = {
-        'GlobalSecondaryIndexUpdates': [
-            {  'Delete': { 'IndexName': 'hello' } }
-        ]}
+        ],
+    }
+    delete_gsi = {"GlobalSecondaryIndexUpdates": [{"Delete": {"IndexName": "hello"}}]}
     with new_test_table(dynamodb, **schema) as table:
         with new_role(cql) as (role, key):
             with new_dynamodb(dynamodb, role, key) as d:
                 tab = d.Table(table.name)
                 # Without ALTER permissions, UpdateTable GSI Create won't work.
-                unauthorized(lambda: tab.meta.client.update_table(TableName=tab.name,
-                    **create_gsi))
+                unauthorized(
+                    lambda: tab.meta.client.update_table(
+                        TableName=tab.name, **create_gsi
+                    )
+                )
                 # With ALTER permissions, it works.
-                with temporary_grant(cql, 'ALTER', cql_table_name(tab), role):
-                    authorized(lambda: tab.meta.client.update_table(TableName=tab.name,
-                        **create_gsi))
-                wait_for_gsi(tab, 'hello')
+                with temporary_grant(cql, "ALTER", cql_table_name(tab), role):
+                    authorized(
+                        lambda: tab.meta.client.update_table(
+                            TableName=tab.name, **create_gsi
+                        )
+                    )
+                wait_for_gsi(tab, "hello")
                 # Without ALTER permissions, UpdateTable GSI Delete won't work.
                 # Note that the GSI Delete operation checks for the existence
                 # of the GSI before checking the permissions, so we needed to
@@ -701,46 +947,60 @@ def test_rbac_updatetable_gsi(dynamodb, cql):
                 # try a different UpdateTable operation (a silly BillingMode
                 # setting) first, wait until what's unauthorized, and then
                 # verify the actual deletion is unauthorized.
-                unauthorized(lambda: tab.meta.client.update_table(TableName=tab.name,
-                    BillingMode='PAY_PER_REQUEST'))
-                with pytest.raises(ClientError, match='AccessDeniedException'):
+                unauthorized(
+                    lambda: tab.meta.client.update_table(
+                        TableName=tab.name, BillingMode="PAY_PER_REQUEST"
+                    )
+                )
+                with pytest.raises(ClientError, match="AccessDeniedException"):
                     tab.meta.client.update_table(TableName=tab.name, **delete_gsi)
                 # With ALTER permissions, it works.
-                with temporary_grant(cql, 'ALTER', cql_table_name(tab), role):
-                    authorized(lambda: tab.meta.client.update_table(TableName=tab.name,
-                        **delete_gsi))
-                wait_for_gsi_gone(tab, 'hello')
+                with temporary_grant(cql, "ALTER", cql_table_name(tab), role):
+                    authorized(
+                        lambda: tab.meta.client.update_table(
+                            TableName=tab.name, **delete_gsi
+                        )
+                    )
+                wait_for_gsi_gone(tab, "hello")
+
 
 # Test the "autogrant" feature of UpdateTable's GSI Create feature: If a role
 # is allowed to create a GSI, this role is automatically given full (SELECT)
 # permissions to the newly-created GSI.
 def test_rbac_updatetable_gsi_autogrant(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }]
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
     }
     create_gsi = {
-        'AttributeDefinitions': [{ 'AttributeName': 'x', 'AttributeType': 'S' }],
-        'GlobalSecondaryIndexUpdates': [
-            {  'Create':
-                {  'IndexName': 'hello',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
+        "AttributeDefinitions": [{"AttributeName": "x", "AttributeType": "S"}],
+        "GlobalSecondaryIndexUpdates": [
+            {
+                "Create": {
+                    "IndexName": "hello",
+                    "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
                 }
             }
-        ]
+        ],
     }
     with new_test_table(dynamodb, **schema) as table:
         with new_role(cql) as (role, key):
             with new_dynamodb(dynamodb, role, key) as d:
                 tab = d.Table(table.name)
                 # Without ALTER permissions, UpdateTable GSI Create won't work:
-                unauthorized(lambda: tab.meta.client.update_table(
-                    TableName=tab.name, **create_gsi))
+                unauthorized(
+                    lambda: tab.meta.client.update_table(
+                        TableName=tab.name, **create_gsi
+                    )
+                )
                 # Adding ALTER permissions, it should work
-                with temporary_grant(cql, 'ALTER', cql_table_name(tab), role):
-                    authorized(lambda: tab.meta.client.update_table(
-                        TableName=tab.name, **create_gsi))
+                with temporary_grant(cql, "ALTER", cql_table_name(tab), role):
+                    authorized(
+                        lambda: tab.meta.client.update_table(
+                            TableName=tab.name, **create_gsi
+                        )
+                    )
                 # Check that after being allowed to create the GSI, this role
                 # is automatically granted permissions to SELECT from this
                 # GSI.
@@ -750,10 +1010,19 @@ def test_rbac_updatetable_gsi_autogrant(dynamodb, cql):
                 p = random_string()
                 x = random_string()
                 v = random_string()
-                item = {'p': p, 'x': x, 'v': v}
+                item = {"p": p, "x": x, "v": v}
                 table.put_item(Item=item)
-                authorized(lambda: assert_index_query(tab, 'hello', [item],
-                    KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}}))
+                authorized(
+                    lambda: assert_index_query(
+                        tab,
+                        "hello",
+                        [item],
+                        KeyConditions={
+                            "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}
+                        },
+                    )
+                )
+
 
 # Test the "autorevoke" feature of UpdateTable's GSI Delete feature: If a role
 # had SELECT permissions on some GSI, and this GSI is deleted, the permissions
@@ -762,54 +1031,83 @@ def test_rbac_updatetable_gsi_autogrant(dynamodb, cql):
 # different GSI with the same name and role1 might be able to read it.
 def test_rbac_updatetable_gsi_autorevoke(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'x', 'AttributeType': 'S' }
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
-        'GlobalSecondaryIndexes': [
-            { 'IndexName': 'hello',
-              'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-              'Projection': { 'ProjectionType': 'ALL' }
+        "GlobalSecondaryIndexes": [
+            {
+                "IndexName": "hello",
+                "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ]
+        ],
     }
-    delete_gsi = {
-        'GlobalSecondaryIndexUpdates': [
-            {  'Delete': { 'IndexName': 'hello' } }
-        ]
-    }
+    delete_gsi = {"GlobalSecondaryIndexUpdates": [{"Delete": {"IndexName": "hello"}}]}
     create_gsi = {
-        'AttributeDefinitions': [{ 'AttributeName': 'x', 'AttributeType': 'S' }],
-        'GlobalSecondaryIndexUpdates': [
-            {  'Create':
-                {  'IndexName': 'hello',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
+        "AttributeDefinitions": [{"AttributeName": "x", "AttributeType": "S"}],
+        "GlobalSecondaryIndexUpdates": [
+            {
+                "Create": {
+                    "IndexName": "hello",
+                    "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
                 }
             }
-        ]
+        ],
     }
     with new_test_table(dynamodb, **schema) as table:
         with new_role(cql) as (role, key):
             with new_dynamodb(dynamodb, role, key) as d:
                 tab = d.Table(table.name)
-                with temporary_grant(cql, 'SELECT', cql_gsi_name(table, 'hello'), role):
+                with temporary_grant(cql, "SELECT", cql_gsi_name(table, "hello"), role):
                     # role was given permission to SELECT this index
                     # so a query on tab's index "hello" should work.
-                    authorized(lambda: tab.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                    authorized(
+                        lambda: tab.query(
+                            IndexName="hello",
+                            KeyConditions={
+                                "x": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            },
+                        )
+                    )
                     # Now, delete the GSI (using the superuser connection
                     # "dynamodb").
                     dynamodb.meta.client.update_table(
-                        TableName=table.name, **delete_gsi)
+                        TableName=table.name, **delete_gsi
+                    )
                     # Now, the superuser create a GSI with the same name
                     # again, *without* giving "role" any permissions.
                     # Check that role really can't read the new GSI.
                     dynamodb.meta.client.update_table(
-                        TableName=table.name, **create_gsi)
-                    unauthorized(lambda: tab.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                        TableName=table.name, **create_gsi
+                    )
+                    unauthorized(
+                        lambda: tab.query(
+                            IndexName="hello",
+                            KeyConditions={
+                                "x": {
+                                    "AttributeValueList": ["hi"],
+                                    "ComparisonOperator": "EQ",
+                                }
+                            },
+                        )
+                    )
                     # (the superuser can read the new GSI, of course)
-                    table.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}})
+                    table.query(
+                        IndexName="hello",
+                        KeyConditions={
+                            "x": {
+                                "AttributeValueList": ["hi"],
+                                "ComparisonOperator": "EQ",
+                            }
+                        },
+                    )
+
 
 # A test for API operations that do not require any permissions, so can be
 # performed on a new role with no grants. This currently includes
@@ -824,10 +1122,11 @@ def test_no_permissions_needed(dynamodb, cql, test_table):
             d.meta.client.list_tables()
             d.meta.client.describe_endpoints()
             r = d.meta.client.describe_table(TableName=test_table.name)
-            arn = r['Table']['TableArn']
+            arn = r["Table"]["TableArn"]
             d.meta.client.list_tags_of_resource(ResourceArn=arn)
             d.meta.client.describe_time_to_live(TableName=test_table.name)
             d.meta.client.describe_continuous_backups(TableName=test_table.name)
+
 
 # A test for permission checks in BatchWriteItem. BatchWriteItem needs the
 # "MODIFY" permission, but one BatchWriteItem may write to several tables
@@ -846,21 +1145,32 @@ def test_rbac_batchwriteitem(dynamodb, cql, test_table, test_table_s):
             # role neither item was written). Only after we grant MODIFY on
             # both tables, it will work.
             batch = {
-                test_table.name: [{'PutRequest': {'Item': {'p': p, 'c': c, 'v': v}}}],
-                test_table_s.name: [{'PutRequest': {'Item': {'p': p, 'c': c, 'v': v}}}],
+                test_table.name: [{"PutRequest": {"Item": {"p": p, "c": c, "v": v}}}],
+                test_table_s.name: [{"PutRequest": {"Item": {"p": p, "c": c, "v": v}}}],
             }
-            unauthorized(lambda: d.meta.client.batch_write_item(RequestItems = batch))
-            with temporary_grant(cql, 'MODIFY', cql_table_name(test_table), role):
-                unauthorized(lambda: d.meta.client.batch_write_item(RequestItems = batch))
+            unauthorized(lambda: d.meta.client.batch_write_item(RequestItems=batch))
+            with temporary_grant(cql, "MODIFY", cql_table_name(test_table), role):
+                unauthorized(lambda: d.meta.client.batch_write_item(RequestItems=batch))
                 # Verify through the superuser role that until now, neither
                 # item was written.
-                assert not 'Item' in test_table.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)
-                assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
-                with temporary_grant(cql, 'MODIFY', cql_table_name(test_table_s), role):
+                assert not "Item" in test_table.get_item(
+                    Key={"p": p, "c": c}, ConsistentRead=True
+                )
+                assert not "Item" in test_table_s.get_item(
+                    Key={"p": p}, ConsistentRead=True
+                )
+                with temporary_grant(cql, "MODIFY", cql_table_name(test_table_s), role):
                     # Finally, with both grants, the write should work:
-                    authorized(lambda: d.meta.client.batch_write_item(RequestItems = batch))
-                    assert 'Item' in test_table.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)
-                    assert 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+                    authorized(
+                        lambda: d.meta.client.batch_write_item(RequestItems=batch)
+                    )
+                    assert "Item" in test_table.get_item(
+                        Key={"p": p, "c": c}, ConsistentRead=True
+                    )
+                    assert "Item" in test_table_s.get_item(
+                        Key={"p": p}, ConsistentRead=True
+                    )
+
 
 # A test for permission checks in BatchGetItem. BatchGetItem needs the
 # "SELECT" permission, but one BatchGetItem may read from several tables
@@ -872,25 +1182,30 @@ def test_rbac_batchgetitem(dynamodb, cql, test_table, test_table_s):
     p = random_string()
     c = random_string()
     v = random_string()
-    test_table.put_item(Item={'p': p, 'c': c, 'v': v})
-    test_table_s.put_item(Item={'p': p, 'v': v})
+    test_table.put_item(Item={"p": p, "c": c, "v": v})
+    test_table_s.put_item(Item={"p": p, "v": v})
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             # Without SELECT permission on *both* tables, the BatchGetItem
             # operation will fail. Only after we grant SELECT to both tables,
             # it will work.
             batch = {
-                test_table.name: {'Keys': [{'p': p, 'c': c}], 'ConsistentRead': True},
-                test_table_s.name: {'Keys': [{'p': p}], 'ConsistentRead': True}
+                test_table.name: {"Keys": [{"p": p, "c": c}], "ConsistentRead": True},
+                test_table_s.name: {"Keys": [{"p": p}], "ConsistentRead": True},
             }
-            unauthorized(lambda: d.meta.client.batch_get_item(RequestItems = batch))
-            with temporary_grant(cql, 'SELECT', cql_table_name(test_table), role):
-                unauthorized(lambda: d.meta.client.batch_get_item(RequestItems = batch))
-                with temporary_grant(cql, 'SELECT', cql_table_name(test_table_s), role):
+            unauthorized(lambda: d.meta.client.batch_get_item(RequestItems=batch))
+            with temporary_grant(cql, "SELECT", cql_table_name(test_table), role):
+                unauthorized(lambda: d.meta.client.batch_get_item(RequestItems=batch))
+                with temporary_grant(cql, "SELECT", cql_table_name(test_table_s), role):
                     # Finally, with both grants, the read should work:
-                    r = authorized(lambda: d.meta.client.batch_get_item(RequestItems = batch)['Responses'])
-                    assert r[test_table.name] == [{'p': p, 'c': c, 'v': v}]
-                    assert r[test_table_s.name] == [{'p': p, 'v': v}]
+                    r = authorized(
+                        lambda: d.meta.client.batch_get_item(RequestItems=batch)[
+                            "Responses"
+                        ]
+                    )
+                    assert r[test_table.name] == [{"p": p, "c": c, "v": v}]
+                    assert r[test_table_s.name] == [{"p": p, "v": v}]
+
 
 # A test for permission checks in TagResource and UntagResource. We
 # consider this a variant of UpdateTable, because one of its uses is to
@@ -898,51 +1213,85 @@ def test_rbac_batchgetitem(dynamodb, cql, test_table, test_table_s):
 # policy), so require the ALTER permission on both.
 def test_rbac_tagresource(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }]
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
     }
     with new_test_table(dynamodb, **schema) as table:
-        arn = table.meta.client.describe_table(TableName=table.name)['Table']['TableArn']
+        arn = table.meta.client.describe_table(TableName=table.name)["Table"][
+            "TableArn"
+        ]
         with new_role(cql) as (role, key):
             with new_dynamodb(dynamodb, role, key) as d:
                 # Without ALTER permission, TagResource and UntagResource
                 # are refused
-                tags = [{'Key': 'hello', 'Value': 'dog'},
-                        {'Key': 'hi', 'Value': '42'}]
-                unauthorized(lambda: d.meta.client.tag_resource(ResourceArn=arn, Tags=tags))
-                unauthorized(lambda: d.meta.client.untag_resource(ResourceArn=arn, TagKeys=['hello']))
+                tags = [{"Key": "hello", "Value": "dog"}, {"Key": "hi", "Value": "42"}]
+                unauthorized(
+                    lambda: d.meta.client.tag_resource(ResourceArn=arn, Tags=tags)
+                )
+                unauthorized(
+                    lambda: d.meta.client.untag_resource(
+                        ResourceArn=arn, TagKeys=["hello"]
+                    )
+                )
                 # With granting ALTER permissions, it works:
-                with temporary_grant(cql, 'ALTER', cql_table_name(table), role):
-                    authorized(lambda: d.meta.client.tag_resource(ResourceArn=arn, Tags=tags))
-                    authorized(lambda: d.meta.client.untag_resource(ResourceArn=arn, TagKeys=['hello']))
+                with temporary_grant(cql, "ALTER", cql_table_name(table), role):
+                    authorized(
+                        lambda: d.meta.client.tag_resource(ResourceArn=arn, Tags=tags)
+                    )
+                    authorized(
+                        lambda: d.meta.client.untag_resource(
+                            ResourceArn=arn, TagKeys=["hello"]
+                        )
+                    )
+
 
 # Test that UpdateTimeToLive requires the ALTER permissions, similar to
 # UpdateTable.
 def test_rbac_updatetimetolive(dynamodb, cql):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }]
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
     ) as table:
         with new_role(cql) as (role, key):
             with new_dynamodb(dynamodb, role, key) as d:
                 # Without ALTER permissions, UpdateTimeToLive will fail with
                 # AccessDeniedException. With the ALTER permissions, it will
                 # succeed.
-                unauthorized(lambda: d.meta.client.update_time_to_live(TableName=table.name,
-                    TimeToLiveSpecification={'AttributeName': 'dog', 'Enabled': True}))
-                with temporary_grant(cql, 'ALTER', cql_table_name(table), role):
-                    authorized(lambda: d.meta.client.update_time_to_live(TableName=table.name,
-                        TimeToLiveSpecification={'AttributeName': 'dog', 'Enabled': True}))
+                unauthorized(
+                    lambda: d.meta.client.update_time_to_live(
+                        TableName=table.name,
+                        TimeToLiveSpecification={
+                            "AttributeName": "dog",
+                            "Enabled": True,
+                        },
+                    )
+                )
+                with temporary_grant(cql, "ALTER", cql_table_name(table), role):
+                    authorized(
+                        lambda: d.meta.client.update_time_to_live(
+                            TableName=table.name,
+                            TimeToLiveSpecification={
+                                "AttributeName": "dog",
+                                "Enabled": True,
+                            },
+                        )
+                    )
+
 
 @pytest.fixture(scope="module")
 def dot_table(dynamodb):
     name = "." + unique_table_name() + ".hello"
-    table = dynamodb.create_table(TableName=name, BillingMode='PAY_PER_REQUEST',
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }])
-    table.meta.client.get_waiter('table_exists').wait(TableName=name)
+    table = dynamodb.create_table(
+        TableName=name,
+        BillingMode="PAY_PER_REQUEST",
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+    )
+    table.meta.client.get_waiter("table_exists").wait(TableName=name)
     yield table
     table.delete()
+
 
 # The rules on Alternator table names are not identical to CQL table names.
 # In particular, an Alternator table's name may contain a dot and the
@@ -955,10 +1304,11 @@ def test_rbac_table_name_with_dot(dynamodb, cql, dot_table):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(dot_table.name)
             # Before granting MODIFY permissions, PutItem fails
-            unauthorized(lambda: tab.put_item(Item={'p': p}))
+            unauthorized(lambda: tab.put_item(Item={"p": p}))
             # Check that grant works despite the illegal (CQL-wise) table name
-            with temporary_grant(cql, 'MODIFY', cql_table_name(tab), role):
-                authorized(lambda: tab.put_item(Item={'p': p}))
+            with temporary_grant(cql, "MODIFY", cql_table_name(tab), role):
+                authorized(lambda: tab.put_item(Item={"p": p}))
+
 
 # A "superuser" role should be able to do any operation. We'll just test
 # this on PutItem, but assuming the permission-checking code uses the same
@@ -969,12 +1319,13 @@ def test_rbac_superuser(dynamodb, cql, test_table_s):
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
-            unauthorized(lambda: tab.put_item(Item={'p': p}))
+            unauthorized(lambda: tab.put_item(Item={"p": p}))
     # But a superuser role, can:
     with new_role(cql, superuser=True) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             tab = d.Table(test_table_s.name)
-            authorized(lambda: tab.put_item(Item={'p': p}))
+            authorized(lambda: tab.put_item(Item={"p": p}))
+
 
 # In the Streams API, the functions ListStreams, DescribeStream and
 # GetShardIterator don't read data and are similar in spirit to DescribeTable
@@ -984,13 +1335,13 @@ def test_rbac_superuser(dynamodb, cql, test_table_s):
 # the permissions, so it uses an empty table with no data.
 def test_rbac_streams(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }],
-        'StreamSpecification': {'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
+        "StreamSpecification": {"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"},
         # Work around issue #16137 that Alternator Streams doesn't work with
         # tablets. When that issue is solved, the following Tags should be
         # removed.
-        'Tags': [{'Key': 'system:initial_tablets', 'Value': 'none'}]
+        "Tags": [{"Key": "system:initial_tablets", "Value": "none"}],
     }
     with new_test_table(dynamodb, **schema) as table:
         with new_role(cql) as (role, key):
@@ -999,19 +1350,22 @@ def test_rbac_streams(dynamodb, cql):
                 # GetShardIterator without being granted permissions.
                 # only for GetRecords we'll need permissions below.
                 streams = ds.list_streams(TableName=table.name)
-                arn = streams['Streams'][0]['StreamArn']
+                arn = streams["Streams"][0]["StreamArn"]
                 desc = ds.describe_stream(StreamArn=arn)
-                shard_id = desc['StreamDescription']['Shards'][0]['ShardId']
-                iter = ds.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']
+                shard_id = desc["StreamDescription"]["Shards"][0]["ShardId"]
+                iter = ds.get_shard_iterator(
+                    StreamArn=arn, ShardId=shard_id, ShardIteratorType="LATEST"
+                )["ShardIterator"]
                 unauthorized(lambda: ds.get_records(ShardIterator=iter))
                 # GetRecords checks the SELECT permissions on the CDC table,
                 # not the base table, so a grant on the base table doesn't
                 # help:
-                with temporary_grant(cql, 'SELECT', cql_table_name(table), role):
+                with temporary_grant(cql, "SELECT", cql_table_name(table), role):
                     unauthorized(lambda: ds.get_records(ShardIterator=iter))
                 # Only a grant on the CDC log table helps:
-                with temporary_grant(cql, 'SELECT', cql_cdclog_name(table), role):
+                with temporary_grant(cql, "SELECT", cql_cdclog_name(table), role):
                     authorized(lambda: ds.get_records(ShardIterator=iter))
+
 
 # In the test above (test_rbac_streams), the superuser creates a table and
 # a stream, and grants a role the ability to read them. In this test, the role
@@ -1021,37 +1375,48 @@ def test_rbac_streams(dynamodb, cql):
 # with streams enabled up-front during creation - and enabling the stream
 # later in an already existing table.
 # Reproduces issue #19798
-@pytest.mark.xfail(reason="#19798")
+@pytest.mark.xfail(reason="Auto-grant and auto-revoke missing for CDC log table #19798")
 @pytest.mark.parametrize("during_creation", [True, False])
 def test_rbac_streams_autogrant(dynamodb, cql, during_creation):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }],
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
         # Work around issue #16137 that Alternator Streams doesn't work with
         # tablets. When that issue is solved, the following Tags should be
         # removed.
-        'Tags': [{'Key': 'system:initial_tablets', 'Value': 'none'}]
+        "Tags": [{"Key": "system:initial_tablets", "Value": "none"}],
     }
-    enable_stream = {'StreamSpecification': {'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'}}
+    enable_stream = {
+        "StreamSpecification": {"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"}
+    }
     if during_creation:
         schema.update(enable_stream)
     with new_role(cql) as (role, key):
-        with new_dynamodb(dynamodb, role, key) as d, new_dynamodb_streams(dynamodb, role, key) as ds:
+        with (
+            new_dynamodb(dynamodb, role, key) as d,
+            new_dynamodb_streams(dynamodb, role, key) as ds,
+        ):
             # Allow the new role to create a table. The table created in the
             # new role should permission to work on it - in particular to
             # use the stream (GetRecords).
-            with temporary_grant(cql, 'CREATE', 'ALL KEYSPACES', role):
+            with temporary_grant(cql, "CREATE", "ALL KEYSPACES", role):
                 table_name = unique_table_name()
                 with new_named_table(d, table_name, **schema) as table:
                     if not during_creation:
                         authorized(lambda: table.update(**enable_stream))
                     streams = ds.list_streams(TableName=table.name)
-                    arn = streams['Streams'][0]['StreamArn']
+                    arn = streams["Streams"][0]["StreamArn"]
                     desc = ds.describe_stream(StreamArn=arn)
-                    shard_id = desc['StreamDescription']['Shards'][0]['ShardId']
-                    iter = ds.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']
+                    shard_id = desc["StreamDescription"]["Shards"][0]["ShardId"]
+                    iter = ds.get_shard_iterator(
+                        StreamArn=arn, ShardId=shard_id, ShardIteratorType="LATEST"
+                    )["ShardIterator"]
                     # Note: use low timeout to avoid slow xfail
-                    authorized(lambda: ds.get_records(ShardIterator=iter), timeout=3*permissions_validity_in_ms(cql))
+                    authorized(
+                        lambda: ds.get_records(ShardIterator=iter),
+                        timeout=3 * permissions_validity_in_ms(cql),
+                    )
+
 
 # Once autogrant works (tested in the above test, test_rbac_streams_autogrant)
 # we also need auto-revoke - i.e., when the stream is deleted the permissions
@@ -1060,18 +1425,22 @@ def test_rbac_streams_autogrant(dynamodb, cql, during_creation):
 # to read the new stream!
 def test_rbac_streams_autorevoke(dynamodb, cql):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }],
-        'StreamSpecification': {'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
+        "StreamSpecification": {"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"},
         # Work around issue #16137 that Alternator Streams doesn't work with
         # tablets. When that issue is solved, the following Tags should be
         # removed.
-        'Tags': [{'Key': 'system:initial_tablets', 'Value': 'none'}]
+        "Tags": [{"Key": "system:initial_tablets", "Value": "none"}],
     }
     table_name = unique_table_name()
     with new_role(cql) as (role1, key1), new_role(cql) as (role2, key2):
-        with new_dynamodb(dynamodb, role1, key1) as d1, new_dynamodb(dynamodb, role2, key2) as d2, new_dynamodb_streams(dynamodb, role1, key1) as ds1:
-            with temporary_grant(cql, 'CREATE', 'ALL KEYSPACES', role1):
+        with (
+            new_dynamodb(dynamodb, role1, key1) as d1,
+            new_dynamodb(dynamodb, role2, key2) as d2,
+            new_dynamodb_streams(dynamodb, role1, key1) as ds1,
+        ):
+            with temporary_grant(cql, "CREATE", "ALL KEYSPACES", role1):
                 with new_named_table(d1, table_name, **schema) as table:
                     # role1 created table_name, so autogrant will now give
                     # it permissions to read the table and the CDC log.
@@ -1080,18 +1449,21 @@ def test_rbac_streams_autorevoke(dynamodb, cql):
                     pass
                 # After role1 deleted the table table_name, let's have
                 # role2 create a table with the same name:
-                with temporary_grant(cql, 'CREATE', 'ALL KEYSPACES', role2):
+                with temporary_grant(cql, "CREATE", "ALL KEYSPACES", role2):
                     with new_named_table(d2, table_name, **schema) as table:
                         # At this point, the new table and its stream should
                         # be readable to role2 but NOT to role1. Let's check
                         # its indeed not reable to role1 (get_records will
                         # fail) - so auto-revoke worked:
                         streams = ds1.list_streams(TableName=table.name)
-                        arn = streams['Streams'][0]['StreamArn']
+                        arn = streams["Streams"][0]["StreamArn"]
                         desc = ds1.describe_stream(StreamArn=arn)
-                        shard_id = desc['StreamDescription']['Shards'][0]['ShardId']
-                        iter = ds1.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']
+                        shard_id = desc["StreamDescription"]["Shards"][0]["ShardId"]
+                        iter = ds1.get_shard_iterator(
+                            StreamArn=arn, ShardId=shard_id, ShardIteratorType="LATEST"
+                        )["ShardIterator"]
                         unauthorized(lambda: ds1.get_records(ShardIterator=iter))
+
 
 # Test that the ability to read from *any* system table through Alternator
 # requires permissions for this specific table. This is different from the
@@ -1105,15 +1477,16 @@ def test_rbac_system_table_read(dynamodb, cql):
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
             client = d.meta.client
-            internal_prefix = '.scylla.alternator.'
-            tbl1 = 'system_schema.tables'
+            internal_prefix = ".scylla.alternator."
+            tbl1 = "system_schema.tables"
             # Without SELECT permissions, reading from the system table will
             # fail:
-            unauthorized(lambda: client.scan(TableName=internal_prefix+tbl1))
+            unauthorized(lambda: client.scan(TableName=internal_prefix + tbl1))
             # Adding SELECT permissions on this specific system table, the
             # read will succeed:
-            with temporary_grant(cql, 'SELECT', tbl1, role):
-                authorized(lambda: client.scan(TableName=internal_prefix+tbl1))
+            with temporary_grant(cql, "SELECT", tbl1, role):
+                authorized(lambda: client.scan(TableName=internal_prefix + tbl1))
+
 
 # Test that the permissions checks for writing to system tables (as requested
 # in issue #12348) are stricter than reading: It's not enough that the user
@@ -1123,38 +1496,44 @@ def test_rbac_system_table_read(dynamodb, cql):
 # is able to turn itself into a superuser (by writing into the roles table)
 # and gain all other permissions.
 def test_rbac_system_table_write(dynamodb, cql, test_table_s):
-    config_table = dynamodb.Table('.scylla.alternator.system.config')
+    config_table = dynamodb.Table(".scylla.alternator.system.config")
     # We use the 'query_tombstone_page_limit' configuration option as
     # something we can harmlessly write to (if we write the same value as we
     # read). If in the future this configuration parameter is dropped, this
     # test should be changed to use a different option.
-    parameter = 'query_tombstone_page_limit'
+    parameter = "query_tombstone_page_limit"
     old_val = config_table.query(
-        KeyConditionExpression='#key=:val',
-        ExpressionAttributeNames={'#key': 'name'},
-        ExpressionAttributeValues={':val': parameter}
-        )['Items'][0]['value']
+        KeyConditionExpression="#key=:val",
+        ExpressionAttributeNames={"#key": "name"},
+        ExpressionAttributeValues={":val": parameter},
+    )["Items"][0]["value"]
     # Try to write to the system table using the superuser role "cql",
     # to skip the test if alternator_allow_system_table_write is false.
     try:
-        config_table.update_item(Key={'name': parameter},
-            UpdateExpression='SET #val = :val',
-            ExpressionAttributeNames={'#val': 'value'},
-            ExpressionAttributeValues={':val': old_val})
+        config_table.update_item(
+            Key={"name": parameter},
+            UpdateExpression="SET #val = :val",
+            ExpressionAttributeNames={"#val": "value"},
+            ExpressionAttributeValues={":val": old_val},
+        )
     except Exception as e:
-        if 'alternator_allow_system_table_write' in str(e):
-            pytest.skip('need alternator_allow_system_table_write=true')
+        if "alternator_allow_system_table_write" in str(e):
+            pytest.skip("need alternator_allow_system_table_write=true")
         else:
             raise
     with new_role(cql) as (role, key):
         with new_dynamodb(dynamodb, role, key) as d:
-            tbl1 = d.Table('.scylla.alternator.system.config')
+            tbl1 = d.Table(".scylla.alternator.system.config")
             # Without special permissions, writing the system table will
             # fail:
-            unauthorized(lambda: tbl1.update_item(Key={'name': parameter},
-                UpdateExpression='SET #val = :val',
-                ExpressionAttributeNames={'#val': 'value'},
-                ExpressionAttributeValues={':val': old_val}))
+            unauthorized(
+                lambda: tbl1.update_item(
+                    Key={"name": parameter},
+                    UpdateExpression="SET #val = :val",
+                    ExpressionAttributeNames={"#val": "value"},
+                    ExpressionAttributeValues={":val": old_val},
+                )
+            )
             # Adding MODIFY permissions on all keyspaces, the read write should
             # still fail because the user is not a superuser.
             # Because it takes time for the permission modification to take
@@ -1165,23 +1544,39 @@ def test_rbac_system_table_write(dynamodb, cql, test_table_s):
             # only then we can check that the write on the system table fails.
             tbl2 = d.Table(test_table_s.name)
             p = random_string()
-            unauthorized(lambda: tbl2.update_item(Key={'p': p},
-                UpdateExpression='SET #val = :val',
-                ExpressionAttributeNames={'#val': 'value'},
-                ExpressionAttributeValues={':val': old_val}))
-            with temporary_grant(cql, 'MODIFY', 'ALL KEYSPACES', role):
-                authorized(lambda: tbl2.update_item(Key={'p': p},
-                    UpdateExpression='SET #val = :val',
-                    ExpressionAttributeNames={'#val': 'value'},
-                    ExpressionAttributeValues={':val': old_val}))
-                unauthorized(lambda: tbl1.update_item(Key={'name': parameter},
-                    UpdateExpression='SET #val = :val',
-                    ExpressionAttributeNames={'#val': 'value'},
-                    ExpressionAttributeValues={':val': old_val}))
+            unauthorized(
+                lambda: tbl2.update_item(
+                    Key={"p": p},
+                    UpdateExpression="SET #val = :val",
+                    ExpressionAttributeNames={"#val": "value"},
+                    ExpressionAttributeValues={":val": old_val},
+                )
+            )
+            with temporary_grant(cql, "MODIFY", "ALL KEYSPACES", role):
+                authorized(
+                    lambda: tbl2.update_item(
+                        Key={"p": p},
+                        UpdateExpression="SET #val = :val",
+                        ExpressionAttributeNames={"#val": "value"},
+                        ExpressionAttributeValues={":val": old_val},
+                    )
+                )
+                unauthorized(
+                    lambda: tbl1.update_item(
+                        Key={"name": parameter},
+                        UpdateExpression="SET #val = :val",
+                        ExpressionAttributeNames={"#val": "value"},
+                        ExpressionAttributeValues={":val": old_val},
+                    )
+                )
             # Finally, if we make the role a superuser, the write to the
             # system table will succeed.
             cql.execute(f'ALTER ROLE "{role}" WITH SUPERUSER = true')
-            authorized(lambda: tbl1.update_item(Key={'name': parameter},
-                UpdateExpression='SET #val = :val',
-                ExpressionAttributeNames={'#val': 'value'},
-                ExpressionAttributeValues={':val': old_val}))
+            authorized(
+                lambda: tbl1.update_item(
+                    Key={"name": parameter},
+                    UpdateExpression="SET #val = :val",
+                    ExpressionAttributeNames={"#val": "value"},
+                    ExpressionAttributeValues={":val": old_val},
+                )
+            )

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -16,7 +16,19 @@ import pytest
 import time
 import itertools
 from botocore.exceptions import ClientError
-from .util import create_test_table, random_string, random_bytes, full_scan, full_query, multiset, list_tables, new_test_table, wait_for_gsi, unique_table_name
+from .util import (
+    create_test_table,
+    random_string,
+    random_bytes,
+    full_scan,
+    full_query,
+    multiset,
+    list_tables,
+    new_test_table,
+    wait_for_gsi,
+    unique_table_name,
+)
+
 
 # GSIs only support eventually consistent reads, so tests that involve
 # writing to a table and then expect to read something from it cannot be
@@ -35,107 +47,147 @@ from .util import create_test_table, random_string, random_bytes, full_scan, ful
 def assert_index_query(table, index_name, expected_items, **kwargs):
     expected = multiset(expected_items)
     for i in range(5):
-        got = multiset(full_query(table, IndexName=index_name, ConsistentRead=False, **kwargs))
+        got = multiset(
+            full_query(table, IndexName=index_name, ConsistentRead=False, **kwargs)
+        )
         if expected == got:
             return
         elif got - expected:
             # If we got any items that weren't expected, there's no point to retry.
-            pytest.fail("assert_index_query() found unexpected items: " + str(got - expected))
-        print('assert_index_query retrying')
+            pytest.fail(
+                "assert_index_query() found unexpected items: " + str(got - expected)
+            )
+        print("assert_index_query retrying")
         time.sleep(1)
-    assert multiset(expected_items) == multiset(full_query(table, IndexName=index_name, ConsistentRead=False, **kwargs))
+    assert multiset(expected_items) == multiset(
+        full_query(table, IndexName=index_name, ConsistentRead=False, **kwargs)
+    )
+
 
 def assert_index_scan(table, index_name, expected_items, **kwargs):
     expected = multiset(expected_items)
     for i in range(5):
-        got =  multiset(full_scan(table, IndexName=index_name, ConsistentRead=False, **kwargs))
+        got = multiset(
+            full_scan(table, IndexName=index_name, ConsistentRead=False, **kwargs)
+        )
         if expected == got:
             return
         elif got - expected:
             # If we got any items that weren't expected, there's no point to retry.
-            pytest.fail("assert_index_scan() found unexpected items: " + str(got - expected))
-        print('assert_index_scan retrying')
+            pytest.fail(
+                "assert_index_scan() found unexpected items: " + str(got - expected)
+            )
+        print("assert_index_scan retrying")
         time.sleep(1)
-    assert multiset(expected_items) == multiset(full_scan(table, IndexName=index_name, ConsistentRead=False, **kwargs))
+    assert multiset(expected_items) == multiset(
+        full_scan(table, IndexName=index_name, ConsistentRead=False, **kwargs)
+    )
+
 
 # Although quite silly, it is actually allowed to create an index which is
 # identical to the base table.
 # The following test does not work for KA/LA tables due to #6157, but we
 # no longer allow writing those in Scylla.
 def test_gsi_identical(dynamodb):
-    with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
-            GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }
-            ]) as table:
-        items = [{'p': random_string(), 'x': random_string()} for i in range(10)]
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "hello",
+                "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    ) as table:
+        items = [{"p": random_string(), "x": random_string()} for i in range(10)]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
         # Scanning the entire table directly or via the index yields the same
         # results (in different order).
         assert multiset(items) == multiset(full_scan(table))
-        assert_index_scan(table, 'hello', items)
+        assert_index_scan(table, "hello", items)
         # We can't scan a non-existent index
-        with pytest.raises(ClientError, match='ValidationException'):
-            full_scan(table, ConsistentRead=False, IndexName='wrong')
+        with pytest.raises(ClientError, match="ValidationException"):
+            full_scan(table, ConsistentRead=False, IndexName="wrong")
+
 
 # One of the simplest forms of a non-trivial GSI: The base table has a hash
 # and sort key, and the index reverses those roles. Other attributes are just
 # copied.
 @pytest.fixture(scope="module")
 def test_table_gsi_1(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'c', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'p', 'KeyType': 'RANGE' },
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "c", "KeyType": "HASH"},
+                    {"AttributeName": "p", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
         ],
-        )
+    )
     yield table
     table.delete()
 
+
 def test_gsi_simple(test_table_gsi_1):
-    items = [{'p': random_string(), 'c': random_string(), 'x': random_string()} for i in range(10)]
+    items = [
+        {"p": random_string(), "c": random_string(), "x": random_string()}
+        for i in range(10)
+    ]
     with test_table_gsi_1.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    c = items[0]['c']
+    c = items[0]["c"]
     # The index allows a query on just a specific sort key, which isn't
     # allowed on the base table.
-    with pytest.raises(ClientError, match='ValidationException'):
-        full_query(test_table_gsi_1, KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
-    expected_items = [x for x in items if x['c'] == c]
-    assert_index_query(test_table_gsi_1, 'hello', expected_items,
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
+    with pytest.raises(ClientError, match="ValidationException"):
+        full_query(
+            test_table_gsi_1,
+            KeyConditions={
+                "c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}
+            },
+        )
+    expected_items = [x for x in items if x["c"] == c]
+    assert_index_query(
+        test_table_gsi_1,
+        "hello",
+        expected_items,
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
     # Scanning the entire table directly or via the index yields the same
     # results (in different order).
-    assert_index_scan(test_table_gsi_1, 'hello', full_scan(test_table_gsi_1))
+    assert_index_scan(test_table_gsi_1, "hello", full_scan(test_table_gsi_1))
+
 
 def test_gsi_same_key(test_table_gsi_1):
-    c = random_string();
+    c = random_string()
     # All these items have the same sort key 'c' but different hash key 'p'
-    items = [{'p': random_string(), 'c': c, 'x': random_string()} for i in range(10)]
+    items = [{"p": random_string(), "c": c, "x": random_string()} for i in range(10)]
     with test_table_gsi_1.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    assert_index_query(test_table_gsi_1, 'hello', items,
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_1,
+        "hello",
+        items,
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
+
 
 # Check we get an appropriate error when trying to read a non-existing index
 # of an existing table. Although the documentation specifies that a
@@ -143,26 +195,47 @@ def test_gsi_same_key(test_table_gsi_1):
 # access a nonexistent table or index", in fact in the specific case that
 # the table does exist but an index does not - we get a ValidationException.
 def test_gsi_missing_index(test_table_gsi_1):
-    with pytest.raises(ClientError, match='ValidationException.*wrong_name'):
-        full_query(test_table_gsi_1, IndexName='wrong_name',
-            KeyConditions={'x': {'AttributeValueList': [1], 'ComparisonOperator': 'EQ'}})
-    with pytest.raises(ClientError, match='ValidationException.*wrong_name'):
-        full_scan(test_table_gsi_1, IndexName='wrong_name')
+    with pytest.raises(ClientError, match="ValidationException.*wrong_name"):
+        full_query(
+            test_table_gsi_1,
+            IndexName="wrong_name",
+            KeyConditions={
+                "x": {"AttributeValueList": [1], "ComparisonOperator": "EQ"}
+            },
+        )
+    with pytest.raises(ClientError, match="ValidationException.*wrong_name"):
+        full_scan(test_table_gsi_1, IndexName="wrong_name")
+
 
 # Nevertheless, if the table itself does not exist, a query should return
 # a ResourceNotFoundException, not ValidationException:
 def test_gsi_missing_table(dynamodb):
-    with pytest.raises(ClientError, match='ResourceNotFoundException'):
-        dynamodb.meta.client.query(TableName='nonexistent_table', IndexName='any_name', KeyConditions={'x': {'AttributeValueList': [1], 'ComparisonOperator': 'EQ'}})
-    with pytest.raises(ClientError, match='ResourceNotFoundException'):
-        dynamodb.meta.client.scan(TableName='nonexistent_table', IndexName='any_name')
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
+        dynamodb.meta.client.query(
+            TableName="nonexistent_table",
+            IndexName="any_name",
+            KeyConditions={
+                "x": {"AttributeValueList": [1], "ComparisonOperator": "EQ"}
+            },
+        )
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
+        dynamodb.meta.client.scan(TableName="nonexistent_table", IndexName="any_name")
+
 
 # Verify that strongly-consistent reads on GSI are *not* allowed.
 def test_gsi_strong_consistency(test_table_gsi_1):
-    with pytest.raises(ClientError, match='ValidationException.*Consistent'):
-        full_query(test_table_gsi_1, KeyConditions={'c': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}, IndexName='hello', ConsistentRead=True)
-    with pytest.raises(ClientError, match='ValidationException.*Consistent'):
-        full_scan(test_table_gsi_1, IndexName='hello', ConsistentRead=True)
+    with pytest.raises(ClientError, match="ValidationException.*Consistent"):
+        full_query(
+            test_table_gsi_1,
+            KeyConditions={
+                "c": {"AttributeValueList": ["hi"], "ComparisonOperator": "EQ"}
+            },
+            IndexName="hello",
+            ConsistentRead=True,
+        )
+    with pytest.raises(ClientError, match="ValidationException.*Consistent"):
+        full_scan(test_table_gsi_1, IndexName="hello", ConsistentRead=True)
+
 
 # Test that setting an indexed string column to an empty string is illegal,
 # since keys cannot contain empty strings
@@ -171,30 +244,46 @@ def test_gsi_strong_consistency(test_table_gsi_1):
 # code paths.
 def test_gsi_empty_value(test_table_gsi_2):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_gsi_2.put_item(Item={'p': p, 'x': ''})
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'x': {'Value': '', 'Action': 'PUT'}})
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_gsi_2.put_item(Item={"p": p, "x": ""})
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_gsi_2.update_item(
+            Key={"p": p}, AttributeUpdates={"x": {"Value": "", "Action": "PUT"}}
+        )
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
         with test_table_gsi_2.batch_writer() as batch:
-            batch.put_item({'p': p, 'x': ''})
+            batch.put_item({"p": p, "x": ""})
+
 
 def test_gsi_empty_value_with_range_key(test_table_gsi_3):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_gsi_3.put_item(Item={'p': p, 'a': '', 'b': p})
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_gsi_3.put_item(Item={'p': p, 'a': p, 'b': ''})
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': '', 'Action': 'PUT'}, 'b': {'Value': p, 'Action': 'PUT'}})
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': p, 'Action': 'PUT'}, 'b': {'Value': '', 'Action': 'PUT'}})
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_gsi_3.put_item(Item={"p": p, "a": "", "b": p})
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_gsi_3.put_item(Item={"p": p, "a": p, "b": ""})
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_gsi_3.update_item(
+            Key={"p": p},
+            AttributeUpdates={
+                "a": {"Value": "", "Action": "PUT"},
+                "b": {"Value": p, "Action": "PUT"},
+            },
+        )
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_gsi_3.update_item(
+            Key={"p": p},
+            AttributeUpdates={
+                "a": {"Value": p, "Action": "PUT"},
+                "b": {"Value": "", "Action": "PUT"},
+            },
+        )
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
         with test_table_gsi_3.batch_writer() as batch:
-            batch.put_item({'p': p, 'a': '', 'b': p})
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
+            batch.put_item({"p": p, "a": "", "b": p})
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
         with test_table_gsi_3.batch_writer() as batch:
-            batch.put_item({'p': p, 'a': p, 'b': ''})
+            batch.put_item({"p": p, "a": p, "b": ""})
+
 
 # In test_gsi_empty_value we validated that writing an empty string to
 # column that is a GSI key fails. We also checked BatchWriteItem. Let's
@@ -204,58 +293,80 @@ def test_gsi_empty_value_in_bigger_batch_write(test_table_gsi_2):
     p1 = random_string()
     p2 = random_string()
     p3 = random_string()
-    items = [{'p': p1, 'x': p1}, {'p': p2, 'x': ''}, {'p': p3, 'x': p3}]
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
+    items = [{"p": p1, "x": p1}, {"p": p2, "x": ""}, {"p": p3, "x": p3}]
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
         with test_table_gsi_2.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
     for p in [p1, p2, p3]:
-        assert not 'Item' in test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)
+        assert not "Item" in test_table_gsi_2.get_item(
+            Key={"p": p}, ConsistentRead=True
+        )
+
 
 # Dynamodb supports special way of setting NULL value.
 # It's different than non existing value.
 def test_gsi_null_value(test_table_gsi_2):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
-        test_table_gsi_2.put_item(Item={'p': p, 'x': None})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
-        test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'x': {'Value': None, 'Action': 'PUT'}})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
+        test_table_gsi_2.put_item(Item={"p": p, "x": None})
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
+        test_table_gsi_2.update_item(
+            Key={"p": p}, AttributeUpdates={"x": {"Value": None, "Action": "PUT"}}
+        )
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
         with test_table_gsi_2.batch_writer() as batch:
-            batch.put_item({'p': p, 'x': None})
+            batch.put_item({"p": p, "x": None})
+
 
 def test_gsi_null_value_with_range_key(test_table_gsi_3):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
-        test_table_gsi_3.put_item(Item={'p': p, 'a': None, 'b': p})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
-        test_table_gsi_3.put_item(Item={'p': p, 'a': p, 'b': None})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
-        test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': None, 'Action': 'PUT'}, 'b': {'Value': p, 'Action': 'PUT'}})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
-        test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': p, 'Action': 'PUT'}, 'b': {'Value': None, 'Action': 'PUT'}})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
+        test_table_gsi_3.put_item(Item={"p": p, "a": None, "b": p})
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
+        test_table_gsi_3.put_item(Item={"p": p, "a": p, "b": None})
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
+        test_table_gsi_3.update_item(
+            Key={"p": p},
+            AttributeUpdates={
+                "a": {"Value": None, "Action": "PUT"},
+                "b": {"Value": p, "Action": "PUT"},
+            },
+        )
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
+        test_table_gsi_3.update_item(
+            Key={"p": p},
+            AttributeUpdates={
+                "a": {"Value": p, "Action": "PUT"},
+                "b": {"Value": None, "Action": "PUT"},
+            },
+        )
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
         with test_table_gsi_3.batch_writer() as batch:
-            batch.put_item({'p': p, 'a': None, 'b': p})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
+            batch.put_item({"p": p, "a": None, "b": p})
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
         with test_table_gsi_3.batch_writer() as batch:
-            batch.put_item({'p': p, 'a': p, 'b': None})
+            batch.put_item({"p": p, "a": p, "b": None})
+
 
 # Verify that a GSI is correctly listed in describe_table
 def test_gsi_describe(test_table_gsi_1):
     desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)
-    assert 'Table' in desc
-    assert 'GlobalSecondaryIndexes' in desc['Table']
-    gsis = desc['Table']['GlobalSecondaryIndexes']
+    assert "Table" in desc
+    assert "GlobalSecondaryIndexes" in desc["Table"]
+    gsis = desc["Table"]["GlobalSecondaryIndexes"]
     assert len(gsis) == 1
     gsi = gsis[0]
-    assert gsi['IndexName'] == 'hello'
-    assert gsi['Projection'] == {'ProjectionType': 'ALL'}
-    assert gsi['KeySchema'] == [{'KeyType': 'HASH', 'AttributeName': 'c'},
-                                {'KeyType': 'RANGE', 'AttributeName': 'p'}]
+    assert gsi["IndexName"] == "hello"
+    assert gsi["Projection"] == {"ProjectionType": "ALL"}
+    assert gsi["KeySchema"] == [
+        {"KeyType": "HASH", "AttributeName": "c"},
+        {"KeyType": "RANGE", "AttributeName": "p"},
+    ]
     # The index's ARN should look like the table's ARN followed by /index/<indexname>.
-    assert gsi['IndexArn'] == desc['Table']['TableArn'] + '/index/hello'
+    assert gsi["IndexArn"] == desc["Table"]["TableArn"] + "/index/hello"
     # TODO: check also ProvisionedThroughput
+
 
 # Test that an already-existing GSI should be listed by DescribeTable with
 # IndexStatus=ACTIVE. A GSI that was just created with UpdateTable and being
@@ -271,39 +382,47 @@ def test_gsi_describe_indexstatus(test_table_gsi_1):
     # So let's wait_for_gsi() just to be sure the view building is over.
     # Note that this makes the explicit IndexStatus check below redundant,
     # because wait_for_gsi() already does it..
-    wait_for_gsi(test_table_gsi_1, 'hello')
+    wait_for_gsi(test_table_gsi_1, "hello")
     desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)
-    gsis = desc['Table']['GlobalSecondaryIndexes']
+    gsis = desc["Table"]["GlobalSecondaryIndexes"]
     assert len(gsis) == 1
     gsi = gsis[0]
-    assert 'IndexStatus' in gsi
-    assert gsi['IndexStatus'] == 'ACTIVE'
+    assert "IndexStatus" in gsi
+    assert gsi["IndexStatus"] == "ACTIVE"
+
 
 # In addition to the basic listing of an GSI in DescribeTable tested above,
 # in this test we check additional fields that should appear in each GSI's
 # description.
-@pytest.mark.xfail(reason="issues #7550, #11466")
+@pytest.mark.xfail(
+    reason="Alternator: missing ItemCount field in return of DescribeTable #7550, Alternator: missing IndexSizeBytes field in return of DescribeTable #11466"
+)
 def test_gsi_describe_fields(test_table_gsi_1):
     desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)
-    gsis = desc['Table']['GlobalSecondaryIndexes']
+    gsis = desc["Table"]["GlobalSecondaryIndexes"]
     assert len(gsis) == 1
     gsi = gsis[0]
-    assert 'IndexSizeBytes' in gsi    # actual size depends on content
-    assert 'ItemCount' in gsi
+    assert "IndexSizeBytes" in gsi  # actual size depends on content
+    assert "ItemCount" in gsi
+
 
 # When a GSI's key includes an attribute not in the base table's key, we
 # need to remember to add its type to AttributeDefinitions.
 def test_gsi_missing_attribute_definition(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*AttributeDefinitions'):
-        create_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ],
+    with pytest.raises(ClientError, match="ValidationException.*AttributeDefinitions"):
+        create_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [ { 'AttributeName': 'c', 'KeyType': 'HASH' } ],
-                    'Projection': { 'ProjectionType': 'ALL' }
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [{"AttributeName": "c", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
                 }
-            ])
+            ],
+        )
+
 
 # test_table_gsi_1_hash_only is a variant of test_table_gsi_1: It's another
 # case where the index doesn't involve non-key attributes. Again the base
@@ -313,85 +432,115 @@ def test_gsi_missing_attribute_definition(dynamodb):
 # clustering key.
 @pytest.fixture(scope="module")
 def test_table_gsi_1_hash_only(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'c', 'KeyType': 'HASH' },
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "c", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
         ],
-        )
+    )
     yield table
     table.delete()
 
+
 def test_gsi_key_not_in_index(test_table_gsi_1_hash_only):
     # Test with items with different 'c' values:
-    items = [{'p': random_string(), 'c': random_string(), 'x': random_string()} for i in range(10)]
+    items = [
+        {"p": random_string(), "c": random_string(), "x": random_string()}
+        for i in range(10)
+    ]
     with test_table_gsi_1_hash_only.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    c = items[0]['c']
-    expected_items = [x for x in items if x['c'] == c]
-    assert_index_query(test_table_gsi_1_hash_only, 'hello', expected_items,
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
+    c = items[0]["c"]
+    expected_items = [x for x in items if x["c"] == c]
+    assert_index_query(
+        test_table_gsi_1_hash_only,
+        "hello",
+        expected_items,
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
     # Test items with the same sort key 'c' but different hash key 'p'
-    c = random_string();
-    items = [{'p': random_string(), 'c': c, 'x': random_string()} for i in range(10)]
+    c = random_string()
+    items = [{"p": random_string(), "c": c, "x": random_string()} for i in range(10)]
     with test_table_gsi_1_hash_only.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    assert_index_query(test_table_gsi_1_hash_only, 'hello', items,
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_1_hash_only,
+        "hello",
+        items,
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
     # Scanning the entire table directly or via the index yields the same
     # results (in different order).
-    assert_index_scan(test_table_gsi_1_hash_only, 'hello', full_scan(test_table_gsi_1_hash_only))
+    assert_index_scan(
+        test_table_gsi_1_hash_only, "hello", full_scan(test_table_gsi_1_hash_only)
+    )
 
 
 # A second scenario of GSI. Base table has just hash key, Index has a
 # different hash key - one of the non-key attributes from the base table.
 @pytest.fixture(scope="module")
 def test_table_gsi_2(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ])
+        ],
+    )
     yield table
     table.delete()
 
+
 def test_gsi_2(test_table_gsi_2):
-    items1 = [{'p': random_string(), 'x': random_string()} for i in range(10)]
-    x1 = items1[0]['x']
+    items1 = [{"p": random_string(), "x": random_string()} for i in range(10)]
+    x1 = items1[0]["x"]
     x2 = random_string()
-    items2 = [{'p': random_string(), 'x': x2} for i in range(10)]
+    items2 = [{"p": random_string(), "x": x2} for i in range(10)]
     items = items1 + items2
     with test_table_gsi_2.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    expected_items = [i for i in items if i['x'] == x1]
-    assert_index_query(test_table_gsi_2, 'hello', expected_items,
-        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
-    expected_items = [i for i in items if i['x'] == x2]
-    assert_index_query(test_table_gsi_2, 'hello', expected_items,
-        KeyConditions={'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
+    expected_items = [i for i in items if i["x"] == x1]
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        expected_items,
+        KeyConditions={"x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"}},
+    )
+    expected_items = [i for i in items if i["x"] == x2]
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        expected_items,
+        KeyConditions={"x": {"AttributeValueList": [x2], "ComparisonOperator": "EQ"}},
+    )
+
 
 # The previous tests just need to create rows in the materialized view.
 # This test adds more elaborate operations which need to create new rows,
@@ -407,44 +556,85 @@ def test_update_gsi_pk(test_table_gsi_2):
     z = random_string()
 
     # Create a new GSI row (x1), see that it appears
-    test_table_gsi_2.put_item(Item={'p': p, 'x': x1, 'y': y, 'z': z})
-    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x1, 'y': y, 'z': z}],
-        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_2.put_item(Item={"p": p, "x": x1, "y": y, "z": z})
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [{"p": p, "x": x1, "y": y, "z": z}],
+        KeyConditions={"x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"}},
+    )
 
     # Update only the unrelated attribute y. Should leave the same row in
     # the GSI (x=x1), just with a modified y (and unmodified z)
     y = random_string()
-    test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'y': {'Value': y, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x1, 'y': y, 'z': z}],
-        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_2.update_item(
+        Key={"p": p}, AttributeUpdates={"y": {"Value": y, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [{"p": p, "x": x1, "y": y, "z": z}],
+        KeyConditions={"x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"}},
+    )
 
     # Update the GSI's key attribute x to x2. The old row (x=x1) should
     # disappear from the GSI, and the new row (x=x2) should appear, with the
     # base row's "y" and "z" value that weren't changed in this update.
     x2 = random_string()
-    test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'x': {'Value': x2, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_2, 'hello', [],
-        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x2, 'y': y, 'z': z}],
-        KeyConditions={'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_2.update_item(
+        Key={"p": p}, AttributeUpdates={"x": {"Value": x2, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [],
+        KeyConditions={"x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"}},
+    )
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [{"p": p, "x": x2, "y": y, "z": z}],
+        KeyConditions={"x": {"AttributeValueList": [x2], "ComparisonOperator": "EQ"}},
+    )
 
     # Delete only the attribute x from our base-table row. The row should
     # remain in the table (with no x), but disappear from the view
-    test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'x': {'Action': 'DELETE'}})
-    assert test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, 'y': y, 'z': z}
-    assert_index_query(test_table_gsi_2, 'hello', [],
-        KeyConditions={'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_2.update_item(
+        Key={"p": p}, AttributeUpdates={"x": {"Action": "DELETE"}}
+    )
+    assert test_table_gsi_2.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        "y": y,
+        "z": z,
+    }
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [],
+        KeyConditions={"x": {"AttributeValueList": [x2], "ComparisonOperator": "EQ"}},
+    )
 
     # Set x again to x1, see the view item re-appears in the view:
-    test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'x': {'Value': x1, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x1, 'y': y, 'z': z}],
-        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_2.update_item(
+        Key={"p": p}, AttributeUpdates={"x": {"Value": x1, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [{"p": p, "x": x1, "y": y, "z": z}],
+        KeyConditions={"x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"}},
+    )
 
     # Delete the entire item in the base table, the view row should also
     # disappear
-    test_table_gsi_2.delete_item(Key={'p': p})
-    assert_index_query(test_table_gsi_2, 'hello', [],
-        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_2.delete_item(Key={"p": p})
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [],
+        KeyConditions={"x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"}},
+    )
+
 
 # Similar to the previous test (test_update_gsi_pk) except that the base's
 # non-key attribute is here a clustering key (sort key).
@@ -456,92 +646,157 @@ def test_update_gsi_ck(test_table_gsi_5):
     z = random_string()
 
     # Create a new GSI row (x1), see that it appears
-    test_table_gsi_5.put_item(Item={'p': p, 'c': c, 'x': x1, 'y': y, 'z': z})
-    assert_index_query(test_table_gsi_5, 'hello', [{'p': p, 'c': c, 'x': x1, 'y': y, 'z': z}],
+    test_table_gsi_5.put_item(Item={"p": p, "c": c, "x": x1, "y": y, "z": z})
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [{"p": p, "c": c, "x": x1, "y": y, "z": z}],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"},
+        },
+    )
 
     # Update only the unrelated attribute y. Should leave the same row in
     # the GSI (x=x1), just with a modified y (and unmodified z)
     y = random_string()
-    test_table_gsi_5.update_item(Key={'p': p, 'c': c}, AttributeUpdates={'y': {'Value': y, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_5, 'hello', [{'p': p, 'c': c, 'x': x1, 'y': y, 'z': z}],
+    test_table_gsi_5.update_item(
+        Key={"p": p, "c": c}, AttributeUpdates={"y": {"Value": y, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [{"p": p, "c": c, "x": x1, "y": y, "z": z}],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"},
+        },
+    )
 
     # Update the GSI's key attribute x to x2. The old row (x=x1) should
     # disappear from the GSI, and the new row (x=x2) should appear, with the
     # base row's "y" and "z" value that weren't changed in this update.
     x2 = random_string()
-    test_table_gsi_5.update_item(Key={'p': p, 'c': c}, AttributeUpdates={'x': {'Value': x2, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_5, 'hello', [],
+    test_table_gsi_5.update_item(
+        Key={"p": p, "c": c}, AttributeUpdates={"x": {"Value": x2, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_5, 'hello', [{'p': p, 'c': c, 'x': x2, 'y': y, 'z': z}],
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [{"p": p, "c": c, "x": x2, "y": y, "z": z}],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x2], "ComparisonOperator": "EQ"},
+        },
+    )
 
     # Delete only the attribute x from our base-table row. The row should
     # remain in the table (with no x), but disappear from the view
-    test_table_gsi_5.update_item(Key={'p': p, 'c': c}, AttributeUpdates={'x': {'Action': 'DELETE'}})
-    assert test_table_gsi_5.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)['Item'] == {'p': p, 'c': c, 'y': y, 'z': z}
-    assert_index_query(test_table_gsi_5, 'hello', [],
+    test_table_gsi_5.update_item(
+        Key={"p": p, "c": c}, AttributeUpdates={"x": {"Action": "DELETE"}}
+    )
+    assert test_table_gsi_5.get_item(Key={"p": p, "c": c}, ConsistentRead=True)[
+        "Item"
+    ] == {"p": p, "c": c, "y": y, "z": z}
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x2], "ComparisonOperator": "EQ"},
+        },
+    )
 
     # Set x again to x1, see the view item re-appears in the view:
-    test_table_gsi_5.update_item(Key={'p': p, 'c': c}, AttributeUpdates={'x': {'Value': x1, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_5, 'hello', [{'p': p, 'c': c, 'x': x1, 'y': y, 'z': z}],
+    test_table_gsi_5.update_item(
+        Key={"p": p, "c": c}, AttributeUpdates={"x": {"Value": x1, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [{"p": p, "c": c, "x": x1, "y": y, "z": z}],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"},
+        },
+    )
 
     # Delete the entire item in the base table, the view row should also
     # disappear
-    test_table_gsi_5.delete_item(Key={'p': p, 'c': c})
-    assert_index_query(test_table_gsi_5, 'hello', [],
+    test_table_gsi_5.delete_item(Key={"p": p, "c": c})
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # Test that when a table has a GSI, if the indexed attribute is missing, the
 # item is added to the base table but not the index.
-@pytest.mark.parametrize('op', ['PutItem', 'UpdateItem', 'BatchWriteItem'])
+@pytest.mark.parametrize("op", ["PutItem", "UpdateItem", "BatchWriteItem"])
 def test_gsi_missing_attribute(test_table_gsi_2, op):
     p1 = random_string()
     x1 = random_string()
     p2 = random_string()
-    if op == 'PutItem':
-        test_table_gsi_2.put_item(Item={'p':  p1, 'x': x1})
-        test_table_gsi_2.put_item(Item={'p':  p2})
-    elif op == 'UpdateItem':
-        test_table_gsi_2.update_item(Key={'p':  p1}, AttributeUpdates={'x': {'Value': x1, 'Action': 'PUT'}})
-        test_table_gsi_2.update_item(Key={'p':  p2}, AttributeUpdates={})
-    elif op == 'BatchWriteItem':
+    if op == "PutItem":
+        test_table_gsi_2.put_item(Item={"p": p1, "x": x1})
+        test_table_gsi_2.put_item(Item={"p": p2})
+    elif op == "UpdateItem":
+        test_table_gsi_2.update_item(
+            Key={"p": p1}, AttributeUpdates={"x": {"Value": x1, "Action": "PUT"}}
+        )
+        test_table_gsi_2.update_item(Key={"p": p2}, AttributeUpdates={})
+    elif op == "BatchWriteItem":
         with test_table_gsi_2.batch_writer() as batch:
-            batch.put_item(Item={'p':  p1, 'x': x1})
-            batch.put_item(Item={'p':  p2})
+            batch.put_item(Item={"p": p1, "x": x1})
+            batch.put_item(Item={"p": p2})
 
     # Both items are now in the base table:
-    assert test_table_gsi_2.get_item(Key={'p':  p1}, ConsistentRead=True)['Item'] == {'p': p1, 'x': x1}
-    assert test_table_gsi_2.get_item(Key={'p':  p2}, ConsistentRead=True)['Item'] == {'p': p2}
+    assert test_table_gsi_2.get_item(Key={"p": p1}, ConsistentRead=True)["Item"] == {
+        "p": p1,
+        "x": x1,
+    }
+    assert test_table_gsi_2.get_item(Key={"p": p2}, ConsistentRead=True)["Item"] == {
+        "p": p2
+    }
 
     # But only the first item is in the index: It can be found using a
     # Query, and a scan of the index won't find it (but a scan on the base
     # will).
-    assert_index_query(test_table_gsi_2, 'hello', [{'p': p1, 'x': x1}],
-        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
-    assert any([i['p'] == p1 for i in full_scan(test_table_gsi_2)])
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [{"p": p1, "x": x1}],
+        KeyConditions={"x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"}},
+    )
+    assert any([i["p"] == p1 for i in full_scan(test_table_gsi_2)])
     # Note: with eventually consistent read, we can't really be sure that
     # and item will "never" appear in the index. We do this test last,
     # so if we had a bug and such item did appear, hopefully we had enough
     # time for the bug to become visible. At least sometimes.
-    assert not any([i['p'] == p2 for i in full_scan(test_table_gsi_2, ConsistentRead=False, IndexName='hello')])
+    assert not any(
+        [
+            i["p"] == p2
+            for i in full_scan(
+                test_table_gsi_2, ConsistentRead=False, IndexName="hello"
+            )
+        ]
+    )
+
 
 # Test when a table has a GSI, if the indexed attribute has the wrong type,
 # the update operation is rejected, and is added to neither base table nor
@@ -553,28 +808,36 @@ def test_gsi_wrong_type_attribute_put(test_table_gsi_2):
     # PutItem with wrong type for 'x' is rejected, item isn't created even
     # in the base table.
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_2.put_item(Item={'p':  p, 'x': 3})
-    assert not 'Item' in test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_2.put_item(Item={"p": p, "x": 3})
+    assert not "Item" in test_table_gsi_2.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 def test_gsi_wrong_type_attribute_update(test_table_gsi_2):
     # An UpdateItem with wrong type for 'x' is also rejected, but naturally
     # if the item already existed, it remains as it was.
     p = random_string()
     x = random_string()
-    test_table_gsi_2.put_item(Item={'p':  p, 'x': x})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_2.update_item(Key={'p':  p}, AttributeUpdates={'x': {'Value': 3, 'Action': 'PUT'}})
-    assert test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, 'x': x}
+    test_table_gsi_2.put_item(Item={"p": p, "x": x})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_2.update_item(
+            Key={"p": p}, AttributeUpdates={"x": {"Value": 3, "Action": "PUT"}}
+        )
+    assert test_table_gsi_2.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        "x": x,
+    }
+
 
 def test_gsi_wrong_type_attribute_batchwrite(test_table_gsi_2):
     # BatchWriteItem with wrong type for 'x' is rejected, item isn't created
     # even in the base table.
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
         with test_table_gsi_2.batch_writer() as batch:
-            batch.put_item({'p':  p, 'x': 3})
-    assert not 'Item' in test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)
+            batch.put_item({"p": p, "x": 3})
+    assert not "Item" in test_table_gsi_2.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 # Since a GSI key x cannot be a map or an array, in particular updates to
 # nested attributes like x.y or x[1] are not legal. The error that DynamoDB
@@ -583,22 +846,29 @@ def test_gsi_wrong_type_attribute_batchwrite(test_table_gsi_2):
 def test_gsi_wrong_type_attribute_update_nested(test_table_gsi_2):
     p = random_string()
     x = random_string()
-    test_table_gsi_2.put_item(Item={'p':  p, 'x': x})
+    test_table_gsi_2.put_item(Item={"p": p, "x": x})
     # We can't write a map into a GSI key column, which in this case can only
     # be a string and in any case can never be a map. DynamoDB and Alternator
     # both report a "type mismatch" error, exactly like in the test
     # test_gsi_wrong_type_attribute_update.
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_2.update_item(Key={'p': p}, UpdateExpression='SET x = :val1',
-            ExpressionAttributeValues={':val1': {'a': 3, 'b': 4}})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_2.update_item(
+            Key={"p": p},
+            UpdateExpression="SET x = :val1",
+            ExpressionAttributeValues={":val1": {"a": 3, "b": 4}},
+        )
     # Here we try to set x.y for the GSI key column x. Here DynamoDB and
     # Alternator produce different error messages - but both make sense.
     # DynamoDB says "Key attributes must be scalars; list random access '[]'
     # and map # lookup '.' are not allowed: IndexKey: x", while Alternator
     # complains that "document paths not valid for this item: x.y".
-    with pytest.raises(ClientError, match='ValidationException'):
-        test_table_gsi_2.update_item(Key={'p': p}, UpdateExpression='SET x.y = :val1',
-            ExpressionAttributeValues={':val1': 3})
+    with pytest.raises(ClientError, match="ValidationException"):
+        test_table_gsi_2.update_item(
+            Key={"p": p},
+            UpdateExpression="SET x.y = :val1",
+            ExpressionAttributeValues={":val1": 3},
+        )
+
 
 def test_gsi_wrong_type_attribute_batch(test_table_gsi_2):
     # In a BatchWriteItem, if any update is forbidden, the entire batch is
@@ -606,15 +876,20 @@ def test_gsi_wrong_type_attribute_batch(test_table_gsi_2):
     p1 = random_string()
     p2 = random_string()
     p3 = random_string()
-    items = [{'p': p1, 'x': random_string()},
-             {'p': p2, 'x': 3},
-             {'p': p3, 'x': random_string()}]
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
+    items = [
+        {"p": p1, "x": random_string()},
+        {"p": p2, "x": 3},
+        {"p": p3, "x": random_string()},
+    ]
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
         with test_table_gsi_2.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
     for p in [p1, p2, p3]:
-        assert not 'Item' in test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)
+        assert not "Item" in test_table_gsi_2.get_item(
+            Key={"p": p}, ConsistentRead=True
+        )
+
 
 # Test when a table has a GSI, if the indexed attribute is a partition key
 # in the GSI and its value is 2048 bytes, the update operation is rejected,
@@ -625,22 +900,28 @@ def test_gsi_wrong_type_attribute_batch(test_table_gsi_2):
 # a pre-existing table. In that case we can't reject the base-table update
 # because the oversized attribute is already there - but can just drop this
 # item from the GSI.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_gsi_limit_partition_key_len_2048(test_table_gsi_2):
     # A value for 'x' (the GSI's partition key) of length 2048 is fine:
     p = random_string()
-    x = 'a'*2048
-    test_table_gsi_2.put_item(Item={'p': p, 'x': x})
-    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x}],
-        KeyConditions={
-            'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    x = "a" * 2048
+    test_table_gsi_2.put_item(Item={"p": p, "x": x})
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [{"p": p, "x": x}],
+        KeyConditions={"x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}},
+    )
     # PutItem with oversized for 'x' is rejected, item isn't created even
     # in the base table.
     p = random_string()
-    x = 'a'*2049
-    with pytest.raises(ClientError, match='ValidationException.*2048'):
-        test_table_gsi_2.put_item(Item={'p':  p, 'x': x})
-    assert not 'Item' in test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)
+    x = "a" * 2049
+    with pytest.raises(ClientError, match="ValidationException.*2048"):
+        test_table_gsi_2.put_item(Item={"p": p, "x": x})
+    assert not "Item" in test_table_gsi_2.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 # This is a variant of the above test, where we don't insist that the
 # partition key length limit must be exactly 2048 bytes as in DynamoDB,
@@ -651,15 +932,20 @@ def test_gsi_limit_partition_key_len_2048(test_table_gsi_2):
 # should pass even if Alternator decides to adopt a different key length
 # limits from DynamoDB. We do have to adopt *some* limit because the
 # internal Scylla implementation has a 64 KB limit on key lengths.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_gsi_limit_partition_key_len(test_table_gsi_2):
     # A value for 'x' (the GSI's partition key) of length 2048 is fine:
     p = random_string()
-    x = 'a'*2048
-    test_table_gsi_2.put_item(Item={'p': p, 'x': x})
-    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x}],
-        KeyConditions={
-            'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    x = "a" * 2048
+    test_table_gsi_2.put_item(Item={"p": p, "x": x})
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [{"p": p, "x": x}],
+        KeyConditions={"x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}},
+    )
     # Attribute, that is a GSI partition key, of length 64 KB + 1 is forbidden:
     # it obviously exceeds DynamoDB's limit (2048 bytes), but also exceeds
     # Scylla's internal limit on key length (64 KB - 1). We except to get a
@@ -667,10 +953,11 @@ def test_gsi_limit_partition_key_len(test_table_gsi_2):
     # We actually used to get this "internal server error" for 64 KB - 2
     # (this is probably related to issue #16772).
     p = random_string()
-    x = 'a'*65536
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
-        test_table_gsi_2.put_item(Item={'p':  p, 'x': x})
-    assert not 'Item' in test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)
+    x = "a" * 65536
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
+        test_table_gsi_2.put_item(Item={"p": p, "x": x})
+    assert not "Item" in test_table_gsi_2.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 # Test when a table has a GSI, if the indexed attribute is a partition key
 # in the GSI and its value is 1024 bytes, the update operation is rejected,
@@ -681,24 +968,34 @@ def test_gsi_limit_partition_key_len(test_table_gsi_2):
 # a pre-existing table. In that case we can't reject the base-table update
 # because the oversized attribute is already there - but can just drop this
 # item from the GSI.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_gsi_limit_sort_key_len_1024(test_table_gsi_5):
     # A value for 'x' (the GSI's partition key) of length 1024 is fine:
     p = random_string()
     c = random_string()
-    x = 'a'*1024
-    test_table_gsi_5.put_item(Item={'p': p, 'c': c, 'x': x})
-    assert_index_query(test_table_gsi_5, 'hello', [{'p': p, 'c': c, 'x': x}],
+    x = "a" * 1024
+    test_table_gsi_5.put_item(Item={"p": p, "c": c, "x": x})
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [{"p": p, "c": c, "x": x}],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"},
+        },
+    )
     # PutItem with oversized for 'x' is rejected, item isn't created even
     # in the base table.
     p = random_string()
-    x = 'a'*1025
-    with pytest.raises(ClientError, match='ValidationException.*1024'):
-        test_table_gsi_5.put_item(Item={'p':  p, 'c': c, 'x': x})
-    assert not 'Item' in test_table_gsi_5.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)
+    x = "a" * 1025
+    with pytest.raises(ClientError, match="ValidationException.*1024"):
+        test_table_gsi_5.put_item(Item={"p": p, "c": c, "x": x})
+    assert not "Item" in test_table_gsi_5.get_item(
+        Key={"p": p, "c": c}, ConsistentRead=True
+    )
+
 
 # This is a variant of the above test, where we don't insist that the
 # partition key length limit must be exactly 1024 bytes as in DynamoDB,
@@ -709,17 +1006,24 @@ def test_gsi_limit_sort_key_len_1024(test_table_gsi_5):
 # should pass even if Alternator decides to adopt a different key length
 # limits from DynamoDB. We do have to adopt *some* limit because the
 # internal Scylla implementation has a 64 KB limit on key lengths.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_gsi_limit_sort_key_len(test_table_gsi_5):
     # A value for 'x' (the GSI's partition key) of length 1024 is fine:
     p = random_string()
     c = random_string()
-    x = 'a'*1024
-    test_table_gsi_5.put_item(Item={'p': p, 'c': c, 'x': x})
-    assert_index_query(test_table_gsi_5, 'hello', [{'p': p, 'c': c, 'x': x}],
+    x = "a" * 1024
+    test_table_gsi_5.put_item(Item={"p": p, "c": c, "x": x})
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [{"p": p, "c": c, "x": x}],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"},
+        },
+    )
     # Attribute, that is a GSI partition key, of length 64 KB + 1 is forbidden:
     # it obviously exceeds DynamoDB's limit (1024 bytes), but also exceeds
     # Scylla's internal limit on key length (64 KB - 1). We except to get a
@@ -727,10 +1031,13 @@ def test_gsi_limit_sort_key_len(test_table_gsi_5):
     # We actually used to get this "internal server error" for 64 KB - 2
     # (this is probably related to issue #16772).
     p = random_string()
-    x = 'a'*65536
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
-        test_table_gsi_5.put_item(Item={'p':  p, 'c': c, 'x': x})
-    assert not 'Item' in test_table_gsi_5.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)
+    x = "a" * 65536
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
+        test_table_gsi_5.put_item(Item={"p": p, "c": c, "x": x})
+    assert not "Item" in test_table_gsi_5.get_item(
+        Key={"p": p, "c": c}, ConsistentRead=True
+    )
+
 
 # A third scenario of GSI. Index has a hash key and a sort key, both are
 # non-key attributes from the base table. This scenario may be very
@@ -739,44 +1046,76 @@ def test_gsi_limit_sort_key_len(test_table_gsi_5):
 # we need two (which, also, aren't actual columns, but map items).
 @pytest.fixture(scope="module")
 def test_table_gsi_3(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'a', 'AttributeType': 'S' },
-                    { 'AttributeName': 'b', 'AttributeType': 'S' }
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "a", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'b', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "a", "KeyType": "HASH"},
+                    {"AttributeName": "b", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ])
+        ],
+    )
     yield table
     table.delete()
 
+
 def test_gsi_3(test_table_gsi_3):
-    items = [{'p': random_string(), 'a': random_string(), 'b': random_string()} for i in range(10)]
+    items = [
+        {"p": random_string(), "a": random_string(), "b": random_string()}
+        for i in range(10)
+    ]
     with test_table_gsi_3.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    assert_index_query(test_table_gsi_3, 'hello', [items[3]],
-        KeyConditions={'a': {'AttributeValueList': [items[3]['a']], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [items[3]['b']], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [items[3]],
+        KeyConditions={
+            "a": {"AttributeValueList": [items[3]["a"]], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [items[3]["b"]], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 def test_gsi_update_second_regular_base_column(test_table_gsi_3):
-    items = [{'p': random_string(), 'a': random_string(), 'b': random_string(), 'd': random_string()} for i in range(10)]
+    items = [
+        {
+            "p": random_string(),
+            "a": random_string(),
+            "b": random_string(),
+            "d": random_string(),
+        }
+        for i in range(10)
+    ]
     with test_table_gsi_3.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    items[3]['b'] = 'updated'
-    test_table_gsi_3.update_item(Key={'p':  items[3]['p']}, AttributeUpdates={'b': {'Value': 'updated', 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [items[3]],
-        KeyConditions={'a': {'AttributeValueList': [items[3]['a']], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [items[3]['b']], 'ComparisonOperator': 'EQ'}})
+    items[3]["b"] = "updated"
+    test_table_gsi_3.update_item(
+        Key={"p": items[3]["p"]},
+        AttributeUpdates={"b": {"Value": "updated", "Action": "PUT"}},
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [items[3]],
+        KeyConditions={
+            "a": {"AttributeValueList": [items[3]["a"]], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [items[3]["b"]], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # Test reproducing issue #11801: In issue #5006 we noticed that in the special
 # case of a GSI with with two non-key attributes as keys (test_table_gsi_3),
@@ -788,31 +1127,56 @@ def test_11801(test_table_gsi_3):
     p = random_string()
     a = random_string()
     b = random_string()
-    item = {'p': p, 'a': a, 'b': b, 'd': random_string()}
+    item = {"p": p, "a": a, "b": b, "d": random_string()}
     test_table_gsi_3.put_item(Item=item)
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     # Update the attribute 'b' to the same value b that it already had.
     # This shouldn't change anything in the base table or in the GSI
-    test_table_gsi_3.update_item(Key={'p':  p}, AttributeUpdates={'b': {'Value': b, 'Action': 'PUT'}})
-    assert item == test_table_gsi_3.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"b": {"Value": b, "Action": "PUT"}}
+    )
+    assert item == test_table_gsi_3.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
     # In issue #11801, the following assertion failed (the view row was
     # deleted and nothing matched the query).
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     # Above we checked that setting 'b' to the same value didn't remove
     # the old GSI row. But the same update may actually modify the GSI row
     # (e.g., an unrelated attribute d) -  check this modification took place:
-    item['d'] = random_string()
-    test_table_gsi_3.update_item(Key={'p':  p},
-        AttributeUpdates={'b': {'Value': b, 'Action': 'PUT'},
-                          'd': {'Value': item['d'], 'Action': 'PUT'}})
-    assert item == test_table_gsi_3.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    item["d"] = random_string()
+    test_table_gsi_3.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "b": {"Value": b, "Action": "PUT"},
+            "d": {"Value": item["d"], "Action": "PUT"},
+        },
+    )
+    assert item == test_table_gsi_3.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # This test is the same as test_11801, but updating the first attribute (a)
 # instead of the second (b). This test didn't fail, showing that issue #11801
@@ -822,15 +1186,30 @@ def test_11801_variant1(test_table_gsi_3):
     a = random_string()
     b = random_string()
     d = random_string()
-    item = {'p': p, 'a': a, 'b': b, 'd': d}
+    item = {"p": p, "a": a, "b": b, "d": d}
     test_table_gsi_3.put_item(Item=item)
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
-    test_table_gsi_3.update_item(Key={'p':  p}, AttributeUpdates={'a': {'Value': a, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"a": {"Value": a, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # This test is the same as test_11801, but updates b to a different value
 # (newb) instead of to the same one. This test didn't fail, showing that
@@ -841,20 +1220,41 @@ def test_11801_variant2(test_table_gsi_3):
     p = random_string()
     a = random_string()
     b = random_string()
-    item = {'p': p, 'a': a, 'b': b, 'd': random_string()}
+    item = {"p": p, "a": a, "b": b, "d": random_string()}
     test_table_gsi_3.put_item(Item=item)
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     newb = random_string()
-    item['b'] = newb
-    test_table_gsi_3.update_item(Key={'p':  p}, AttributeUpdates={'b': {'Value': newb, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [newb], 'ComparisonOperator': 'EQ'}})
+    item["b"] = newb
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"b": {"Value": newb, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [newb], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # This test is the same as test_11801, but uses a different table schema
 # (test_table_gsi_5) where there is only one new key column in the view (x).
@@ -864,16 +1264,34 @@ def test_11801_variant3(test_table_gsi_5):
     p = random_string()
     c = random_string()
     x = random_string()
-    item = {'p': p, 'c': c, 'x': x, 'd': random_string()}
+    item = {"p": p, "c": c, "x": x, "d": random_string()}
     test_table_gsi_5.put_item(Item=item)
-    assert_index_query(test_table_gsi_5, 'hello', [item],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
-    test_table_gsi_5.update_item(Key={'p':  p, 'c': c}, AttributeUpdates={'x': {'Value': x, 'Action': 'PUT'}})
-    assert item == test_table_gsi_5.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)['Item']
-    assert_index_query(test_table_gsi_5, 'hello', [item],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [item],
+        KeyConditions={
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"},
+        },
+    )
+    test_table_gsi_5.update_item(
+        Key={"p": p, "c": c}, AttributeUpdates={"x": {"Value": x, "Action": "PUT"}}
+    )
+    assert (
+        item
+        == test_table_gsi_5.get_item(Key={"p": p, "c": c}, ConsistentRead=True)["Item"]
+    )
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        [item],
+        KeyConditions={
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # Another test similar to test_11801, but instead of updating a view key
 # column to the same value it already has, simply don't update it at all
@@ -884,19 +1302,34 @@ def test_11801_variant4(test_table_gsi_3):
     p = random_string()
     a = random_string()
     b = random_string()
-    item = {'p': p, 'a': a, 'b': b, 'd': random_string()}
+    item = {"p": p, "a": a, "b": b, "d": random_string()}
     test_table_gsi_3.put_item(Item=item)
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     # An update that doesn't change the GSI keys (a or b), just a regular
     # column d.
-    item['d'] = random_string()
-    test_table_gsi_3.update_item(Key={'p':  p}, AttributeUpdates={'d': {'Value': item['d'], 'Action': 'PUT'}})
-    assert item == test_table_gsi_3.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    item["d"] = random_string()
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"d": {"Value": item["d"], "Action": "PUT"}}
+    )
+    assert item == test_table_gsi_3.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # An additional test for the case that two non-key attributes in the base
 # table become keys of the view. In this test we try to cover all the
@@ -907,109 +1340,271 @@ def test_gsi_3_long(test_table_gsi_3):
     a = random_string()
     b = random_string()
     z = random_string()
-    test_table_gsi_3.put_item(Item={'p': p, 'a': a, 'b': b, 'z': z})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a, 'b': b, 'z': z}],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.put_item(Item={"p": p, "a": a, "b": b, "z": z})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a, "b": b, "z": z}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     # Change z, the existing view row changes:
     z2 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'z': {'Value': z2, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a, 'b': b, 'z': z2}],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"z": {"Value": z2, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a, "b": b, "z": z2}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     # Change a, the original row (a,b) is deleted, a new one (a2, b) created
     a2 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': a2, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a2, 'b': b, 'z': z2}],
-        KeyConditions={'a': {'AttributeValueList': [a2], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"a": {"Value": a2, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a2, "b": b, "z": z2}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a2], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     # Change b, the original row (a2, b) is deleted, a new one (a2, b2) created
     b2 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'b': {'Value': b2, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a2], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a2, 'b': b2, 'z': z2}],
-        KeyConditions={'a': {'AttributeValueList': [a2], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b2], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"b": {"Value": b2, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a2], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a2, "b": b2, "z": z2}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a2], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b2], "ComparisonOperator": "EQ"},
+        },
+    )
     # Change both a and b, the old row (a2, b2) is deleted, a new one
     # (a3, b3) is created
     a3 = random_string()
     b3 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': a3, 'Action': 'PUT'}, 'b': {'Value': b3, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a2], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b2], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a3, 'b': b3, 'z': z2}],
-        KeyConditions={'a': {'AttributeValueList': [a3], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b3], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": a3, "Action": "PUT"},
+            "b": {"Value": b3, "Action": "PUT"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a2], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b2], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a3, "b": b3, "z": z2}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a3], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b3], "ComparisonOperator": "EQ"},
+        },
+    )
     # Delete attribute a and at the same time change b to b4. This is *not* the
     # same as just not setting a (as we checked above). In this case, the
     # old row should be deleted, but no new view row is created.
     b4 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Action': 'DELETE'}, 'b': {'Value': b4, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a3], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b3], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a3], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b4], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Action": "DELETE"},
+            "b": {"Value": b4, "Action": "PUT"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a3], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b3], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a3], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b4], "ComparisonOperator": "EQ"},
+        },
+    )
     # Set "a" again (to a4), and the view row (a4, b4) appears
     a4 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': a4, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a4, 'b': b4, 'z': z2}],
-        KeyConditions={'a': {'AttributeValueList': [a4], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b4], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"a": {"Value": a4, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a4, "b": b4, "z": z2}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a4], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b4], "ComparisonOperator": "EQ"},
+        },
+    )
     # Similar to above, but for second column: Delete attribute b and at the
     # same time change a to a5. the old row should be deleted, but no new
     # view row is created.
     a5 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'b': {'Action': 'DELETE'}, 'a': {'Value': a5, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a4], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b4], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a5], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b4], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "b": {"Action": "DELETE"},
+            "a": {"Value": a5, "Action": "PUT"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a4], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b4], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a5], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b4], "ComparisonOperator": "EQ"},
+        },
+    )
     # Set "b" again (to b5), and the view row (a5, b5) appears
     b5 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'b': {'Value': b5, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a5, 'b': b5, 'z': z2}],
-        KeyConditions={'a': {'AttributeValueList': [a5], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b5], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"b": {"Value": b5, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a5, "b": b5, "z": z2}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a5], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b5], "ComparisonOperator": "EQ"},
+        },
+    )
     # Now unset both a and b. The view row disappears, and setting only a,
     # or only b, doesn't bring it back.
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Action': 'DELETE'}, 'b': {'Action': 'DELETE'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a5], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b5], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p},
+        AttributeUpdates={"a": {"Action": "DELETE"}, "b": {"Action": "DELETE"}},
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a5], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b5], "ComparisonOperator": "EQ"},
+        },
+    )
     a6 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': a6, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a6], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b5], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"a": {"Value": a6, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a6], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b5], "ComparisonOperator": "EQ"},
+        },
+    )
     b6 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'b': {'Value': b6, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a6, 'b': b6, 'z': z2}],
-        KeyConditions={'a': {'AttributeValueList': [a6], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b6], 'ComparisonOperator': 'EQ'}})
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Action': 'DELETE'}, 'b': {'Action': 'DELETE'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a6], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b6], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"b": {"Value": b6, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a6, "b": b6, "z": z2}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a6], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b6], "ComparisonOperator": "EQ"},
+        },
+    )
+    test_table_gsi_3.update_item(
+        Key={"p": p},
+        AttributeUpdates={"a": {"Action": "DELETE"}, "b": {"Action": "DELETE"}},
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a6], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b6], "ComparisonOperator": "EQ"},
+        },
+    )
     b7 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'b': {'Value': b7, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a6], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b7], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"b": {"Value": b7, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a6], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b7], "ComparisonOperator": "EQ"},
+        },
+    )
     a7 = random_string()
-    test_table_gsi_3.update_item(Key={'p': p}, AttributeUpdates={'a': {'Value': a7, 'Action': 'PUT'}})
-    assert_index_query(test_table_gsi_3, 'hello', [{'p': p, 'a': a7, 'b': b7, 'z': z2}],
-        KeyConditions={'a': {'AttributeValueList': [a7], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b7], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"a": {"Value": a7, "Action": "PUT"}}
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [{"p": p, "a": a7, "b": b7, "z": z2}],
+        KeyConditions={
+            "a": {"AttributeValueList": [a7], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b7], "ComparisonOperator": "EQ"},
+        },
+    )
 
 
 # Test that when a table has a GSI, if the indexed attribute is missing, the
@@ -1025,131 +1620,214 @@ def test_gsi_missing_attribute_3(test_table_gsi_3):
     b = random_string()
     # First, add an item with a missing "a" value. It should appear in the
     # base table, but not in the index:
-    test_table_gsi_3.put_item(Item={'p':  p, 'b': b})
-    assert test_table_gsi_3.get_item(Key={'p':  p}, ConsistentRead=True)['Item'] == {'p': p, 'b': b}
+    test_table_gsi_3.put_item(Item={"p": p, "b": b})
+    assert test_table_gsi_3.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        "b": b,
+    }
     # Note: with eventually consistent read, we can't really be sure that
     # an item will "never" appear in the index. We hope that if a bug exists
     # and such an item did appear, sometimes the delay here will be enough
     # for the unexpected item to become visible.
-    assert not any([i['p'] == p for i in full_scan(test_table_gsi_3, ConsistentRead=False, IndexName='hello')])
+    assert not any(
+        [
+            i["p"] == p
+            for i in full_scan(
+                test_table_gsi_3, ConsistentRead=False, IndexName="hello"
+            )
+        ]
+    )
     # Same thing for an item with a missing "b" value:
-    test_table_gsi_3.put_item(Item={'p':  p, 'a': a})
-    assert test_table_gsi_3.get_item(Key={'p':  p}, ConsistentRead=True)['Item'] == {'p': p, 'a': a}
-    assert not any([i['p'] == p for i in full_scan(test_table_gsi_3, ConsistentRead=False, IndexName='hello')])
+    test_table_gsi_3.put_item(Item={"p": p, "a": a})
+    assert test_table_gsi_3.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        "a": a,
+    }
+    assert not any(
+        [
+            i["p"] == p
+            for i in full_scan(
+                test_table_gsi_3, ConsistentRead=False, IndexName="hello"
+            )
+        ]
+    )
     # And for an item missing both:
-    test_table_gsi_3.put_item(Item={'p':  p})
-    assert test_table_gsi_3.get_item(Key={'p':  p}, ConsistentRead=True)['Item'] == {'p': p}
-    assert not any([i['p'] == p for i in full_scan(test_table_gsi_3, ConsistentRead=False, IndexName='hello')])
+    test_table_gsi_3.put_item(Item={"p": p})
+    assert test_table_gsi_3.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p
+    }
+    assert not any(
+        [
+            i["p"] == p
+            for i in full_scan(
+                test_table_gsi_3, ConsistentRead=False, IndexName="hello"
+            )
+        ]
+    )
+
 
 # A fourth scenario of GSI. Two GSIs on a single base table.
 @pytest.fixture(scope="module")
 def test_table_gsi_4(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'a', 'AttributeType': 'S' },
-                    { 'AttributeName': 'b', 'AttributeType': 'S' }
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "a", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello_a',
-                'KeySchema': [
-                    { 'AttributeName': 'a', 'KeyType': 'HASH' },
+            {
+                "IndexName": "hello_a",
+                "KeySchema": [
+                    {"AttributeName": "a", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             },
-            {   'IndexName': 'hello_b',
-                'KeySchema': [
-                    { 'AttributeName': 'b', 'KeyType': 'HASH' },
+            {
+                "IndexName": "hello_b",
+                "KeySchema": [
+                    {"AttributeName": "b", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
-            }
-        ])
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    )
     yield table
     table.delete()
 
+
 # Test that a base table with two GSIs updates both as expected.
 def test_gsi_4(test_table_gsi_4):
-    items = [{'p': random_string(), 'a': random_string(), 'b': random_string()} for i in range(10)]
+    items = [
+        {"p": random_string(), "a": random_string(), "b": random_string()}
+        for i in range(10)
+    ]
     with test_table_gsi_4.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    assert_index_query(test_table_gsi_4, 'hello_a', [items[3]],
-        KeyConditions={'a': {'AttributeValueList': [items[3]['a']], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_4, 'hello_b', [items[3]],
-        KeyConditions={'b': {'AttributeValueList': [items[3]['b']], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_4,
+        "hello_a",
+        [items[3]],
+        KeyConditions={
+            "a": {"AttributeValueList": [items[3]["a"]], "ComparisonOperator": "EQ"}
+        },
+    )
+    assert_index_query(
+        test_table_gsi_4,
+        "hello_b",
+        [items[3]],
+        KeyConditions={
+            "b": {"AttributeValueList": [items[3]["b"]], "ComparisonOperator": "EQ"}
+        },
+    )
+
 
 # Verify that describe_table lists the two GSIs.
 def test_gsi_4_describe(test_table_gsi_4):
     desc = test_table_gsi_4.meta.client.describe_table(TableName=test_table_gsi_4.name)
-    assert 'Table' in desc
-    assert 'GlobalSecondaryIndexes' in desc['Table']
-    gsis = desc['Table']['GlobalSecondaryIndexes']
+    assert "Table" in desc
+    assert "GlobalSecondaryIndexes" in desc["Table"]
+    gsis = desc["Table"]["GlobalSecondaryIndexes"]
     assert len(gsis) == 2
-    assert multiset([g['IndexName'] for g in gsis]) == multiset(['hello_a', 'hello_b'])
+    assert multiset([g["IndexName"] for g in gsis]) == multiset(["hello_a", "hello_b"])
+
 
 # A scenario for GSI in which the table has both hash and sort key
 @pytest.fixture(scope="module")
 def test_table_gsi_5(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'x', 'KeyType': 'RANGE' },
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ])
+        ],
+    )
     yield table
     table.delete()
 
+
 def test_gsi_5(test_table_gsi_5):
-    items1 = [{'p': random_string(), 'c': random_string(), 'x': random_string()} for i in range(10)]
-    p1, x1 = items1[0]['p'], items1[0]['x']
+    items1 = [
+        {"p": random_string(), "c": random_string(), "x": random_string()}
+        for i in range(10)
+    ]
+    p1, x1 = items1[0]["p"], items1[0]["x"]
     p2, x2 = random_string(), random_string()
-    items2 = [{'p': p2, 'c': random_string(), 'x': x2} for i in range(10)]
+    items2 = [{"p": p2, "c": random_string(), "x": x2} for i in range(10)]
     items = items1 + items2
     with test_table_gsi_5.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    expected_items = [i for i in items if i['p'] == p1 and i['x'] == x1]
-    assert_index_query(test_table_gsi_5, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p1], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
-    expected_items = [i for i in items if i['p'] == p2 and i['x'] == x2]
-    assert_index_query(test_table_gsi_5, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p2], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
+    expected_items = [i for i in items if i["p"] == p1 and i["x"] == x1]
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p1], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"},
+        },
+    )
+    expected_items = [i for i in items if i["p"] == p2 and i["x"] == x2]
+    assert_index_query(
+        test_table_gsi_5,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p2], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": [x2], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # Verify that DescribeTable correctly returns the schema of both base-table
 # and secondary indexes. KeySchema is given for each of the base table and
 # indexes, and AttributeDefinitions is merged for all of them together.
 def test_gsi_5_describe_table_schema(test_table_gsi_5):
-    got = test_table_gsi_5.meta.client.describe_table(TableName=test_table_gsi_5.name)['Table']
+    got = test_table_gsi_5.meta.client.describe_table(TableName=test_table_gsi_5.name)[
+        "Table"
+    ]
     # Copied from test_table_gsi_5 fixture
     expected_base_keyschema = [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'c', 'KeyType': 'RANGE' } ]
+        {"AttributeName": "p", "KeyType": "HASH"},
+        {"AttributeName": "c", "KeyType": "RANGE"},
+    ]
     expected_gsi_keyschema = [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'x', 'KeyType': 'RANGE' } ]
+        {"AttributeName": "p", "KeyType": "HASH"},
+        {"AttributeName": "x", "KeyType": "RANGE"},
+    ]
     expected_all_attribute_definitions = [
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' } ]
-    assert got['KeySchema'] == expected_base_keyschema
-    gsis = got['GlobalSecondaryIndexes']
+        {"AttributeName": "p", "AttributeType": "S"},
+        {"AttributeName": "c", "AttributeType": "S"},
+        {"AttributeName": "x", "AttributeType": "S"},
+    ]
+    assert got["KeySchema"] == expected_base_keyschema
+    gsis = got["GlobalSecondaryIndexes"]
     assert len(gsis) == 1
-    assert gsis[0]['KeySchema'] == expected_gsi_keyschema
+    assert gsis[0]["KeySchema"] == expected_gsi_keyschema
     # The list of attribute definitions may be arbitrarily reordered
-    assert multiset(got['AttributeDefinitions']) == multiset(expected_all_attribute_definitions)
+    assert multiset(got["AttributeDefinitions"]) == multiset(
+        expected_all_attribute_definitions
+    )
+
 
 # Similar DescribeTable schema test for test_table_gsi_2. The peculiarity
 # in that table is that the base table has only a hash key p, and index
@@ -1159,19 +1837,25 @@ def test_gsi_5_describe_table_schema(test_table_gsi_5):
 # returned as a range key, because the user didn't ask for it.
 # This test reproduces issue #5320.
 def test_gsi_2_describe_table_schema(test_table_gsi_2):
-    got = test_table_gsi_2.meta.client.describe_table(TableName=test_table_gsi_2.name)['Table']
+    got = test_table_gsi_2.meta.client.describe_table(TableName=test_table_gsi_2.name)[
+        "Table"
+    ]
     # Copied from test_table_gsi_2 fixture
-    expected_base_keyschema = [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ]
-    expected_gsi_keyschema = [ { 'AttributeName': 'x', 'KeyType': 'HASH' } ]
+    expected_base_keyschema = [{"AttributeName": "p", "KeyType": "HASH"}]
+    expected_gsi_keyschema = [{"AttributeName": "x", "KeyType": "HASH"}]
     expected_all_attribute_definitions = [
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' } ]
-    assert got['KeySchema'] == expected_base_keyschema
-    gsis = got['GlobalSecondaryIndexes']
+        {"AttributeName": "p", "AttributeType": "S"},
+        {"AttributeName": "x", "AttributeType": "S"},
+    ]
+    assert got["KeySchema"] == expected_base_keyschema
+    gsis = got["GlobalSecondaryIndexes"]
     assert len(gsis) == 1
-    assert gsis[0]['KeySchema'] == expected_gsi_keyschema
+    assert gsis[0]["KeySchema"] == expected_gsi_keyschema
     # The list of attribute definitions may be arbitrarily reordered
-    assert multiset(got['AttributeDefinitions']) == multiset(expected_all_attribute_definitions)
+    assert multiset(got["AttributeDefinitions"]) == multiset(
+        expected_all_attribute_definitions
+    )
+
 
 # This test is a comprehensive regression test for issue #5320, testing that
 # DescribeTable shows the correct user-requested GSI key even when Alternator
@@ -1191,65 +1875,82 @@ def test_gsi_2_describe_table_schema(test_table_gsi_2):
 def test_gsi_describe_table_schema_all(dynamodb):
     # We have two options for the base table: it can have either have just a
     # hash key (['a']) or both a hash key and a range key (['a', 'b'])
-    for base_keys in [ ['a'], ['a', 'b'] ]:
+    for base_keys in [["a"], ["a", "b"]]:
         # The GSI key can have either one component (just hash) or two (hash
         # and range). We build in gsi_keys_options a list of all the options
         # for the GSI key - it's a list of vectors, each of length one or two.
-        gsi_keys_options=[]
+        gsi_keys_options = []
         # First add to gsi_keys_options all options for GSI keys with just one
         # key component. It can be one of the base_keys, or some unrelated
         # regular column (which we'll take as 'x')
         for bk in base_keys:
             gsi_keys_options.append([bk])
-        gsi_keys_options.append(['x'])
+        gsi_keys_options.append(["x"])
         # Now add to gsi_keys_options GSI keys with two key component. We need
         # all the ordered pairs of two different items taken from base_keys
         # or two other regular columns x and y.
-        for pair in itertools.permutations(base_keys + ['x', 'y'], 2):
+        for pair in itertools.permutations(base_keys + ["x", "y"], 2):
             # If the key has just y, not x, it's a redundant option and we
             # can drop it - the same key with just x represents the same thing.
-            if 'y' in pair and 'x' not in pair:
+            if "y" in pair and "x" not in pair:
                 continue
             # Similarly, the pair y,x is redundant - it's the same as x,y
             # (note that when the base key columns are involved, the order
             # does matter! a,x is not the same as x,a and we should try both)
-            if pair == ('y', 'x'):
+            if pair == ("y", "x"):
                 continue
             gsi_keys_options.append(pair)
-        print(f'{len(gsi_keys_options)} options for {base_keys}: {gsi_keys_options}')
+        print(f"{len(gsi_keys_options)} options for {base_keys}: {gsi_keys_options}")
         # Finally, create a base table with base_keys and a bunch of GSIs with
         # all the different GSI key options we collected in gsi_keys_options
         if len(base_keys) == 1:
-            key_schema=[ { 'AttributeName': base_keys[0], 'KeyType': 'HASH' } ]
+            key_schema = [{"AttributeName": base_keys[0], "KeyType": "HASH"}]
         else:
-            key_schema=[ { 'AttributeName': base_keys[0], 'KeyType': 'HASH' },
-                         { 'AttributeName': base_keys[1], 'KeyType': 'RANGE' } ]
-        attribute_definitions = [ {'AttributeName': attr, 'AttributeType': 'S' } for attr in (base_keys + ['x', 'y']) ]
+            key_schema = [
+                {"AttributeName": base_keys[0], "KeyType": "HASH"},
+                {"AttributeName": base_keys[1], "KeyType": "RANGE"},
+            ]
+        attribute_definitions = [
+            {"AttributeName": attr, "AttributeType": "S"}
+            for attr in (base_keys + ["x", "y"])
+        ]
         gsis = []
         for i, gsi_keys in enumerate(gsi_keys_options):
             if len(gsi_keys) == 1:
-                gsi_key_schema=[ { 'AttributeName': gsi_keys[0], 'KeyType': 'HASH' } ]
+                gsi_key_schema = [{"AttributeName": gsi_keys[0], "KeyType": "HASH"}]
             else:
-                gsi_key_schema=[ { 'AttributeName': gsi_keys[0], 'KeyType': 'HASH' },
-                                 { 'AttributeName': gsi_keys[1], 'KeyType': 'RANGE' } ]
-            gsis.append({ 'IndexName': f'index{i}',
-                          'KeySchema': gsi_key_schema,
-                          'Projection': { 'ProjectionType': 'ALL' } })
-        with new_test_table(dynamodb,
+                gsi_key_schema = [
+                    {"AttributeName": gsi_keys[0], "KeyType": "HASH"},
+                    {"AttributeName": gsi_keys[1], "KeyType": "RANGE"},
+                ]
+            gsis.append(
+                {
+                    "IndexName": f"index{i}",
+                    "KeySchema": gsi_key_schema,
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            )
+        with new_test_table(
+            dynamodb,
             KeySchema=key_schema,
             AttributeDefinitions=attribute_definitions,
-            GlobalSecondaryIndexes=gsis) as table:
+            GlobalSecondaryIndexes=gsis,
+        ) as table:
             # Check that DescribeTable shows the table and all its GSIs correctly
-            got = table.meta.client.describe_table(TableName=table.name)['Table']
-            assert got['KeySchema'] == key_schema
-            got_gsis = got['GlobalSecondaryIndexes']
+            got = table.meta.client.describe_table(TableName=table.name)["Table"]
+            assert got["KeySchema"] == key_schema
+            got_gsis = got["GlobalSecondaryIndexes"]
             # We want to compare got_gsis to the original gsis, but got_gsis
             # may have extra attributes that DescribeTable added beyond what
             # was present in the origin table creation. So let's leave in
             # got_gsis only the columns that were present in gsis[0].
-            got_gsis = [ {k: v for k, v in got_gsi.items() if k in gsis[0]} for got_gsi in got_gsis ]
+            got_gsis = [
+                {k: v for k, v in got_gsi.items() if k in gsis[0]}
+                for got_gsi in got_gsis
+            ]
             # Use multiset to compare ignoring order
             assert multiset(got_gsis) == multiset(gsis)
+
 
 # All tests above involved "ProjectionType: ALL". This test checks how
 # "ProjectionType:: KEYS_ONLY" works. We note that it projects both
@@ -1257,113 +1958,151 @@ def test_gsi_describe_table_schema_all(dynamodb):
 # base-table keys cannot suddenly become the same item in the index.
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_keys_only(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
             }
-        ]) as table:
-        items = [{'p': random_string(), 'x': random_string(), 'y': random_string()} for i in range(10)]
+        ],
+    ) as table:
+        items = [
+            {"p": random_string(), "x": random_string(), "y": random_string()}
+            for i in range(10)
+        ]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
-        wanted = ['p', 'x']
+        wanted = ["p", "x"]
         expected_items = [{k: x[k] for k in wanted if k in x} for x in items]
-        assert_index_scan(table, 'hello', expected_items)
+        assert_index_scan(table, "hello", expected_items)
+
 
 # Test for "ProjectionType: INCLUDE". The secondary table includes the
 # its own and the base's keys (as in KEYS_ONLY) plus the extra keys given
 # in NonKeyAttributes.
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_include(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'INCLUDE',
-                                'NonKeyAttributes': ['a', 'b'] }
+                "Projection": {
+                    "ProjectionType": "INCLUDE",
+                    "NonKeyAttributes": ["a", "b"],
+                },
             }
-        ]) as table:
+        ],
+    ) as table:
         # Some items have the projected attributes a,b and some don't:
-        items = [{'p': random_string(), 'x': random_string(), 'a': random_string(), 'b': random_string(), 'y': random_string()} for i in range(10)]
-        items = items + [{'p': random_string(), 'x': random_string(), 'y': random_string()} for i in range(10)]
+        items = [
+            {
+                "p": random_string(),
+                "x": random_string(),
+                "a": random_string(),
+                "b": random_string(),
+                "y": random_string(),
+            }
+            for i in range(10)
+        ]
+        items = items + [
+            {"p": random_string(), "x": random_string(), "y": random_string()}
+            for i in range(10)
+        ]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
-        wanted = ['p', 'x', 'a', 'b']
+        wanted = ["p", "x", "a", "b"]
         expected_items = [{k: x[k] for k in wanted if k in x} for x in items]
-        assert_index_scan(table, 'hello', expected_items)
+        assert_index_scan(table, "hello", expected_items)
         print(len(expected_items))
+
 
 # Test that when "ProjectionType" is set to anything but "INCLUDE" (i.e.,
 # "ALL" or "KEYS_ONLY"), "NonKeyAttributes" must not be specified.
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_nonkeyattributess_forbidden(dynamodb):
-    for projection_type in ['ALL', 'KEYS_ONLY']:
-        with pytest.raises(ClientError, match='ValidationException.*NonKeyAttributes'):
-            with new_test_table(dynamodb,
-                KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    for projection_type in ["ALL", "KEYS_ONLY"]:
+        with pytest.raises(ClientError, match="ValidationException.*NonKeyAttributes"):
+            with new_test_table(
+                dynamodb,
+                KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
                 AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' },
+                    {"AttributeName": "p", "AttributeType": "S"},
+                    {"AttributeName": "x", "AttributeType": "S"},
                 ],
                 GlobalSecondaryIndexes=[
-                    {   'IndexName': 'hello',
-                        'KeySchema': [
-                            { 'AttributeName': 'x', 'KeyType': 'HASH' },
+                    {
+                        "IndexName": "hello",
+                        "KeySchema": [
+                            {"AttributeName": "x", "KeyType": "HASH"},
                         ],
-                        'Projection': { 'ProjectionType': projection_type,
-                                        'NonKeyAttributes': ['a', 'b'] }
+                        "Projection": {
+                            "ProjectionType": projection_type,
+                            "NonKeyAttributes": ["a", "b"],
+                        },
                     }
-                ]) as table:
+                ],
+            ) as table:
                 pass
+
 
 # Despite the name "NonKeyAttributes", key attributes *may* be listed.
 # But they have no effect - because key attributes are always projected
 # anyway.
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_include_keyattributes(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'x', 'AttributeType': 'S' } ],
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
+        ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'INCLUDE',
-                                'NonKeyAttributes': ['a', 'x'] }
+                "Projection": {
+                    "ProjectionType": "INCLUDE",
+                    "NonKeyAttributes": ["a", "x"],
+                },
             }
-        ]) as table:
-        p = random_string();
-        x = random_string();
-        a = random_string();
-        b = random_string();
-        table.put_item(Item={'p': p, 'x': x, 'a': a, 'b': b})
+        ],
+    ) as table:
+        p = random_string()
+        x = random_string()
+        a = random_string()
+        b = random_string()
+        table.put_item(Item={"p": p, "x": x, "a": a, "b": b})
         # We expect both key attributes ('p' and 'x') to be projected, as
         # well as 'a' listed on NonKeyAttributes. The fact that 'x' was
         # also listed on NonKeyAttributes and 'p' wasn't doesn't make a
         # difference. The non-key 'b' wasn't listed, so it will not be
         # retrieved from the GSI.
-        expected_items = [{'p': p, 'x': x, 'a': a}]
-        assert_index_scan(table, 'hello', expected_items)
+        expected_items = [{"p": p, "x": x, "a": a}]
+        assert_index_scan(table, "hello", expected_items)
+
 
 # In this test, we add two GSIs, one projecting the other GSI's key.
 # This is an interesting case in Alternator's implementation, because
@@ -1372,41 +2111,49 @@ def test_gsi_projection_include_keyattributes(dynamodb):
 # to project both real columns and map elements into the view.
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_include_otherkey(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'x', 'AttributeType': 'S' },
-            { 'AttributeName': 'a', 'AttributeType': 'S' },
-            { 'AttributeName': 'z', 'AttributeType': 'S' } ],
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
+            {"AttributeName": "a", "AttributeType": "S"},
+            {"AttributeName": "z", "AttributeType": "S"},
+        ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'indexx',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+            {
+                "IndexName": "indexx",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'INCLUDE',
-                                'NonKeyAttributes': ['a', 'b'] }
+                "Projection": {
+                    "ProjectionType": "INCLUDE",
+                    "NonKeyAttributes": ["a", "b"],
+                },
             },
-            {   'IndexName': 'indexa',
-                'KeySchema': [
-                    { 'AttributeName': 'a', 'KeyType': 'HASH' },
+            {
+                "IndexName": "indexa",
+                "KeySchema": [
+                    {"AttributeName": "a", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
             },
-            {   'IndexName': 'indexz',
-                'KeySchema': [
-                    { 'AttributeName': 'z', 'KeyType': 'HASH' },
+            {
+                "IndexName": "indexz",
+                "KeySchema": [
+                    {"AttributeName": "z", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
-            }
-        ]) as table:
-        p = random_string();
-        x = random_string();
-        a = random_string();
-        b = random_string();
-        c = random_string();
-        z = random_string();
-        table.put_item(Item={'p': p, 'x': x, 'a': a, 'b': b, 'c': c, 'z': z})
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
+            },
+        ],
+    ) as table:
+        p = random_string()
+        x = random_string()
+        a = random_string()
+        b = random_string()
+        c = random_string()
+        z = random_string()
+        table.put_item(Item={"p": p, "x": x, "a": a, "b": b, "c": c, "z": z})
         # When scanning indexx, we expect both its key attributes ('x')
         # and the base table's ('p') to be projected, as well as 'a' and 'b'
         # listed on NonKeyAttributes. 'c' isn't projected, and neither is 'z'
@@ -1414,108 +2161,132 @@ def test_gsi_projection_include_otherkey(dynamodb):
         # also happens to be some other GSI's key, while 'b' isn't, allowing
         # us to exercise both code paths (Alternator stores regular attributes
         # differently from attributes which are keys of some GSI).
-        expected_items = [{'p': p, 'x': x, 'a': a, 'b': b}]
-        assert_index_scan(table, 'indexx', expected_items)
+        expected_items = [{"p": p, "x": x, "a": a, "b": b}]
+        assert_index_scan(table, "indexx", expected_items)
+
 
 # With ProjectionType=INCLUDE, NonKeyAttributes must not be missing:
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_error_missing_nonkeyattributes(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*NonKeyAttributes'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with pytest.raises(ClientError, match="ValidationException.*NonKeyAttributes"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'x', 'KeyType': 'HASH' },
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [
+                        {"AttributeName": "x", "KeyType": "HASH"},
                     ],
-                    'Projection': { 'ProjectionType': 'INCLUDE' }
+                    "Projection": {"ProjectionType": "INCLUDE"},
                 }
-            ]) as table:
+            ],
+        ) as table:
             pass
+
 
 # With ProjectionType!=INCLUDE, NonKeyAttributes must not be present:
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_error_superflous_nonkeyattributes(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*NonKeyAttributes'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with pytest.raises(ClientError, match="ValidationException.*NonKeyAttributes"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'x', 'KeyType': 'HASH' },
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [
+                        {"AttributeName": "x", "KeyType": "HASH"},
                     ],
-                    'Projection': { 'ProjectionType': 'ALL',
-                                    'NonKeyAttributes': ['a'] }
+                    "Projection": {"ProjectionType": "ALL", "NonKeyAttributes": ["a"]},
                 }
-            ]) as table:
+            ],
+        ) as table:
             pass
+
 
 # Duplicate attribute names in NonKeyAttributes of INCLUDE are not allowed:
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_error_duplicate(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*Duplicate'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with pytest.raises(ClientError, match="ValidationException.*Duplicate"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'x', 'KeyType': 'HASH' },
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [
+                        {"AttributeName": "x", "KeyType": "HASH"},
                     ],
-                    'Projection': { 'ProjectionType': 'INCLUDE',
-                                    'NonKeyAttributes': ['a', 'a'] }
+                    "Projection": {
+                        "ProjectionType": "INCLUDE",
+                        "NonKeyAttributes": ["a", "a"],
+                    },
                 }
-            ]) as table:
+            ],
+        ) as table:
             pass
+
 
 # NonKeyAttributes must be a list of strings. Non-strings in this list
 # result, for some reason, in SerializationException instead of the more
 # usual ValidationException.
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_error_nonstring_nonkeyattributes(dynamodb):
-    with pytest.raises(ClientError, match='SerializationException'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with pytest.raises(ClientError, match="SerializationException"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'x', 'KeyType': 'HASH' },
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [
+                        {"AttributeName": "x", "KeyType": "HASH"},
                     ],
-                    'Projection': { 'ProjectionType': 'INCLUDE',
-                                    'NonKeyAttributes': ['a', 123] }
+                    "Projection": {
+                        "ProjectionType": "INCLUDE",
+                        "NonKeyAttributes": ["a", 123],
+                    },
                 }
-            ]) as table:
+            ],
+        ) as table:
             pass
+
 
 # An unsupported ProjectionType value should result in an error:
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_bad_projection_type(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*nonsense'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
+    with pytest.raises(ClientError, match="ValidationException.*nonsense"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'nonsense' }
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "nonsense"},
                 }
-            ]) as table:
+            ],
+        ) as table:
             pass
+
 
 # DynamoDB's says the "Projection" argument of GlobalSecondaryIndexes is
 # mandatory, and indeed Boto3 enforces that it must be passed. The
@@ -1525,33 +2296,44 @@ def test_gsi_bad_projection_type(dynamodb):
 # ProjectionType: null".
 @pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_missing_projection_type(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*ProjectionType'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
+    with pytest.raises(ClientError, match="ValidationException.*ProjectionType"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-                    'Projection': {}
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+                    "Projection": {},
                 }
-            ]) as table:
+            ],
+        ) as table:
             pass
+
 
 # Utility function for creating a new table a GSI with the given name,
 # and, if creation was successful, delete it. Useful for testing which
 # GSI names work.
 def create_gsi(dynamodb, index_name):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
         GlobalSecondaryIndexes=[
-            {   'IndexName': index_name,
-                'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-                'Projection': { 'ProjectionType': 'ALL' }
+            {
+                "IndexName": index_name,
+                "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ]) as table:
+        ],
+    ) as table:
         # Verify that the GSI wasn't just ignored, as Scylla originally did ;-)
-        assert 'GlobalSecondaryIndexes' in table.meta.client.describe_table(TableName=table.name)['Table']
+        assert (
+            "GlobalSecondaryIndexes"
+            in table.meta.client.describe_table(TableName=table.name)["Table"]
+        )
+
 
 # Like table names (tested in test_table.py), index names must must also
 # be 3-255 characters and match the regex [a-zA-Z0-9._-]+. This test
@@ -1560,40 +2342,49 @@ def create_gsi(dynamodb, index_name):
 # names, because both table name and index name, together, have to fit in
 # 221 characters. But we don't verify here this specific limitation.
 def test_gsi_unsupported_names(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*3'):
-        create_gsi(dynamodb, 'n')
-    with pytest.raises(ClientError, match='ValidationException.*3'):
-        create_gsi(dynamodb, 'nn')
-    with pytest.raises(ClientError, match='ValidationException.*nnnnn'):
-        create_gsi(dynamodb, 'n' * 256)
-    with pytest.raises(ClientError, match='ValidationException.*nyh'):
-        create_gsi(dynamodb, 'nyh@test')
+    with pytest.raises(ClientError, match="ValidationException.*3"):
+        create_gsi(dynamodb, "n")
+    with pytest.raises(ClientError, match="ValidationException.*3"):
+        create_gsi(dynamodb, "nn")
+    with pytest.raises(ClientError, match="ValidationException.*nnnnn"):
+        create_gsi(dynamodb, "n" * 256)
+    with pytest.raises(ClientError, match="ValidationException.*nyh"):
+        create_gsi(dynamodb, "nyh@test")
+
 
 # On the other hand, names following the above rules should be accepted. Even
 # names which the Scylla rules forbid, such as a name starting with .
 def test_gsi_non_scylla_name(dynamodb):
-    create_gsi(dynamodb, '.alternator_test')
+    create_gsi(dynamodb, ".alternator_test")
+
 
 # Index names with 255 characters are allowed in Dynamo. In Scylla, the
 # limit is different - the sum of both table and index length plus an extra 1
 # cannot exceed 222 characters.
 # (compare test_create_and_delete_table_255/222()).
-@pytest.mark.xfail(reason="Alternator limits table name length + GSI name length to 221")
+@pytest.mark.xfail(
+    reason="Alternator limits table name length + GSI name length to 221"
+)
 def test_gsi_very_long_name_255(dynamodb):
-    create_gsi(dynamodb, 'n' * 255)
+    create_gsi(dynamodb, "n" * 255)
+
+
 def test_gsi_very_long_name_256(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_gsi(dynamodb, 'n' * 256)
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_gsi(dynamodb, "n" * 256)
+
+
 def test_gsi_very_long_name_222(dynamodb, scylla_only):
     # If we subtract from 222 the table's name length (we assume that
     # unique_table_name() always returns the same length) and an extra 1,
     # this is how long the GSI's name may be:
     max = 222 - len(unique_table_name()) - 1
     # This max length should work:
-    create_gsi(dynamodb, 'n' * max)
+    create_gsi(dynamodb, "n" * max)
     # But a name one byte longer should fail:
-    with pytest.raises(ClientError, match='ValidationException.*total length'):
-        create_gsi(dynamodb, 'n' * (max+1))
+    with pytest.raises(ClientError, match="ValidationException.*total length"):
+        create_gsi(dynamodb, "n" * (max + 1))
+
 
 # Verify that ListTables does not list materialized views used for indexes.
 # This is hard to test, because we don't really know which table names
@@ -1603,29 +2394,34 @@ def test_gsi_very_long_name_222(dynamodb, scylla_only):
 # name. This assumes that materialized-view names are composed using the
 # index's name (which is currently what we do).
 
+
 @pytest.fixture(scope="module")
 def test_table_gsi_random_name(dynamodb):
     index_name = random_string()
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': index_name,
-                'KeySchema': [
-                    { 'AttributeName': 'c', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'p', 'KeyType': 'RANGE' },
+            {
+                "IndexName": index_name,
+                "KeySchema": [
+                    {"AttributeName": "c", "KeyType": "HASH"},
+                    {"AttributeName": "p", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
         ],
-        )
+    )
     yield [table, index_name]
     table.delete()
+
 
 def test_gsi_list_tables(dynamodb, test_table_gsi_random_name):
     table, index_name = test_table_gsi_random_name
@@ -1635,6 +2431,7 @@ def test_gsi_list_tables(dynamodb, test_table_gsi_random_name):
         assert not index_name in name
     # But of course, the table's name should be in the list:
     assert table.name in tables
+
 
 # Test the "Select" parameter of a Query on a GSI. We have in test_query.py
 # a test 'test_query_select' for this parameter on a query of a normal (base)
@@ -1646,86 +2443,154 @@ def test_gsi_list_tables(dynamodb, test_table_gsi_random_name):
 # of Select, and the second requiring also a proper implementation of
 # projection of just a subset of the attributes.
 def test_gsi_query_select_1(test_table_gsi_1):
-    items = [{'p': random_string(), 'c': random_string(), 'x': random_string(), 'y': random_string()} for i in range(10)]
+    items = [
+        {
+            "p": random_string(),
+            "c": random_string(),
+            "x": random_string(),
+            "y": random_string(),
+        }
+        for i in range(10)
+    ]
     with test_table_gsi_1.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    c = items[0]['c']
-    expected_items = [x for x in items if x['c'] == c]
-    assert_index_query(test_table_gsi_1, 'hello', expected_items,
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
+    c = items[0]["c"]
+    expected_items = [x for x in items if x["c"] == c]
+    assert_index_query(
+        test_table_gsi_1,
+        "hello",
+        expected_items,
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
     # Unlike in base tables, here Select=ALL_PROJECTED_ATTRIBUTES is
     # allowed, and in this case (all attributes are projected into this
     # index) returns all attributes.
-    assert_index_query(test_table_gsi_1, 'hello', expected_items,
-        Select='ALL_PROJECTED_ATTRIBUTES',
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_1,
+        "hello",
+        expected_items,
+        Select="ALL_PROJECTED_ATTRIBUTES",
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
     # Because in this GSI all attributes are projected into the index,
     # ALL_ATTRIBUTES is allowed as well. And so is SPECIFIC_ATTRIBUTES
     # (with AttributesToGet / ProjectionExpression) for any attributes,
     # and of course so is COUNT.
-    assert_index_query(test_table_gsi_1, 'hello', expected_items,
-        Select='ALL_ATTRIBUTES',
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
-    expected_items = [{'y': x['y']} for x in items if x['c'] == c]
-    assert_index_query(test_table_gsi_1, 'hello', expected_items,
-        Select='SPECIFIC_ATTRIBUTES',
-        AttributesToGet=['y'],
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
-    assert not 'Items' in test_table_gsi_1.query(ConsistentRead=False,
-        IndexName='hello',
-        Select='COUNT',
-        KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_1,
+        "hello",
+        expected_items,
+        Select="ALL_ATTRIBUTES",
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
+    expected_items = [{"y": x["y"]} for x in items if x["c"] == c]
+    assert_index_query(
+        test_table_gsi_1,
+        "hello",
+        expected_items,
+        Select="SPECIFIC_ATTRIBUTES",
+        AttributesToGet=["y"],
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
+    assert not "Items" in test_table_gsi_1.query(
+        ConsistentRead=False,
+        IndexName="hello",
+        Select="COUNT",
+        KeyConditions={"c": {"AttributeValueList": [c], "ComparisonOperator": "EQ"}},
+    )
+
 
 @pytest.mark.xfail(reason="Projection not supported yet. Issue #5036")
 def test_gsi_query_select_2(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [ { 'AttributeName': 'x', 'KeyType': 'HASH' } ],
-                'Projection': { 'ProjectionType': 'INCLUDE',
-                                'NonKeyAttributes': ['a'] }
+            {
+                "IndexName": "hello",
+                "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "INCLUDE", "NonKeyAttributes": ["a"]},
             }
-        ]) as table:
-        items = [{'p': random_string(), 'x': random_string(), 'a': random_string(), 'b': random_string()} for i in range(10)]
+        ],
+    ) as table:
+        items = [
+            {
+                "p": random_string(),
+                "x": random_string(),
+                "a": random_string(),
+                "b": random_string(),
+            }
+            for i in range(10)
+        ]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
-        x = items[0]['x']
+        x = items[0]["x"]
         # Unlike in base tables, here Select=ALL_PROJECTED_ATTRIBUTES is
         # allowed, and only the projected attributes are returned (in this
         # case the key of both base and GSI ('p' and 'x') and 'a' - but not
         # 'b'. Moreover, it is the default if Select isn't specified at all.
-        expected_items = [{'p': z['p'], 'x': z['x'], 'a': z['a']} for z in items if z['x'] == x]
-        assert_index_query(table, 'hello', expected_items,
-            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
-        assert_index_query(table, 'hello', expected_items,
-            Select='ALL_PROJECTED_ATTRIBUTES',
-            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        expected_items = [
+            {"p": z["p"], "x": z["x"], "a": z["a"]} for z in items if z["x"] == x
+        ]
+        assert_index_query(
+            table,
+            "hello",
+            expected_items,
+            KeyConditions={
+                "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}
+            },
+        )
+        assert_index_query(
+            table,
+            "hello",
+            expected_items,
+            Select="ALL_PROJECTED_ATTRIBUTES",
+            KeyConditions={
+                "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}
+            },
+        )
         # Because in this GSI not all attributes are projected into the index,
         # Select=ALL_ATTRIBUTES is *not* allowed.
-        with pytest.raises(ClientError, match='ValidationException.*ALL_ATTRIBUTES'):
-            assert_index_query(table, 'hello', expected_items,
-                Select='ALL_ATTRIBUTES',
-                KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        with pytest.raises(ClientError, match="ValidationException.*ALL_ATTRIBUTES"):
+            assert_index_query(
+                table,
+                "hello",
+                expected_items,
+                Select="ALL_ATTRIBUTES",
+                KeyConditions={
+                    "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}
+                },
+            )
         # SPECIFIC_ATTRIBUTES (with AttributesToGet / ProjectionExpression)
         # is allowed for the projected attributes, but not for unprojected
         # attributes.
-        expected_items = [{'a': z['a']} for z in items if z['x'] == x]
-        assert_index_query(table, 'hello', expected_items,
-            Select='SPECIFIC_ATTRIBUTES',
-            AttributesToGet=['a'],
-            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        expected_items = [{"a": z["a"]} for z in items if z["x"] == x]
+        assert_index_query(
+            table,
+            "hello",
+            expected_items,
+            Select="SPECIFIC_ATTRIBUTES",
+            AttributesToGet=["a"],
+            KeyConditions={
+                "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}
+            },
+        )
         # Select=COUNT is also allowed, and doesn't return item content
-        assert not 'Items' in table.query(ConsistentRead=False,
-            IndexName='hello',
-            Select='COUNT',
-            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        assert not "Items" in table.query(
+            ConsistentRead=False,
+            IndexName="hello",
+            Select="COUNT",
+            KeyConditions={
+                "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}
+            },
+        )
+
 
 # In all GSIs above, the GSI's key was a string from the base table
 # (AttributeType: S). While most of the GSI functionality is independent of
@@ -1736,57 +2601,66 @@ def test_gsi_query_select_2(dynamodb):
 # key or clustering key.
 @pytest.fixture(scope="module")
 def test_table_gsi_6(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 's', 'AttributeType': 'S' },
-                    { 'AttributeName': 'b', 'AttributeType': 'B' },
-                    { 'AttributeName': 'n', 'AttributeType': 'N' }
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "s", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "B"},
+            {"AttributeName": "n", "AttributeType": "N"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'gsi_s',
-                'KeySchema': [
-                    { 'AttributeName': 's', 'KeyType': 'HASH' },
+            {
+                "IndexName": "gsi_s",
+                "KeySchema": [
+                    {"AttributeName": "s", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             },
-            {   'IndexName': 'gsi_ss',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 's', 'KeyType': 'RANGE' },
+            {
+                "IndexName": "gsi_ss",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "s", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             },
-            {   'IndexName': 'gsi_b',
-                'KeySchema': [
-                    { 'AttributeName': 'b', 'KeyType': 'HASH' },
+            {
+                "IndexName": "gsi_b",
+                "KeySchema": [
+                    {"AttributeName": "b", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             },
-            {   'IndexName': 'gsi_sb',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'b', 'KeyType': 'RANGE' },
+            {
+                "IndexName": "gsi_sb",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "b", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             },
-            {   'IndexName': 'gsi_n',
-                'KeySchema': [
-                    { 'AttributeName': 'n', 'KeyType': 'HASH' },
+            {
+                "IndexName": "gsi_n",
+                "KeySchema": [
+                    {"AttributeName": "n", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             },
-            {   'IndexName': 'gsi_sn',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'n', 'KeyType': 'RANGE' },
+            {
+                "IndexName": "gsi_sn",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "n", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
-            }
-        ])
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    )
     yield table
     table.delete()
+
 
 # Tests for test_table_gsi_6, just checking that the write of different types
 # doesn't fail (below we'll have additional tests that also read the GSI).
@@ -1795,54 +2669,60 @@ def test_table_gsi_6(dynamodb):
 # tests is to check the "computed function" which our implementation uses to
 # parse the base-table values of different types.
 def test_gsi_6_write_s(test_table_gsi_6):
-    test_table_gsi_6.put_item(Item={'p': random_string(), 's': random_string()})
+    test_table_gsi_6.put_item(Item={"p": random_string(), "s": random_string()})
+
 
 def test_gsi_6_write_s_fail(test_table_gsi_6):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_gsi_6.put_item(Item={'p': p, 's': ''})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 's': 3})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 's': b'hi'})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 's': True})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 's': {'hi', 'there'}})
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_gsi_6.put_item(Item={"p": p, "s": ""})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "s": 3})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "s": b"hi"})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "s": True})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "s": {"hi", "there"}})
+
 
 def test_gsi_6_write_b(test_table_gsi_6):
     p = random_string()
     b = random_bytes()
-    test_table_gsi_6.put_item(Item={'p': p, 'b': b})
+    test_table_gsi_6.put_item(Item={"p": p, "b": b})
+
 
 def test_gsi_6_write_b_fail(test_table_gsi_6):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_gsi_6.put_item(Item={'p': p, 'b': b''})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 'b': 3})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 'b': 'hi'})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 'b': True})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 'b': {'hi', 'there'}})
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_gsi_6.put_item(Item={"p": p, "b": b""})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "b": 3})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "b": "hi"})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "b": True})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "b": {"hi", "there"}})
+
 
 def test_gsi_6_write_n(test_table_gsi_6):
     p = random_string()
     n = 87
-    test_table_gsi_6.put_item(Item={'p': p, 'n': n})
+    test_table_gsi_6.put_item(Item={"p": p, "n": n})
+
 
 def test_gsi_6_write_n_fail(test_table_gsi_6):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 'n': b'hi'})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 'n': 'hi'})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 'n': True})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_gsi_6.put_item(Item={'p': p, 'n': {'hi', 'there'}})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "n": b"hi"})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "n": "hi"})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "n": True})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_gsi_6.put_item(Item={"p": p, "n": {"hi", "there"}})
+
 
 def test_gsi_6(test_table_gsi_6):
     p = random_string()
@@ -1850,23 +2730,57 @@ def test_gsi_6(test_table_gsi_6):
     b = random_bytes()
     n = 17
     x = random_string()
-    item={'p': p, 's': s, 'b': b, 'n': n, 'x': x}
+    item = {"p": p, "s": s, "b": b, "n": n, "x": x}
     test_table_gsi_6.put_item(Item=item)
     # Check that all six GSIs as usable with their different keys.
     # Note that we're reading from six different GSIs, so we need to use
     # the maybe-retrying assert_index_query() for each of them.
-    assert_index_query(test_table_gsi_6, 'gsi_s', [item],
-        KeyConditions={'s': {'AttributeValueList': [s], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_6, 'gsi_ss', [item],
-        KeyConditions={'s': {'AttributeValueList': [s], 'ComparisonOperator': 'EQ'}, 'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_6, 'gsi_b', [item],
-        KeyConditions={'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_6, 'gsi_sb', [item],
-        KeyConditions={'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}, 'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_6, 'gsi_n', [item],
-        KeyConditions={'n': {'AttributeValueList': [n], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_6, 'gsi_sn', [item],
-        KeyConditions={'n': {'AttributeValueList': [n], 'ComparisonOperator': 'EQ'}, 'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_6,
+        "gsi_s",
+        [item],
+        KeyConditions={"s": {"AttributeValueList": [s], "ComparisonOperator": "EQ"}},
+    )
+    assert_index_query(
+        test_table_gsi_6,
+        "gsi_ss",
+        [item],
+        KeyConditions={
+            "s": {"AttributeValueList": [s], "ComparisonOperator": "EQ"},
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_6,
+        "gsi_b",
+        [item],
+        KeyConditions={"b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"}},
+    )
+    assert_index_query(
+        test_table_gsi_6,
+        "gsi_sb",
+        [item],
+        KeyConditions={
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_6,
+        "gsi_n",
+        [item],
+        KeyConditions={"n": {"AttributeValueList": [n], "ComparisonOperator": "EQ"}},
+    )
+    assert_index_query(
+        test_table_gsi_6,
+        "gsi_sn",
+        [item],
+        KeyConditions={
+            "n": {"AttributeValueList": [n], "ComparisonOperator": "EQ"},
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # Test that trying to create a table with two GSIs with the same name is an
 # error.
@@ -1875,67 +2789,81 @@ def test_gsi_6(test_table_gsi_6):
 # See also test_lsi.py::test_lsi_and_gsi_same_same which shows even GSIs
 # and LSIs may not have the same name (and explains why)
 def test_gsi_same_name_forbidden(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*Duplicate.*index1'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
+    with pytest.raises(ClientError, match="ValidationException.*Duplicate.*index1"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
-                { 'AttributeName': 'y', 'AttributeType': 'S' }
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
+                {"AttributeName": "y", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'index1',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
+                {
+                    "IndexName": "index1",
+                    "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
                 },
-                {   'IndexName': 'index1', # different index, samed name!
-                    'KeySchema': [{ 'AttributeName': 'y', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }
-            ]) as table:
+                {
+                    "IndexName": "index1",  # different index, samed name!
+                    "KeySchema": [{"AttributeName": "y", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+        ) as table:
             pass
     # Even if the two indexes are identical twins - having the same definition
     # exactly - it's not allowed.
-    with pytest.raises(ClientError, match='ValidationException.*Duplicate.*index1'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
+    with pytest.raises(ClientError, match="ValidationException.*Duplicate.*index1"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'index1',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
+                {
+                    "IndexName": "index1",
+                    "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
                 },
-                {   'IndexName': 'index1',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }
-            ]) as table:
+                {
+                    "IndexName": "index1",
+                    "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+        ) as table:
             pass
+
 
 # Trying to create two differently-named GSIs in the same table indexing
 # the same attribute with exactly the same parameters is redundant, but
 # allowed, and works (and not recommended because it is very wasteful...)
 def test_gsi_duplicate_with_different_name(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'index1',
-                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                'Projection': { 'ProjectionType': 'ALL' }
+            {
+                "IndexName": "index1",
+                "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
             },
-            {   'IndexName': 'index2', # same index, different name
-                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                'Projection': { 'ProjectionType': 'ALL' }
-            }
-        ]) as table:
+            {
+                "IndexName": "index2",  # same index, different name
+                "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    ) as table:
         pass
+
 
 # But, trying to create two different GSIs with different type for the same
 # key is NOT allowed. The reason is that DynamoDB wants to insist that future
@@ -1947,29 +2875,34 @@ def test_gsi_duplicate_with_different_name(dynamodb):
 # Reproduces #13870 (see also test_create_table_duplicate_attribute_name in
 # test_table.py).
 def test_gsi_key_type_conflict_on_create(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*uplicate.*xyz'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
+    with pytest.raises(ClientError, match="ValidationException.*uplicate.*xyz"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
             # Note how because how this API works, having two different types
             # for the same attribute 'xyz' looks very strange (there is not even
             # a way to say which definition applies to which index) so
             # unsurprisingly it's not accepted.
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'xyz', 'AttributeType': 'S' },
-                { 'AttributeName': 'xyz', 'AttributeType': 'N' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "xyz", "AttributeType": "S"},
+                {"AttributeName": "xyz", "AttributeType": "N"},
             ],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'index1',
-                    'KeySchema': [{ 'AttributeName': 'xyz', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-            },
-                {   'IndexName': 'index2',
-                    'KeySchema': [{ 'AttributeName': 'xyz', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }
-            ]) as table:
+                {
+                    "IndexName": "index1",
+                    "KeySchema": [{"AttributeName": "xyz", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+                {
+                    "IndexName": "index2",
+                    "KeySchema": [{"AttributeName": "xyz", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+        ) as table:
             pass
+
 
 # Test similar to test_11801 and test_11801_variant2, but this test first
 # updates the range key b to a new value (like variant2) and then sets it
@@ -1981,35 +2914,70 @@ def test_17119(test_table_gsi_3):
     p = random_string()
     a = random_string()
     b = random_string()
-    item = {'p': p, 'a': a, 'b': b, 'd': random_string()}
+    item = {"p": p, "a": a, "b": b, "d": random_string()}
     test_table_gsi_3.put_item(Item=item)
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     # Change the GSI range key b to a different value newb.
     newb = random_string()
-    test_table_gsi_3.update_item(Key={'p':  p}, AttributeUpdates={'b': {'Value': newb, 'Action': 'PUT'}})
-    item['b'] = newb
-    assert item == test_table_gsi_3.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"b": {"Value": newb, "Action": "PUT"}}
+    )
+    item["b"] = newb
+    assert item == test_table_gsi_3.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
     # The item newb should appear in the GSI, item b should be gone:
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [newb], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [newb], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
     # Change the GSI range key b back to its original value. Item newb
     # should disappear from the GSI, and item b should reappear:
-    test_table_gsi_3.update_item(Key={'p':  p}, AttributeUpdates={'b': {'Value': b, 'Action': 'PUT'}})
-    item['b'] = b
-    assert item == test_table_gsi_3.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    assert_index_query(test_table_gsi_3, 'hello', [],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [newb], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_3.update_item(
+        Key={"p": p}, AttributeUpdates={"b": {"Value": b, "Action": "PUT"}}
+    )
+    item["b"] = b
+    assert item == test_table_gsi_3.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [newb], "ComparisonOperator": "EQ"},
+        },
+    )
     # This assertion failed in issue #17119:
-    assert_index_query(test_table_gsi_3, 'hello', [item],
-        KeyConditions={'a': {'AttributeValueList': [a], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_3,
+        "hello",
+        [item],
+        KeyConditions={
+            "a": {"AttributeValueList": [a], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # This test is like test_17119 above, just in a table with just one new
 # key column in the GSI. The bug of #17119 doesn't reproduce here, showing
@@ -2017,29 +2985,54 @@ def test_17119(test_table_gsi_3):
 def test_17119a(test_table_gsi_2):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x, 'z': random_string()}
+    item = {"p": p, "x": x, "z": random_string()}
     test_table_gsi_2.put_item(Item=item)
-    assert_index_query(test_table_gsi_2, 'hello', [item],
-        KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [item],
+        KeyConditions={"x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}},
+    )
     # Change the GSI range key x to a different value.
     newx = random_string()
-    test_table_gsi_2.update_item(Key={'p':  p}, AttributeUpdates={'x': {'Value': newx, 'Action': 'PUT'}})
-    item['x'] = newx
-    assert item == test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_gsi_2.update_item(
+        Key={"p": p}, AttributeUpdates={"x": {"Value": newx, "Action": "PUT"}}
+    )
+    item["x"] = newx
+    assert item == test_table_gsi_2.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
     # The item newx should appear in the GSI, item x should be gone:
-    assert_index_query(test_table_gsi_2, 'hello', [item],
-        KeyConditions={'x': {'AttributeValueList': [newx], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_2, 'hello', [],
-        KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [item],
+        KeyConditions={"x": {"AttributeValueList": [newx], "ComparisonOperator": "EQ"}},
+    )
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [],
+        KeyConditions={"x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}},
+    )
     # Change the GSI range key x back to its original value. Item newx
     # should disappear from the GSI, and item x should reappear:
-    test_table_gsi_2.update_item(Key={'p':  p}, AttributeUpdates={'x': {'Value': x, 'Action': 'PUT'}})
-    item['x'] = x
-    assert item == test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    assert_index_query(test_table_gsi_2, 'hello', [],
-        KeyConditions={'x': {'AttributeValueList': [newx], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_gsi_2, 'hello', [item],
-        KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    test_table_gsi_2.update_item(
+        Key={"p": p}, AttributeUpdates={"x": {"Value": x, "Action": "PUT"}}
+    )
+    item["x"] = x
+    assert item == test_table_gsi_2.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [],
+        KeyConditions={"x": {"AttributeValueList": [newx], "ComparisonOperator": "EQ"}},
+    )
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [item],
+        KeyConditions={"x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}},
+    )
+
 
 # The following test checks what happens when we have an LSI and a GSI using
 # the same base-table attribute. We want to verify that if the implementation
@@ -2063,45 +3056,63 @@ def test_17119a(test_table_gsi_2):
 def test_gsi_and_lsi_same_key(dynamodb):
     # A table whose non-key column "x" serves as a range key in an LSI,
     # and partition key in a GSI.
-    with new_test_table(dynamodb,
+    with new_test_table(
+        dynamodb,
         KeySchema=[
             # Must have both hash key and range key to allow LSI creation
-            { 'AttributeName': 'p', 'KeyType': 'HASH' },
-            { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'c', 'AttributeType': 'S' },
-            { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'lsi',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'x', 'KeyType': 'RANGE' },
+            {
+                "IndexName": "lsi",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'gsi',
-                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                'Projection': { 'ProjectionType': 'ALL' }
+            {
+                "IndexName": "gsi",
+                "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ]) as table:
+        ],
+    ) as table:
         # Write some data with attribute x, see it appear in the base table
         # and both LSI and GSI.
-        p = random_string() # key column in base (and therefore in GSI & LSI)
-        c = random_string() # key column in base (and therefore in GSI & LSI)
-        x = random_string() # key column in LSI and GSI (regular in base)
-        y = random_string() # not a key anywhere
-        item = {'p': p, 'c': c, 'x': x, 'y': y}
+        p = random_string()  # key column in base (and therefore in GSI & LSI)
+        c = random_string()  # key column in base (and therefore in GSI & LSI)
+        x = random_string()  # key column in LSI and GSI (regular in base)
+        y = random_string()  # not a key anywhere
+        item = {"p": p, "c": c, "x": x, "y": y}
         table.put_item(Item=item)
-        assert table.get_item(Key={'p':  p, 'c': c}, ConsistentRead=True)['Item'] == item
-        assert_index_query(table, 'lsi', [item],
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}, 'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
-        assert_index_query(table, 'gsi', [item],
-            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        assert table.get_item(Key={"p": p, "c": c}, ConsistentRead=True)["Item"] == item
+        assert_index_query(
+            table,
+            "lsi",
+            [item],
+            KeyConditions={
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+                "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"},
+            },
+        )
+        assert_index_query(
+            table,
+            "gsi",
+            [item],
+            KeyConditions={
+                "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}
+            },
+        )
+
 
 # Check that any type besides S(tring), B(ytes) or N(umber)s is *not* NOT
 # allowed as the type of a GSI key attribute. We don't check here that these
@@ -2111,78 +3122,117 @@ def test_gsi_invalid_key_types(dynamodb):
     # The following are all the types that DynamoDB supports, as documented in
     # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.LowLevelAPI.html
     # also the non-existent type "junk" yields the same error message.
-    for key_type in ['BOOL', 'NULL', 'M', 'L', 'SS', 'NS', 'BS', 'junk']:
+    for key_type in ["BOOL", "NULL", "M", "L", "SS", "NS", "BS", "junk"]:
         # DynamDB's and Alternator's error messages are different, but both
         # include the invalid type's name in single quotes.
         with pytest.raises(ClientError, match=f"ValidationException.*'{key_type}'"):
-            with new_test_table(dynamodb,
-                KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+            with new_test_table(
+                dynamodb,
+                KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
                 AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': key_type },
+                    {"AttributeName": "p", "AttributeType": "S"},
+                    {"AttributeName": "x", "AttributeType": key_type},
                 ],
-                GlobalSecondaryIndexes=[{
-                    'IndexName': 'gsi',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }]) as table:
+                GlobalSecondaryIndexes=[
+                    {
+                        "IndexName": "gsi",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                ],
+            ) as table:
                 pass
+
 
 # In test_table_gsi_2, the base table has just a hash key "p", and the GSI
 # has just the hash key "x". The materialized view that Alternator uses to
 # implement this GSI needs to add "p" as an extra clustering key, but it
 # doesn't mean that "p" should be allowed in a KeyConditions or
 # KeyConditionExpression - it shouldn't because it's not a real range key.
-@pytest.mark.xfail(reason="Issue #26103")
+@pytest.mark.xfail(
+    reason="Alternator streams may generate event even if item did not really change #26103"
+)
 def test_faux_range_key_in_keyconditions(test_table_gsi_2):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x, 'z': random_string()}
+    item = {"p": p, "x": x, "z": random_string()}
     test_table_gsi_2.put_item(Item=item)
     # The GSI 'hello' has just "x" as a hash key, so it can be used in a
     # KeyConditions in Query:
-    assert_index_query(test_table_gsi_2, 'hello', [item],
-        KeyConditions={ 'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [item],
+        KeyConditions={"x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"}},
+    )
     # "p" is not a range key of this GSI, so it cannot be used in a
     # KeyConditions, and should be an error.
-    with pytest.raises(ClientError, match='ValidationException.*key condition'):
-        assert_index_query(test_table_gsi_2, 'hello', [item],
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                           'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    with pytest.raises(ClientError, match="ValidationException.*key condition"):
+        assert_index_query(
+            test_table_gsi_2,
+            "hello",
+            [item],
+            KeyConditions={
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+                "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"},
+            },
+        )
     # "z" is not a key of the GSI, so obviously the following command
     # must not work, but let's also check that the error message mentions
     # the write thing, not the irrelevant "p". The DynamoDB error message
     # is just "Query key condition not supported".
-    with pytest.raises(ClientError, match='ValidationException.*key condition'):
-        assert_index_query(test_table_gsi_2, 'hello', [item],
-            KeyConditions={'z': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                           'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+    with pytest.raises(ClientError, match="ValidationException.*key condition"):
+        assert_index_query(
+            test_table_gsi_2,
+            "hello",
+            [item],
+            KeyConditions={
+                "z": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+                "x": {"AttributeValueList": [x], "ComparisonOperator": "EQ"},
+            },
+        )
 
-@pytest.mark.xfail(reason="Issue #26103")
+
+@pytest.mark.xfail(
+    reason="Alternator streams may generate event even if item did not really change #26103"
+)
 def test_faux_range_key_in_keyconditionexpression(test_table_gsi_2):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x, 'z': random_string()}
+    item = {"p": p, "x": x, "z": random_string()}
     test_table_gsi_2.put_item(Item=item)
     # The GSI 'hello' has just "x" as a hash key, so it can be used in a
     # KeyConditionExpression in Query:
-    assert_index_query(test_table_gsi_2, 'hello', [item],
-        KeyConditionExpression='x=:x',
-        ExpressionAttributeValues={':x': x})
+    assert_index_query(
+        test_table_gsi_2,
+        "hello",
+        [item],
+        KeyConditionExpression="x=:x",
+        ExpressionAttributeValues={":x": x},
+    )
     # "p" is not a range key of this GSI, so it cannot be used in a
     # KeyConditionExpression, and should be an error.
-    with pytest.raises(ClientError, match='ValidationException.*key condition'):
-        assert_index_query(test_table_gsi_2, 'hello', [item],
-            KeyConditionExpression='x=:x AND p=:p',
-            ExpressionAttributeValues={':x': x, ':p': p})
+    with pytest.raises(ClientError, match="ValidationException.*key condition"):
+        assert_index_query(
+            test_table_gsi_2,
+            "hello",
+            [item],
+            KeyConditionExpression="x=:x AND p=:p",
+            ExpressionAttributeValues={":x": x, ":p": p},
+        )
     # "z" is not a key of the GSI, so obviously the following command
     # must not work, but let's also check that the error message mentions
     # the write thing, not the irrelevant "p". The DynamoDB error message
     # is just "Query key condition not supported".
-    with pytest.raises(ClientError, match='ValidationException.*key condition'):
-        assert_index_query(test_table_gsi_2, 'hello', [item],
-            KeyConditionExpression='x=:x AND z=:z',
-            ExpressionAttributeValues={':x': x, ':z': p})
+    with pytest.raises(ClientError, match="ValidationException.*key condition"):
+        assert_index_query(
+            test_table_gsi_2,
+            "hello",
+            [item],
+            KeyConditionExpression="x=:x AND z=:z",
+            ExpressionAttributeValues={":x": x, ":z": p},
+        )
+
 
 # While in test_scan.py and test_query.py we have extensive tests that
 # paging works for Scan and Query, the paging on a GSI might in theory
@@ -2191,7 +3241,7 @@ def test_faux_range_key_in_keyconditionexpression(test_table_gsi_2):
 # For simplicity, we'll test here just Query, not Scan.
 def test_gsi_query_paging(test_table_gsi_5):
     p = random_string()
-    items = [{'p': p, 'c': str(i), 'x': str(i%3)} for i in range(23)]
+    items = [{"p": p, "c": str(i), "x": str(i % 3)} for i in range(23)]
     with test_table_gsi_5.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
@@ -2201,23 +3251,28 @@ def test_gsi_query_paging(test_table_gsi_5):
         timeout = time.time() + 10
         while time.time() < timeout:
             query_args = {
-                'ConsistentRead': False,
-                'IndexName': 'hello',
-                'KeyConditions': {'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
-                'Limit': limit
+                "ConsistentRead": False,
+                "IndexName": "hello",
+                "KeyConditions": {
+                    "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}
+                },
+                "Limit": limit,
             }
             response = test_table_gsi_5.query(**query_args)
-            got_items = response['Items']
-            assert len(response['Items']) <= limit
-            while 'LastEvaluatedKey' in response:
-                response = test_table_gsi_5.query(ExclusiveStartKey=response['LastEvaluatedKey'], **query_args)
-                got_items.extend(response['Items'])
-                assert len(response['Items']) <= limit
+            got_items = response["Items"]
+            assert len(response["Items"]) <= limit
+            while "LastEvaluatedKey" in response:
+                response = test_table_gsi_5.query(
+                    ExclusiveStartKey=response["LastEvaluatedKey"], **query_args
+                )
+                got_items.extend(response["Items"])
+                assert len(response["Items"]) <= limit
             if multiset(items) == multiset(got_items):
                 # Test (for this limit) done successfully
                 break
             time.sleep(0.1)
         assert multiset(items) == multiset(got_items)
+
 
 # The previous test (test_gsi_query_paging) showed that paging a Query
 # on a GSI works correctly. In particular it means that each page returned an
@@ -2246,7 +3301,7 @@ def test_gsi_query_paging(test_table_gsi_5):
 # besides paging.
 def test_gsi_query_exclusivestartkey(test_table_gsi_5):
     p = random_string()
-    items = [{'p': p, 'c': str(i), 'x': str(i%3)} for i in range(23)]
+    items = [{"p": p, "c": str(i), "x": str(i % 3)} for i in range(23)]
     with test_table_gsi_5.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
@@ -2254,15 +3309,18 @@ def test_gsi_query_exclusivestartkey(test_table_gsi_5):
     # but usually, we won't.
     timeout = time.time() + 10
     while time.time() < timeout:
-        exclusive_start_key = {'p': p, 'x': '1', 'c': '7'}
+        exclusive_start_key = {"p": p, "x": "1", "c": "7"}
         query_args = {
-            'ConsistentRead': False,
-            'IndexName': 'hello',
-            'KeyConditions': {'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+            "ConsistentRead": False,
+            "IndexName": "hello",
+            "KeyConditions": {
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}
+            },
         }
         response = test_table_gsi_5.query(
-            ExclusiveStartKey=exclusive_start_key, **query_args)
-        got_items = response['Items']
+            ExclusiveStartKey=exclusive_start_key, **query_args
+        )
+        got_items = response["Items"]
         # Now we have a problem - we don't know which order to expect items
         # to be returned. We do know that items are sorted by x, but don't
         # know how items tied on x will be sorted! In Scylla, the tied items
@@ -2272,18 +3330,19 @@ def test_gsi_query_exclusivestartkey(test_table_gsi_5):
         # So what we can do is the read *all* the items from the GSI (without
         # an ExclusiveStartKey), and then verify that ExclusiveStartKey
         # started in the right place of that all_gsi_items.
-        all_gsi_items = test_table_gsi_5.query(**query_args)['Items']
+        all_gsi_items = test_table_gsi_5.query(**query_args)["Items"]
         if multiset(all_gsi_items) != multiset(items):
             # we didn't read yet all items, need to retry
             time.sleep(0.1)
             continue
         index = all_gsi_items.index(exclusive_start_key)
-        expected_items = all_gsi_items[index+1:]
+        expected_items = all_gsi_items[index + 1 :]
         if multiset(expected_items) == multiset(got_items):
             # Test done successfully
             break
         time.sleep(0.1)
     assert multiset(expected_items) == multiset(got_items)
+
 
 # In the previous test (test_gsi_query_exclusivestartkey) we should that
 # ExclusiveStartKey contain all the base and GSI key columns (in our
@@ -2293,96 +3352,117 @@ def test_gsi_query_exclusivestartkey_missing_column(test_table_gsi_5):
     # The error that DynamoDB reports if the sort key is missing in
     # ExclusiveStartKey is "The provided starting key is invalid". In
     # Alternator, the error is "Key column c not found".
-    with pytest.raises(ClientError, match='ValidationException.*[kK]ey'):
+    with pytest.raises(ClientError, match="ValidationException.*[kK]ey"):
         test_table_gsi_5.query(
             ConsistentRead=False,
-            IndexName='hello',
-            KeyConditions={'p': { 'AttributeValueList': ['dog'], 'ComparisonOperator': 'EQ'}},
+            IndexName="hello",
+            KeyConditions={
+                "p": {"AttributeValueList": ["dog"], "ComparisonOperator": "EQ"}
+            },
             # missing 'c':
-            ExclusiveStartKey= { 'p': 'dog', 'x': 'cat' })
-    with pytest.raises(ClientError, match='ValidationException.*[kK]ey'):
+            ExclusiveStartKey={"p": "dog", "x": "cat"},
+        )
+    with pytest.raises(ClientError, match="ValidationException.*[kK]ey"):
         test_table_gsi_5.query(
             ConsistentRead=False,
-            IndexName='hello',
-            KeyConditions={'p': { 'AttributeValueList': ['dog'], 'ComparisonOperator': 'EQ'}},
+            IndexName="hello",
+            KeyConditions={
+                "p": {"AttributeValueList": ["dog"], "ComparisonOperator": "EQ"}
+            },
             # missing 'x':
-            ExclusiveStartKey= { 'p': 'dog', 'c': 'cat' })
-    with pytest.raises(ClientError, match='ValidationException.*[kK]ey'):
+            ExclusiveStartKey={"p": "dog", "c": "cat"},
+        )
+    with pytest.raises(ClientError, match="ValidationException.*[kK]ey"):
         test_table_gsi_5.query(
             ConsistentRead=False,
-            IndexName='hello',
-            KeyConditions={'p': { 'AttributeValueList': ['dog'], 'ComparisonOperator': 'EQ'}},
+            IndexName="hello",
+            KeyConditions={
+                "p": {"AttributeValueList": ["dog"], "ComparisonOperator": "EQ"}
+            },
             # missing 'p':
-            ExclusiveStartKey= { 'c': 'dog', 'x': 'cat' })
+            ExclusiveStartKey={"c": "dog", "x": "cat"},
+        )
+
 
 # When Query'ing on a certain GSI partition key and/or sort key,
 # ExclusiveStartKey must have the same partition/sort key value.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(
+    reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988"
+)
 def test_gsi_query_exclusivestartkey_wrong_partition(test_table_gsi_5):
     # The error that DynamoDB reports if the wrong partition is mentioned
     # in ExclusiveStartKey is "The provided starting key is outside query
     # boundaries based on provided conditions".
     # Query a whole GSI partition:
-    with pytest.raises(ClientError, match='ValidationException.*starting key'):
+    with pytest.raises(ClientError, match="ValidationException.*starting key"):
         test_table_gsi_5.query(
             ConsistentRead=False,
-            IndexName='hello',
-            KeyConditions={'p': { 'AttributeValueList': ['right'], 'ComparisonOperator': 'EQ'}},
-            ExclusiveStartKey= { 'p': 'wrong', 'c': 'dog', 'x': 'cat' })
+            IndexName="hello",
+            KeyConditions={
+                "p": {"AttributeValueList": ["right"], "ComparisonOperator": "EQ"}
+            },
+            ExclusiveStartKey={"p": "wrong", "c": "dog", "x": "cat"},
+        )
     # Query with a GSI partition and sort key (this can still return
     # multiple items, so ExclusiveStartKey makes sense).
-    with pytest.raises(ClientError, match='ValidationException.*starting key'):
+    with pytest.raises(ClientError, match="ValidationException.*starting key"):
         test_table_gsi_5.query(
             ConsistentRead=False,
-            IndexName='hello',
+            IndexName="hello",
             KeyConditions={
-                'p': { 'AttributeValueList': ['rightp'], 'ComparisonOperator': 'EQ'},
-                'x': { 'AttributeValueList': ['rightx'], 'ComparisonOperator': 'EQ'}
+                "p": {"AttributeValueList": ["rightp"], "ComparisonOperator": "EQ"},
+                "x": {"AttributeValueList": ["rightx"], "ComparisonOperator": "EQ"},
             },
-            ExclusiveStartKey= { 'p': 'rightp', 'c': 'dog', 'x': 'wrongx' })
+            ExclusiveStartKey={"p": "rightp", "c": "dog", "x": "wrongx"},
+        )
     # Confirm that rightp, rightx the ExclusiveStartKey *is* supported
     test_table_gsi_5.query(
         ConsistentRead=False,
-        IndexName='hello',
+        IndexName="hello",
         KeyConditions={
-            'p': { 'AttributeValueList': ['rightp'], 'ComparisonOperator': 'EQ'},
-            'x': { 'AttributeValueList': ['rightx'], 'ComparisonOperator': 'EQ'}
+            "p": {"AttributeValueList": ["rightp"], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": ["rightx"], "ComparisonOperator": "EQ"},
         },
-        ExclusiveStartKey= { 'p': 'rightp', 'c': 'dog', 'x': 'rightx' })
+        ExclusiveStartKey={"p": "rightp", "c": "dog", "x": "rightx"},
+    )
     # If ExclusiveStartKey's p includes the wrong value but x is right,
     # DynamoDB prints a different - and strange - error message: "The query
     # can return at most one row and cannot be restarted". This message is not
     # really true: As we saw in the previous statement, when ExclusiveStartKey
     # does contain the right values - it is allowed, and this query doesn't
     # really return just one row.
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="ValidationException"):
         test_table_gsi_5.query(
             ConsistentRead=False,
-            IndexName='hello',
+            IndexName="hello",
             KeyConditions={
-                'p': { 'AttributeValueList': ['rightp'], 'ComparisonOperator': 'EQ'},
-                'x': { 'AttributeValueList': ['rightx'], 'ComparisonOperator': 'EQ'}
+                "p": {"AttributeValueList": ["rightp"], "ComparisonOperator": "EQ"},
+                "x": {"AttributeValueList": ["rightx"], "ComparisonOperator": "EQ"},
             },
-            ExclusiveStartKey= { 'p': 'wrongp', 'c': 'dog', 'x': 'rightx' })
+            ExclusiveStartKey={"p": "wrongp", "c": "dog", "x": "rightx"},
+        )
+
 
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key columns of the base and the GSI.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(
+    reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988"
+)
 def test_gsi_query_exclusivestartkey_spurious_column(test_table_gsi_5):
     query_args = {
-        'ConsistentRead': False,
-        'IndexName': 'hello',
-        'KeyConditions': {
-            'p': { 'AttributeValueList': ['dog'], 'ComparisonOperator': 'EQ'},
-            'x': { 'AttributeValueList': ['cat'], 'ComparisonOperator': 'EQ'}
-        }
+        "ConsistentRead": False,
+        "IndexName": "hello",
+        "KeyConditions": {
+            "p": {"AttributeValueList": ["dog"], "ComparisonOperator": "EQ"},
+            "x": {"AttributeValueList": ["cat"], "ComparisonOperator": "EQ"},
+        },
     }
-    exclusive_start_key = { 'p': 'dog', 'c': 'mouse', 'x': 'cat' }
+    exclusive_start_key = {"p": "dog", "c": "mouse", "x": "cat"}
     # This ExclusiveStartKey has the right columns - p, c and x - and works.
     test_table_gsi_5.query(ExclusiveStartKey=exclusive_start_key, **query_args)
     # If we add to exclusive_start_key a spurious column y, it fails.
-    exclusive_start_key['y'] = 'meerkat'
-    with pytest.raises(ClientError, match='ValidationException.*starting key'):
+    exclusive_start_key["y"] = "meerkat"
+    with pytest.raises(ClientError, match="ValidationException.*starting key"):
         test_table_gsi_5.query(ExclusiveStartKey=exclusive_start_key, **query_args)

--- a/test/alternator/test_gsi_updatetable.py
+++ b/test/alternator/test_gsi_updatetable.py
@@ -10,9 +10,17 @@
 
 import pytest
 from botocore.exceptions import ClientError
-from .util import random_string, full_scan, full_query, multiset, \
-    new_test_table, wait_for_gsi, wait_for_gsi_gone
+from .util import (
+    random_string,
+    full_scan,
+    full_query,
+    multiset,
+    new_test_table,
+    wait_for_gsi,
+    wait_for_gsi_gone,
+)
 from .test_gsi import assert_index_query
+
 
 # All tests in test_gsi.py involved creating a new table with a GSI up-front.
 # This test will be about creating a base table *without* a GSI, putting data
@@ -28,39 +36,62 @@ def test_gsi_backfill(dynamodb):
     # indexed. Items in item2 have no value for 'x', and in intems in
     # items3 'x' is in not a string; So the items in items2 and items3
     # will be missing in the index that we'll create later.
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
-        items1 = [{'p': random_string(), 'x': random_string(), 'y': random_string()} for i in range(10)]
-        items2 = [{'p': random_string(), 'y': random_string()} for i in range(10)]
-        items3 = [{'p': random_string(), 'x': i} for i in range(10)]
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+    ) as table:
+        items1 = [
+            {"p": random_string(), "x": random_string(), "y": random_string()}
+            for i in range(10)
+        ]
+        items2 = [{"p": random_string(), "y": random_string()} for i in range(10)]
+        items3 = [{"p": random_string(), "x": i} for i in range(10)]
         items = items1 + items2 + items3
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
         assert multiset(items) == multiset(full_scan(table))
         # Now use UpdateTable to create the GSI
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' }],
-            GlobalSecondaryIndexUpdates=[ {  'Create':
-                {  'IndexName': 'hello',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }}])
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "S"}],
+            GlobalSecondaryIndexUpdates=[
+                {
+                    "Create": {
+                        "IndexName": "hello",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                }
+            ],
+        )
         # update_table is an asynchronous operation. We need to wait until it
         # finishes and the table is backfilled.
-        wait_for_gsi(table, 'hello')
+        wait_for_gsi(table, "hello")
         # As explained above, only items in items1 got copied to the gsi,
         # so this is what a full table scan on the GSI 'hello' should return.
         # Note that we don't need to retry the reads here (i.e., use the
         # assert_index_scan() function) because after we waited for
         # backfilling to complete, we know all the pre-existing data is
         # already in the index.
-        assert multiset(items1) == multiset(full_scan(table, ConsistentRead=False, IndexName='hello'))
+        assert multiset(items1) == multiset(
+            full_scan(table, ConsistentRead=False, IndexName="hello")
+        )
         # We can also use Query on the new GSI, to search on the attribute x:
-        assert multiset([items1[3]]) == multiset(full_query(table,
-            ConsistentRead=False, IndexName='hello',
-            KeyConditions={'x': {'AttributeValueList': [items1[3]['x']], 'ComparisonOperator': 'EQ'}}))
+        assert multiset([items1[3]]) == multiset(
+            full_query(
+                table,
+                ConsistentRead=False,
+                IndexName="hello",
+                KeyConditions={
+                    "x": {
+                        "AttributeValueList": [items1[3]["x"]],
+                        "ComparisonOperator": "EQ",
+                    }
+                },
+            )
+        )
         # Because the GSI now exists, we are no longer allowed to add to the
         # base table items with a wrong type for x (like we were able to add
         # earlier - see items3). But if x is missing (as in items2), we
@@ -68,21 +99,31 @@ def test_gsi_backfill(dynamodb):
         # (but the view table doesn't change).
         p = random_string()
         y = random_string()
-        table.put_item(Item={'p': p, 'y': y})
-        assert table.get_item(Key={'p':  p}, ConsistentRead=True)['Item'] == {'p': p, 'y': y}
-        with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-            table.put_item(Item={'p': random_string(), 'x': 3})
+        table.put_item(Item={"p": p, "y": y})
+        assert table.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+            "p": p,
+            "y": y,
+        }
+        with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+            table.put_item(Item={"p": random_string(), "x": 3})
 
         # Let's also test that we cannot add another index with the same name
         # that already exists
-        with pytest.raises(ClientError, match='ValidationException.*already exists'):
-            dynamodb.meta.client.update_table(TableName=table.name,
-                AttributeDefinitions=[{ 'AttributeName': 'y', 'AttributeType': 'S' }],
-                GlobalSecondaryIndexUpdates=[ {  'Create':
-                    {  'IndexName': 'hello',
-                        'KeySchema': [{ 'AttributeName': 'y', 'KeyType': 'HASH' }],
-                        'Projection': { 'ProjectionType': 'ALL' }
-                    }}])
+        with pytest.raises(ClientError, match="ValidationException.*already exists"):
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                AttributeDefinitions=[{"AttributeName": "y", "AttributeType": "S"}],
+                GlobalSecondaryIndexUpdates=[
+                    {
+                        "Create": {
+                            "IndexName": "hello",
+                            "KeySchema": [{"AttributeName": "y", "KeyType": "HASH"}],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    }
+                ],
+            )
+
 
 # Another test similar to the above test_gsi_backfill(), but here we add
 # a GSI to a table that already has an LSI with the same key column, and
@@ -91,137 +132,213 @@ def test_gsi_backfill(dynamodb):
 # that instead of the usual computed column.
 def test_gsi_backfill_with_lsi(dynamodb):
     # First create, and fill, a table with an LSI but without GSI.
-    with new_test_table(dynamodb,
-            KeySchema=[
-                # Must have both hash key and range key to allow LSI creation
-                { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                { 'AttributeName': 'c', 'KeyType': 'RANGE' }
-            ],
-            AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'c', 'AttributeType': 'S' },
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
-            ],
-            LocalSecondaryIndexes=[
-                {   'IndexName': 'lsi',
-                    'KeySchema': [
-                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'x', 'KeyType': 'RANGE' },
-                    ],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }
-            ]) as table:
-        items = [{'p': random_string(), 'c': random_string(), 'x': random_string(), 'y': random_string()} for i in range(10)]
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            # Must have both hash key and range key to allow LSI creation
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
+        ],
+        LocalSecondaryIndexes=[
+            {
+                "IndexName": "lsi",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    ) as table:
+        items = [
+            {
+                "p": random_string(),
+                "c": random_string(),
+                "x": random_string(),
+                "y": random_string(),
+            }
+            for i in range(10)
+        ]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
         assert multiset(items) == multiset(full_scan(table))
         # Now use UpdateTable to create the GSI
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' }],
-            GlobalSecondaryIndexUpdates=[ {  'Create':
-                {   'IndexName': 'gsi',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }}])
-        wait_for_gsi(table, 'gsi')
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "S"}],
+            GlobalSecondaryIndexUpdates=[
+                {
+                    "Create": {
+                        "IndexName": "gsi",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                }
+            ],
+        )
+        wait_for_gsi(table, "gsi")
         # Check that the GSI got backfilled as expected.
-        assert multiset(items) == multiset(full_scan(table, ConsistentRead=False, IndexName='gsi'))
+        assert multiset(items) == multiset(
+            full_scan(table, ConsistentRead=False, IndexName="gsi")
+        )
         # Let's also test that we cannot add a GSI with the same name as an
         # already existing LSI (see test_lsi.py::test_lsi_and_gsi_same_same
         # for an explanation why this is so)
-        with pytest.raises(ClientError, match='ValidationException.*already exists'):
-            dynamodb.meta.client.update_table(TableName=table.name,
-                AttributeDefinitions=[{ 'AttributeName': 'y', 'AttributeType': 'S' }],
-                GlobalSecondaryIndexUpdates=[ {  'Create':
-                    {  'IndexName': 'lsi',
-                        'KeySchema': [{ 'AttributeName': 'y', 'KeyType': 'HASH' }],
-                        'Projection': { 'ProjectionType': 'ALL' }
-                    }}])
+        with pytest.raises(ClientError, match="ValidationException.*already exists"):
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                AttributeDefinitions=[{"AttributeName": "y", "AttributeType": "S"}],
+                GlobalSecondaryIndexUpdates=[
+                    {
+                        "Create": {
+                            "IndexName": "lsi",
+                            "KeySchema": [{"AttributeName": "y", "KeyType": "HASH"}],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    }
+                ],
+            )
         # When we created the GSI above we had to specify in
         # AttributeDefinitons the type of "x", even though DynamoDB already
         # knows it (because it's already a base key column). Let's verify we
         # aren't allowed to skip this AttributeDefinitions, even if it's
         # redundant:
-        with pytest.raises(ClientError, match='ValidationException.*AttributeDefinitions'):
-            dynamodb.meta.client.update_table(TableName=table.name,
-                GlobalSecondaryIndexUpdates=[ {  'Create':
-                    {   'IndexName': 'gsi2',
-                        'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                        'Projection': { 'ProjectionType': 'ALL' }
-                    }}])
+        with pytest.raises(
+            ClientError, match="ValidationException.*AttributeDefinitions"
+        ):
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                GlobalSecondaryIndexUpdates=[
+                    {
+                        "Create": {
+                            "IndexName": "gsi2",
+                            "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    }
+                ],
+            )
+
 
 # Another test similar to the above test_gsi_backfill_with_lsi() where we
 # checked the case of a new GSI key being a real column because it was an
 # LSI key. In this test the GSI key is a real column because it was a
 # key column of the base table itself.
 def test_gsi_backfill_with_real_column(dynamodb):
-    with new_test_table(dynamodb,
-            KeySchema=[
-                { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                { 'AttributeName': 'c', 'KeyType': 'RANGE' }
-            ],
-            AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'c', 'AttributeType': 'S' },
-            ]) as table:
-        items = [{'p': random_string(), 'c': random_string(), 'x': random_string(), 'y': random_string()} for i in range(10)]
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
+    ) as table:
+        items = [
+            {
+                "p": random_string(),
+                "c": random_string(),
+                "x": random_string(),
+                "y": random_string(),
+            }
+            for i in range(10)
+        ]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
         assert multiset(items) == multiset(full_scan(table))
         # Now use UpdateTable to create the GSI, with the key "c", already
         # a key column in the base table
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'c', 'AttributeType': 'S' }],
-            GlobalSecondaryIndexUpdates=[ {  'Create':
-                {   'IndexName': 'gsi',
-                    'KeySchema': [{ 'AttributeName': 'c', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }}])
-        wait_for_gsi(table, 'gsi')
-        assert multiset(items) == multiset(full_scan(table, ConsistentRead=False, IndexName='gsi'))
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[{"AttributeName": "c", "AttributeType": "S"}],
+            GlobalSecondaryIndexUpdates=[
+                {
+                    "Create": {
+                        "IndexName": "gsi",
+                        "KeySchema": [{"AttributeName": "c", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                }
+            ],
+        )
+        wait_for_gsi(table, "gsi")
+        assert multiset(items) == multiset(
+            full_scan(table, ConsistentRead=False, IndexName="gsi")
+        )
+
 
 # Test deleting an existing GSI using UpdateTable
 def test_gsi_delete(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "x", "KeyType": "HASH"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ]) as table:
-        items = [{'p': random_string(), 'x': random_string()} for i in range(10)]
+        ],
+    ) as table:
+        items = [{"p": random_string(), "x": random_string()} for i in range(10)]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
         # So far, we have the GSI for "x" and can use it:
-        assert_index_query(table, 'hello', [items[3]],
-            KeyConditions={'x': {'AttributeValueList': [items[3]['x']], 'ComparisonOperator': 'EQ'}})
+        assert_index_query(
+            table,
+            "hello",
+            [items[3]],
+            KeyConditions={
+                "x": {"AttributeValueList": [items[3]["x"]], "ComparisonOperator": "EQ"}
+            },
+        )
         # Now use UpdateTable to delete the GSI for "x"
-        dynamodb.meta.client.update_table(TableName=table.name,
-            GlobalSecondaryIndexUpdates=[{  'Delete':
-                { 'IndexName': 'hello' } }])
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            GlobalSecondaryIndexUpdates=[{"Delete": {"IndexName": "hello"}}],
+        )
         # update_table() is an asynchronous operation. We need to wait until
         # it finishes and the GSI is removed.
-        wait_for_gsi_gone(table, 'hello')
+        wait_for_gsi_gone(table, "hello")
         # Now index is gone. We cannot query using it.
-        with pytest.raises(ClientError, match='ValidationException.*hello'):
-            full_query(table, ConsistentRead=False, IndexName='hello',
-                KeyConditions={'x': {'AttributeValueList': [items[3]['x']], 'ComparisonOperator': 'EQ'}})
+        with pytest.raises(ClientError, match="ValidationException.*hello"):
+            full_query(
+                table,
+                ConsistentRead=False,
+                IndexName="hello",
+                KeyConditions={
+                    "x": {
+                        "AttributeValueList": [items[3]["x"]],
+                        "ComparisonOperator": "EQ",
+                    }
+                },
+            )
         # When we had a GSI on x with type S, we weren't allowed to insert
         # items with a number for x. Now, after dropping this GSI, we should
         # be able to insert any type for x:
         p = random_string()
-        table.put_item(Item={'p': p, 'x': 7})
-        assert table.get_item(Key={'p':  p}, ConsistentRead=True)['Item'] == {'p': p, 'x': 7}
+        table.put_item(Item={"p": p, "x": 7})
+        assert table.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+            "p": p,
+            "x": 7,
+        }
+
 
 # Another test for deleting a GSI using UpdateTable, similar to the previous
 # test test_gsi_delete() but in this test we *also* have an LSI whose range
@@ -233,78 +350,116 @@ def test_gsi_delete(dynamodb):
 def test_gsi_delete_with_lsi(dynamodb):
     # A table whose non-key column "x" serves as a range key in an LSI,
     # and partition key in a GSI.
-    with new_test_table(dynamodb,
+    with new_test_table(
+        dynamodb,
         KeySchema=[
             # Must have both hash key and range key to allow LSI creation
-            { 'AttributeName': 'p', 'KeyType': 'HASH' },
-            { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'c', 'AttributeType': 'S' },
-            { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'lsi',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'x', 'KeyType': 'RANGE' },
+            {
+                "IndexName": "lsi",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'gsi',
-                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                'Projection': { 'ProjectionType': 'ALL' }
+            {
+                "IndexName": "gsi",
+                "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ]) as table:
+        ],
+    ) as table:
         # We shouldn't need to wait for a GSI created together with the
         # table, but let's do it anyway to work around bug #9059 (which
         # isn't what this test is trying to reproduce).
-        wait_for_gsi(table, 'gsi')
-        items = [{'p': random_string(), 'c': random_string(), 'x': random_string()} for i in range(10)]
+        wait_for_gsi(table, "gsi")
+        items = [
+            {"p": random_string(), "c": random_string(), "x": random_string()}
+            for i in range(10)
+        ]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
         # So far, we have the GSI for "x" and can use it:
-        assert_index_query(table, 'gsi', [items[3]],
-            KeyConditions={'x': {'AttributeValueList': [items[3]['x']], 'ComparisonOperator': 'EQ'}})
+        assert_index_query(
+            table,
+            "gsi",
+            [items[3]],
+            KeyConditions={
+                "x": {"AttributeValueList": [items[3]["x"]], "ComparisonOperator": "EQ"}
+            },
+        )
         # As a sanity check, see we can't create a GSI called 'gsi' because
         # this name is already taken.
-        with pytest.raises(ClientError, match='ValidationException.*already exists'):
-            dynamodb.meta.client.update_table(TableName=table.name,
-                AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' }],
-                GlobalSecondaryIndexUpdates=[{ 'Create': {
-                    'IndexName': 'gsi',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }}}])
+        with pytest.raises(ClientError, match="ValidationException.*already exists"):
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "S"}],
+                GlobalSecondaryIndexUpdates=[
+                    {
+                        "Create": {
+                            "IndexName": "gsi",
+                            "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    }
+                ],
+            )
         # Now use UpdateTable to delete the GSI for "x"
-        dynamodb.meta.client.update_table(TableName=table.name,
-            GlobalSecondaryIndexUpdates=[{ 'Delete': { 'IndexName': 'gsi' } }])
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            GlobalSecondaryIndexUpdates=[{"Delete": {"IndexName": "gsi"}}],
+        )
         # update_table is an asynchronous operation. We need to wait until it
         # finishes and the GSI is removed.
-        wait_for_gsi_gone(table, 'gsi')
+        wait_for_gsi_gone(table, "gsi")
         # Now index is gone. We can no longer query using it.
-        with pytest.raises(ClientError, match='ValidationException.*gsi'):
-            full_query(table, ConsistentRead=False, IndexName='gsi',
-                KeyConditions={'x': {'AttributeValueList': [items[3]['x']], 'ComparisonOperator': 'EQ'}})
+        with pytest.raises(ClientError, match="ValidationException.*gsi"):
+            full_query(
+                table,
+                ConsistentRead=False,
+                IndexName="gsi",
+                KeyConditions={
+                    "x": {
+                        "AttributeValueList": [items[3]["x"]],
+                        "ComparisonOperator": "EQ",
+                    }
+                },
+            )
         # The attribute "x" is still a LSI key of type S, so we still aren't
         # allowed to insert items with a number for x.
-        with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-            table.put_item(Item={'p': random_string(), 'c': random_string(), 'x': 7})
+        with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+            table.put_item(Item={"p": random_string(), "c": random_string(), "x": 7})
         # Of course, we can't delete the same GSI again after it's deleted
-        with pytest.raises(ClientError, match='ResourceNotFoundException'):
-            dynamodb.meta.client.update_table(TableName=table.name,
-                GlobalSecondaryIndexUpdates=[{ 'Delete': { 'IndexName': 'gsi' } }])
+        with pytest.raises(ClientError, match="ResourceNotFoundException"):
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                GlobalSecondaryIndexUpdates=[{"Delete": {"IndexName": "gsi"}}],
+            )
         # A GSI can be deleted, but an LSI can't. Alternator and DynamoDB
         # give different errors in this case - Alternator gives a
         # ResourceNotFoundException since no such GSI exists, but DynamoDB
         # gives a ValidationException saying it knows it's an index but
         # it's not a GSI. I think this difference is acceptable.
-        with pytest.raises(ClientError, match='ResourceNotFoundException|ValidationException'):
-            dynamodb.meta.client.update_table(TableName=table.name,
-                GlobalSecondaryIndexUpdates=[{ 'Delete': { 'IndexName': 'lsi' } }])
+        with pytest.raises(
+            ClientError, match="ResourceNotFoundException|ValidationException"
+        ):
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                GlobalSecondaryIndexUpdates=[{"Delete": {"IndexName": "lsi"}}],
+            )
+
 
 # In the previous tests we performed a UpdateTable GSI Create or Delete
 # operation on a table set up by CreateTable. In this test we try several
@@ -312,65 +467,101 @@ def test_gsi_delete_with_lsi(dynamodb):
 # delete a GSI that we just added, recreate a GSI that we just deleted, etc.
 def test_gsi_creates_and_deletes(dynamodb):
     schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' }]
+        "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
     }
     create_gsi = lambda name, key: {
-        'AttributeDefinitions': [{ 'AttributeName': key, 'AttributeType': 'S' }],
-        'GlobalSecondaryIndexUpdates': [
-            {  'Create':
-                {  'IndexName': name,
-                    'KeySchema': [{ 'AttributeName': key, 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
+        "AttributeDefinitions": [{"AttributeName": key, "AttributeType": "S"}],
+        "GlobalSecondaryIndexUpdates": [
+            {
+                "Create": {
+                    "IndexName": name,
+                    "KeySchema": [{"AttributeName": key, "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
                 }
             }
-        ]}
+        ],
+    }
     delete_gsi = lambda name: {
-        'GlobalSecondaryIndexUpdates': [
-            {  'Delete': { 'IndexName': name } }
-        ]}
+        "GlobalSecondaryIndexUpdates": [{"Delete": {"IndexName": name}}]
+    }
     with new_test_table(dynamodb, **schema) as table:
-        items = [{'p': random_string(), 'x': random_string(), 'y': random_string()} for i in range(10)]
+        items = [
+            {"p": random_string(), "x": random_string(), "y": random_string()}
+            for i in range(10)
+        ]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
         # Create indexes gsi1 and gsi2 for "x" and for "y" respectively,
         # in two separate UpdateTable requests:
         dynamodb.meta.client.update_table(
-            TableName=table.name, **create_gsi('gsi1', 'x'))
-        wait_for_gsi(table, 'gsi1')
+            TableName=table.name, **create_gsi("gsi1", "x")
+        )
+        wait_for_gsi(table, "gsi1")
         dynamodb.meta.client.update_table(
-            TableName=table.name, **create_gsi('gsi2', 'y'))
-        wait_for_gsi(table, 'gsi2')
+            TableName=table.name, **create_gsi("gsi2", "y")
+        )
+        wait_for_gsi(table, "gsi2")
         # We have the index for "x" and "y" and can use it. We don't
         # need a retry loop (like assert_index_query()) because we waited
         # for the view build to complete.
-        assert [items[3]] == full_query(table,
-            ConsistentRead=False, IndexName='gsi1',
-            KeyConditions={'x': {'AttributeValueList': [items[3]['x']], 'ComparisonOperator': 'EQ'}})
-        assert [items[3]] == full_query(table,
-            ConsistentRead=False, IndexName='gsi2',
-            KeyConditions={'y': {'AttributeValueList': [items[3]['y']], 'ComparisonOperator': 'EQ'}})
+        assert [items[3]] == full_query(
+            table,
+            ConsistentRead=False,
+            IndexName="gsi1",
+            KeyConditions={
+                "x": {"AttributeValueList": [items[3]["x"]], "ComparisonOperator": "EQ"}
+            },
+        )
+        assert [items[3]] == full_query(
+            table,
+            ConsistentRead=False,
+            IndexName="gsi2",
+            KeyConditions={
+                "y": {"AttributeValueList": [items[3]["y"]], "ComparisonOperator": "EQ"}
+            },
+        )
         # Now delete the GSI for "x" that we added above:
-        dynamodb.meta.client.update_table(
-            TableName=table.name, **delete_gsi('gsi1'))
-        wait_for_gsi_gone(table, 'gsi1')
+        dynamodb.meta.client.update_table(TableName=table.name, **delete_gsi("gsi1"))
+        wait_for_gsi_gone(table, "gsi1")
         # Now index for x is gone. We cannot query using it, but index for y
         # is still there:
-        with pytest.raises(ClientError, match='ValidationException.*gsi1'):
-            full_query(table, ConsistentRead=False, IndexName='gsi1',
-                KeyConditions={'x': {'AttributeValueList': [items[3]['x']], 'ComparisonOperator': 'EQ'}})
-        assert [items[3]] == full_query(table,
-            ConsistentRead=False, IndexName='gsi2',
-            KeyConditions={'y': {'AttributeValueList': [items[3]['y']], 'ComparisonOperator': 'EQ'}})
+        with pytest.raises(ClientError, match="ValidationException.*gsi1"):
+            full_query(
+                table,
+                ConsistentRead=False,
+                IndexName="gsi1",
+                KeyConditions={
+                    "x": {
+                        "AttributeValueList": [items[3]["x"]],
+                        "ComparisonOperator": "EQ",
+                    }
+                },
+            )
+        assert [items[3]] == full_query(
+            table,
+            ConsistentRead=False,
+            IndexName="gsi2",
+            KeyConditions={
+                "y": {"AttributeValueList": [items[3]["y"]], "ComparisonOperator": "EQ"}
+            },
+        )
         # Finally, re-add an index gsi1 for "x", and see it begins to work
         # again:
         dynamodb.meta.client.update_table(
-            TableName=table.name, **create_gsi('gsi1', 'x'))
-        wait_for_gsi(table, 'gsi1')
-        assert [items[3]] == full_query(table,
-            ConsistentRead=False, IndexName='gsi1',
-            KeyConditions={'x': {'AttributeValueList': [items[3]['x']], 'ComparisonOperator': 'EQ'}})
+            TableName=table.name, **create_gsi("gsi1", "x")
+        )
+        wait_for_gsi(table, "gsi1")
+        assert [items[3]] == full_query(
+            table,
+            ConsistentRead=False,
+            IndexName="gsi1",
+            KeyConditions={
+                "x": {"AttributeValueList": [items[3]["x"]], "ComparisonOperator": "EQ"}
+            },
+        )
+
 
 # As noted in test_gsi.py's test_gsi_empty_value(), setting an indexed string
 # column to an empty string is rejected, since keys (including GSI keys) are
@@ -381,54 +572,81 @@ def test_gsi_creates_and_deletes(dynamodb):
 # skipped while filling the GSI - even if Scylla actually capable of
 # representing such empty view keys (see issue #9375).
 # Reproduces issue #9424.
-@pytest.mark.xfail(reason="issue #9424")
+@pytest.mark.xfail(
+    reason="Alternator GSIs should exclude items with empty-string key components #9424"
+)
 def test_gsi_backfill_empty_string(dynamodb):
     # First create, and fill, a table without GSI:
-    with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' },
-                                   { 'AttributeName': 'c', 'AttributeType': 'S' } ]) as table:
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
+    ) as table:
         p1 = random_string()
         p2 = random_string()
         c = random_string()
         # Create two items, one has an empty-string "x" attribute, the other
         # is a non-empty string.
-        table.put_item(Item={'p': p1, 'c': c, 'x': 'hello'})
-        table.put_item(Item={'p': p2, 'c': c, 'x': ''})
+        table.put_item(Item={"p": p1, "c": c, "x": "hello"})
+        table.put_item(Item={"p": p2, "c": c, "x": ""})
         # Now use UpdateTable to create two GSIs. In one of them "x" will be
         # the partition key, and in the other "x" will be a sort key.
         # DynamoDB limits the number of indexes that can be added in one
         # UpdateTable command to just one, so we need to do it in two separate
         # commands and wait for each to complete.
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' }],
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "S"}],
             GlobalSecondaryIndexUpdates=[
-                { 'Create': { 'IndexName': 'index1',
-                              'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                              'Projection': { 'ProjectionType': 'ALL' }}
+                {
+                    "Create": {
+                        "IndexName": "index1",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 }
-            ])
-        wait_for_gsi(table, 'index1')
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' },
-                                  { 'AttributeName': 'c', 'AttributeType': 'S' }],
+            ],
+        )
+        wait_for_gsi(table, "index1")
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[
+                {"AttributeName": "x", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+            ],
             GlobalSecondaryIndexUpdates=[
-                { 'Create': { 'IndexName': 'index2',
-                              'KeySchema': [{ 'AttributeName': 'c', 'KeyType': 'HASH' },
-                                            { 'AttributeName': 'x', 'KeyType': 'RANGE' }],
-                              'Projection': { 'ProjectionType': 'ALL' }}
+                {
+                    "Create": {
+                        "IndexName": "index2",
+                        "KeySchema": [
+                            {"AttributeName": "c", "KeyType": "HASH"},
+                            {"AttributeName": "x", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 }
-            ])
-        wait_for_gsi(table, 'index2')
+            ],
+        )
+        wait_for_gsi(table, "index2")
         # Verify that the items with the empty-string x are missing from both
         # GSIs, so only the one item with x != '' should appear in both.
         # Note that we don't need to retry the reads here (i.e., use the
         # assert_index_scan() or assert_index_query() functions) because after
         # we waited for backfilling to complete, we know all the pre-existing
         # data is already in the index.
-        assert [{'p': p1, 'c': c, 'x': 'hello'}] == full_scan(table, ConsistentRead=False, IndexName='index1')
-        assert [{'p': p1, 'c': c, 'x': 'hello'}] == full_scan(table, ConsistentRead=False, IndexName='index2')
+        assert [{"p": p1, "c": c, "x": "hello"}] == full_scan(
+            table, ConsistentRead=False, IndexName="index1"
+        )
+        assert [{"p": p1, "c": c, "x": "hello"}] == full_scan(
+            table, ConsistentRead=False, IndexName="index2"
+        )
+
 
 # Trying to create two different GSIs with different types for the same key is
 # NOT allowed. The reason is that DynamoDB wants to insist that future writes
@@ -439,18 +657,21 @@ def test_gsi_backfill_empty_string(dynamodb):
 # added after the table already exists with the first GSI.
 # Reproduces #13870.
 def test_gsi_key_type_conflict_on_update(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
         AttributeDefinitions=[
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'xyz', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "xyz", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'index1',
-                'KeySchema': [{ 'AttributeName': 'xyz', 'KeyType': 'HASH' }],
-                'Projection': { 'ProjectionType': 'ALL' }
+            {
+                "IndexName": "index1",
+                "KeySchema": [{"AttributeName": "xyz", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ]) as table:
+        ],
+    ) as table:
         # Now use UpdateTable to create a second GSI, with a different
         # type for attribute xyz. DynamoDB gives a lengthy error message:
         #   "One or more parameter values were invalid: Attributes cannot be
@@ -458,34 +679,45 @@ def test_gsi_key_type_conflict_on_update(dynamodb):
         #    previously defined.
         #    Existing schema: Schema:[SchemaElement: key{xyz:S:HASH}]
         #    New schema: Schema:[SchemaElement: key{xyz:N:HASH}]"
-        with pytest.raises(ClientError, match='ValidationException.*redefined'):
-            dynamodb.meta.client.update_table(TableName=table.name,
-                AttributeDefinitions=[{ 'AttributeName': 'xyz', 'AttributeType': 'N' }],
-                GlobalSecondaryIndexUpdates=[ {  'Create':
-                    {  'IndexName': 'index2',
-                        'KeySchema': [{ 'AttributeName': 'xyz', 'KeyType': 'HASH' }],
-                        'Projection': { 'ProjectionType': 'ALL' }
-                    }}])
+        with pytest.raises(ClientError, match="ValidationException.*redefined"):
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                AttributeDefinitions=[{"AttributeName": "xyz", "AttributeType": "N"}],
+                GlobalSecondaryIndexUpdates=[
+                    {
+                        "Create": {
+                            "IndexName": "index2",
+                            "KeySchema": [{"AttributeName": "xyz", "KeyType": "HASH"}],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    }
+                ],
+            )
+
 
 @pytest.fixture(scope="module")
 def table1(dynamodb):
-    with new_test_table(dynamodb,
-            KeySchema=[
-                { 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-            ]) as table:
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+        ],
+    ) as table:
         yield table
+
 
 # An empty update_table() call, without any parameters changed, is not allowed.
 def test_updatetable_empty(dynamodb, table1):
-    with pytest.raises(ClientError, match='ValidationException.*UpdateTable'):
+    with pytest.raises(ClientError, match="ValidationException.*UpdateTable"):
         dynamodb.meta.client.update_table(TableName=table1.name)
     # An empty GlobalSecondaryIndexUpdates array is the same as no parameter
     # at all:
-    with pytest.raises(ClientError, match='ValidationException.*UpdateTable'):
-        dynamodb.meta.client.update_table(TableName=table1.name,
-            GlobalSecondaryIndexUpdates=[])
+    with pytest.raises(ClientError, match="ValidationException.*UpdateTable"):
+        dynamodb.meta.client.update_table(
+            TableName=table1.name, GlobalSecondaryIndexUpdates=[]
+        )
+
 
 # Test various invalid cases of UpdateTable's GlobalSecondaryIndexUpdates.
 def test_gsi_updatetable_errors(dynamodb, table1):
@@ -493,9 +725,12 @@ def test_gsi_updatetable_errors(dynamodb, table1):
 
     # Each operation in the GlobalSecondaryIndexUpdates array must contain
     # some operation - Create, Update, or Delete. It can't be an empty map.
-    with pytest.raises(ClientError, match='ValidationException.*GlobalSecondaryIndexUpdate'):
-        dynamodb.meta.client.update_table(TableName=table1.name,
-            GlobalSecondaryIndexUpdates=[{}])
+    with pytest.raises(
+        ClientError, match="ValidationException.*GlobalSecondaryIndexUpdate"
+    ):
+        dynamodb.meta.client.update_table(
+            TableName=table1.name, GlobalSecondaryIndexUpdates=[{}]
+        )
 
     # Allowed operations in GlobalSecondaryIndexUpdates are Create, Update
     # and Delete. An unsupported operation like "Dog" should result in a
@@ -508,70 +743,100 @@ def test_gsi_updatetable_errors(dynamodb, table1):
     # the "Dog" to behave like "Create", to allow the request to be sent
     # to the server - and let the server reject this invalid operation.
     service_model = client.meta.service_model
-    client.meta.service_model._instance_cache = {} # clear cached shapes
+    client.meta.service_model._instance_cache = {}  # clear cached shapes
     shape_resolver = service_model._shape_resolver
-    shape = shape_resolver._shape_map['GlobalSecondaryIndexUpdate']
-    shape['members']['Dog'] = shape['members']['Create']
+    shape = shape_resolver._shape_map["GlobalSecondaryIndexUpdate"]
+    shape["members"]["Dog"] = shape["members"]["Create"]
 
-    with pytest.raises(ClientError, match='ValidationException.*GlobalSecondaryIndexUpdate'):
-        client.update_table(TableName=table1.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'N' }],
-            GlobalSecondaryIndexUpdates=[ {  'Dog':
-            {  'IndexName': 'ind',
-                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                'Projection': { 'ProjectionType': 'ALL' }
-            }}])
+    with pytest.raises(
+        ClientError, match="ValidationException.*GlobalSecondaryIndexUpdate"
+    ):
+        client.update_table(
+            TableName=table1.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "N"}],
+            GlobalSecondaryIndexUpdates=[
+                {
+                    "Dog": {
+                        "IndexName": "ind",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                }
+            ],
+        )
 
     # A single map in the GlobalSecondaryIndexUpdates array can't have both
     # Create and Delete entries, for example:
-    with pytest.raises(ClientError, match='ValidationException.*one'):
-        client.update_table(TableName=table1.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'N' }],
+    with pytest.raises(ClientError, match="ValidationException.*one"):
+        client.update_table(
+            TableName=table1.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "N"}],
             GlobalSecondaryIndexUpdates=[
-                {  'Create': {  'IndexName': 'ind',
-                                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                                'Projection': { 'ProjectionType': 'ALL' } },
-                   'Delete': {  'IndexName': 'xyz' }
-                }])
+                {
+                    "Create": {
+                        "IndexName": "ind",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    },
+                    "Delete": {"IndexName": "xyz"},
+                }
+            ],
+        )
 
     # GlobalSecondaryIndexUpdates can also have more than one seaprate map
     # in the array, each supposedly indicating a different operation, but
     # creating more than one GSI in the same UpdateTable is NOT allowed.
     # DynamoDB throws a LimitExceededException:
-    with pytest.raises(ClientError, match='LimitExceededException'):
-        client.update_table(TableName=table1.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'N' }],
+    with pytest.raises(ClientError, match="LimitExceededException"):
+        client.update_table(
+            TableName=table1.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "N"}],
             GlobalSecondaryIndexUpdates=[
-                {  'Create': {  'IndexName': 'ind1',
-                                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                                'Projection': { 'ProjectionType': 'ALL' } }
+                {
+                    "Create": {
+                        "IndexName": "ind1",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 },
-                {  'Create': {  'IndexName': 'ind2',
-                                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                            'Projection': { 'ProjectionType': 'ALL' } }
+                {
+                    "Create": {
+                        "IndexName": "ind2",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 },
-            ])
+            ],
+        )
 
     # Similarly, can't delete two GSIs in one UpdateTable operation:
-    with pytest.raises(ClientError, match='LimitExceededException'):
-        client.update_table(TableName=table1.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'N' }],
+    with pytest.raises(ClientError, match="LimitExceededException"):
+        client.update_table(
+            TableName=table1.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "N"}],
             GlobalSecondaryIndexUpdates=[
-                { 'Delete': {  'IndexName': 'ind1' } },
-                { 'Delete': {  'IndexName': 'ind2' } }
-            ])
+                {"Delete": {"IndexName": "ind1"}},
+                {"Delete": {"IndexName": "ind2"}},
+            ],
+        )
 
     # Similarly, can't delete a GSI and create another one:
-    with pytest.raises(ClientError, match='LimitExceededException'):
-        client.update_table(TableName=table1.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'N' }],
+    with pytest.raises(ClientError, match="LimitExceededException"):
+        client.update_table(
+            TableName=table1.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "N"}],
             GlobalSecondaryIndexUpdates=[
-                {  'Create': {  'IndexName': 'ind1',
-                                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                                'Projection': { 'ProjectionType': 'ALL' } }
+                {
+                    "Create": {
+                        "IndexName": "ind1",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 },
-                { 'Delete': {  'IndexName': 'ind2' } }
-            ])
+                {"Delete": {"IndexName": "ind2"}},
+            ],
+        )
+
 
 # Whereas CreateTable rejects spurious entries in AttributeDefinitions
 # (entries which aren't used as a key of the table or any GSI or LSI),
@@ -582,26 +847,36 @@ def test_gsi_updatetable_errors(dynamodb, table1):
 # notice problems (see #19784). So because we differ from DynamoDB on this,
 # this test is marked scylla_only.
 def test_gsi_updatetable_spurious_attribute_definitions(table1, scylla_only):
-    with pytest.raises(ClientError, match='ValidationException.*AttributeDefinitions'):
-        table1.meta.client.update_table(TableName=table1.name,
+    with pytest.raises(ClientError, match="ValidationException.*AttributeDefinitions"):
+        table1.meta.client.update_table(
+            TableName=table1.name,
             AttributeDefinitions=[
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
-                { 'AttributeName': 'y', 'AttributeType': 'S' }],
-            GlobalSecondaryIndexUpdates=[ {  'Create':
-                {   'IndexName': 'gsi2',
-                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }}])
+                {"AttributeName": "x", "AttributeType": "S"},
+                {"AttributeName": "y", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexUpdates=[
+                {
+                    "Create": {
+                        "IndexName": "gsi2",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
+                }
+            ],
+        )
         # Just in case the update_table didn't fail as expected...
-        wait_for_gsi(table1, 'gsi2')
+        wait_for_gsi(table1, "gsi2")
+
 
 # Check that attempting to delete a GSI that doesn't exist results in
 # the expected ResourceNotFoundException.
 def test_updatetable_delete_missing_gsi(dynamodb, table1):
-    with pytest.raises(ClientError, match='ResourceNotFoundException'):
-        dynamodb.meta.client.update_table(TableName=table1.name,
-            GlobalSecondaryIndexUpdates=[{  'Delete':
-                { 'IndexName': 'nonexistent' } }])
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
+        dynamodb.meta.client.update_table(
+            TableName=table1.name,
+            GlobalSecondaryIndexUpdates=[{"Delete": {"IndexName": "nonexistent"}}],
+        )
+
 
 # Whereas DynamoDB allows attribute values to reach a generous length (they
 # are only limited by the item's size limit, 400 KB), an attribute which is
@@ -623,51 +898,76 @@ def test_updatetable_delete_missing_gsi(dynamodb, table1):
 # test_gsi_backfill_key_limits will check the specific limits.
 def test_gsi_backfill_oversized_key(dynamodb):
     # First create, and fill, a table without GSI:
-    with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' },
-                                   { 'AttributeName': 'c', 'AttributeType': 'S' } ]) as table:
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
+    ) as table:
         p1 = random_string()
         p2 = random_string()
         c = random_string()
         # Create two items, one has a small "x" attribute, the other has
         # a 65 KB "x" attribute.
-        table.put_item(Item={'p': p1, 'c': c, 'x': 'hello'})
-        table.put_item(Item={'p': p2, 'c': c, 'x': 'a'*66500})
+        table.put_item(Item={"p": p1, "c": c, "x": "hello"})
+        table.put_item(Item={"p": p2, "c": c, "x": "a" * 66500})
         # Now use UpdateTable to create two GSIs. In one of them "x" will be
         # the partition key, and in the other "x" will be a sort key.
         # DynamoDB limits the number of indexes that can be added in one
         # UpdateTable command to just one, so we need to do it in two separate
         # commands and wait for each to complete.
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' }],
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "S"}],
             GlobalSecondaryIndexUpdates=[
-                { 'Create': { 'IndexName': 'index1',
-                              'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                              'Projection': { 'ProjectionType': 'ALL' }}
+                {
+                    "Create": {
+                        "IndexName": "index1",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 }
-            ])
-        wait_for_gsi(table, 'index1')
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' },
-                                  { 'AttributeName': 'c', 'AttributeType': 'S' }],
+            ],
+        )
+        wait_for_gsi(table, "index1")
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[
+                {"AttributeName": "x", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+            ],
             GlobalSecondaryIndexUpdates=[
-                { 'Create': { 'IndexName': 'index2',
-                              'KeySchema': [{ 'AttributeName': 'c', 'KeyType': 'HASH' },
-                                            { 'AttributeName': 'x', 'KeyType': 'RANGE' }],
-                              'Projection': { 'ProjectionType': 'ALL' }}
+                {
+                    "Create": {
+                        "IndexName": "index2",
+                        "KeySchema": [
+                            {"AttributeName": "c", "KeyType": "HASH"},
+                            {"AttributeName": "x", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 }
-            ])
-        wait_for_gsi(table, 'index2')
+            ],
+        )
+        wait_for_gsi(table, "index2")
         # Verify that the items with the oversized x are missing from both
         # GSIs, so only the one item with x = hello should appear in both.
         # Note that we don't need to retry the reads here (i.e., use the
         # assert_index_scan() or assert_index_query() functions) because after
         # we waited for backfilling to complete, we know all the pre-existing
         # data is already in the index.
-        assert [{'p': p1, 'c': c, 'x': 'hello'}] == full_scan(table, ConsistentRead=False, IndexName='index1')
-        assert [{'p': p1, 'c': c, 'x': 'hello'}] == full_scan(table, ConsistentRead=False, IndexName='index2')
+        assert [{"p": p1, "c": c, "x": "hello"}] == full_scan(
+            table, ConsistentRead=False, IndexName="index1"
+        )
+        assert [{"p": p1, "c": c, "x": "hello"}] == full_scan(
+            table, ConsistentRead=False, IndexName="index2"
+        )
+
 
 # The previous test, test_gsi_backfill_oversized_key(), checked that a
 # grossly oversized GSI key attribute (over Scylla's internal key limit
@@ -677,55 +977,82 @@ def test_gsi_backfill_oversized_key(dynamodb):
 # item that has an attribute longer than that should simply be skipped
 # during view building.
 # Reproduces issue #10347.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_gsi_backfill_key_limits(dynamodb):
     # First create, and fill, a table without GSI:
-    with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' },
-                                   { 'AttributeName': 'c', 'AttributeType': 'S' } ]) as table:
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
+    ) as table:
         # Create four items, with 'x' attribute sizes of 1024, 1025, 2048
         # and 2049. Only one item (1024) has x suitable for a sort key,
         # and three (1024, 1025 and 2048) have length suitable for a partition
         # key. The unsuitable items will be missing from the indexes.
         lengths = [1024, 1025, 2048, 2049]
         p = [random_string() for length in lengths]
-        x = ['a'*length for length in lengths]
+        x = ["a" * length for length in lengths]
         c = random_string()
         for i in range(len(lengths)):
-            table.put_item(Item={'p': p[i], 'c': c, 'x': x[i]})
+            table.put_item(Item={"p": p[i], "c": c, "x": x[i]})
         # Now use UpdateTable to create two GSIs. In one of them "x" will be
         # the partition key, and in the other "x" will be a sort key.
         # DynamoDB limits the number of indexes that can be added in one
         # UpdateTable command to just one, so we need to do it in two separate
         # commands and wait for each to complete.
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' }],
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[{"AttributeName": "x", "AttributeType": "S"}],
             GlobalSecondaryIndexUpdates=[
-                { 'Create': { 'IndexName': 'index1',
-                              'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                              'Projection': { 'ProjectionType': 'ALL' }}
+                {
+                    "Create": {
+                        "IndexName": "index1",
+                        "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 }
-            ])
-        wait_for_gsi(table, 'index1')
-        dynamodb.meta.client.update_table(TableName=table.name,
-            AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' },
-                                  { 'AttributeName': 'c', 'AttributeType': 'S' }],
+            ],
+        )
+        wait_for_gsi(table, "index1")
+        dynamodb.meta.client.update_table(
+            TableName=table.name,
+            AttributeDefinitions=[
+                {"AttributeName": "x", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+            ],
             GlobalSecondaryIndexUpdates=[
-                { 'Create': { 'IndexName': 'index2',
-                              'KeySchema': [{ 'AttributeName': 'c', 'KeyType': 'HASH' },
-                                            { 'AttributeName': 'x', 'KeyType': 'RANGE' }],
-                              'Projection': { 'ProjectionType': 'ALL' }}
+                {
+                    "Create": {
+                        "IndexName": "index2",
+                        "KeySchema": [
+                            {"AttributeName": "c", "KeyType": "HASH"},
+                            {"AttributeName": "x", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {"ProjectionType": "ALL"},
+                    }
                 }
-            ])
-        wait_for_gsi(table, 'index2')
+            ],
+        )
+        wait_for_gsi(table, "index2")
         # Verify that the items with the oversized x are missing from both
         # GSIs. For index1 (x is a partition key, limited to 2048 bytes)
         # items 0,1,2 should appear, for index2 (x is a sort key, limited
         # to 1024 bytes), only item 0 should appear.
-        assert multiset([{'p': p[i], 'c': c, 'x': x[i]} for i in range(3)]) == multiset(full_scan(table, ConsistentRead=False, IndexName='index1'))
-        assert [{'p': p[0], 'c': c, 'x': x[0]}] == full_scan(table, ConsistentRead=False, IndexName='index2')
+        assert multiset([{"p": p[i], "c": c, "x": x[i]} for i in range(3)]) == multiset(
+            full_scan(table, ConsistentRead=False, IndexName="index1")
+        )
+        assert [{"p": p[0], "c": c, "x": x[0]}] == full_scan(
+            table, ConsistentRead=False, IndexName="index2"
+        )
+
 
 # Index names with 255 characters are allowed in Dynamo. In Scylla, the
 # limit is different - the sum of both table and index length plus an extra 1
@@ -733,34 +1060,47 @@ def test_gsi_backfill_key_limits(dynamodb):
 # (test_gsi_very_long_name_* check the same thing for a GSI created at the
 # same time as the table.
 
+
 def add_and_delete_gsi(table, gsi_name):
-    table.meta.client.update_table(TableName=table.name,
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
-        GlobalSecondaryIndexUpdates=[ {  'Create':
-            {   'IndexName': gsi_name,
-                'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-                    'Projection': { 'ProjectionType': 'ALL' }
-                }}])
+    table.meta.client.update_table(
+        TableName=table.name,
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+        GlobalSecondaryIndexUpdates=[
+            {
+                "Create": {
+                    "IndexName": gsi_name,
+                    "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            }
+        ],
+    )
     wait_for_gsi(table, gsi_name)
-    table.meta.client.update_table(TableName=table.name,
-        GlobalSecondaryIndexUpdates=[{  'Delete':
-            { 'IndexName': gsi_name } }])
+    table.meta.client.update_table(
+        TableName=table.name,
+        GlobalSecondaryIndexUpdates=[{"Delete": {"IndexName": gsi_name}}],
+    )
     wait_for_gsi_gone(table, gsi_name)
 
-@pytest.mark.xfail(reason="Alternator limits table name length + GSI name length to 221")
+
+@pytest.mark.xfail(
+    reason="Alternator limits table name length + GSI name length to 221"
+)
 def test_gsi_updatetable_very_long_name_255(table1):
-    add_and_delete_gsi(table1, 'n' * 255)
+    add_and_delete_gsi(table1, "n" * 255)
+
 
 def test_gsi_updatetable_very_long_name_256(table1):
-    with pytest.raises(ClientError, match='ValidationException'):
-        add_and_delete_gsi(table1, 'n' * 256)
+    with pytest.raises(ClientError, match="ValidationException"):
+        add_and_delete_gsi(table1, "n" * 256)
+
 
 def test_gsi_updatetable_very_long_name_222(table1, scylla_only):
     # If we subtract from 222 the table's name length and an extra 1,
     # this is how long the GSI's name may be:
     max = 222 - len(table1.name) - 1
     # This max length should work:
-    add_and_delete_gsi(table1, 'n' * max)
+    add_and_delete_gsi(table1, "n" * max)
     # But a name one byte longer should fail:
-    with pytest.raises(ClientError, match='ValidationException.*total length'):
-        add_and_delete_gsi(table1, 'n' * (max+1))
+    with pytest.raises(ClientError, match="ValidationException.*total length"):
+        add_and_delete_gsi(table1, "n" * (max + 1))

--- a/test/alternator/test_limits.py
+++ b/test/alternator/test_limits.py
@@ -25,37 +25,75 @@ from test.alternator.test_gsi import assert_index_query
 # also limited to 255 character. We test the last fact in a different test
 # file: test_ttl.py::test_update_ttl_errors.
 
+
 # Attribute length test 1: non-key attribute names below 64KB are usable in
 # PutItem, UpdateItem, GetItem, and also in various expressions (condition,
 # update and projection) and their archaic pre-expression alternatives.
 def test_limit_attribute_length_nonkey_good(test_table_s):
     p = random_string()
-    too_long_name = random_string(64)*1024
+    too_long_name = random_string(64) * 1024
     long_name = too_long_name[:-1]
     # Try legal long_name:
-    test_table_s.put_item(Item={'p': p, long_name: 1, 'another': 2 })
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, long_name: 1, 'another': 2 }
+    test_table_s.put_item(Item={"p": p, long_name: 1, "another": 2})
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        long_name: 1,
+        "another": 2,
+    }
 
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True,
-        ProjectionExpression='#name', ExpressionAttributeNames={'#name': long_name})['Item'] == {long_name: 1}
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True,
-        AttributesToGet=[long_name])['Item'] == {long_name: 1}
+    assert test_table_s.get_item(
+        Key={"p": p},
+        ConsistentRead=True,
+        ProjectionExpression="#name",
+        ExpressionAttributeNames={"#name": long_name},
+    )["Item"] == {long_name: 1}
+    assert test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True, AttributesToGet=[long_name]
+    )["Item"] == {long_name: 1}
 
-    test_table_s.update_item(Key={'p': p}, AttributeUpdates={long_name: {'Value': 2, 'Action': 'PUT'}})
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, long_name: 2, 'another': 2 }
-    test_table_s.update_item(Key={'p': p}, UpdateExpression='SET #name = :val',
-        ExpressionAttributeNames={'#name': long_name},
-        ExpressionAttributeValues={':val': 3})
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, long_name: 3, 'another': 2 }
-    test_table_s.update_item(Key={'p': p}, UpdateExpression='SET #name = #name+:val',
-        ExpressionAttributeNames={'#name': long_name},
-        ExpressionAttributeValues={':val': 1})
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, long_name: 4, 'another': 2 }
-    test_table_s.update_item(Key={'p': p}, UpdateExpression='SET #name = #name+:val',
-        ConditionExpression='#name = :oldval',
-        ExpressionAttributeNames={'#name': long_name},
-        ExpressionAttributeValues={':val': 1, ':oldval': 4})
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, long_name: 5, 'another': 2 }
+    test_table_s.update_item(
+        Key={"p": p}, AttributeUpdates={long_name: {"Value": 2, "Action": "PUT"}}
+    )
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        long_name: 2,
+        "another": 2,
+    }
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression="SET #name = :val",
+        ExpressionAttributeNames={"#name": long_name},
+        ExpressionAttributeValues={":val": 3},
+    )
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        long_name: 3,
+        "another": 2,
+    }
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression="SET #name = #name+:val",
+        ExpressionAttributeNames={"#name": long_name},
+        ExpressionAttributeValues={":val": 1},
+    )
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        long_name: 4,
+        "another": 2,
+    }
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression="SET #name = #name+:val",
+        ConditionExpression="#name = :oldval",
+        ExpressionAttributeNames={"#name": long_name},
+        ExpressionAttributeValues={":val": 1, ":oldval": 4},
+    )
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        long_name: 5,
+        "another": 2,
+    }
+
 
 # Attribute length test 2: attribute names 64KB or above generate an error
 # in the aforementioned cases. Note that contrary to what the DynamoDB
@@ -64,25 +102,38 @@ def test_limit_attribute_length_nonkey_good(test_table_s):
 # Reproduces issue #9169.
 def test_limit_attribute_length_nonkey_bad(test_table_s):
     p = random_string()
-    too_long_name = random_string(64)*1024
-    with pytest.raises(ClientError, match='ValidationException.*6553[56]'):
-        test_table_s.put_item(Item={'p': p, too_long_name: 1})
-    with pytest.raises(ClientError, match='ValidationException.*6553[56]'):
-        test_table_s.get_item(Key={'p': p}, ProjectionExpression='#name',
-            ExpressionAttributeNames={'#name': too_long_name})
-    with pytest.raises(ClientError, match='ValidationException.*6553[56]'):
-        test_table_s.get_item(Key={'p': p}, AttributesToGet=[too_long_name])
-    with pytest.raises(ClientError, match='ValidationException.*6553[56]'):
-        test_table_s.update_item(Key={'p': p}, AttributeUpdates={too_long_name: {'Value': 2, 'Action': 'PUT'}})
-    with pytest.raises(ClientError, match='ValidationException.*6553[56]'):
-        test_table_s.update_item(Key={'p': p}, UpdateExpression='SET #name = :val',
-            ExpressionAttributeNames={'#name': too_long_name},
-            ExpressionAttributeValues={':val': 3})
-    with pytest.raises(ClientError, match='ValidationException.*6553[56]'):
-        test_table_s.update_item(Key={'p': p}, UpdateExpression='SET a = :val',
-            ConditionExpression='#name = :val',
-            ExpressionAttributeNames={'#name': too_long_name},
-            ExpressionAttributeValues={':val': 1})
+    too_long_name = random_string(64) * 1024
+    with pytest.raises(ClientError, match="ValidationException.*6553[56]"):
+        test_table_s.put_item(Item={"p": p, too_long_name: 1})
+    with pytest.raises(ClientError, match="ValidationException.*6553[56]"):
+        test_table_s.get_item(
+            Key={"p": p},
+            ProjectionExpression="#name",
+            ExpressionAttributeNames={"#name": too_long_name},
+        )
+    with pytest.raises(ClientError, match="ValidationException.*6553[56]"):
+        test_table_s.get_item(Key={"p": p}, AttributesToGet=[too_long_name])
+    with pytest.raises(ClientError, match="ValidationException.*6553[56]"):
+        test_table_s.update_item(
+            Key={"p": p},
+            AttributeUpdates={too_long_name: {"Value": 2, "Action": "PUT"}},
+        )
+    with pytest.raises(ClientError, match="ValidationException.*6553[56]"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET #name = :val",
+            ExpressionAttributeNames={"#name": too_long_name},
+            ExpressionAttributeValues={":val": 3},
+        )
+    with pytest.raises(ClientError, match="ValidationException.*6553[56]"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET a = :val",
+            ConditionExpression="#name = :val",
+            ExpressionAttributeNames={"#name": too_long_name},
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 # Attribute length test 3: Test that *key* (hash and range) attribute names
 # up to 255 characters are allowed. In the test below we'll see that larger
@@ -90,14 +141,22 @@ def test_limit_attribute_length_nonkey_bad(test_table_s):
 def test_limit_attribute_length_key_good(dynamodb):
     long_name1 = random_string(255)
     long_name2 = random_string(255)
-    with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': long_name1, 'KeyType': 'HASH' },
-                        { 'AttributeName': long_name2, 'KeyType': 'RANGE' } ],
-            AttributeDefinitions=[
-                 { 'AttributeName': long_name1, 'AttributeType': 'S' },
-                 { 'AttributeName': long_name2, 'AttributeType': 'S' }]) as table:
-        table.put_item(Item={long_name1: 'hi', long_name2: 'ho', 'another': 2 })
-        assert table.get_item(Key={long_name1: 'hi', long_name2: 'ho'}, ConsistentRead=True)['Item'] == {long_name1: 'hi', long_name2: 'ho', 'another': 2 }
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": long_name1, "KeyType": "HASH"},
+            {"AttributeName": long_name2, "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": long_name1, "AttributeType": "S"},
+            {"AttributeName": long_name2, "AttributeType": "S"},
+        ],
+    ) as table:
+        table.put_item(Item={long_name1: "hi", long_name2: "ho", "another": 2})
+        assert table.get_item(
+            Key={long_name1: "hi", long_name2: "ho"}, ConsistentRead=True
+        )["Item"] == {long_name1: "hi", long_name2: "ho", "another": 2}
+
 
 # Attribute length test 4: Test that *key* attribute names more than 255
 # characters are not allowed - not for hash key and not for range key.
@@ -109,20 +168,34 @@ def test_limit_attribute_length_key_bad(dynamodb):
     too_long_name = random_string(256)
 
     # Test with HASH-type or non-RANGE-type key name too long
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': too_long_name, 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': too_long_name, 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": too_long_name, "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": too_long_name, "AttributeType": "S"}
+            ],
+        ) as table:
             pass
 
     # Test with RANGE-type (or non-HASH-type key) name too long
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'x', 'KeyType': 'HASH', },
-                        { 'AttributeName': too_long_name, 'KeyType': 'RANGE' } ],
-            AttributeDefinitions=[ { 'AttributeName': too_long_name, 'AttributeType': 'S' },
-                                   { 'AttributeName': 'x', 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {
+                    "AttributeName": "x",
+                    "KeyType": "HASH",
+                },
+                {"AttributeName": too_long_name, "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": too_long_name, "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
+            ],
+        ) as table:
             pass
+
 
 # Test that *key* attribute names more than 255 characters are not allowed,
 # not for hash key and not for range key. Strangely, this limitation is not
@@ -137,32 +210,59 @@ def test_limit_attribute_length_key_bad_incoherent_names(dynamodb):
     too_long_name = random_string(256)
 
     # Tests with HASH-type or non-RANGE-type key name too long
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': too_long_name, 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': "incoherent-short-name", 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": too_long_name, "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "incoherent-short-name", "AttributeType": "S"}
+            ],
+        ) as table:
             pass
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': "incoherent-short-name", 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': too_long_name, 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "incoherent-short-name", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": too_long_name, "AttributeType": "S"}
+            ],
+        ) as table:
             pass
 
     # Tests with RANGE-type (or non-HASH-type key) name too long
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'x', 'KeyType': 'HASH', },
-                        { 'AttributeName': too_long_name, 'KeyType': 'RANGE' } ],
-            AttributeDefinitions=[ { 'AttributeName': "incoherent-short-name", 'AttributeType': 'S' },
-                                   { 'AttributeName': 'x', 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {
+                    "AttributeName": "x",
+                    "KeyType": "HASH",
+                },
+                {"AttributeName": too_long_name, "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "incoherent-short-name", "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
+            ],
+        ) as table:
             pass
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'x', 'KeyType': 'HASH', },
-                        { 'AttributeName': "incoherent-short-name", 'KeyType': 'RANGE' } ],
-            AttributeDefinitions=[ { 'AttributeName': too_long_name, 'AttributeType': 'S' },
-                                   { 'AttributeName': 'x', 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {
+                    "AttributeName": "x",
+                    "KeyType": "HASH",
+                },
+                {"AttributeName": "incoherent-short-name", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": too_long_name, "AttributeType": "S"},
+                {"AttributeName": "x", "AttributeType": "S"},
+            ],
+        ) as table:
             pass
+
 
 # Attribute length tests 5,6: similar as the above tests for the 255-byte
 # limit for base table length, here we check that the same limit also applies
@@ -172,82 +272,141 @@ def test_limit_attribute_length_gsi_lsi_good(dynamodb):
     long_name2 = random_string(255)
     long_name3 = random_string(255)
     long_name4 = random_string(255)
-    with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': long_name1, 'KeyType': 'HASH' },
-                        { 'AttributeName': long_name2, 'KeyType': 'RANGE' } ],
-            AttributeDefinitions=[
-                 { 'AttributeName': long_name1, 'AttributeType': 'S' },
-                 { 'AttributeName': long_name2, 'AttributeType': 'S' },
-                 { 'AttributeName': long_name3, 'AttributeType': 'S' },
-                 { 'AttributeName': long_name4, 'AttributeType': 'S' }],
-            GlobalSecondaryIndexes=[
-                 { 'IndexName': 'gsi', 'KeySchema': [
-                      { 'AttributeName': long_name3, 'KeyType': 'HASH' },
-                      { 'AttributeName': long_name4, 'KeyType': 'RANGE' },
-                   ], 'Projection': { 'ProjectionType': 'ALL' }
-                 }
-            ],
-            LocalSecondaryIndexes=[
-                 { 'IndexName': 'lsi', 'KeySchema': [
-                      { 'AttributeName': long_name1, 'KeyType': 'HASH' },
-                      { 'AttributeName': long_name4, 'KeyType': 'RANGE' },
-                   ], 'Projection': { 'ProjectionType': 'ALL' }
-                 }
-            ]) as table:
-        table.put_item(Item={long_name1: 'hi', long_name2: 'ho', long_name3: 'dog', long_name4: 'cat' })
-        assert table.get_item(Key={long_name1: 'hi', long_name2: 'ho'}, ConsistentRead=True)['Item'] == {long_name1: 'hi', long_name2: 'ho', long_name3: 'dog', long_name4: 'cat' }
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": long_name1, "KeyType": "HASH"},
+            {"AttributeName": long_name2, "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": long_name1, "AttributeType": "S"},
+            {"AttributeName": long_name2, "AttributeType": "S"},
+            {"AttributeName": long_name3, "AttributeType": "S"},
+            {"AttributeName": long_name4, "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "gsi",
+                "KeySchema": [
+                    {"AttributeName": long_name3, "KeyType": "HASH"},
+                    {"AttributeName": long_name4, "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        LocalSecondaryIndexes=[
+            {
+                "IndexName": "lsi",
+                "KeySchema": [
+                    {"AttributeName": long_name1, "KeyType": "HASH"},
+                    {"AttributeName": long_name4, "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    ) as table:
+        table.put_item(
+            Item={
+                long_name1: "hi",
+                long_name2: "ho",
+                long_name3: "dog",
+                long_name4: "cat",
+            }
+        )
+        assert table.get_item(
+            Key={long_name1: "hi", long_name2: "ho"}, ConsistentRead=True
+        )["Item"] == {
+            long_name1: "hi",
+            long_name2: "ho",
+            long_name3: "dog",
+            long_name4: "cat",
+        }
         # Verify the content through the indexes. LSI can use ConsistentRead
         # but GSI might need to retry to find the content:
-        assert full_query(table, IndexName='lsi', ConsistentRead=True,
+        assert full_query(
+            table,
+            IndexName="lsi",
+            ConsistentRead=True,
             KeyConditions={
-              long_name1: {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'},
-              long_name4: {'AttributeValueList': ['cat'], 'ComparisonOperator': 'EQ'},
-            }) == [{long_name1: 'hi', long_name2: 'ho', long_name3: 'dog', long_name4: 'cat'}]
-        assert_index_query(table, 'gsi',
-            [{long_name1: 'hi', long_name2: 'ho', long_name3: 'dog', long_name4: 'cat'}],
+                long_name1: {"AttributeValueList": ["hi"], "ComparisonOperator": "EQ"},
+                long_name4: {"AttributeValueList": ["cat"], "ComparisonOperator": "EQ"},
+            },
+        ) == [
+            {long_name1: "hi", long_name2: "ho", long_name3: "dog", long_name4: "cat"}
+        ]
+        assert_index_query(
+            table,
+            "gsi",
+            [
+                {
+                    long_name1: "hi",
+                    long_name2: "ho",
+                    long_name3: "dog",
+                    long_name4: "cat",
+                }
+            ],
             KeyConditions={
-              long_name3: {'AttributeValueList': ['dog'], 'ComparisonOperator': 'EQ'},
-              long_name4: {'AttributeValueList': ['cat'], 'ComparisonOperator': 'EQ'},
-            })
+                long_name3: {"AttributeValueList": ["dog"], "ComparisonOperator": "EQ"},
+                long_name4: {"AttributeValueList": ["cat"], "ComparisonOperator": "EQ"},
+            },
+        )
+
 
 # Reproduces issue #9169.
 def test_limit_attribute_length_gsi_lsi_bad(dynamodb):
     too_long_name = random_string(256)
 
     # GSI attr. name length test
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'b', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "a", "KeyType": "HASH"},
+                {"AttributeName": "b", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                 { 'AttributeName': 'a', 'AttributeType': 'S' },
-                 { 'AttributeName': 'b', 'AttributeType': 'S' },
-                 { 'AttributeName': too_long_name, 'AttributeType': 'S' } ],
+                {"AttributeName": "a", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
+                {"AttributeName": too_long_name, "AttributeType": "S"},
+            ],
             GlobalSecondaryIndexes=[
-                 { 'IndexName': 'gsi', 'KeySchema': [
-                      { 'AttributeName': too_long_name, 'KeyType': 'HASH' },
-                   ], 'Projection': { 'ProjectionType': 'ALL' }
-                 }
-            ]) as table:
+                {
+                    "IndexName": "gsi",
+                    "KeySchema": [
+                        {"AttributeName": too_long_name, "KeyType": "HASH"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        ) as table:
             pass
 
     # LSI attr. name length test
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'b', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "a", "KeyType": "HASH"},
+                {"AttributeName": "b", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                 { 'AttributeName': 'a', 'AttributeType': 'S' },
-                 { 'AttributeName': 'b', 'AttributeType': 'S' },
-                 { 'AttributeName': too_long_name, 'AttributeType': 'S' } ],
+                {"AttributeName": "a", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
+                {"AttributeName": too_long_name, "AttributeType": "S"},
+            ],
             LocalSecondaryIndexes=[
-                 { 'IndexName': 'lsi', 'KeySchema': [
-                      { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                      { 'AttributeName': too_long_name, 'KeyType': 'RANGE' },
-                   ], 'Projection': { 'ProjectionType': 'ALL' }
-                 }
-            ]) as table:
+                {
+                    "IndexName": "lsi",
+                    "KeySchema": [
+                        {"AttributeName": "a", "KeyType": "HASH"},
+                        {"AttributeName": too_long_name, "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        ) as table:
             pass
+
 
 # The tests here cover the cases of too long names in incorrect (incoherent)
 # user requests. The incoherence here means:
@@ -262,70 +421,103 @@ def test_limit_attribute_length_gsi_lsi_bad_incoherent_names(dynamodb):
     too_long_name = random_string(256)
 
     # GSI attr. name length tests
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'b', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "a", "KeyType": "HASH"},
+                {"AttributeName": "b", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                 { 'AttributeName': 'a', 'AttributeType': 'S' },
-                 { 'AttributeName': 'b', 'AttributeType': 'S' },
-                 { 'AttributeName': too_long_name, 'AttributeType': 'S' } ],
+                {"AttributeName": "a", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
+                {"AttributeName": too_long_name, "AttributeType": "S"},
+            ],
             GlobalSecondaryIndexes=[
-                 { 'IndexName': 'gsi', 'KeySchema': [
-                      { 'AttributeName': "incoherent-short-name", 'KeyType': 'HASH' },
-                   ], 'Projection': { 'ProjectionType': 'ALL' }
-                 }
-            ]) as table:
+                {
+                    "IndexName": "gsi",
+                    "KeySchema": [
+                        {"AttributeName": "incoherent-short-name", "KeyType": "HASH"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        ) as table:
             pass
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'b', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "a", "KeyType": "HASH"},
+                {"AttributeName": "b", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                 { 'AttributeName': 'a', 'AttributeType': 'S' },
-                 { 'AttributeName': 'b', 'AttributeType': 'S' },
-                 { 'AttributeName': "incoherent-short-name", 'AttributeType': 'S' } ],
+                {"AttributeName": "a", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
+                {"AttributeName": "incoherent-short-name", "AttributeType": "S"},
+            ],
             GlobalSecondaryIndexes=[
-                 { 'IndexName': 'gsi', 'KeySchema': [
-                      { 'AttributeName': too_long_name, 'KeyType': 'HASH' },
-                   ], 'Projection': { 'ProjectionType': 'ALL' }
-                 }
-            ]) as table:
+                {
+                    "IndexName": "gsi",
+                    "KeySchema": [
+                        {"AttributeName": too_long_name, "KeyType": "HASH"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        ) as table:
             pass
 
     # LSI attr. name length tests
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'b', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "a", "KeyType": "HASH"},
+                {"AttributeName": "b", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                 { 'AttributeName': 'a', 'AttributeType': 'S' },
-                 { 'AttributeName': 'b', 'AttributeType': 'S' },
-                 { 'AttributeName': too_long_name, 'AttributeType': 'S' } ],
+                {"AttributeName": "a", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
+                {"AttributeName": too_long_name, "AttributeType": "S"},
+            ],
             LocalSecondaryIndexes=[
-                 { 'IndexName': 'lsi', 'KeySchema': [
-                      { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                      { 'AttributeName': "incoherent-short-name", 'KeyType': 'RANGE' },
-                   ], 'Projection': { 'ProjectionType': 'ALL' }
-                 }
-            ]) as table:
+                {
+                    "IndexName": "lsi",
+                    "KeySchema": [
+                        {"AttributeName": "a", "KeyType": "HASH"},
+                        {"AttributeName": "incoherent-short-name", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        ) as table:
             pass
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'b', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "a", "KeyType": "HASH"},
+                {"AttributeName": "b", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                 { 'AttributeName': 'a', 'AttributeType': 'S' },
-                 { 'AttributeName': 'b', 'AttributeType': 'S' },
-                 { 'AttributeName': "incoherent-short-name", 'AttributeType': 'S' } ],
+                {"AttributeName": "a", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
+                {"AttributeName": "incoherent-short-name", "AttributeType": "S"},
+            ],
             LocalSecondaryIndexes=[
-                 { 'IndexName': 'lsi', 'KeySchema': [
-                      { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                      { 'AttributeName': too_long_name, 'KeyType': 'RANGE' },
-                   ], 'Projection': { 'ProjectionType': 'ALL' }
-                 }
-            ]) as table:
+                {
+                    "IndexName": "lsi",
+                    "KeySchema": [
+                        {"AttributeName": "a", "KeyType": "HASH"},
+                        {"AttributeName": too_long_name, "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        ) as table:
             pass
+
 
 # Attribute length tests 7,8: In an LSI, projected attribute names are also
 # limited to 255 bytes. This is explicitly mentioned in the DynamoDB
@@ -334,42 +526,63 @@ def test_limit_attribute_length_gsi_lsi_bad_incoherent_names(dynamodb):
 # attributes projected as part as ALL can be bigger (up to the usual 64KB
 # limit).
 # Reproduces issue #9169.
-@pytest.mark.xfail(reason="issue #5036: projection in GSI and LSI not supported")
+@pytest.mark.xfail(reason="Alternator: support Projection in GSI and LSI #5036")
 def test_limit_attribute_length_gsi_lsi_projection_bad(dynamodb):
     too_long_name = random_string(256)
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'b', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "a", "KeyType": "HASH"},
+                {"AttributeName": "b", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                 { 'AttributeName': 'a', 'AttributeType': 'S' },
-                 { 'AttributeName': 'b', 'AttributeType': 'S' },
-                 { 'AttributeName': 'c', 'AttributeType': 'S' } ],
+                {"AttributeName": "a", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+            ],
             GlobalSecondaryIndexes=[
-                 { 'IndexName': 'gsi', 'KeySchema': [
-                      { 'AttributeName': 'c', 'KeyType': 'HASH' },
-                   ], 'Projection': { 'ProjectionType': 'INCLUDE',
-                                      'NonKeyAttributes': [too_long_name]}
-                 }
-            ]) as table:
+                {
+                    "IndexName": "gsi",
+                    "KeySchema": [
+                        {"AttributeName": "c", "KeyType": "HASH"},
+                    ],
+                    "Projection": {
+                        "ProjectionType": "INCLUDE",
+                        "NonKeyAttributes": [too_long_name],
+                    },
+                }
+            ],
+        ) as table:
             pass
-    with pytest.raises(ClientError, match='ValidationException.*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'b', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "a", "KeyType": "HASH"},
+                {"AttributeName": "b", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                 { 'AttributeName': 'a', 'AttributeType': 'S' },
-                 { 'AttributeName': 'b', 'AttributeType': 'S' },
-                 { 'AttributeName': 'c', 'AttributeType': 'S' } ],
+                {"AttributeName": "a", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+            ],
             LocalSecondaryIndexes=[
-                 { 'IndexName': 'lsi', 'KeySchema': [
-                      { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                      { 'AttributeName': 'c', 'KeyType': 'RANGE' },
-                   ], 'Projection': { 'ProjectionType': 'INCLUDE',
-                                      'NonKeyAttributes': [too_long_name]}
-                 }
-            ]) as table:
+                {
+                    "IndexName": "lsi",
+                    "KeySchema": [
+                        {"AttributeName": "a", "KeyType": "HASH"},
+                        {"AttributeName": "c", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {
+                        "ProjectionType": "INCLUDE",
+                        "NonKeyAttributes": [too_long_name],
+                    },
+                }
+            ],
+        ) as table:
             pass
+
 
 # Above we tested asking to project a specific column which has very long
 # name, and failed the table creation. Here we show that a GSI/LSI which
@@ -377,45 +590,65 @@ def test_limit_attribute_length_gsi_lsi_projection_bad(dynamodb):
 # normal attribute name limit of 64KB, gets projected fine.
 def test_limit_attribute_length_gsi_lsi_projection_all(dynamodb):
     too_long_name = random_string(256)
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'b', 'KeyType': 'RANGE' }
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "a", "KeyType": "HASH"},
+            {"AttributeName": "b", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-             { 'AttributeName': 'a', 'AttributeType': 'S' },
-             { 'AttributeName': 'b', 'AttributeType': 'S' },
-             { 'AttributeName': 'c', 'AttributeType': 'S' }
+            {"AttributeName": "a", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-             { 'IndexName': 'gsi', 'KeySchema': [
-                  { 'AttributeName': 'c', 'KeyType': 'HASH' },
-               ], 'Projection': { 'ProjectionType': 'ALL' }
-             },
+            {
+                "IndexName": "gsi",
+                "KeySchema": [
+                    {"AttributeName": "c", "KeyType": "HASH"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
         ],
         LocalSecondaryIndexes=[
-             { 'IndexName': 'lsi', 'KeySchema': [
-                  { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                  { 'AttributeName': 'c', 'KeyType': 'RANGE' },
-               ], 'Projection': { 'ProjectionType': 'ALL' }
-             }
-        ]) as table:
+            {
+                "IndexName": "lsi",
+                "KeySchema": [
+                    {"AttributeName": "a", "KeyType": "HASH"},
+                    {"AttributeName": "c", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    ) as table:
         # As we tested above, there is no problem adding a non-key attribute
         # which has a >255 byte name. This is true even if this attribute is
         # implicitly copied to the GSI or LSI by the ProjectionType=ALL.
-        table.put_item(Item={'a': 'hi', 'b': 'ho', 'c': 'dog', too_long_name: 'cat' })
-        assert table.get_item(Key={'a': 'hi', 'b': 'ho'}, ConsistentRead=True)['Item'] == {'a': 'hi', 'b': 'ho', 'c': 'dog', too_long_name: 'cat' }
+        table.put_item(Item={"a": "hi", "b": "ho", "c": "dog", too_long_name: "cat"})
+        assert table.get_item(Key={"a": "hi", "b": "ho"}, ConsistentRead=True)[
+            "Item"
+        ] == {"a": "hi", "b": "ho", "c": "dog", too_long_name: "cat"}
         # GSI cannot use ConsistentRead so we may need to retry the read, so
         # we reuse a function that does this
-        assert_index_query(table, 'gsi',
-            [{'a': 'hi', 'b': 'ho', 'c': 'dog', too_long_name: 'cat'}],
-            KeyConditions={'c': {'AttributeValueList': ['dog'],
-            'ComparisonOperator': 'EQ'}})
-        # LSI can use ConsistentRead:
-        assert full_query(table, IndexName='lsi', ConsistentRead=True,
+        assert_index_query(
+            table,
+            "gsi",
+            [{"a": "hi", "b": "ho", "c": "dog", too_long_name: "cat"}],
             KeyConditions={
-              'a': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'},
-              'c': {'AttributeValueList': ['dog'], 'ComparisonOperator': 'EQ'},
-            }) == [{'a': 'hi', 'b': 'ho', 'c': 'dog', too_long_name: 'cat'}]
+                "c": {"AttributeValueList": ["dog"], "ComparisonOperator": "EQ"}
+            },
+        )
+        # LSI can use ConsistentRead:
+        assert full_query(
+            table,
+            IndexName="lsi",
+            ConsistentRead=True,
+            KeyConditions={
+                "a": {"AttributeValueList": ["hi"], "ComparisonOperator": "EQ"},
+                "c": {"AttributeValueList": ["dog"], "ComparisonOperator": "EQ"},
+            },
+        ) == [{"a": "hi", "b": "ho", "c": "dog", too_long_name: "cat"}]
+
 
 #############################################################################
 # The following tests test various limits of expressions
@@ -423,45 +656,72 @@ def test_limit_attribute_length_gsi_lsi_projection_all(dynamodb):
 # FilterExpression) as documented in
 # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html
 
+
 # The maximum string length of any of the expression parameters is 4 KB.
 # Check that the length 4096 is allowed, 4097 isn't - on all four expression
 # types.
 def test_limit_expression_len(test_table_s):
     p = random_string()
-    string4096 = 'x'*4096
-    string4097 = 'x'*4097
+    string4096 = "x" * 4096
+    string4097 = "x" * 4097
     # ProjectionExpression:
-    test_table_s.get_item(Key={'p': p}, ProjectionExpression=string4096)
-    with pytest.raises(ClientError, match='ValidationException.*ProjectionExpression'):
-        test_table_s.get_item(Key={'p': p}, ProjectionExpression=string4097)
+    test_table_s.get_item(Key={"p": p}, ProjectionExpression=string4096)
+    with pytest.raises(ClientError, match="ValidationException.*ProjectionExpression"):
+        test_table_s.get_item(Key={"p": p}, ProjectionExpression=string4097)
     # UpdateExpression:
-    spaces4085 = ' '*4085
-    test_table_s.update_item(Key={'p': p}, UpdateExpression=f'SET{spaces4085}a = :val',
-        ExpressionAttributeValues={':val': 1})
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, 'a': 1}
-    with pytest.raises(ClientError, match='ValidationException.*UpdateExpression'):
-        test_table_s.update_item(Key={'p': p}, UpdateExpression=f'SET {spaces4085}a = :val',
-            ExpressionAttributeValues={':val': 1})
+    spaces4085 = " " * 4085
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression=f"SET{spaces4085}a = :val",
+        ExpressionAttributeValues={":val": 1},
+    )
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        "a": 1,
+    }
+    with pytest.raises(ClientError, match="ValidationException.*UpdateExpression"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression=f"SET {spaces4085}a = :val",
+            ExpressionAttributeValues={":val": 1},
+        )
     # ConditionExpression:
-    test_table_s.update_item(Key={'p': p}, UpdateExpression='SET a = :newval',
-        ExpressionAttributeValues={':newval': 2, ':oldval': 1},
-        ConditionExpression=f'a{spaces4085} = :oldval')
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, 'a': 2}
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression'):
-        test_table_s.update_item(Key={'p': p}, UpdateExpression='SET a = :newval',
-            ExpressionAttributeValues={':newval': 3, ':oldval': 2},
-            ConditionExpression=f'a {spaces4085} = :oldval')
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression="SET a = :newval",
+        ExpressionAttributeValues={":newval": 2, ":oldval": 1},
+        ConditionExpression=f"a{spaces4085} = :oldval",
+    )
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"] == {
+        "p": p,
+        "a": 2,
+    }
+    with pytest.raises(ClientError, match="ValidationException.*ConditionExpression"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET a = :newval",
+            ExpressionAttributeValues={":newval": 3, ":oldval": 2},
+            ConditionExpression=f"a {spaces4085} = :oldval",
+        )
     # FilterExpression:
-    assert full_query(test_table_s, ConsistentRead=True,
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
-            FilterExpression=f'a{spaces4085} = :theval',
-            ExpressionAttributeValues={':theval': 2}
-        ) == [{'p': p, 'a': 2}]
-    with pytest.raises(ClientError, match='ValidationException.*FilterExpression'):
-        full_query(test_table_s, ConsistentRead=True,
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
-            FilterExpression=f'a {spaces4085} = :theval',
-            ExpressionAttributeValues={':theval': 2})
+    assert full_query(
+        test_table_s,
+        ConsistentRead=True,
+        KeyConditions={"p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}},
+        FilterExpression=f"a{spaces4085} = :theval",
+        ExpressionAttributeValues={":theval": 2},
+    ) == [{"p": p, "a": 2}]
+    with pytest.raises(ClientError, match="ValidationException.*FilterExpression"):
+        full_query(
+            test_table_s,
+            ConsistentRead=True,
+            KeyConditions={
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}
+            },
+            FilterExpression=f"a {spaces4085} = :theval",
+            ExpressionAttributeValues={":theval": 2},
+        )
+
 
 # The previous test (test_limit_expression_len) makes the 4096-byte length
 # limit of expressions appear very benign - so what if we accept a 10,000-byte
@@ -474,77 +734,112 @@ def test_limit_expression_len(test_table_s):
 def test_limit_expression_len_crash1(test_table_s):
     # a<b and (a<b and (a<b and (a<b and (a<b and (...))))):
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     depth = 20000
-    condition = "a<b " + "and (a<b "*depth +")"*depth
+    condition = "a<b " + "and (a<b " * depth + ")" * depth
     # For this expression longer than 4096 bytes, DynamoDB produces the
     # error "Invalid ConditionExpression: Expression size has exceeded the
     # maximum allowed size; expression size: 200004". Scylla used to crash
     # here (after very deep recursion) instead of a clean error.
-    with pytest.raises(ClientError, match='ValidationException.*expression size'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 1})
+    with pytest.raises(ClientError, match="ValidationException.*expression size"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 def test_limit_expression_len_crash2(test_table_s):
     # (((((((((((((((a<b)))))))))))))))
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     depth = 20000
-    condition = "("*depth + "a<b" + ")"*depth
-    with pytest.raises(ClientError, match='ValidationException.*expression size'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 1})
+    condition = "(" * depth + "a<b" + ")" * depth
+    with pytest.raises(ClientError, match="ValidationException.*expression size"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 def test_limit_expression_len_crash3(test_table_s):
     # ((((((((((((((((((((((((((( - a syntax error
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
-    condition = "("*15000
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
+    condition = "(" * 15000
     # Although this expression is a syntax error, the fact it is too long
     # should be recognized first.
-    with pytest.raises(ClientError, match='ValidationException.*expression size'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 1})
+    with pytest.raises(ClientError, match="ValidationException.*expression size"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 def test_limit_expression_len_crash4(test_table_s):
     # not not not not not ... not a<b
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     depth = 20000
-    condition = "not "*depth + "a<b"
-    with pytest.raises(ClientError, match='ValidationException.*expression size'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 1})
+    condition = "not " * depth + "a<b"
+    with pytest.raises(ClientError, match="ValidationException.*expression size"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 def test_limit_expression_len_crash5(test_table_s):
     # a < f(f(f(f(...(b)))))
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     depth = 20000
-    condition = "a < " + "f("*depth + "b" + ")"*depth
-    with pytest.raises(ClientError, match='ValidationException.*expression size'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 1})
+    condition = "a < " + "f(" * depth + "b" + ")" * depth
+    with pytest.raises(ClientError, match="ValidationException.*expression size"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 # The above tests test_limit_expression_len_crash* checked various cases
 # where very long (>4096 bytes) and very deeply nested expressions caused
@@ -553,15 +848,22 @@ def test_limit_expression_len_crash5(test_table_s):
 def test_deeply_nested_expression_1(test_table_s):
     # ((((((((((((((((((((((((((( - a syntax error
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     condition = "(" * 4096
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 1})
+    with pytest.raises(ClientError, match="ValidationException.*ConditionExpression"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 # Continuing the above test, check that Alternator prints a normal "syntax
 # error" for just "(((" but a "expression nested too deeply" for 4096
@@ -570,14 +872,26 @@ def test_deeply_nested_expression_1(test_table_s):
 # But I wanted to test that Alternator's error messages are as designed.
 def test_deeply_nested_expression_1a(test_table_s, scylla_only):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression.*syntax error'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :x', ExpressionAttributeValues={':x': 1},
-            ConditionExpression='(((')
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression.*expression nested too deeply'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :x', ExpressionAttributeValues={':x': 1},
-            ConditionExpression='('*4000)
+    with pytest.raises(
+        ClientError, match="ValidationException.*ConditionExpression.*syntax error"
+    ):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :x",
+            ExpressionAttributeValues={":x": 1},
+            ConditionExpression="(((",
+        )
+    with pytest.raises(
+        ClientError,
+        match="ValidationException.*ConditionExpression.*expression nested too deeply",
+    ):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :x",
+            ExpressionAttributeValues={":x": 1},
+            ConditionExpression="(" * 4000,
+        )
+
 
 # Even if an expression is shorter than 4096 bytes, DynamoDB can reject
 # if it has more than 300 "operators" - in the expression below we fit
@@ -591,29 +905,38 @@ def test_deeply_nested_expression_1a(test_table_s, scylla_only):
 def test_deeply_nested_expression_2(test_table_s):
     # a<b or (a<b or (a<b or (a<b or (...)))):
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     # depth=149 has a total of 299 "<" and "or" operators so should work.
     # Importantly, parentheses and spaces are *not* counted among the
     # "operators", only the "<" and "or".
     depth = 149
-    condition = "a<b " + "or (a<b "*depth +")"*depth
-    test_table_s.update_item(Key={'p': p},
-        UpdateExpression='SET z = :val',
-            ConditionExpression=condition,
-            ExpressionAttributeValues={':val': 1})
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']['z'] == 1
+    condition = "a<b " + "or (a<b " * depth + ")" * depth
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression="SET z = :val",
+        ConditionExpression=condition,
+        ExpressionAttributeValues={":val": 1},
+    )
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]["z"] == 1
     # depth=454 is still below 4096 bytes, but rejected by DynamoDB because
     # it has more than 300 operators, and by Scylla because 454 > MAX_DEPTH.
     depth = 454
-    condition = "a<b " + "or (a<b "*depth +")"*depth
+    condition = "a<b " + "or (a<b " * depth + ")" * depth
     assert len(condition) < 4096
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 1})
+    with pytest.raises(ClientError, match="ValidationException.*ConditionExpression"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 # Same as above test, but without parentheses, just a lot of OR - like
 # "a<b or a<b or a<b or a<b or ...". Alternator's parser actually implements
@@ -625,31 +948,40 @@ def test_deeply_nested_expression_2(test_table_s):
 # specific limit in Scylla. So this test is Scylla-only.
 def test_deeply_nested_expression_2a(test_table_s, scylla_only):
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     # repeating the "OR a<b" n=584 times generates an expression which is still
     # just below 4096 bytes. This expression is rejected by DynamoDB because
     # it has more than 300 operators, but because no recursion is involved in
     # parsing it, it is not rejected by Alternator even though n > MAX_DEPTH(=400).
     n = 584
-    condition = "a<b " + "or a<b "*n
+    condition = "a<b " + "or a<b " * n
     assert len(condition) < 4096
-    test_table_s.update_item(Key={'p': p},
-        UpdateExpression='SET z = :val',
-            ConditionExpression=condition,
-            ExpressionAttributeValues={':val': 1})
-    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']['z'] == 1
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression="SET z = :val",
+        ConditionExpression=condition,
+        ExpressionAttributeValues={":val": 1},
+    )
+    assert test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]["z"] == 1
     # n=585 results in an expression longer than 4096, so will be rejected
     # because of that limitation.
     n = 585
-    condition = "a<b " + "or a<b "*n
+    condition = "a<b " + "or a<b " * n
     assert len(condition) > 4096
-    with pytest.raises(ClientError, match='ValidationException.*expression size'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 1})
+    with pytest.raises(ClientError, match="ValidationException.*expression size"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 1},
+        )
+
 
 # Another deeply-recursive expression, (((((((((a<b))))))))), that used to
 # crash Scylla when the expression was very long but shouldn't crash it
@@ -663,17 +995,24 @@ def test_deeply_nested_expression_2a(test_table_s, scylla_only):
 def test_deeply_nested_expression_3(test_table_s):
     # (((((((((((((((a<b)))))))))))))))
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     depth = 2046
-    condition = "("*depth + "a<b" + ")"*depth
+    condition = "(" * depth + "a<b" + ")" * depth
     assert len(condition) < 4096
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 2})
+    with pytest.raises(ClientError, match="ValidationException.*ConditionExpression"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 2},
+        )
+
 
 # Another example of a deeply-nested expression which is shorter than
 # the 4096-byte limit, but has more than 300 operators (it has 1000 "NOT"
@@ -683,17 +1022,24 @@ def test_deeply_nested_expression_3(test_table_s):
 def test_deeply_nested_expression_4(test_table_s):
     # not not not not ... not not a<b
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
-    depth = 1000 # even, so condition is equivalent to just a<b
-    condition = "not "*depth + "a<b"
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
+    depth = 1000  # even, so condition is equivalent to just a<b
+    condition = "not " * depth + "a<b"
     assert len(condition) < 4096
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 2})
+    with pytest.raises(ClientError, match="ValidationException.*ConditionExpression"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 2},
+        )
+
 
 # Another example of a deeply-nested expression shorter than the limit of
 # 4096 bytes, a < f(f(f(f(...(b))))). DynamoDB apparently doesn't count
@@ -702,33 +1048,42 @@ def test_deeply_nested_expression_4(test_table_s):
 def test_deeply_nested_expression_5(test_table_s):
     # a < f(f(f(f(...(b)))))
     p = random_string()
-    test_table_s.update_item(Key={'p': p},
-            AttributeUpdates={'a': {'Value': 1, 'Action': 'PUT'},
-                              'b': {'Value': 2, 'Action': 'PUT'}})
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={
+            "a": {"Value": 1, "Action": "PUT"},
+            "b": {"Value": 2, "Action": "PUT"},
+        },
+    )
     depth = 1355
-    condition = "a < " + "f("*depth + "b" + ")"*depth
+    condition = "a < " + "f(" * depth + "b" + ")" * depth
     assert len(condition) < 4096
     # DynamoDB prints: "Invalid ConditionExpression: Invalid function name;
     # function: f". Scylla fails parsing this expression because the depth
     # exceeds MAX_DEPTH. We think this is fine.
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 2})
+    with pytest.raises(ClientError, match="ValidationException.*ConditionExpression"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 2},
+        )
 
     # a < size(size(size(size(...size(b)))))
     # Here the function exists, but the innermost size returns an integer,
     # which the surrounding size() doesn't like (it's not defined on an int)
     # In Scylla it is still rejected because of MAX_DEPTH.
     depth = 680
-    condition = "a < " + "size("*depth + "b" + ")"*depth
+    condition = "a < " + "size(" * depth + "b" + ")" * depth
     assert len(condition) < 4096
-    with pytest.raises(ClientError, match='ValidationException.*ConditionExpression'):
-        test_table_s.update_item(Key={'p': p},
-            UpdateExpression='SET z = :val',
-                ConditionExpression=condition,
-                ExpressionAttributeValues={':val': 2})
+    with pytest.raises(ClientError, match="ValidationException.*ConditionExpression"):
+        test_table_s.update_item(
+            Key={"p": p},
+            UpdateExpression="SET z = :val",
+            ConditionExpression=condition,
+            ExpressionAttributeValues={":val": 2},
+        )
+
 
 # TODO: additional expression limits documented in DynamoDB's documentation
 # that we should test here:
@@ -739,6 +1094,7 @@ def test_deeply_nested_expression_5(test_table_s):
 #   is limited to 2MB (not a very interesting limit...)
 
 #############################################################################
+
 
 # DynamoDB documentation says that the sort key must be between 1 and 1024
 # bytes in length. We already test (test_item.py::test_update_item_empty_key)
@@ -751,34 +1107,37 @@ def test_deeply_nested_expression_5(test_table_s):
 # decision. In any case, Alternator must have some key-length limits (the
 # internal implementation limits key length to 64 KB), so the test after this
 # one should pass.
-@pytest.mark.xfail(reason="issue #10347: sort key limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_limit_sort_key_len_1024(test_table_ss, test_table_sb):
     p = random_string()
     # String sort key with length 1024 is fine:
-    key = {'p': p, 'c': 'x'*1024}
+    key = {"p": p, "c": "x" * 1024}
     test_table_ss.put_item(Item=key)
-    assert test_table_ss.get_item(Key=key, ConsistentRead=True)['Item'] == key
+    assert test_table_ss.get_item(Key=key, ConsistentRead=True)["Item"] == key
     # But sort key with length 1025 is forbidden - in both read and write.
     # DynamoDB's message says "Aggregated size of all range keys has exceeded
     # the size limit of 1024 bytes". It's not clear what "all range keys"
     # actually refers to, as there can be only one. We investigate this
     # further below in test_limit_sort_key_len_lsi().
-    key = {'p': p, 'c': 'x'*1025}
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    key = {"p": p, "c": "x" * 1025}
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_ss.put_item(Item=key)
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_ss.get_item(Key=key, ConsistentRead=True)
 
     # The same limits are true for the bytes type. The length of a bytes
     # array is its real length - not the length of its base64 encoding.
-    key = {'p': p, 'c': bytearray([123]*1024)}
+    key = {"p": p, "c": bytearray([123] * 1024)}
     test_table_sb.put_item(Item=key)
-    assert test_table_sb.get_item(Key=key, ConsistentRead=True)['Item'] == key
-    key = {'p': p, 'c': bytearray([123]*1025)}
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    assert test_table_sb.get_item(Key=key, ConsistentRead=True)["Item"] == key
+    key = {"p": p, "c": bytearray([123] * 1025)}
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_sb.put_item(Item=key)
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_sb.get_item(Key=key, ConsistentRead=True)
+
 
 # This is a variant of the above test, where we don't insist that the
 # sort key length limit must be exactly 1024 bytes as in DynamoDB, but
@@ -789,33 +1148,36 @@ def test_limit_sort_key_len_1024(test_table_ss, test_table_sb):
 # Alternator decides to adopt a different sort-key-length limit from
 # DynamoDB. We do have to adopt *some* limit because the internal Scylla
 # implementation has a 64 KB limit on key lengths.
-@pytest.mark.xfail(reason="issue #10347: sort key limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_limit_sort_key_len(test_table_ss, test_table_sb):
     p = random_string()
     # String sort key with length 1024 is fine:
-    key = {'p': p, 'c': 'x'*1024}
+    key = {"p": p, "c": "x" * 1024}
     test_table_ss.put_item(Item=key)
-    assert test_table_ss.get_item(Key=key, ConsistentRead=True)['Item'] == key
+    assert test_table_ss.get_item(Key=key, ConsistentRead=True)["Item"] == key
     # Sort key of length 64 KB + 1 is forbidden - it obviously exceeds
     # DynamoDB's limit (1024 bytes), but also exceeds Scylla's internal
     # limit on key length (64 KB). We except to get a reasonable error
     # on request validation - not some "internal server error".
-    key = {'p': p, 'c': 'x'*65537}
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    key = {"p": p, "c": "x" * 65537}
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_ss.put_item(Item=key)
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_ss.get_item(Key=key, ConsistentRead=True)
 
     # The same limits are true for the bytes type. The length of a bytes
     # array is its real length - not the length of its base64 encoding.
-    key = {'p': p, 'c': bytearray([123]*1024)}
+    key = {"p": p, "c": bytearray([123] * 1024)}
     test_table_sb.put_item(Item=key)
-    assert test_table_sb.get_item(Key=key, ConsistentRead=True)['Item'] == key
-    key = {'p': p, 'c': bytearray([123]*65537)}
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    assert test_table_sb.get_item(Key=key, ConsistentRead=True)["Item"] == key
+    key = {"p": p, "c": bytearray([123] * 65537)}
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_sb.put_item(Item=key)
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_sb.get_item(Key=key, ConsistentRead=True)
+
 
 # As mentioned above, DynamoDB's error about sort key length exceeding the
 # 1024 byte limit says that "Aggregated size of all range keys has exceeded
@@ -827,26 +1189,45 @@ def test_limit_sort_key_len(test_table_ss, test_table_sb):
 # one if the base table's sort key and the other is an LSI's sort key.
 # DyanamoDB's error message appears to be nothing more than a mistake.
 def test_limit_sort_key_len_lsi(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'b', 'KeyType': 'RANGE' }
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "a", "KeyType": "HASH"},
+            {"AttributeName": "b", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-             { 'AttributeName': 'a', 'AttributeType': 'S' },
-             { 'AttributeName': 'b', 'AttributeType': 'S' },
-             { 'AttributeName': 'c', 'AttributeType': 'S' }
+            {"AttributeName": "a", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
         ],
         LocalSecondaryIndexes=[
-             { 'IndexName': 'lsi', 'KeySchema': [
-                  { 'AttributeName': 'a', 'KeyType': 'HASH' },
-                  { 'AttributeName': 'c', 'KeyType': 'RANGE' },
-               ], 'Projection': { 'ProjectionType': 'ALL' }
-             }
-        ]) as table:
-        item = {'a': 'hello', 'b': 'x'*1024, 'c': 'y'*1024 }
+            {
+                "IndexName": "lsi",
+                "KeySchema": [
+                    {"AttributeName": "a", "KeyType": "HASH"},
+                    {"AttributeName": "c", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    ) as table:
+        item = {"a": "hello", "b": "x" * 1024, "c": "y" * 1024}
         table.put_item(Item=item)
-        assert table.get_item(Key={'a': 'hello', 'b': 'x'*1024}, ConsistentRead=True)['Item'] == item
-        assert table.query(IndexName='lsi', KeyConditions={'a': {'AttributeValueList': ['hello'], 'ComparisonOperator': 'EQ'}, 'c': {'AttributeValueList': ['y'*1024], 'ComparisonOperator': 'EQ'}}, ConsistentRead=True)['Items'] == [item]
+        assert (
+            table.get_item(Key={"a": "hello", "b": "x" * 1024}, ConsistentRead=True)[
+                "Item"
+            ]
+            == item
+        )
+        assert table.query(
+            IndexName="lsi",
+            KeyConditions={
+                "a": {"AttributeValueList": ["hello"], "ComparisonOperator": "EQ"},
+                "c": {"AttributeValueList": ["y" * 1024], "ComparisonOperator": "EQ"},
+            },
+            ConsistentRead=True,
+        )["Items"] == [item]
+
 
 # DynamoDB documentation says that the partition key must be between 1 and 2048
 # bytes in length. We already test (test_item.py::test_update_item_empty_key)
@@ -859,29 +1240,40 @@ def test_limit_sort_key_len_lsi(dynamodb):
 # decision. In any case, Alternator must have some key-length limits (the
 # internal implementation limits key length to 64 KB), so even if this test
 # won't pass, the one after it should pass.
-@pytest.mark.xfail(reason="issue #10347: sort key limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_limit_partition_key_len_2048(test_table_s, test_table_b):
     # String partition key with length 2048 is fine:
-    item = {'p': 'x'*2048, 'z': 'hello'}
+    item = {"p": "x" * 2048, "z": "hello"}
     test_table_s.put_item(Item=item)
-    assert test_table_s.get_item(Key={'p': 'x'*2048}, ConsistentRead=True)['Item'] == item
+    assert (
+        test_table_s.get_item(Key={"p": "x" * 2048}, ConsistentRead=True)["Item"]
+        == item
+    )
     # But partition key with length 2049 is forbidden - in both read and write.
-    key = {'p': 'x'*2049}
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    key = {"p": "x" * 2049}
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_s.put_item(Item=key)
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_s.get_item(Key=key, ConsistentRead=True)
 
     # The same limits are true for the bytes type. The length of a bytes
     # array is its real length - not the length of its base64 encoding.
-    item = {'p': bytearray([123]*2048), 'z': 'hello'}
+    item = {"p": bytearray([123] * 2048), "z": "hello"}
     test_table_b.put_item(Item=item)
-    assert test_table_b.get_item(Key={'p': bytearray([123]*2048)}, ConsistentRead=True)['Item'] == item
-    key = {'p': bytearray([123]*2049)}
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    assert (
+        test_table_b.get_item(Key={"p": bytearray([123] * 2048)}, ConsistentRead=True)[
+            "Item"
+        ]
+        == item
+    )
+    key = {"p": bytearray([123] * 2049)}
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_b.put_item(Item=key)
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_b.get_item(Key=key, ConsistentRead=True)
+
 
 # This is a variant of the above test, where we don't insist that the
 # partition key length limit must be exactly 2048 bytes as in DynamoDB, but
@@ -892,50 +1284,74 @@ def test_limit_partition_key_len_2048(test_table_s, test_table_b):
 # Alternator decides to adopt a different sort-key-length limit from
 # DynamoDB. We do have to adopt *some* limit because the internal Scylla
 # implementation has a 64 KB limit on key lengths.
-@pytest.mark.xfail(reason="issue #10347: sort key limits not enforced")
+@pytest.mark.xfail(
+    reason="Alternator doesn't limit partition and sort key lengths #10347"
+)
 def test_limit_partition_key_len(test_table_s, test_table_b):
     # String partition key with length 2048 is fine:
-    item = {'p': 'x'*2048, 'z': 'hello'}
+    item = {"p": "x" * 2048, "z": "hello"}
     test_table_s.put_item(Item=item)
-    assert test_table_s.get_item(Key={'p': 'x'*2048}, ConsistentRead=True)['Item'] == item
+    assert (
+        test_table_s.get_item(Key={"p": "x" * 2048}, ConsistentRead=True)["Item"]
+        == item
+    )
     # Partition key of length 64 KB + 1 is forbidden - it obviously exceeds
     # DynamoDB's limit (2048 bytes), but also exceeds Scylla's internal
     # limit on key length (64 KB). We except to get a reasonable error
     # on request validation - not some "internal server error".
-    key = {'p': 'x'*65537}
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    key = {"p": "x" * 65537}
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_s.put_item(Item=key)
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_s.get_item(Key=key, ConsistentRead=True)
 
     # The same limits are true for the bytes type. The length of a bytes
     # array is its real length - not the length of its base64 encoding.
-    item = {'p': bytearray([123]*2048), 'z': 'hello'}
+    item = {"p": bytearray([123] * 2048), "z": "hello"}
     test_table_b.put_item(Item=item)
-    assert test_table_b.get_item(Key={'p': bytearray([123]*2048)}, ConsistentRead=True)['Item'] == item
-    key = {'p': bytearray([123]*65537)}
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    assert (
+        test_table_b.get_item(Key={"p": bytearray([123] * 2048)}, ConsistentRead=True)[
+            "Item"
+        ]
+        == item
+    )
+    key = {"p": bytearray([123] * 65537)}
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_b.put_item(Item=key)
-    with pytest.raises(ClientError, match='ValidationException.*limit'):
+    with pytest.raises(ClientError, match="ValidationException.*limit"):
         test_table_b.get_item(Key=key, ConsistentRead=True)
+
 
 # Test attr name limit of UpdateTable's GlobalSecondaryIndexUpdates.
 # Reproduces issue #9169.
 def test_limit_gsiu_key_len_bad(dynamodb):
     too_long_name = random_string(256)
 
-    with pytest.raises(ClientError, match='ValidationException..*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException..*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+        ) as table:
             # Now use UpdateTable to create the GSI
-            dynamodb.meta.client.update_table(TableName=table.name,
-                AttributeDefinitions=[{ 'AttributeName': too_long_name, 'AttributeType': 'S' }],
-                GlobalSecondaryIndexUpdates=[ {  'Create':
-                    {  'IndexName': 'hello',
-                        'KeySchema': [{ 'AttributeName': too_long_name, 'KeyType': 'HASH' }],
-                        'Projection': { 'ProjectionType': 'ALL' }
-                    }}])
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                AttributeDefinitions=[
+                    {"AttributeName": too_long_name, "AttributeType": "S"}
+                ],
+                GlobalSecondaryIndexUpdates=[
+                    {
+                        "Create": {
+                            "IndexName": "hello",
+                            "KeySchema": [
+                                {"AttributeName": too_long_name, "KeyType": "HASH"}
+                            ],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    }
+                ],
+            )
+
 
 # Test attr name limit of UpdateTable with GlobalSecondaryIndexUpdates.
 # The tests here cover the cases of too long names in incorrect (incoherent)
@@ -947,28 +1363,55 @@ def test_limit_gsiu_key_len_bad(dynamodb):
 def test_limit_gsiu_key_len_bad_incoherent_names(dynamodb):
     too_long_name = random_string(256)
 
-    with pytest.raises(ClientError, match='ValidationException..*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException..*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+        ) as table:
             # Now use UpdateTable to create the GSI
-            dynamodb.meta.client.update_table(TableName=table.name,
-                AttributeDefinitions=[{ 'AttributeName': too_long_name, 'AttributeType': 'S' }],
-                GlobalSecondaryIndexUpdates=[ {  'Create':
-                    {  'IndexName': 'hello',
-                        'KeySchema': [{ 'AttributeName': "incoherent-short-name", 'KeyType': 'HASH' }],
-                        'Projection': { 'ProjectionType': 'ALL' }
-                    }}])
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                AttributeDefinitions=[
+                    {"AttributeName": too_long_name, "AttributeType": "S"}
+                ],
+                GlobalSecondaryIndexUpdates=[
+                    {
+                        "Create": {
+                            "IndexName": "hello",
+                            "KeySchema": [
+                                {
+                                    "AttributeName": "incoherent-short-name",
+                                    "KeyType": "HASH",
+                                }
+                            ],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    }
+                ],
+            )
 
-    with pytest.raises(ClientError, match='ValidationException..*25[56]'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
+    with pytest.raises(ClientError, match="ValidationException..*25[56]"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+        ) as table:
             # Now use UpdateTable to create the GSI
-            dynamodb.meta.client.update_table(TableName=table.name,
-                AttributeDefinitions=[{ 'AttributeName': "incoherent-short-name", 'AttributeType': 'S' }],
-                GlobalSecondaryIndexUpdates=[ {  'Create':
-                    {  'IndexName': 'hello',
-                        'KeySchema': [{ 'AttributeName': too_long_name, 'KeyType': 'HASH' }],
-                        'Projection': { 'ProjectionType': 'ALL' }
-                    }}])
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                AttributeDefinitions=[
+                    {"AttributeName": "incoherent-short-name", "AttributeType": "S"}
+                ],
+                GlobalSecondaryIndexUpdates=[
+                    {
+                        "Create": {
+                            "IndexName": "hello",
+                            "KeySchema": [
+                                {"AttributeName": too_long_name, "KeyType": "HASH"}
+                            ],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    }
+                ],
+            )

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -14,394 +14,601 @@ import pytest
 import requests
 from botocore.exceptions import ClientError
 
-from test.alternator.util import create_test_table, new_test_table, random_string, full_scan, full_query, multiset, unique_table_name
+from test.alternator.util import (
+    create_test_table,
+    new_test_table,
+    random_string,
+    full_scan,
+    full_query,
+    multiset,
+    unique_table_name,
+)
 
 
 # LSIs support strongly-consistent reads, so the following functions do not
 # need to retry like we did in test_gsi.py for GSIs:
 def assert_index_query(table, index_name, expected_items, **kwargs):
-    assert multiset(expected_items) == multiset(full_query(table, IndexName=index_name, **kwargs))
+    assert multiset(expected_items) == multiset(
+        full_query(table, IndexName=index_name, **kwargs)
+    )
+
+
 def assert_index_scan(table, index_name, expected_items, **kwargs):
-    assert multiset(expected_items) == multiset(full_scan(table, IndexName=index_name, **kwargs))
+    assert multiset(expected_items) == multiset(
+        full_scan(table, IndexName=index_name, **kwargs)
+    )
+
 
 # A version doing retries instead of ConsistentRead, to be used just for the
 # one test below which has both GSI and LSI:
 def retrying_assert_index_query(table, index_name, expected_items, **kwargs):
     for i in range(3):
-        if multiset(expected_items) == multiset(full_query(table, IndexName=index_name, ConsistentRead=False, **kwargs)):
+        if multiset(expected_items) == multiset(
+            full_query(table, IndexName=index_name, ConsistentRead=False, **kwargs)
+        ):
             return
-        print('retrying_assert_index_query retrying')
+        print("retrying_assert_index_query retrying")
         time.sleep(1)
-    assert multiset(expected_items) == multiset(full_query(table, IndexName=index_name, ConsistentRead=False, **kwargs))
+    assert multiset(expected_items) == multiset(
+        full_query(table, IndexName=index_name, ConsistentRead=False, **kwargs)
+    )
+
 
 # Although quite silly, it is actually allowed to create an index which is
 # identical to the base table.
 def test_lsi_identical(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'S' }],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
-                'Projection': { 'ProjectionType': 'ALL' }
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "c", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ])
-    items = [{'p': random_string(), 'c': random_string()} for i in range(10)]
+        ],
+    )
+    items = [{"p": random_string(), "c": random_string()} for i in range(10)]
     with table.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
     # Scanning the entire table directly or via the index yields the same
     # results (in different order).
     assert multiset(items) == multiset(full_scan(table))
-    assert_index_scan(table, 'hello', items)
+    assert_index_scan(table, "hello", items)
     # We can't scan a non-existent index
-    with pytest.raises(ClientError, match='ValidationException'):
-        full_scan(table, IndexName='wrong')
+    with pytest.raises(ClientError, match="ValidationException"):
+        full_scan(table, IndexName="wrong")
     table.delete()
+
 
 # Check that providing a hash key different than the base table is not
 # allowed:
 def test_lsi_wrong_different_hash(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*hash key'):
-        table = create_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
+    with pytest.raises(ClientError, match="ValidationException.*hash key"):
+        table = create_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "p", "KeyType": "HASH"},
+                {"AttributeName": "c", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                        { 'AttributeName': 'p', 'AttributeType': 'S' },
-                        { 'AttributeName': 'c', 'AttributeType': 'S' },
-                        { 'AttributeName': 'b', 'AttributeType': 'S' }
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+                {"AttributeName": "b", "AttributeType": "S"},
             ],
             LocalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'b', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'p', 'KeyType': 'RANGE' }
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [
+                        {"AttributeName": "b", "KeyType": "HASH"},
+                        {"AttributeName": "p", "KeyType": "RANGE"},
                     ],
-                    'Projection': { 'ProjectionType': 'ALL' }
+                    "Projection": {"ProjectionType": "ALL"},
                 }
-            ])
+            ],
+        )
         table.delete()
+
 
 # Check that it's not allowed to create an LSI without specifying a range
 # key cannot be missing, or (obviously) making it the same as the hash key:
 def test_lsi_wrong_bad_range(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*same'):
-        table = create_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*same"):
+        table = create_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "p", "KeyType": "HASH"},
+                {"AttributeName": "c", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                        { 'AttributeName': 'p', 'AttributeType': 'S' },
-                        { 'AttributeName': 'c', 'AttributeType': 'S' }
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
             ],
             LocalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'p', 'KeyType': 'RANGE' }
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [
+                        {"AttributeName": "p", "KeyType": "HASH"},
+                        {"AttributeName": "p", "KeyType": "RANGE"},
                     ],
-                    'Projection': { 'ProjectionType': 'ALL' }
+                    "Projection": {"ProjectionType": "ALL"},
                 }
-            ])
+            ],
+        )
         table.delete()
-    with pytest.raises(ClientError, match='ValidationException.*'):
-        table = create_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*"):
+        table = create_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "p", "KeyType": "HASH"},
+                {"AttributeName": "c", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                        { 'AttributeName': 'p', 'AttributeType': 'S' },
-                        { 'AttributeName': 'c', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
             ],
             LocalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'p', 'KeyType': 'HASH' }
-                    ],
-                    'Projection': { 'ProjectionType': 'ALL' }
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
                 }
-            ])
+            ],
+        )
         table.delete()
+
 
 # The purpose of an LSI is to allow an alternative sort key for the
 # existing partitions - the partitions do not change. So it doesn't make
 # sense to create an LSI on a table that did not originally have a sort key
 # (so has only single-item partitions) - and this case is not allowed.
 def test_lsi_wrong_no_sort_key(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*'):
-        table = create_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+    with pytest.raises(ClientError, match="ValidationException.*"):
+        table = create_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
             AttributeDefinitions=[
-                        { 'AttributeName': 'p', 'AttributeType': 'S' },
-                        { 'AttributeName': 'c', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
             ],
             LocalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [
+                        {"AttributeName": "p", "KeyType": "HASH"},
+                        {"AttributeName": "c", "KeyType": "RANGE"},
                     ],
-                    'Projection': { 'ProjectionType': 'ALL' }
+                    "Projection": {"ProjectionType": "ALL"},
                 }
-            ])
+            ],
+        )
         table.delete()
+
 
 # A simple scenario for LSI. Base table has a partition key and a sort key,
 # index has the same partition key key but a different sort key - one of
 # the non-key attributes from the base table.
 @pytest.fixture(scope="module")
 def test_table_lsi_1(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'b', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "S"},
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'b', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "b", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ])
+        ],
+    )
     yield table
     table.delete()
 
+
 def test_lsi_1(test_table_lsi_1):
-    items1 = [{'p': random_string(), 'c': random_string(), 'b': random_string()} for i in range(10)]
-    p1, b1 = items1[0]['p'], items1[0]['b']
+    items1 = [
+        {"p": random_string(), "c": random_string(), "b": random_string()}
+        for i in range(10)
+    ]
+    p1, b1 = items1[0]["p"], items1[0]["b"]
     p2, b2 = random_string(), random_string()
-    items2 = [{'p': p2, 'c': p2, 'b': b2}]
+    items2 = [{"p": p2, "c": p2, "b": b2}]
     items = items1 + items2
     with test_table_lsi_1.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    expected_items = [i for i in items if i['p'] == p1 and i['b'] == b1]
-    assert_index_query(test_table_lsi_1, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p1], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b1], 'ComparisonOperator': 'EQ'}})
-    expected_items = [i for i in items if i['p'] == p2 and i['b'] == b2]
-    assert_index_query(test_table_lsi_1, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p2], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b2], 'ComparisonOperator': 'EQ'}})
+    expected_items = [i for i in items if i["p"] == p1 and i["b"] == b1]
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p1], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b1], "ComparisonOperator": "EQ"},
+        },
+    )
+    expected_items = [i for i in items if i["p"] == p2 and i["b"] == b2]
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p2], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b2], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # The same as test_table_lsi_1, but with a clustering key of type bytes
 @pytest.fixture(scope="module")
 def test_table_lsi_2(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'b', 'AttributeType': 'B' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "B"},
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'b', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "b", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ])
+        ],
+    )
     yield table
     table.delete()
+
 
 # A second scenario of LSI. Base table has both hash and sort keys,
 # a local index is created on each non-key parameter
 @pytest.fixture(scope="module")
 def test_table_lsi_4(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x1', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x2', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x3', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x4', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x1", "AttributeType": "S"},
+            {"AttributeName": "x2", "AttributeType": "S"},
+            {"AttributeName": "x3", "AttributeType": "S"},
+            {"AttributeName": "x4", "AttributeType": "S"},
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'hello_' + column,
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': column, 'KeyType': 'RANGE' }
+            {
+                "IndexName": "hello_" + column,
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": column, "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'ALL' }
-            } for column in ['x1','x2','x3','x4']
-        ])
+                "Projection": {"ProjectionType": "ALL"},
+            }
+            for column in ["x1", "x2", "x3", "x4"]
+        ],
+    )
     yield table
     table.delete()
 
+
 def test_lsi_4(test_table_lsi_4):
-    items1 = [{'p': random_string(), 'c': random_string(),
-               'x1': random_string(), 'x2': random_string(), 'x3': random_string(), 'x4': random_string()} for i in range(10)]
+    items1 = [
+        {
+            "p": random_string(),
+            "c": random_string(),
+            "x1": random_string(),
+            "x2": random_string(),
+            "x3": random_string(),
+            "x4": random_string(),
+        }
+        for i in range(10)
+    ]
     i_values = items1[0]
     i5 = random_string()
-    items2 = [{'p': i5, 'c': i5, 'x1': i5, 'x2': i5, 'x3': i5, 'x4': i5}]
+    items2 = [{"p": i5, "c": i5, "x1": i5, "x2": i5, "x3": i5, "x4": i5}]
     items = items1 + items2
     with test_table_lsi_4.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    for column in ['x1', 'x2', 'x3', 'x4']:
-        expected_items = [i for i in items if (i['p'], i[column]) == (i_values['p'], i_values[column])]
-        assert_index_query(test_table_lsi_4, 'hello_' + column, expected_items,
-            KeyConditions={'p': {'AttributeValueList': [i_values['p']], 'ComparisonOperator': 'EQ'},
-                           column: {'AttributeValueList': [i_values[column]], 'ComparisonOperator': 'EQ'}})
-        expected_items = [i for i in items if (i['p'], i[column]) == (i5, i5)]
-        assert_index_query(test_table_lsi_4, 'hello_' + column, expected_items,
-            KeyConditions={'p': {'AttributeValueList': [i5], 'ComparisonOperator': 'EQ'},
-                           column: {'AttributeValueList': [i5], 'ComparisonOperator': 'EQ'}})
+    for column in ["x1", "x2", "x3", "x4"]:
+        expected_items = [
+            i for i in items if (i["p"], i[column]) == (i_values["p"], i_values[column])
+        ]
+        assert_index_query(
+            test_table_lsi_4,
+            "hello_" + column,
+            expected_items,
+            KeyConditions={
+                "p": {
+                    "AttributeValueList": [i_values["p"]],
+                    "ComparisonOperator": "EQ",
+                },
+                column: {
+                    "AttributeValueList": [i_values[column]],
+                    "ComparisonOperator": "EQ",
+                },
+            },
+        )
+        expected_items = [i for i in items if (i["p"], i[column]) == (i5, i5)]
+        assert_index_query(
+            test_table_lsi_4,
+            "hello_" + column,
+            expected_items,
+            KeyConditions={
+                "p": {"AttributeValueList": [i5], "ComparisonOperator": "EQ"},
+                column: {"AttributeValueList": [i5], "ComparisonOperator": "EQ"},
+            },
+        )
+
 
 # Test that setting an indexed string column to an empty string is illegal,
 # since keys cannot contain empty strings
 def test_lsi_empty_value(test_table_lsi_1):
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_lsi_1.put_item(Item={'p': random_string(), 'c': random_string(), 'b': ''})
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_lsi_1.put_item(
+            Item={"p": random_string(), "c": random_string(), "b": ""}
+        )
+
 
 # Setting a binary key to an empty value is also illegal.
 def test_lsi_empty_value_binary(test_table_lsi_2):
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
-        test_table_lsi_2.put_item(Item={'p':  random_string(), 'c': random_string(), 'b': b''})
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
+        test_table_lsi_2.put_item(
+            Item={"p": random_string(), "c": random_string(), "b": b""}
+        )
+
 
 # Test that if an item in a batch has an empty indexed column and fails the
 # verification, none of the other writes in the batch get done either.
 def test_lsi_empty_value_in_bigger_batch_write(test_table_lsi_1):
     items = [
-        {'p': random_string(), 'c': random_string(), 'b': random_string()},
-        {'p': random_string(), 'c': random_string(), 'b': random_string()},
-        {'p': random_string(), 'c': random_string(), 'b': ''}
+        {"p": random_string(), "c": random_string(), "b": random_string()},
+        {"p": random_string(), "c": random_string(), "b": random_string()},
+        {"p": random_string(), "c": random_string(), "b": ""},
     ]
-    with pytest.raises(ClientError, match='ValidationException.*empty'):
+    with pytest.raises(ClientError, match="ValidationException.*empty"):
         with test_table_lsi_1.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
     for item in items:
-        assert not 'Item' in test_table_lsi_1.get_item(Key={'p': item['p'], 'c': item['c']}, ConsistentRead=True)
+        assert not "Item" in test_table_lsi_1.get_item(
+            Key={"p": item["p"], "c": item["c"]}, ConsistentRead=True
+        )
+
 
 def test_lsi_null_index(test_table_lsi_1):
     # Dynamodb supports special way of setting NULL value. It's different than
     # non existing value.
     p = random_string()
     c = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
-        test_table_lsi_1.put_item(Item={'p': p, 'c': c, 'b': None})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
-        test_table_lsi_1.update_item(Key={'p': p, 'c': c}, AttributeUpdates={'b': {'Value': None, 'Action': 'PUT'}})
-    with pytest.raises(ClientError, match='ValidationException.*NULL'):
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
+        test_table_lsi_1.put_item(Item={"p": p, "c": c, "b": None})
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
+        test_table_lsi_1.update_item(
+            Key={"p": p, "c": c},
+            AttributeUpdates={"b": {"Value": None, "Action": "PUT"}},
+        )
+    with pytest.raises(ClientError, match="ValidationException.*NULL"):
         with test_table_lsi_1.batch_writer() as batch:
-            batch.put_item({'p': p, 'c': c, 'b': None})
+            batch.put_item({"p": p, "c": c, "b": None})
+
 
 def test_lsi_describe(test_table_lsi_4):
     desc = test_table_lsi_4.meta.client.describe_table(TableName=test_table_lsi_4.name)
-    assert 'Table' in desc
-    assert 'LocalSecondaryIndexes' in desc['Table']
-    lsis = desc['Table']['LocalSecondaryIndexes']
-    assert(sorted([lsi['IndexName'] for lsi in lsis]) == ['hello_x1', 'hello_x2', 'hello_x3', 'hello_x4'])
+    assert "Table" in desc
+    assert "LocalSecondaryIndexes" in desc["Table"]
+    lsis = desc["Table"]["LocalSecondaryIndexes"]
+    assert sorted([lsi["IndexName"] for lsi in lsis]) == [
+        "hello_x1",
+        "hello_x2",
+        "hello_x3",
+        "hello_x4",
+    ]
     for lsi in lsis:
-        assert lsi['IndexArn'] == desc['Table']['TableArn'] + '/index/' + lsi['IndexName']
-        assert lsi['Projection'] == {'ProjectionType': 'ALL'}
+        assert (
+            lsi["IndexArn"] == desc["Table"]["TableArn"] + "/index/" + lsi["IndexName"]
+        )
+        assert lsi["Projection"] == {"ProjectionType": "ALL"}
+
 
 # Whereas GSIs have an IndexStatus when described by DescribeTable,
 # LSIs do not. IndexStatus is not needed because LSIs cannot be added
 # after the base table is created.
 def test_lsi_describe_indexstatus(test_table_lsi_1):
     desc = test_table_lsi_1.meta.client.describe_table(TableName=test_table_lsi_1.name)
-    assert 'Table' in desc
-    assert 'LocalSecondaryIndexes' in desc['Table']
-    lsis = desc['Table']['LocalSecondaryIndexes']
+    assert "Table" in desc
+    assert "LocalSecondaryIndexes" in desc["Table"]
+    lsis = desc["Table"]["LocalSecondaryIndexes"]
     assert len(lsis) == 1
     lsi = lsis[0]
-    assert not 'IndexStatus' in lsi
+    assert not "IndexStatus" in lsi
+
 
 # In addition to the basic listing of an LSI in DescribeTable tested above,
 # in this test we check additional fields that should appear in each LSI's
 # description.
-@pytest.mark.xfail(reason="issues #7550, #11466")
+@pytest.mark.xfail(
+    reason="Alternator: missing ItemCount field in return of DescribeTable #7550, Alternator: missing IndexSizeBytes field in return of DescribeTable #11466"
+)
 def test_lsi_describe_fields(test_table_lsi_1):
     desc = test_table_lsi_1.meta.client.describe_table(TableName=test_table_lsi_1.name)
-    assert 'Table' in desc
-    assert 'LocalSecondaryIndexes' in desc['Table']
-    lsis = desc['Table']['LocalSecondaryIndexes']
+    assert "Table" in desc
+    assert "LocalSecondaryIndexes" in desc["Table"]
+    lsis = desc["Table"]["LocalSecondaryIndexes"]
     assert len(lsis) == 1
     lsi = lsis[0]
-    assert lsi['IndexName'] == 'hello'
-    assert 'IndexSizeBytes' in lsi     # actual size depends on content
-    assert 'ItemCount' in lsi
+    assert lsi["IndexName"] == "hello"
+    assert "IndexSizeBytes" in lsi  # actual size depends on content
+    assert "ItemCount" in lsi
     # Whereas GSIs has ProvisionedThroughput, LSIs do not. An LSI shares
     # its provisioning with the base table.
-    assert not 'ProvisionedThroughput' in lsi
-    assert lsi['KeySchema'] == [{'KeyType': 'HASH', 'AttributeName': 'p'},
-                                {'KeyType': 'RANGE', 'AttributeName': 'b'}]
+    assert not "ProvisionedThroughput" in lsi
+    assert lsi["KeySchema"] == [
+        {"KeyType": "HASH", "AttributeName": "p"},
+        {"KeyType": "RANGE", "AttributeName": "b"},
+    ]
     # The index's ARN should look like the table's ARN followed by /index/<indexname>.
-    assert lsi['IndexArn'] == desc['Table']['TableArn'] + '/index/hello'
+    assert lsi["IndexArn"] == desc["Table"]["TableArn"] + "/index/hello"
+
 
 # A table with selective projection - only keys are projected into the index
 @pytest.fixture(scope="module")
 def test_table_lsi_keys_only(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'b', 'AttributeType': 'S' }
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "S"},
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'b', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "b", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
             }
-        ])
+        ],
+    )
     yield table
     table.delete()
+
 
 # Check that it's possible to extract a non-projected attribute from the index,
 # as the documentation promises
 def test_lsi_get_not_projected_attribute(test_table_lsi_keys_only):
-    items1 = [{'p': random_string(), 'c': random_string(), 'b': random_string(), 'd': random_string()} for i in range(10)]
-    p1, b1, d1 = items1[0]['p'], items1[0]['b'], items1[0]['d']
+    items1 = [
+        {
+            "p": random_string(),
+            "c": random_string(),
+            "b": random_string(),
+            "d": random_string(),
+        }
+        for i in range(10)
+    ]
+    p1, b1, d1 = items1[0]["p"], items1[0]["b"], items1[0]["d"]
     p2, b2, d2 = random_string(), random_string(), random_string()
-    items2 = [{'p': p2, 'c': p2, 'b': b2, 'd': d2}]
+    items2 = [{"p": p2, "c": p2, "b": b2, "d": d2}]
     items = items1 + items2
     with test_table_lsi_keys_only.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    expected_items = [i for i in items if i['p'] == p1 and i['b'] == b1 and i['d'] == d1]
-    assert_index_query(test_table_lsi_keys_only, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p1], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b1], 'ComparisonOperator': 'EQ'}},
-        Select='ALL_ATTRIBUTES')
-    expected_items = [i for i in items if i['p'] == p2 and i['b'] == b2 and i['d'] == d2]
-    assert_index_query(test_table_lsi_keys_only, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p2], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b2], 'ComparisonOperator': 'EQ'}},
-        Select='ALL_ATTRIBUTES')
-    expected_items = [{'d': i['d']} for i in items if i['p'] == p2 and i['b'] == b2 and i['d'] == d2]
-    assert_index_query(test_table_lsi_keys_only, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p2], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b2], 'ComparisonOperator': 'EQ'}},
-        Select='SPECIFIC_ATTRIBUTES', AttributesToGet=['d'])
+    expected_items = [
+        i for i in items if i["p"] == p1 and i["b"] == b1 and i["d"] == d1
+    ]
+    assert_index_query(
+        test_table_lsi_keys_only,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p1], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b1], "ComparisonOperator": "EQ"},
+        },
+        Select="ALL_ATTRIBUTES",
+    )
+    expected_items = [
+        i for i in items if i["p"] == p2 and i["b"] == b2 and i["d"] == d2
+    ]
+    assert_index_query(
+        test_table_lsi_keys_only,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p2], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b2], "ComparisonOperator": "EQ"},
+        },
+        Select="ALL_ATTRIBUTES",
+    )
+    expected_items = [
+        {"d": i["d"]} for i in items if i["p"] == p2 and i["b"] == b2 and i["d"] == d2
+    ]
+    assert_index_query(
+        test_table_lsi_keys_only,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p2], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b2], "ComparisonOperator": "EQ"},
+        },
+        Select="SPECIFIC_ATTRIBUTES",
+        AttributesToGet=["d"],
+    )
+
 
 # Check that by default (Select=ALL_PROJECTED_ATTRIBUTES), only projected
 # attributes are extracted
 @pytest.mark.xfail(reason="LSI in alternator currently only implement full projections")
 def test_lsi_get_all_projected_attributes(test_table_lsi_keys_only):
-    items1 = [{'p': random_string(), 'c': random_string(), 'b': random_string(), 'd': random_string()} for i in range(10)]
-    p1, b1, d1 = items1[0]['p'], items1[0]['b'], items1[0]['d']
+    items1 = [
+        {
+            "p": random_string(),
+            "c": random_string(),
+            "b": random_string(),
+            "d": random_string(),
+        }
+        for i in range(10)
+    ]
+    p1, b1, d1 = items1[0]["p"], items1[0]["b"], items1[0]["d"]
     p2, b2, d2 = random_string(), random_string(), random_string()
-    items2 = [{'p': p2, 'c': p2, 'b': b2, 'd': d2}]
+    items2 = [{"p": p2, "c": p2, "b": b2, "d": d2}]
     items = items1 + items2
     with test_table_lsi_keys_only.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    expected_items = [{'p': i['p'], 'c': i['c'],'b': i['b']} for i in items if i['p'] == p1 and i['b'] == b1]
-    assert_index_query(test_table_lsi_keys_only, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p1], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b1], 'ComparisonOperator': 'EQ'}})
+    expected_items = [
+        {"p": i["p"], "c": i["c"], "b": i["b"]}
+        for i in items
+        if i["p"] == p1 and i["b"] == b1
+    ]
+    assert_index_query(
+        test_table_lsi_keys_only,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p1], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b1], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # Test the "Select" parameter of a Query on a LSI. We have in test_query.py
 # a test 'test_query_select' for this parameter on a query of a normal (base)
@@ -409,136 +616,219 @@ def test_lsi_get_all_projected_attributes(test_table_lsi_keys_only):
 # allowed (and in fact is the default), and we want to test it.
 @pytest.mark.xfail(reason="Projection and Select not supported yet. Issue #5036, #5058")
 def test_lsi_query_select(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'b', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "b", "AttributeType": "S"},
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'b', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "hello",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "b", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'INCLUDE',
-                                'NonKeyAttributes': ['a'] }
+                "Projection": {"ProjectionType": "INCLUDE", "NonKeyAttributes": ["a"]},
             }
-        ]) as table:
-        items = [{'p': random_string(), 'c': random_string(), 'b': random_string(), 'a': random_string(), 'x': random_string()} for i in range(10)]
+        ],
+    ) as table:
+        items = [
+            {
+                "p": random_string(),
+                "c": random_string(),
+                "b": random_string(),
+                "a": random_string(),
+                "x": random_string(),
+            }
+            for i in range(10)
+        ]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
-        p = items[0]['p']
-        b = items[0]['b']
+        p = items[0]["p"]
+        b = items[0]["b"]
         # Although in LSI all attributes are available (as we'll check
         # below) the default Select is ALL_PROJECTED_ATTRIBUTES, and
         # returns just the projected attributes (in this case all key
         # attributes in either base or LSI, and 'a' - but not 'x'):
-        expected_items = [{'p': z['p'], 'c': z['c'], 'b': z['b'], 'a': z['a']} for z in items if z['b'] == b]
-        assert_index_query(table, 'hello', expected_items,
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                           'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
-        assert_index_query(table, 'hello', expected_items,
-            Select='ALL_PROJECTED_ATTRIBUTES',
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                           'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+        expected_items = [
+            {"p": z["p"], "c": z["c"], "b": z["b"], "a": z["a"]}
+            for z in items
+            if z["b"] == b
+        ]
+        assert_index_query(
+            table,
+            "hello",
+            expected_items,
+            KeyConditions={
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+                "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+            },
+        )
+        assert_index_query(
+            table,
+            "hello",
+            expected_items,
+            Select="ALL_PROJECTED_ATTRIBUTES",
+            KeyConditions={
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+                "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+            },
+        )
         # Unlike in GSI, in LSI Select=ALL_ATTRIBUTES *is* allowed even
         # when only a subset of the attributes being projected:
-        expected_items = [z for z in items if z['b'] == b]
-        assert_index_query(table, 'hello', expected_items,
-            Select='ALL_ATTRIBUTES',
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                           'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+        expected_items = [z for z in items if z["b"] == b]
+        assert_index_query(
+            table,
+            "hello",
+            expected_items,
+            Select="ALL_ATTRIBUTES",
+            KeyConditions={
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+                "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+            },
+        )
         # Also in LSI, SPECIFIC_ATTRIBUTES (with AttributesToGet /
         # ProjectionExpression) is allowed for any attribute, projected
         # or not projected. Let's try 'a' (projected) and 'x' (not projected):
-        expected_items = [{'a': z['a'], 'x': z['x']} for z in items if z['b'] == b]
-        assert_index_query(table, 'hello', expected_items,
-            Select='SPECIFIC_ATTRIBUTES',
-            AttributesToGet=['a', 'x'],
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                           'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+        expected_items = [{"a": z["a"], "x": z["x"]} for z in items if z["b"] == b]
+        assert_index_query(
+            table,
+            "hello",
+            expected_items,
+            Select="SPECIFIC_ATTRIBUTES",
+            AttributesToGet=["a", "x"],
+            KeyConditions={
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+                "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+            },
+        )
         # Select=COUNT is also allowed, and as expected returns no content.
-        assert not 'Items' in table.query(ConsistentRead=False,
-            IndexName='hello',
-            Select='COUNT',
-            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                           'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+        assert not "Items" in table.query(
+            ConsistentRead=False,
+            IndexName="hello",
+            Select="COUNT",
+            KeyConditions={
+                "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+                "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+            },
+        )
+
 
 # Check that strongly consistent reads are allowed for LSI
 def test_lsi_consistent_read(test_table_lsi_1):
-    items1 = [{'p': random_string(), 'c': random_string(), 'b': random_string()} for i in range(10)]
-    p1, b1 = items1[0]['p'], items1[0]['b']
+    items1 = [
+        {"p": random_string(), "c": random_string(), "b": random_string()}
+        for i in range(10)
+    ]
+    p1, b1 = items1[0]["p"], items1[0]["b"]
     p2, b2 = random_string(), random_string()
-    items2 = [{'p': p2, 'c': p2, 'b': b2}]
+    items2 = [{"p": p2, "c": p2, "b": b2}]
     items = items1 + items2
     with test_table_lsi_1.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    expected_items = [i for i in items if i['p'] == p1 and i['b'] == b1]
-    assert_index_query(test_table_lsi_1, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p1], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b1], 'ComparisonOperator': 'EQ'}})
-    expected_items = [i for i in items if i['p'] == p2 and i['b'] == b2]
-    assert_index_query(test_table_lsi_1, 'hello', expected_items,
-        KeyConditions={'p': {'AttributeValueList': [p2], 'ComparisonOperator': 'EQ'},
-                       'b': {'AttributeValueList': [b2], 'ComparisonOperator': 'EQ'}})
+    expected_items = [i for i in items if i["p"] == p1 and i["b"] == b1]
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p1], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b1], "ComparisonOperator": "EQ"},
+        },
+    )
+    expected_items = [i for i in items if i["p"] == p2 and i["b"] == b2]
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        expected_items,
+        KeyConditions={
+            "p": {"AttributeValueList": [p2], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b2], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 # A table with both gsi and lsi present
 @pytest.fixture(scope="module")
 def test_table_lsi_gsi(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x1', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x1", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello_g1',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'x1', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "hello_g1",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x1", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
             }
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'hello_l1',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'x1', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "hello_l1",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x1", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
             }
-        ])
+        ],
+    )
     yield table
     table.delete()
 
+
 # Test that GSI and LSI can coexist, even if they're identical
 def test_lsi_and_gsi(test_table_lsi_gsi):
-    desc = test_table_lsi_gsi.meta.client.describe_table(TableName=test_table_lsi_gsi.name)
-    assert 'Table' in desc
-    assert 'LocalSecondaryIndexes' in desc['Table']
-    assert 'GlobalSecondaryIndexes' in desc['Table']
-    lsis = desc['Table']['LocalSecondaryIndexes']
-    gsis = desc['Table']['GlobalSecondaryIndexes']
-    assert(sorted([lsi['IndexName'] for lsi in lsis]) == ['hello_l1'])
-    assert(sorted([gsi['IndexName'] for gsi in gsis]) == ['hello_g1'])
+    desc = test_table_lsi_gsi.meta.client.describe_table(
+        TableName=test_table_lsi_gsi.name
+    )
+    assert "Table" in desc
+    assert "LocalSecondaryIndexes" in desc["Table"]
+    assert "GlobalSecondaryIndexes" in desc["Table"]
+    lsis = desc["Table"]["LocalSecondaryIndexes"]
+    gsis = desc["Table"]["GlobalSecondaryIndexes"]
+    assert sorted([lsi["IndexName"] for lsi in lsis]) == ["hello_l1"]
+    assert sorted([gsi["IndexName"] for gsi in gsis]) == ["hello_g1"]
 
-    items = [{'p': random_string(), 'c': random_string(), 'x1': random_string()} for i in range(17)]
-    p1, x1 = items[0]['p'], items[0]['x1']
+    items = [
+        {"p": random_string(), "c": random_string(), "x1": random_string()}
+        for i in range(17)
+    ]
+    p1, x1 = items[0]["p"], items[0]["x1"]
     with test_table_lsi_gsi.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
 
-    for index in ['hello_g1', 'hello_l1']:
-        expected_items = [i for i in items if i['p'] == p1 and i['x1'] == x1]
-        retrying_assert_index_query(test_table_lsi_gsi, index, expected_items,
-            KeyConditions={'p': {'AttributeValueList': [p1], 'ComparisonOperator': 'EQ'},
-                           'x1': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+    for index in ["hello_g1", "hello_l1"]:
+        expected_items = [i for i in items if i["p"] == p1 and i["x1"] == x1]
+        retrying_assert_index_query(
+            test_table_lsi_gsi,
+            index,
+            expected_items,
+            KeyConditions={
+                "p": {"AttributeValueList": [p1], "ComparisonOperator": "EQ"},
+                "x1": {"AttributeValueList": [x1], "ComparisonOperator": "EQ"},
+            },
+        )
+
 
 # This test is a version of test_filter_expression_and_projection_expression
 # from test_filter_expression, which involves a Query which projects only
@@ -553,22 +843,27 @@ def test_lsi_and_gsi(test_table_lsi_gsi):
 # This test reproduces issue #6951.
 def test_lsi_filter_expression_and_projection_expression(test_table_lsi_1):
     p = random_string()
-    test_table_lsi_1.put_item(Item={'p': p, 'c': 'hi', 'b': 'dog', 'y': 'cat'})
-    test_table_lsi_1.put_item(Item={'p': p, 'c': 'yo', 'b': 'mouse', 'y': 'horse'})
+    test_table_lsi_1.put_item(Item={"p": p, "c": "hi", "b": "dog", "y": "cat"})
+    test_table_lsi_1.put_item(Item={"p": p, "c": "yo", "b": "mouse", "y": "horse"})
     # Case 1: b (the LSI key) is in filter but not in projection:
-    got_items = full_query(test_table_lsi_1,
-        KeyConditionExpression='p=:p',
-        FilterExpression='b=:b',
-        ProjectionExpression='y',
-        ExpressionAttributeValues={':p': p, ':b': 'mouse'})
-    assert(got_items == [{'y': 'horse'}])
+    got_items = full_query(
+        test_table_lsi_1,
+        KeyConditionExpression="p=:p",
+        FilterExpression="b=:b",
+        ProjectionExpression="y",
+        ExpressionAttributeValues={":p": p, ":b": "mouse"},
+    )
+    assert got_items == [{"y": "horse"}]
     # Case 2: b (the LSI key) is in the projection, but not the filter:
-    got_items = full_query(test_table_lsi_1,
-        KeyConditionExpression='p=:p',
-        FilterExpression='y=:y',
-        ProjectionExpression='b',
-        ExpressionAttributeValues={':p': p, ':y': 'cat'})
-    assert(got_items == [{'b': 'dog'}])
+    got_items = full_query(
+        test_table_lsi_1,
+        KeyConditionExpression="p=:p",
+        FilterExpression="y=:y",
+        ProjectionExpression="b",
+        ExpressionAttributeValues={":p": p, ":y": "cat"},
+    )
+    assert got_items == [{"b": "dog"}]
+
 
 # We tested above that a table can have both an LSI and a GSI.
 # Although Alternator makes a distinction in how it stores the two types of
@@ -579,55 +874,77 @@ def test_lsi_filter_expression_and_projection_expression(test_table_lsi_1):
 # Duplicate index name: samename"
 # Reproduces issue #10789.
 def test_lsi_and_gsi_same_name(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*Duplicate'):
-        table = create_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    with pytest.raises(ClientError, match="ValidationException.*Duplicate"):
+        table = create_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "p", "KeyType": "HASH"},
+                {"AttributeName": "c", "KeyType": "RANGE"},
+            ],
             AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x1', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+                {"AttributeName": "x1", "AttributeType": "S"},
             ],
             GlobalSecondaryIndexes=[
-                {   'IndexName': 'samename',
-                    'KeySchema': [
-                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'x1', 'KeyType': 'RANGE' }
+                {
+                    "IndexName": "samename",
+                    "KeySchema": [
+                        {"AttributeName": "p", "KeyType": "HASH"},
+                        {"AttributeName": "x1", "KeyType": "RANGE"},
                     ],
-                    'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
                 }
             ],
             LocalSecondaryIndexes=[
-                {   'IndexName': 'samename',
-                    'KeySchema': [
-                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                        { 'AttributeName': 'x1', 'KeyType': 'RANGE' }
+                {
+                    "IndexName": "samename",
+                    "KeySchema": [
+                        {"AttributeName": "p", "KeyType": "HASH"},
+                        {"AttributeName": "x1", "KeyType": "RANGE"},
                     ],
-                    'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
                 }
-            ])
+            ],
+        )
         table.delete()
+
 
 # Test that creating multiple LSIs with the same key schema but different names
 # is allowed.
 def test_lsi_identical_indexes_with_different_names(dynamodb):
-    with new_test_table(dynamodb,
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'c', 'AttributeType': 'S' },
-            { 'AttributeName': 'x', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'index1',
-                'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'x', 'KeyType': 'RANGE' }],
-                'Projection': { 'ProjectionType': 'ALL' }
+            {
+                "IndexName": "index1",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
             },
-            {   'IndexName': 'index2',
-                'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'x', 'KeyType': 'RANGE' }],
-                'Projection': { 'ProjectionType': 'ALL' }
-            }
-        ]):
+            {
+                "IndexName": "index2",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    ):
         pass
+
 
 # Test that the LSI table can be addressed in Scylla's REST API (obviously,
 # since this test is for the REST API, it is Scylla-only and can't be run on
@@ -641,11 +958,11 @@ def test_lsi_name_rest_api(test_table_lsi_1, rest_api):
     # whose CQL name contains the Alternator table's name, and the
     # LSI's name ('hello'). As of this writing, it will actually be
     # alternator_<name>:<name>!:<lsi> - but the test doesn't enshrine this.
-    resp = requests.get(f'{rest_api}/column_family/name')
+    resp = requests.get(f"{rest_api}/column_family/name")
     resp.raise_for_status()
     lsi_rest_name = None
     for name in resp.json():
-        if test_table_lsi_1.name in name and 'hello' in name:
+        if test_table_lsi_1.name in name and "hello" in name:
             lsi_rest_name = name
             break
     assert lsi_rest_name
@@ -653,13 +970,16 @@ def test_lsi_name_rest_api(test_table_lsi_1, rest_api):
     # We'll use the compaction_strategy request here, but if for some
     # reason in the future we decide to drop that request, any other
     # request will be fine.
-    resp = requests.get(f'{rest_api}/column_family/compaction_strategy/{lsi_rest_name}')
+    resp = requests.get(f"{rest_api}/column_family/compaction_strategy/{lsi_rest_name}")
     resp.raise_for_status()
     # Let's make things difficult for the server by URL encoding the
     # lsi_rest_name - exposing issue #5883.
     encoded_lsi_rest_name = requests.utils.quote(lsi_rest_name)
-    resp = requests.get(f'{rest_api}/column_family/compaction_strategy/{encoded_lsi_rest_name}')
+    resp = requests.get(
+        f"{rest_api}/column_family/compaction_strategy/{encoded_lsi_rest_name}"
+    )
     resp.raise_for_status()
+
 
 # Test that when a table has an LSI, then if the indexed attribute is
 # missing, the item is added to the base table but not the index.
@@ -669,12 +989,16 @@ def test_lsi_missing_attribute(test_table_lsi_1):
     b1 = random_string()
     p2 = random_string()
     c2 = random_string()
-    test_table_lsi_1.put_item(Item={'p':  p1, 'c': c1, 'b': b1})
-    test_table_lsi_1.put_item(Item={'p':  p2, 'c': c2})  # missing b
+    test_table_lsi_1.put_item(Item={"p": p1, "c": c1, "b": b1})
+    test_table_lsi_1.put_item(Item={"p": p2, "c": c2})  # missing b
 
     # Both items are now in the base table:
-    assert test_table_lsi_1.get_item(Key={'p': p1, 'c': c1}, ConsistentRead=True)['Item'] == {'p': p1, 'c': c1, 'b': b1}
-    assert test_table_lsi_1.get_item(Key={'p': p2, 'c': c2}, ConsistentRead=True)['Item'] == {'p': p2, 'c': c2}
+    assert test_table_lsi_1.get_item(Key={"p": p1, "c": c1}, ConsistentRead=True)[
+        "Item"
+    ] == {"p": p1, "c": c1, "b": b1}
+    assert test_table_lsi_1.get_item(Key={"p": p2, "c": c2}, ConsistentRead=True)[
+        "Item"
+    ] == {"p": p2, "c": c2}
 
     # But only the first item is in the index: The first item can be found
     # using a Query, and a scan of the index won't find the second item.
@@ -682,12 +1006,24 @@ def test_lsi_missing_attribute(test_table_lsi_1):
     # the second item will "never" appear in the index. We do that read last,
     # so if we had a bug and such item did appear, hopefully we had enough
     # time for the bug to become visible. At least sometimes.
-    assert_index_query(test_table_lsi_1, 'hello', [{'p': p1, 'c': c1, 'b': b1}],
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        [{"p": p1, "c": c1, "b": b1}],
         KeyConditions={
-            'p': {'AttributeValueList': [p1], 'ComparisonOperator': 'EQ'},
-            'b': {'AttributeValueList': [b1], 'ComparisonOperator': 'EQ'},
-        })
-    assert not any([i['p'] == p2 and i['c'] == c2 for i in full_scan(test_table_lsi_1, ConsistentRead=False, IndexName='hello')])
+            "p": {"AttributeValueList": [p1], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b1], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert not any(
+        [
+            i["p"] == p2 and i["c"] == c2
+            for i in full_scan(
+                test_table_lsi_1, ConsistentRead=False, IndexName="hello"
+            )
+        ]
+    )
+
 
 # The wrong type attributes tests check if a table with an LSI on a string
 # attribute rejects operations setting the attribute to values of other type.
@@ -696,9 +1032,12 @@ def test_lsi_wrong_type_attribute_put(test_table_lsi_1):
     # in the base table.
     p = random_string()
     c = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_lsi_1.put_item(Item={'p':  p, 'c': c, 'b': 3})
-    assert not 'Item' in test_table_lsi_1.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_lsi_1.put_item(Item={"p": p, "c": c, "b": 3})
+    assert not "Item" in test_table_lsi_1.get_item(
+        Key={"p": p, "c": c}, ConsistentRead=True
+    )
+
 
 def test_lsi_wrong_type_attribute_update(test_table_lsi_1):
     # An UpdateItem with wrong type for 'b' is also rejected, but naturally
@@ -706,10 +1045,15 @@ def test_lsi_wrong_type_attribute_update(test_table_lsi_1):
     p = random_string()
     c = random_string()
     b = random_string()
-    test_table_lsi_1.put_item(Item={'p':  p, 'c': c, 'b': b})
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_lsi_1.update_item(Key={'p':  p, 'c': c}, AttributeUpdates={'b': {'Value': 3, 'Action': 'PUT'}})
-    assert test_table_lsi_1.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)['Item'] == {'p': p, 'c': c, 'b': b}
+    test_table_lsi_1.put_item(Item={"p": p, "c": c, "b": b})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_lsi_1.update_item(
+            Key={"p": p, "c": c}, AttributeUpdates={"b": {"Value": 3, "Action": "PUT"}}
+        )
+    assert test_table_lsi_1.get_item(Key={"p": p, "c": c}, ConsistentRead=True)[
+        "Item"
+    ] == {"p": p, "c": c, "b": b}
+
 
 # Since an LSI key b cannot be a map or an array, in particular updates to
 # nested attributes like b.y or b[1] are not legal.
@@ -717,81 +1061,119 @@ def test_lsi_wrong_type_attribute_update_nested(test_table_lsi_1):
     p = random_string()
     c = random_string()
     b = random_string()
-    test_table_lsi_1.put_item(Item={'p':  p, 'c': c, 'b': b})
+    test_table_lsi_1.put_item(Item={"p": p, "c": c, "b": b})
     # Here we try to write a map into the LSI key column b.
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
-        test_table_lsi_1.update_item(Key={'p': p, 'c': c}, UpdateExpression='SET b = :val1',
-            ExpressionAttributeValues={':val1': {'a': 3, 'b': 4}})
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
+        test_table_lsi_1.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET b = :val1",
+            ExpressionAttributeValues={":val1": {"a": 3, "b": 4}},
+        )
     # Here we try to set b.y for the LSI key column b. Here DynamoDB and
     # Alternator produce different error messages - but both make sense.
     # DynamoDB says "Key attributes must be scalars; list random access '[]'
     # and map # lookup '.' are not allowed: IndexKey: b", while Alternator
     # complains that "document paths not valid for this item: b.y".
-    with pytest.raises(ClientError, match='ValidationException'):
-        test_table_lsi_1.update_item(Key={'p': p, 'c': c}, UpdateExpression='SET b.y = :val1',
-            ExpressionAttributeValues={':val1': 3})
+    with pytest.raises(ClientError, match="ValidationException"):
+        test_table_lsi_1.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET b.y = :val1",
+            ExpressionAttributeValues={":val1": 3},
+        )
+
 
 def test_lsi_wrong_type_attribute_batchwrite(test_table_lsi_1):
     # BatchWriteItem with wrong type for 'b' is rejected, item isn't created
     # even in the base table.
     p = random_string()
     c = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
         with test_table_lsi_1.batch_writer() as batch:
-            batch.put_item({'p':  p, 'c': c, 'b': 3})
-    assert not 'Item' in test_table_lsi_1.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)
+            batch.put_item({"p": p, "c": c, "b": 3})
+    assert not "Item" in test_table_lsi_1.get_item(
+        Key={"p": p, "c": c}, ConsistentRead=True
+    )
+
 
 def test_lsi_wrong_type_attribute_batch(test_table_lsi_1):
     # In a BatchWriteItem, if any update is forbidden, the entire batch is
     # rejected, and none of the updates happen at all.
     p = [random_string() for _ in range(3)]
     c = [random_string() for _ in range(3)]
-    items = [{'p': p[0], 'c': c[0], 'b': random_string()},
-             {'p': p[1], 'c': c[0], 'b': 3},
-             {'p': p[2], 'c': c[0], 'b': random_string()}]
-    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
+    items = [
+        {"p": p[0], "c": c[0], "b": random_string()},
+        {"p": p[1], "c": c[0], "b": 3},
+        {"p": p[2], "c": c[0], "b": random_string()},
+    ]
+    with pytest.raises(ClientError, match="ValidationException.*mismatch"):
         with test_table_lsi_1.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
     for p, c in zip(p, c):
-        assert not 'Item' in test_table_lsi_1.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)
+        assert not "Item" in test_table_lsi_1.get_item(
+            Key={"p": p, "c": c}, ConsistentRead=True
+        )
+
 
 # Utility function for creating a new table (whose name is chosen by
 # unique_table_name()) with an LSI with the given name. If creation was
 # successful, the table is deleted. Useful for testing which LSI names work.
 def create_lsi(dynamodb, index_name):
-    with new_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'S' }],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
         LocalSecondaryIndexes=[
-            {   'IndexName': index_name,
-                'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
-                'Projection': { 'ProjectionType': 'ALL' }
+            {
+                "IndexName": index_name,
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "c", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
             }
-        ]) as table:
+        ],
+    ) as table:
         # Verify that the LSI wasn't just ignored
-        assert 'LocalSecondaryIndexes' in table.meta.client.describe_table(TableName=table.name)['Table']
+        assert (
+            "LocalSecondaryIndexes"
+            in table.meta.client.describe_table(TableName=table.name)["Table"]
+        )
+
 
 # Index names with 255 characters are allowed in Dynamo. In Scylla, the
 # limit is different - the sum of both table and index length plus an extra 2
 # cannot exceed 222 characters.
 # (compare test_create_and_delete_table_255/222() and test_gsi_very_long_name*).
-@pytest.mark.xfail(reason="Alternator limits table name length + LSI name length to 220")
+@pytest.mark.xfail(
+    reason="Alternator limits table name length + LSI name length to 220"
+)
 def test_lsi_very_long_name_255(dynamodb):
-    create_lsi(dynamodb, 'n' * 255)
+    create_lsi(dynamodb, "n" * 255)
+
+
 def test_lsi_very_long_name_256(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_lsi(dynamodb, 'n' * 256)
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_lsi(dynamodb, "n" * 256)
+
+
 def test_lsi_very_long_name_222(dynamodb, scylla_only):
     # If we subtract from 222 the table's name length (we assume that
     # unique_table_name() always returns the same length) and an extra 2,
     # this is how long the LSI's name may be:
     max = 222 - len(unique_table_name()) - 2
     # This max length should work:
-    create_lsi(dynamodb, 'n' * max)
+    create_lsi(dynamodb, "n" * max)
     # But a name one byte longer should fail:
-    with pytest.raises(ClientError, match='ValidationException.*total length'):
-        create_lsi(dynamodb, 'n' * (max+1))
+    with pytest.raises(ClientError, match="ValidationException.*total length"):
+        create_lsi(dynamodb, "n" * (max + 1))
+
 
 # This test validates that PutItem replaces the entire item, including the
 # attribute 'b' used in the LSI key. The new item won't have 'b', so it should
@@ -800,70 +1182,110 @@ def test_lsi_put_overwrites_lsi_column(test_table_lsi_1):
     p = random_string()
     c = random_string()
     b = random_string()
-    key = {'p': p, 'c': c}
-    item = {**key, 'b': b}
+    key = {"p": p, "c": c}
+    item = {**key, "b": b}
 
     # Create an item with the LSI key column 'b'.
     test_table_lsi_1.put_item(Item=item)
-    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)['Item'] == item
+    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)["Item"] == item
     # The item should be added to the index.
-    assert_index_query(test_table_lsi_1, 'hello', [item],
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        [item],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
 
     # Replace the item with an empty item. This should delete 'b'.
     test_table_lsi_1.put_item(Item=key)
-    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)['Item'] == key
+    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)["Item"] == key
     # Validate that PutItem also removed the item from the LSI index.
-    assert_index_query(test_table_lsi_1, 'hello', [],
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        [],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 def test_lsi_update_modifies_index(test_table_lsi_1):
     p = random_string()
     c = random_string()
     b1 = random_string()
     b2 = random_string()
-    key = {'p': p, 'c': c}
-    item = {**key, 'b': b1}
+    key = {"p": p, "c": c}
+    item = {**key, "b": b1}
 
     # Create an item with the LSI key column 'b' set to b1.
     test_table_lsi_1.put_item(Item=item)
-    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)['Item'] == item
-    assert_index_query(test_table_lsi_1, 'hello', [item],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}})
+    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)["Item"] == item
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        [item],
+        KeyConditions={"p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}},
+    )
     # Set b to b2 instead of b1.
-    test_table_lsi_1.update_item(Key=key, AttributeUpdates={'b': {'Value': b2, 'Action': 'PUT'}})
-    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)['Item'] == {**key, 'b': b2}
+    test_table_lsi_1.update_item(
+        Key=key, AttributeUpdates={"b": {"Value": b2, "Action": "PUT"}}
+    )
+    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)["Item"] == {
+        **key,
+        "b": b2,
+    }
     # Validate that the item is no longer in the index under b1, but under b2.
-    assert_index_query(test_table_lsi_1, 'hello', [],
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        [],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'b': {'AttributeValueList': [b1], 'ComparisonOperator': 'EQ'}})
-    assert_index_query(test_table_lsi_1, 'hello', [{'p': p, 'c': c, 'b': b2}],
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b1], "ComparisonOperator": "EQ"},
+        },
+    )
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        [{"p": p, "c": c, "b": b2}],
         KeyConditions={
-            'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-            'b': {'AttributeValueList': [b2], 'ComparisonOperator': 'EQ'}})
+            "p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"},
+            "b": {"AttributeValueList": [b2], "ComparisonOperator": "EQ"},
+        },
+    )
+
 
 def test_lsi_delete_modifies_index(test_table_lsi_1):
     p = random_string()
-    key = {'p': p, 'c': random_string()}
-    item = {**key, 'b': random_string()}
+    key = {"p": p, "c": random_string()}
+    item = {**key, "b": random_string()}
 
     # Create an item with the LSI key column 'b'.
     test_table_lsi_1.put_item(Item=item)
-    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)['Item'] == item
+    assert test_table_lsi_1.get_item(Key=key, ConsistentRead=True)["Item"] == item
     # The item should be added to the index.
-    assert_index_query(test_table_lsi_1, 'hello', [item],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        [item],
+        KeyConditions={"p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}},
+    )
     # Delete the item.
     test_table_lsi_1.delete_item(Key=key)
-    assert not 'Item' in test_table_lsi_1.get_item(Key=key, ConsistentRead=True)
+    assert not "Item" in test_table_lsi_1.get_item(Key=key, ConsistentRead=True)
     # Validate that the item is no longer in the index.
-    assert_index_query(test_table_lsi_1, 'hello', [],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(
+        test_table_lsi_1,
+        "hello",
+        [],
+        KeyConditions={"p": {"AttributeValueList": [p], "ComparisonOperator": "EQ"}},
+    )
+
 
 # This test verifies that DescribeTable shows the correct user-requested LSI
 # key even when Alternator had to add to the underlying materialized view an
@@ -883,36 +1305,50 @@ def test_lsi_delete_modifies_index(test_table_lsi_1):
 def test_lsi_describe_table_schema_all(dynamodb):
     # If we are to use an LSI the base table must have both hash key and sort
     # key. Let's call them 'a', 'b':
-    base_keys = ['a', 'b']
+    base_keys = ["a", "b"]
     # The LSI key must have the same hash key as the base ('a'), must
     # have a range key, and that range key can either be 'b' or not-'b'
     # (for which we take 'x'). So we only have these two options for what
     # the LSI key might be:
-    lsi_keys_options = [['a', 'b'], ['a', 'x']]
+    lsi_keys_options = [["a", "b"], ["a", "x"]]
     # Create a base table with base_keys and the two LSIs with the
     # LSI key options we collected in lsi_keys_options
-    key_schema=[ { 'AttributeName': base_keys[0], 'KeyType': 'HASH' },
-                 { 'AttributeName': base_keys[1], 'KeyType': 'RANGE' } ]
-    attribute_definitions = [ {'AttributeName': attr, 'AttributeType': 'S' } for attr in (base_keys + ['x']) ]
+    key_schema = [
+        {"AttributeName": base_keys[0], "KeyType": "HASH"},
+        {"AttributeName": base_keys[1], "KeyType": "RANGE"},
+    ]
+    attribute_definitions = [
+        {"AttributeName": attr, "AttributeType": "S"} for attr in (base_keys + ["x"])
+    ]
     lsis = []
     for i, lsi_keys in enumerate(lsi_keys_options):
-        lsi_key_schema=[ { 'AttributeName': lsi_keys[0], 'KeyType': 'HASH' },
-                         { 'AttributeName': lsi_keys[1], 'KeyType': 'RANGE' } ]
-        lsis.append({ 'IndexName': f'index{i}',
-                      'KeySchema': lsi_key_schema,
-                      'Projection': { 'ProjectionType': 'ALL' } })
-    with new_test_table(dynamodb,
+        lsi_key_schema = [
+            {"AttributeName": lsi_keys[0], "KeyType": "HASH"},
+            {"AttributeName": lsi_keys[1], "KeyType": "RANGE"},
+        ]
+        lsis.append(
+            {
+                "IndexName": f"index{i}",
+                "KeySchema": lsi_key_schema,
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        )
+    with new_test_table(
+        dynamodb,
         KeySchema=key_schema,
         AttributeDefinitions=attribute_definitions,
-        LocalSecondaryIndexes=lsis) as table:
+        LocalSecondaryIndexes=lsis,
+    ) as table:
         # Check that DescribeTable shows the table and its LSIs correctly:
-        got = table.meta.client.describe_table(TableName=table.name)['Table']
-        assert got['KeySchema'] == key_schema
-        got_lsis = got['LocalSecondaryIndexes']
+        got = table.meta.client.describe_table(TableName=table.name)["Table"]
+        assert got["KeySchema"] == key_schema
+        got_lsis = got["LocalSecondaryIndexes"]
         # We want to compare got_lsis to the original lsis, but got_lsis may
         # have extra attributes that DescribeTable added beyond what was
         # present in the origin table creation. So let's leave in got_lsis
         # only the columns that were present in lsis[0].
-        got_lsis = [ {k: v for k, v in got_lsi.items() if k in lsis[0]} for got_lsi in got_lsis ]
+        got_lsis = [
+            {k: v for k, v in got_lsi.items() if k in lsis[0]} for got_lsi in got_lsis
+        ]
         # Use multiset to compare ignoring order
         assert multiset(got_lsis) == multiset(lsis)

--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -147,7 +147,7 @@ def test_too_large_request_content_length(dynamodb, test_table, mb):
 # we can use the same limit too. In all useful cases, headers will be
 # much shorter.
 # Reproduces #23438.
-@pytest.mark.xfail(reason="issue #23438")
+@pytest.mark.xfail(reason="Alternator should reject requests with very large headers #23438")
 def test_too_large_request_headers(dynamodb, test_table):
     # First prepare a valid signed request, which works:
     req = get_signed_request(dynamodb, 'PutItem',
@@ -177,7 +177,7 @@ def test_too_large_request_headers(dynamodb, test_table):
 # can use the same limit too. In all useful cases, the request line will
 # be much shorter (for ordinary API requests, it is even empty).
 # Reproduces #23438.
-@pytest.mark.xfail(reason="issue #23438")
+@pytest.mark.xfail(reason="Alternator should reject requests with very large headers #23438")
 def test_too_large_request_line(dynamodb, test_table):
     # First prepare a valid signed request, which works:
     req = get_signed_request(dynamodb, 'PutItem',
@@ -594,7 +594,7 @@ def test_keep_alive(dynamodb, test_table, use_keep_alive):
 # We don't want to store the malformed value on disk and only discover the
 # problem when reading the value back. We want the write to fail immediately,
 # and this is what this test checks. Reproduces issue #8070.
-@pytest.mark.xfail(reason="issue #8070")
+@pytest.mark.xfail(reason="Alternator: validate user-provided nested document structure during first write #8070")
 @pytest.mark.parametrize("op", ['PutItem', 'UpdateItem', 'BatchWriteItem'])
 def test_write_malformed_value(dynamodb, test_table_s, op):
     p = random_string()

--- a/test/alternator/test_query.py
+++ b/test/alternator/test_query.py
@@ -395,7 +395,7 @@ def test_query_exclusivestartkey_missing_sortkey(test_table_sn):
 # When Query'ing on the partition key 'right', ExclusiveStartKey must be in
 # the same partition 'right' being queried - it must not be some other
 # partition. Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_exclusivestartkey_wrong_partition(test_table_sn):
     # The error that DynamoDB reports if the wrong partition is mentioned
     # in ExclusiveStartKey is "The provided starting key is outside query
@@ -410,7 +410,7 @@ def test_query_exclusivestartkey_wrong_partition(test_table_sn):
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key (here a partition key and sort key)
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_exclusivestartkey_spurious_column(test_table_sn):
     p = random_string()
     # The error that DynamoDB reports if ExclusiveStartKey has spurious
@@ -440,7 +440,7 @@ def test_query_no_sort_key(test_table_s):
 # response shouldn't include the given key, the response would be completely
 # empty...  So DynamoDB doesn't allow this case at all.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_no_sort_key_exclusive_start_key(test_table_s):
     p = random_string()
     # DynamoDB gives the error message "The provided exclusive start key

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -8,82 +8,117 @@ import pytest
 from boto3.dynamodb.conditions import Attr
 from botocore.exceptions import ClientError
 
-from test.alternator.util import random_string, random_bytes, full_scan, full_scan_and_count, multiset, new_test_table, scylla_config_read
+from test.alternator.util import (
+    random_string,
+    random_bytes,
+    full_scan,
+    full_scan_and_count,
+    multiset,
+    new_test_table,
+    scylla_config_read,
+)
 
 
 # Test that scanning works fine with/without pagination
 def test_scan_basic(filled_test_table):
     test_table, items = filled_test_table
-    for limit in [None,1,2,4,33,50,100,9007,16*1024*1024]:
+    for limit in [None, 1, 2, 4, 33, 50, 100, 9007, 16 * 1024 * 1024]:
         pos = None
         got_items = []
         while True:
             if limit:
-                response = test_table.scan(Limit=limit, ConsistentRead=True, ExclusiveStartKey=pos) if pos else test_table.scan(Limit=limit, ConsistentRead=True)
-                assert len(response['Items']) <= limit
+                response = (
+                    test_table.scan(
+                        Limit=limit, ConsistentRead=True, ExclusiveStartKey=pos
+                    )
+                    if pos
+                    else test_table.scan(Limit=limit, ConsistentRead=True)
+                )
+                assert len(response["Items"]) <= limit
             else:
-                response = test_table.scan(ExclusiveStartKey=pos, ConsistentRead=True) if pos else test_table.scan(ConsistentRead=True)
-            pos = response.get('LastEvaluatedKey', None)
-            got_items += response['Items']
+                response = (
+                    test_table.scan(ExclusiveStartKey=pos, ConsistentRead=True)
+                    if pos
+                    else test_table.scan(ConsistentRead=True)
+                )
+            pos = response.get("LastEvaluatedKey", None)
+            got_items += response["Items"]
             if not pos:
                 break
 
         assert len(items) == len(got_items)
         assert multiset(items) == multiset(got_items)
 
+
 # test_scan_basic() above and most other tests below use the table
 # "filled_test_table", whose schema has a partition key and a sort key.
 # We want to make sure that Scan also works correctly on a table without
 # a sort key, and in particular when paging is involved.
 def test_scan_without_sort_key(dynamodb):
-    with new_test_table(dynamodb,
-            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'N' }]) as table:
-        items = [{'p': i, 's': str(i)} for i in range(23)]
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "N"}],
+    ) as table:
+        items = [{"p": i, "s": str(i)} for i in range(23)]
         with table.batch_writer() as batch:
             for item in items:
                 batch.put_item(item)
-        for limit in [None,1,2,4,33]:
-            print(f'LIMIT {limit}')
+        for limit in [None, 1, 2, 4, 33]:
+            print(f"LIMIT {limit}")
             pos = None
             got_items = []
             while True:
                 if limit:
-                    response = table.scan(Limit=limit, ConsistentRead=True, ExclusiveStartKey=pos) if pos else table.scan(Limit=limit, ConsistentRead=True)
-                    assert len(response['Items']) <= limit
+                    response = (
+                        table.scan(
+                            Limit=limit, ConsistentRead=True, ExclusiveStartKey=pos
+                        )
+                        if pos
+                        else table.scan(Limit=limit, ConsistentRead=True)
+                    )
+                    assert len(response["Items"]) <= limit
                 else:
-                    response = table.scan(ExclusiveStartKey=pos, ConsistentRead=True) if pos else table.scan(ConsistentRead=True)
-                pos = response.get('LastEvaluatedKey', None)
-                got_items += response['Items']
+                    response = (
+                        table.scan(ExclusiveStartKey=pos, ConsistentRead=True)
+                        if pos
+                        else table.scan(ConsistentRead=True)
+                    )
+                pos = response.get("LastEvaluatedKey", None)
+                got_items += response["Items"]
                 if not pos:
                     break
             assert len(items) == len(got_items)
             assert multiset(items) == multiset(got_items)
+
 
 def test_scan_nonexistent_table(dynamodb):
     client = dynamodb.meta.client
     with pytest.raises(ClientError, match="ResourceNotFoundException"):
         client.scan(TableName="i_do_not_exist")
 
+
 def test_scan_with_paginator(dynamodb, filled_test_table):
     test_table, items = filled_test_table
-    paginator = dynamodb.meta.client.get_paginator('scan')
+    paginator = dynamodb.meta.client.get_paginator("scan")
 
     got_items = []
     for page in paginator.paginate(TableName=test_table.name):
-        got_items += page['Items']
+        got_items += page["Items"]
 
     assert len(items) == len(got_items)
     assert multiset(items) == multiset(got_items)
 
     for page_size in [1, 17, 1234]:
         got_items = []
-        for page in paginator.paginate(TableName=test_table.name, PaginationConfig={'PageSize': page_size}):
-            got_items += page['Items']
+        for page in paginator.paginate(
+            TableName=test_table.name, PaginationConfig={"PageSize": page_size}
+        ):
+            got_items += page["Items"]
 
     assert len(items) == len(got_items)
     assert multiset(items) == multiset(got_items)
+
 
 # Although partitions are scanned in seemingly-random order, inside a
 # partition items must be returned by Scan sorted in sort-key order.
@@ -94,12 +129,13 @@ def test_scan_sort_order_string(filled_test_table):
     got_items = full_scan(test_table)
     assert len(items) == len(got_items)
     # Extract just the sort key ("c") from the partition "long"
-    items_long = [x['c'] for x in items if x['p'] == 'long']
-    got_items_long = [x['c'] for x in got_items if x['p'] == 'long']
+    items_long = [x["c"] for x in items if x["p"] == "long"]
+    got_items_long = [x["c"] for x in got_items if x["p"] == "long"]
     # Verify that got_items_long are already sorted (in string order)
     assert sorted(got_items_long) == got_items_long
     # Verify that got_items_long are a sorted version of the expected items_long
     assert sorted(items_long) == got_items_long
+
 
 # Test Scan with the AttributesToGet parameter. Result should include the
 # selected attributes only - if one wants the key attributes as well, one
@@ -108,43 +144,47 @@ def test_scan_sort_order_string(filled_test_table):
 # returned too, as empty items - they are not outright missing.
 def test_scan_attributes_to_get(dynamodb, filled_test_table):
     table, items = filled_test_table
-    for wanted in [ ['another'],       # only non-key attributes (one item doesn't have it!)
-                    ['c', 'another'],  # a key attribute (sort key) and non-key
-                    ['p', 'c'],        # entire key
-                    ['nonexistent']    # none of the items have this attribute!
-                   ]:
+    for wanted in [
+        ["another"],  # only non-key attributes (one item doesn't have it!)
+        ["c", "another"],  # a key attribute (sort key) and non-key
+        ["p", "c"],  # entire key
+        ["nonexistent"],  # none of the items have this attribute!
+    ]:
         print(wanted)
         got_items = full_scan(table, AttributesToGet=wanted)
         expected_items = [{k: x[k] for k in wanted if k in x} for x in items]
         assert multiset(expected_items) == multiset(got_items)
 
+
 def test_scan_with_attribute_equality_filtering(dynamodb, filled_test_table):
     table, items = filled_test_table
     scan_filter = {
-        "attribute" : {
-            "AttributeValueList" : [ "xxxxx" ],
-            "ComparisonOperator": "EQ"
-        }
+        "attribute": {"AttributeValueList": ["xxxxx"], "ComparisonOperator": "EQ"}
     }
 
     got_items = full_scan(table, ScanFilter=scan_filter)
-    expected_items = [item for item in items if "attribute" in item.keys() and item["attribute"] == "xxxxx" ]
+    expected_items = [
+        item
+        for item in items
+        if "attribute" in item.keys() and item["attribute"] == "xxxxx"
+    ]
     assert multiset(expected_items) == multiset(got_items)
 
     scan_filter = {
-        "another" : {
-            "AttributeValueList" : [ "y" ],
-            "ComparisonOperator": "EQ"
-        },
-        "attribute" : {
-            "AttributeValueList" : [ "xxxxx" ],
-            "ComparisonOperator": "EQ"
-        }
+        "another": {"AttributeValueList": ["y"], "ComparisonOperator": "EQ"},
+        "attribute": {"AttributeValueList": ["xxxxx"], "ComparisonOperator": "EQ"},
     }
 
     got_items = full_scan(table, ScanFilter=scan_filter)
-    expected_items = [item for item in items if "attribute" in item.keys() and item["attribute"] == "xxxxx" and item["another"] == "y" ]
+    expected_items = [
+        item
+        for item in items
+        if "attribute" in item.keys()
+        and item["attribute"] == "xxxxx"
+        and item["another"] == "y"
+    ]
     assert multiset(expected_items) == multiset(got_items)
+
 
 # Test that FilterExpression works as expected
 def test_scan_filter_expression(filled_test_table):
@@ -152,50 +192,47 @@ def test_scan_filter_expression(filled_test_table):
 
     got_items = full_scan(test_table, FilterExpression=Attr("attribute").eq("xxxx"))
     print(got_items)
-    assert multiset([item for item in items if 'attribute' in item.keys() and item['attribute'] == 'xxxx']) == multiset(got_items)
+    assert multiset(
+        [
+            item
+            for item in items
+            if "attribute" in item.keys() and item["attribute"] == "xxxx"
+        ]
+    ) == multiset(got_items)
 
-    got_items = full_scan(test_table, FilterExpression=Attr("attribute").eq("xxxx") & Attr("another").eq("yy"))
+    got_items = full_scan(
+        test_table,
+        FilterExpression=Attr("attribute").eq("xxxx") & Attr("another").eq("yy"),
+    )
     print(got_items)
-    assert multiset([item for item in items if 'attribute' in item.keys() and 'another' in item.keys() and item['attribute'] == 'xxxx' and item['another'] == 'yy']) == multiset(got_items)
+    assert multiset(
+        [
+            item
+            for item in items
+            if "attribute" in item.keys()
+            and "another" in item.keys()
+            and item["attribute"] == "xxxx"
+            and item["another"] == "yy"
+        ]
+    ) == multiset(got_items)
+
 
 def test_scan_with_key_equality_filtering(dynamodb, filled_test_table):
     table, items = filled_test_table
-    scan_filter_p = {
-        "p" : {
-            "AttributeValueList" : [ "7" ],
-            "ComparisonOperator": "EQ"
-        }
-    }
-    scan_filter_c = {
-        "c" : {
-            "AttributeValueList" : [ "9" ],
-            "ComparisonOperator": "EQ"
-        }
-    }
+    scan_filter_p = {"p": {"AttributeValueList": ["7"], "ComparisonOperator": "EQ"}}
+    scan_filter_c = {"c": {"AttributeValueList": ["9"], "ComparisonOperator": "EQ"}}
     scan_filter_p_and_attribute = {
-        "p" : {
-            "AttributeValueList" : [ "7" ],
-            "ComparisonOperator": "EQ"
-        },
-        "attribute" : {
-            "AttributeValueList" : [ "x"*7 ],
-            "ComparisonOperator": "EQ"
-        }
+        "p": {"AttributeValueList": ["7"], "ComparisonOperator": "EQ"},
+        "attribute": {"AttributeValueList": ["x" * 7], "ComparisonOperator": "EQ"},
     }
     scan_filter_c_and_another = {
-        "c" : {
-            "AttributeValueList" : [ "9" ],
-            "ComparisonOperator": "EQ"
-        },
-        "another" : {
-            "AttributeValueList" : [ "y"*16 ],
-            "ComparisonOperator": "EQ"
-        }
+        "c": {"AttributeValueList": ["9"], "ComparisonOperator": "EQ"},
+        "another": {"AttributeValueList": ["y" * 16], "ComparisonOperator": "EQ"},
     }
 
     # Filtering on the hash key
     got_items = full_scan(table, ScanFilter=scan_filter_p)
-    expected_items = [item for item in items if "p" in item.keys() and item["p"] == "7" ]
+    expected_items = [item for item in items if "p" in item.keys() and item["p"] == "7"]
     assert multiset(expected_items) == multiset(got_items)
 
     # Filtering on the sort key
@@ -205,13 +242,28 @@ def test_scan_with_key_equality_filtering(dynamodb, filled_test_table):
 
     # Filtering on the hash key and an attribute
     got_items = full_scan(table, ScanFilter=scan_filter_p_and_attribute)
-    expected_items = [item for item in items if "p" in item.keys() and "another" in item.keys() and item["p"] == "7" and item["another"] == "y"*16]
+    expected_items = [
+        item
+        for item in items
+        if "p" in item.keys()
+        and "another" in item.keys()
+        and item["p"] == "7"
+        and item["another"] == "y" * 16
+    ]
     assert multiset(expected_items) == multiset(got_items)
 
     # Filtering on the sort key and an attribute
     got_items = full_scan(table, ScanFilter=scan_filter_c_and_another)
-    expected_items = [item for item in items if "c" in item.keys() and "another" in item.keys() and item["c"] == "9" and item["another"] == "y"*16]
+    expected_items = [
+        item
+        for item in items
+        if "c" in item.keys()
+        and "another" in item.keys()
+        and item["c"] == "9"
+        and item["another"] == "y" * 16
+    ]
     assert multiset(expected_items) == multiset(got_items)
+
 
 # Test the "Select" parameter of Scan. The default Select mode,
 # ALL_ATTRIBUTES, returns items with all their attributes. Other modes
@@ -225,25 +277,29 @@ def test_scan_select(filled_test_table):
     assert multiset(items) == multiset(got_items)
     # Select=ALL_ATTRIBUTES does exactly the same as the default - return
     # all attributes:
-    got_items = full_scan(test_table, Select='ALL_ATTRIBUTES')
+    got_items = full_scan(test_table, Select="ALL_ATTRIBUTES")
     assert multiset(items) == multiset(got_items)
     # Select=ALL_PROJECTED_ATTRIBUTES is not allowed on a base table (it
     # is just for indexes, when IndexName is specified)
-    with pytest.raises(ClientError, match='ValidationException'):
-        full_scan(test_table, Select='ALL_PROJECTED_ATTRIBUTES')
+    with pytest.raises(ClientError, match="ValidationException"):
+        full_scan(test_table, Select="ALL_PROJECTED_ATTRIBUTES")
     # Select=SPECIFIC_ATTRIBUTES requires that either a AttributesToGet
     # or ProjectionExpression appears, but then really does nothing beyond
     # what AttributesToGet and ProjectionExpression already do:
-    with pytest.raises(ClientError, match='ValidationException'):
-        full_scan(test_table, Select='SPECIFIC_ATTRIBUTES')
-    wanted = ['c', 'another']
-    got_items = full_scan(test_table, Select='SPECIFIC_ATTRIBUTES', AttributesToGet=wanted)
+    with pytest.raises(ClientError, match="ValidationException"):
+        full_scan(test_table, Select="SPECIFIC_ATTRIBUTES")
+    wanted = ["c", "another"]
+    got_items = full_scan(
+        test_table, Select="SPECIFIC_ATTRIBUTES", AttributesToGet=wanted
+    )
     expected_items = [{k: x[k] for k in wanted if k in x} for x in items]
     assert multiset(expected_items) == multiset(got_items)
-    got_items = full_scan(test_table, Select='SPECIFIC_ATTRIBUTES', ProjectionExpression=','.join(wanted))
+    got_items = full_scan(
+        test_table, Select="SPECIFIC_ATTRIBUTES", ProjectionExpression=",".join(wanted)
+    )
     assert multiset(expected_items) == multiset(got_items)
     # Select=COUNT just returns a count - not any items
-    (got_count, got_items) = full_scan_and_count(test_table, Select='COUNT')
+    (got_count, got_items) = full_scan_and_count(test_table, Select="COUNT")
     assert got_count == len(items)
     assert got_items == []
     # Check that we also get a count in regular scans - not just with
@@ -252,20 +308,21 @@ def test_scan_select(filled_test_table):
     assert got_count == len(items)
     assert multiset(items) == multiset(got_items)
     # Select with some unknown string generates a validation exception:
-    with pytest.raises(ClientError, match='ValidationException'):
-        full_scan(test_table, Select='UNKNOWN')
+    with pytest.raises(ClientError, match="ValidationException"):
+        full_scan(test_table, Select="UNKNOWN")
     # If either AttributesToGet or ProjectionExpression appear, only
     # Select=SPECIFIC_ATTRIBUTES (or nothing) is allowed - other Select
     # settings contradict the AttributesToGet or ProjectionExpression, and
     # therefore forbidden:
-    with pytest.raises(ClientError, match='ValidationException.*AttributesToGet'):
-        full_scan(test_table, Select='ALL_ATTRIBUTES', AttributesToGet=['x'])
-    with pytest.raises(ClientError, match='ValidationException.*AttributesToGet'):
-        full_scan(test_table, Select='COUNT', AttributesToGet=['x'])
-    with pytest.raises(ClientError, match='ValidationException.*ProjectionExpression'):
-        full_scan(test_table, Select='ALL_ATTRIBUTES', ProjectionExpression='x')
-    with pytest.raises(ClientError, match='ValidationException.*ProjectionExpression'):
-        full_scan(test_table, Select='COUNT', ProjectionExpression='x')
+    with pytest.raises(ClientError, match="ValidationException.*AttributesToGet"):
+        full_scan(test_table, Select="ALL_ATTRIBUTES", AttributesToGet=["x"])
+    with pytest.raises(ClientError, match="ValidationException.*AttributesToGet"):
+        full_scan(test_table, Select="COUNT", AttributesToGet=["x"])
+    with pytest.raises(ClientError, match="ValidationException.*ProjectionExpression"):
+        full_scan(test_table, Select="ALL_ATTRIBUTES", ProjectionExpression="x")
+    with pytest.raises(ClientError, match="ValidationException.*ProjectionExpression"):
+        full_scan(test_table, Select="COUNT", ProjectionExpression="x")
+
 
 # Test parallel scan, i.e., the Segments and TotalSegments options.
 # In the following test we check that these parameters allow splitting
@@ -275,30 +332,40 @@ def test_scan_select(filled_test_table):
 def test_scan_parallel(filled_test_table):
     test_table, items = filled_test_table
     for nsegments in [1, 2, 17]:
-        print('Testing TotalSegments={}'.format(nsegments))
+        print("Testing TotalSegments={}".format(nsegments))
         got_items = []
         for segment in range(nsegments):
-            got_items.extend(full_scan(test_table, TotalSegments=nsegments, Segment=segment))
+            got_items.extend(
+                full_scan(test_table, TotalSegments=nsegments, Segment=segment)
+            )
         # The following comparison verifies that each of the expected item
         # in items was returned in one - and just one - of the segments.
         assert multiset(items) == multiset(got_items)
+
 
 # Test correct handling of incorrect parallel scan parameters.
 # Most of the corner cases (like TotalSegments=0) are validated
 # by boto3 itself, but some checks can still be performed.
 def test_scan_parallel_incorrect(filled_test_table):
     test_table, items = filled_test_table
-    with pytest.raises(ClientError, match='ValidationException.*Segment'):
+    with pytest.raises(ClientError, match="ValidationException.*Segment"):
         full_scan(test_table, TotalSegments=1000001, Segment=0)
     for segment in [7, 9]:
-        with pytest.raises(ClientError, match='ValidationException.*Segment'):
+        with pytest.raises(ClientError, match="ValidationException.*Segment"):
             full_scan(test_table, TotalSegments=5, Segment=segment)
+
 
 # ExclusiveStartKey must lie within the segment when using Segment/TotalSegment.
 def test_scan_parallel_with_exclusive_start_key(filled_test_table):
     test_table, items = filled_test_table
-    with pytest.raises(ClientError, match='ValidationException.*Exclusive'):
-        full_scan(test_table, TotalSegments=1000000, Segment=0, ExclusiveStartKey={'p': '0', 'c': '0'})
+    with pytest.raises(ClientError, match="ValidationException.*Exclusive"):
+        full_scan(
+            test_table,
+            TotalSegments=1000000,
+            Segment=0,
+            ExclusiveStartKey={"p": "0", "c": "0"},
+        )
+
 
 # We used to have a bug with formatting of LastEvaluatedKey in the response
 # of Query and Scan with bytes keys (issue #7768). In test_query_paging_byte()
@@ -310,19 +377,21 @@ def test_scan_paging_bytes(test_table_b):
     # to contain at least two items, and then Scan it with Limit=1 and stop
     # after one page. Before #7768 was fixed, the test failed when the
     # LastEvaluatedKey in the response could not be parsed.
-    items = [{'p': random_bytes()}, {'p': random_bytes()}]
+    items = [{"p": random_bytes()}, {"p": random_bytes()}]
     with test_table_b.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
     response = test_table_b.scan(ConsistentRead=True, Limit=1)
-    assert 'LastEvaluatedKey' in response
+    assert "LastEvaluatedKey" in response
+
 
 # A fixture to read query_tombstone_page_limit from Scylla's configuration.
 # A test using this fixture will be skipped if the test is not running
 # against Scylla.
 @pytest.fixture(scope="module")
 def query_tombstone_page_limit(dynamodb, scylla_only):
-    return int(scylla_config_read(dynamodb, 'query_tombstone_page_limit'))
+    return int(scylla_config_read(dynamodb, "query_tombstone_page_limit"))
+
 
 # The following two tests reproduced issue #7933, where a scan encounters a
 # long string of row/partition tombstones, and because it is expected to
@@ -359,31 +428,37 @@ def query_tombstone_page_limit(dynamodb, scylla_only):
 # to stop early, and also that we know when- after "query_tombstone_page_limit".
 def test_scan_long_row_tombstone_string(dynamodb, query_tombstone_page_limit):
     N = query_tombstone_page_limit + 10
-    with new_test_table(dynamodb,
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' },
-                   { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'N' },
-                               { 'AttributeName': 'c', 'AttributeType': 'N' }]
-        ) as table:
+    with new_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "N"},
+            {"AttributeName": "c", "AttributeType": "N"},
+        ],
+    ) as table:
         # Create two items with c=0 and c=N, and N-2 deletions between them.
         # Although the deleted items never existed, Scylla is forced to keep
         # tombstones for them.
         with table.batch_writer() as batch:
-            batch.put_item(Item={ 'p': 1, 'c': 0 })
-            for i in range(1, N-1):
-                batch.delete_item(Key={ 'p': 1, 'c': i })
-            batch.put_item(Item={ 'p': 1, 'c': N })
+            batch.put_item(Item={"p": 1, "c": 0})
+            for i in range(1, N - 1):
+                batch.delete_item(Key={"p": 1, "c": i})
+            batch.put_item(Item={"p": 1, "c": N})
         response = table.scan()
 
-        found = len(response['Items'])
+        found = len(response["Items"])
         assert found == 1
 
         # Let's finish the scan for as many pages as it takes (some of them
         # may be empty!), and confirm we eventually got the two results.
-        while 'LastEvaluatedKey' in response:
-            response = table.scan(ExclusiveStartKey=response['LastEvaluatedKey'])
-            found += len(response['Items'])
+        while "LastEvaluatedKey" in response:
+            response = table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
+            found += len(response["Items"])
         assert found == 2
+
 
 # A similar test to the above, but here we have a table with two partitions
 # separated by a long string of partition tombstones. Again, the Scan should
@@ -396,13 +471,14 @@ def test_scan_long_partition_tombstone_string(dynamodb, query_tombstone_page_lim
     # significantly more before the split. Experimentally "* 8" works here
     # with test/alternator/run, but may need to be changed in the future.
     N = int(query_tombstone_page_limit * 8)
-    with new_test_table(dynamodb,
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'N' }],
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "N"}],
         # This test does a lot of writes, so let's do them without LWT
         # to make the test less slow.
-        Tags=[{'Key': 'system:write_isolation', 'Value': 'forbid_rmw'}]
-        ) as table:
+        Tags=[{"Key": "system:write_isolation", "Value": "forbid_rmw"}],
+    ) as table:
         # We want to have two live partitions with a lot of partition
         # tombstones between them. But the hash function is pseudo-random
         # so we don't know which partitions would be the first and last.
@@ -412,31 +488,32 @@ def test_scan_long_partition_tombstone_string(dynamodb, query_tombstone_page_lim
         # write later will fall between those two partitions.
         with table.batch_writer() as batch:
             for i in range(100):
-                batch.put_item(Item={ 'p': i })
+                batch.put_item(Item={"p": i})
         r = table.scan()
-        first = r['Items'][0]['p']
-        while 'LastEvaluatedKey' in r:
-            r = table.scan(ExclusiveStartKey=r['LastEvaluatedKey'])
-        last = r['Items'][-1]['p']
+        first = r["Items"][0]["p"]
+        while "LastEvaluatedKey" in r:
+            r = table.scan(ExclusiveStartKey=r["LastEvaluatedKey"])
+        last = r["Items"][-1]["p"]
         print("first", first, "last", last)
         # Now write all N items - all except "first" and "last" are deletions
         with table.batch_writer() as batch:
             for i in range(N):
                 if i == first or i == last:
-                    batch.put_item(Item={ 'p': i })
+                    batch.put_item(Item={"p": i})
                 else:
-                    batch.delete_item(Key={ 'p': i })
+                    batch.delete_item(Key={"p": i})
         response = table.scan()
 
-        found = len(response['Items'])
+        found = len(response["Items"])
         assert found == 1
 
         # Let's finish the scan for as many pages as it takes (some of them
         # may be empty!), and confirm we eventually got the two results.
-        while 'LastEvaluatedKey' in response:
-            response = table.scan(ExclusiveStartKey=response['LastEvaluatedKey'])
-            found += len(response['Items'])
+        while "LastEvaluatedKey" in response:
+            response = table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
+            found += len(response["Items"])
         assert found == 2
+
 
 # Verify that even if no "Limit" is specified for a Scan, the size of a
 # single returned page is still limited. DynamoDB specifies it should be
@@ -460,26 +537,37 @@ def test_scan_long_partition_tombstone_string(dynamodb, query_tombstone_page_lim
 # checks reverse queries, but it also checks the unreversed unlimited query).
 # For single-partition scans, the page size is more exactly 1 MB.
 #
-@pytest.mark.parametrize("KB", [
-    pytest.param(1500, marks=pytest.mark.xfail(
-        reason="Issue #10327: small tables don't respect paging limits")),
-    8000
-])
+@pytest.mark.parametrize(
+    "KB",
+    [
+        pytest.param(
+            1500,
+            marks=pytest.mark.xfail(
+                reason="Page size in whole-table scan of a small table is larger than 1 MB #10327"
+            ),
+        ),
+        8000,
+    ],
+)
 def test_scan_paging_missing_limit(dynamodb, KB):
-    with new_test_table(dynamodb,
-            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'N' }]) as table:
+    with new_test_table(
+        dynamodb,
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "N"}],
+    ) as table:
         # Insert data in multiple smaller partitions.
-        str = 'x' * 10240
+        str = "x" * 10240
         N = KB // 10
         with table.batch_writer() as batch:
             for i in range(N):
-                batch.put_item({'p': i, 's': str})
-        n = len(table.scan(ConsistentRead=True)['Items'])
+                batch.put_item({"p": i, "s": str})
+        n = len(table.scan(ConsistentRead=True)["Items"])
         # we don't know how big n should be (hopefully around 100)
         # but definitely not N.
-        assert n < N, f"The response was not paged, {n*len(str)/1024} kB of data returned in a single page"
+        assert n < N, (
+            f"The response was not paged, {n * len(str) / 1024} kB of data returned in a single page"
+        )
+
 
 # When a table has a partition key and sort key, both are required in
 # ExclusiveStartKey to specify where to start the scan. Although it
@@ -494,20 +582,23 @@ def test_scan_exclusivestartkey_missing_sortkey(filled_test_table):
     # ExclusiveStartKey is "The provided starting key is invalid: The
     # provided key element does not match the schema". In Alternator,
     # the error is "Key column c not found".
-    with pytest.raises(ClientError, match='ValidationException.*[kK]ey'):
+    with pytest.raises(ClientError, match="ValidationException.*[kK]ey"):
         # missing 'c' in ExclusiveStartKey!
-        test_table.scan(ExclusiveStartKey={'p': p})
+        test_table.scan(ExclusiveStartKey={"p": p})
+
 
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key (here a partition key and sort key)
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(
+    reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988"
+)
 def test_scan_exclusivestartkey_spurious_column(filled_test_table):
     test_table, items = filled_test_table
     p = random_string()
     # The error that DynamoDB reports if ExclusiveStartKey has spurious
     # columns is: "The provided starting key is invalid: The provided key
     # element does not match the schema".
-    with pytest.raises(ClientError, match='ValidationException.*starting key'):
+    with pytest.raises(ClientError, match="ValidationException.*starting key"):
         # 'x' is not part of the key, so this should cause an error
-        test_table.scan(ExclusiveStartKey={'p': p, 'c': 'hi', 'x': 3})
+        test_table.scan(ExclusiveStartKey={"p": p, "c": "hi", "x": 3})

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -14,19 +14,32 @@ import pytest
 from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
 
-from test.alternator.util import is_aws, scylla_config_temporary, unique_table_name, create_test_table, new_test_table, random_string, full_scan, freeze, list_tables, get_region, manual_request
+from test.alternator.util import (
+    is_aws,
+    scylla_config_temporary,
+    unique_table_name,
+    create_test_table,
+    new_test_table,
+    random_string,
+    full_scan,
+    freeze,
+    list_tables,
+    get_region,
+    manual_request,
+)
 
 # All tests in this file are expected to fail with tablets due to #23838.
 # To ensure that Alternator Streams is still being tested, instead of
 # xfailing these tests, we temporarily coerce the tests below to avoid
 # using default tablets setting, even if it's available. We do this by
 # using the following tags when creating each table below:
-TAGS = [{'Key': 'system:initial_tablets', 'Value': 'none'}]
+TAGS = [{"Key": "system:initial_tablets", "Value": "none"}]
 
-stream_types = [ 'OLD_IMAGE', 'NEW_IMAGE', 'KEYS_ONLY', 'NEW_AND_OLD_IMAGES']
+stream_types = ["OLD_IMAGE", "NEW_IMAGE", "KEYS_ONLY", "NEW_AND_OLD_IMAGES"]
+
 
 def disable_stream(dynamodbstreams, table):
-    table.update(StreamSpecification={'StreamEnabled': False});
+    table.update(StreamSpecification={"StreamEnabled": False})
     # Wait for the stream to really be disabled. A table may have multiple
     # historic streams - we need all of them to become DISABLED. One of
     # them (the current one) may remain DISABLING for some time.
@@ -34,39 +47,46 @@ def disable_stream(dynamodbstreams, table):
     while time.process_time() < exp:
         streams = dynamodbstreams.list_streams(TableName=table.name)
         disabled = True
-        for stream in streams['Streams']:
-            desc = dynamodbstreams.describe_stream(StreamArn=stream['StreamArn'])['StreamDescription']
-            if desc['StreamStatus'] != 'DISABLED':
+        for stream in streams["Streams"]:
+            desc = dynamodbstreams.describe_stream(StreamArn=stream["StreamArn"])[
+                "StreamDescription"
+            ]
+            if desc["StreamStatus"] != "DISABLED":
                 disabled = False
                 break
         if disabled:
-            print('disabled stream on {}'.format(table.name))
+            print("disabled stream on {}".format(table.name))
             return
         time.sleep(0.5)
     pytest.fail("timed out")
-            
+
+
 # Cannot use fixtures. Because real dynamodb cannot _remove_ a stream
-# once created. It can only expire 24h later. So reusing test_table for 
+# once created. It can only expire 24h later. So reusing test_table for
 # example works great for scylla/local testing, but once we run against
-# actual aws instances, we get lingering streams, and worse: cannot 
-# create new ones to replace it, because we have overlapping types etc. 
-# 
-# So we have to create and delete a table per test. And not run this 
-# test to often against aws.  
+# actual aws instances, we get lingering streams, and worse: cannot
+# create new ones to replace it, because we have overlapping types etc.
+#
+# So we have to create and delete a table per test. And not run this
+# test to often against aws.
 @contextmanager
 def create_stream_test_table(dynamodb, StreamViewType=None):
-    spec = { 'StreamEnabled': False }
+    spec = {"StreamEnabled": False}
     if StreamViewType != None:
-        spec = {'StreamEnabled': True, 'StreamViewType': StreamViewType}
-    table = create_test_table(dynamodb, StreamSpecification=spec,
+        spec = {"StreamEnabled": True, "StreamViewType": StreamViewType}
+    table = create_test_table(
+        dynamodb,
+        StreamSpecification=spec,
         Tags=TAGS,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-        ])
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
+    )
     try:
         yield table
     finally:
@@ -78,65 +98,73 @@ def create_stream_test_table(dynamodb, StreamViewType=None):
             except ClientError as ce:
                 # if the table has a stream currently being created we cannot
                 # delete the table immediately. Again, only with real dynamo
-                if ce.response['Error']['Code'] == 'ResourceInUseException':
-                    print('Could not delete table yet. Sleeping 5s.')
+                if ce.response["Error"]["Code"] == "ResourceInUseException":
+                    print("Could not delete table yet. Sleeping 5s.")
                     time.sleep(5)
-                    continue;
+                    continue
                 raise
+
 
 def wait_for_active_stream(dynamodbstreams, table, timeout=60):
     exp = time.process_time() + timeout
     while time.process_time() < exp:
         streams = dynamodbstreams.list_streams(TableName=table.name)
-        for stream in streams['Streams']:
-            arn = stream['StreamArn']
+        for stream in streams["Streams"]:
+            arn = stream["StreamArn"]
             if arn == None:
                 continue
-            desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
-            if not 'StreamStatus' in desc or desc.get('StreamStatus') == 'ENABLED':
-                return (arn, stream['StreamLabel']);
+            desc = dynamodbstreams.describe_stream(StreamArn=arn)["StreamDescription"]
+            if not "StreamStatus" in desc or desc.get("StreamStatus") == "ENABLED":
+                return (arn, stream["StreamLabel"])
         # real dynamo takes some time until a stream is usable
         print("Stream not available. Sleep 5s...")
         time.sleep(5)
     assert False
 
-# Local java dynamodb server version behaves differently from 
-# the "real" one. Most importantly, it does not verify a number of 
-# parameters, and consequently does not throw when called with borked 
-# args. This will try to check if we are in fact running against 
-# this test server, and if so, just raise the error here and be done 
-# with it. All this just so we can run through the tests on 
-# aws, scylla and local. 
+
+# Local java dynamodb server version behaves differently from
+# the "real" one. Most importantly, it does not verify a number of
+# parameters, and consequently does not throw when called with borked
+# args. This will try to check if we are in fact running against
+# this test server, and if so, just raise the error here and be done
+# with it. All this just so we can run through the tests on
+# aws, scylla and local.
 def is_local_java(dynamodbstreams):
-    # no good way to check, but local server runs on a Jetty, 
-    # so check for that. 
+    # no good way to check, but local server runs on a Jetty,
+    # so check for that.
     url = dynamodbstreams.meta.endpoint_url
-    try: 
+    try:
         urllib.request.urlopen(url)
     except URLError as e:
-        if hasattr(e, 'info'):
-            return e.info()['Server'].startswith('Jetty')
+        if hasattr(e, "info"):
+            return e.info()["Server"].startswith("Jetty")
     return False
 
-def ensure_java_server(dynamodbstreams, error='ValidationException'):
-    # no good way to check, but local server has a "shell" builtin, 
-    # so check for that. 
+
+def ensure_java_server(dynamodbstreams, error="ValidationException"):
+    # no good way to check, but local server has a "shell" builtin,
+    # so check for that.
     if is_local_java(dynamodbstreams):
         if error != None:
-            raise ClientError({'Error': { 'Code' : error }}, '')
+            raise ClientError({"Error": {"Code": error}}, "")
         return
     assert False
+
 
 def test_list_streams_create(dynamodb, dynamodbstreams):
     for type in stream_types:
         with create_stream_test_table(dynamodb, StreamViewType=type) as table:
             wait_for_active_stream(dynamodbstreams, table)
 
+
 def test_list_streams_alter(dynamodb, dynamodbstreams):
     for type in stream_types:
         with create_stream_test_table(dynamodb, StreamViewType=None) as table:
-            table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': type});
+            table.update(
+                StreamSpecification={"StreamEnabled": True, "StreamViewType": type}
+            )
             wait_for_active_stream(dynamodbstreams, table)
+
 
 def test_list_streams_paged(dynamodb, dynamodbstreams):
     # There is no reason to run this test for all stream types - we have
@@ -149,16 +177,21 @@ def test_list_streams_paged(dynamodb, dynamodbstreams):
                 wait_for_active_stream(dynamodbstreams, table2)
                 streams = dynamodbstreams.list_streams(Limit=1)
                 assert streams
-                assert streams.get('Streams')
-                assert streams.get('LastEvaluatedStreamArn')
-                tables = [ table1.name, table2.name ]
+                assert streams.get("Streams")
+                assert streams.get("LastEvaluatedStreamArn")
+                tables = [table1.name, table2.name]
                 while True:
-                    for s in streams['Streams']:
-                        name = s['TableName']
-                        if name in tables: tables.remove(name)
+                    for s in streams["Streams"]:
+                        name = s["TableName"]
+                        if name in tables:
+                            tables.remove(name)
                     if not tables:
                         break
-                    streams = dynamodbstreams.list_streams(Limit=1, ExclusiveStartStreamArn=streams['LastEvaluatedStreamArn'])
+                    streams = dynamodbstreams.list_streams(
+                        Limit=1,
+                        ExclusiveStartStreamArn=streams["LastEvaluatedStreamArn"],
+                    )
+
 
 # ListStreams with paging should be able correctly return a full list of
 # pre-existing streams even if additional tables were added between pages
@@ -170,40 +203,46 @@ def test_list_streams_paged(dynamodb, dynamodbstreams):
 # we suspect the hash table got different order for different pages for
 # other reasons - not because of added tables.
 def test_list_streams_paged_with_new_table(dynamodb, dynamodbstreams):
-    N1    = 4  # Number of tables to create initially
+    N1 = 4  # Number of tables to create initially
     LIMIT = 2  # Number of tables out of N1 to list in the first page
-    N2    = 30 # Number of additional tables to create later
+    N2 = 30  # Number of additional tables to create later
     N1_tables = []
     with ExitStack() as created_tables:
         for i in range(N1):
-            table = created_tables.enter_context(create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY'))
+            table = created_tables.enter_context(
+                create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY")
+            )
             wait_for_active_stream(dynamodbstreams, table)
             N1_tables.append(table.name)
         streams = dynamodbstreams.list_streams(Limit=LIMIT)
         assert streams
-        assert 'Streams' in streams
-        assert len(streams['Streams']) == LIMIT
-        first_tables = [s['TableName'] for s in streams['Streams']]
-        last_arn = streams['LastEvaluatedStreamArn']
+        assert "Streams" in streams
+        assert len(streams["Streams"]) == LIMIT
+        first_tables = [s["TableName"] for s in streams["Streams"]]
+        last_arn = streams["LastEvaluatedStreamArn"]
         for i in range(N2):
-            table = created_tables.enter_context(create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY'))
+            table = created_tables.enter_context(
+                create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY")
+            )
             wait_for_active_stream(dynamodbstreams, table)
         # Get the rest of the streams (no limit, assuming we don't have
         # a huge number of streams)
         streams = dynamodbstreams.list_streams(ExclusiveStartStreamArn=last_arn)
-        assert 'Streams' in streams
-        tables = first_tables + [s['TableName'] for s in streams['Streams']]
+        assert "Streams" in streams
+        tables = first_tables + [s["TableName"] for s in streams["Streams"]]
         # Each of the N1 tables must have been returned from the paged
         # iteration, and only once. The tables in N2 may or may not be
         # returned. Tables not related to this test may also be returned.
         for t in N1_tables:
             assert tables.count(t) == 1
 
+
 def test_list_streams_zero_limit(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
-        with pytest.raises(ClientError, match='ValidationException'):
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
+        with pytest.raises(ClientError, match="ValidationException"):
             wait_for_active_stream(dynamodbstreams, table)
             dynamodbstreams.list_streams(Limit=0)
+
 
 # The DynamoDB documentation for ListStreams says that for Limit, "the upper
 # limit is 100.". Indeed, if we try 101, we get a ValidationException.
@@ -213,253 +252,327 @@ def test_list_streams_zero_limit(dynamodb, dynamodbstreams):
 # in a huge response, which we don't want to allow.
 @pytest.mark.xfail(reason="no upper limit for Limit")
 def test_list_streams_too_high_limit(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
-        with pytest.raises(ClientError, match='ValidationException'):
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
+        with pytest.raises(ClientError, match="ValidationException"):
             wait_for_active_stream(dynamodbstreams, table)
             dynamodbstreams.list_streams(Limit=100000)
 
+
 def test_create_streams_wrong_type(dynamodb, dynamodbstreams, test_table):
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="ValidationException"):
         # should throw
-        test_table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'Fisk'});
+        test_table.update(
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "Fisk"}
+        )
         # just in case the test fails, disable stream again
-        test_table.update(StreamSpecification={'StreamEnabled': False});
+        test_table.update(StreamSpecification={"StreamEnabled": False})
+
 
 def test_list_streams_empty(dynamodb, dynamodbstreams, test_table):
     streams = dynamodbstreams.list_streams(TableName=test_table.name)
-    assert 'Streams' in streams
-    assert not streams['Streams'] # empty
+    assert "Streams" in streams
+    assert not streams["Streams"]  # empty
+
 
 def test_list_streams_with_nonexistent_last_stream(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
-        with pytest.raises(ClientError, match='ValidationException'):
-            streams = dynamodbstreams.list_streams(TableName=table.name, ExclusiveStartStreamArn='kossaapaaasdafsdaasdasdasdasasdasfadfadfasdasdas')
-            assert 'Streams' in streams
-            assert not streams['Streams'] # empty
-            # local java dynamodb does _not_ raise validation error for 
-            # malformed stream arn here. verify 
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
+        with pytest.raises(ClientError, match="ValidationException"):
+            streams = dynamodbstreams.list_streams(
+                TableName=table.name,
+                ExclusiveStartStreamArn="kossaapaaasdafsdaasdasdasdasasdasfadfadfasdasdas",
+            )
+            assert "Streams" in streams
+            assert not streams["Streams"]  # empty
+            # local java dynamodb does _not_ raise validation error for
+            # malformed stream arn here. verify
             ensure_java_server(dynamodbstreams)
 
+
 def test_describe_stream(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
         streams = dynamodbstreams.list_streams(TableName=table.name)
-        arn = streams['Streams'][0]['StreamArn'];
+        arn = streams["Streams"][0]["StreamArn"]
         desc = dynamodbstreams.describe_stream(StreamArn=arn)
-        assert desc;
-        assert desc.get('StreamDescription')
-        assert desc['StreamDescription']['StreamArn'] == arn
-        assert desc['StreamDescription']['StreamStatus'] != 'DISABLED'
-        assert desc['StreamDescription']['StreamViewType'] == 'KEYS_ONLY'
-        assert desc['StreamDescription']['TableName'] == table.name
-        assert desc['StreamDescription'].get('Shards')
-        assert desc['StreamDescription']['Shards'][0].get('ShardId')
-        assert desc['StreamDescription']['Shards'][0].get('SequenceNumberRange')
-        assert desc['StreamDescription']['Shards'][0]['SequenceNumberRange'].get('StartingSequenceNumber')
+        assert desc
+        assert desc.get("StreamDescription")
+        assert desc["StreamDescription"]["StreamArn"] == arn
+        assert desc["StreamDescription"]["StreamStatus"] != "DISABLED"
+        assert desc["StreamDescription"]["StreamViewType"] == "KEYS_ONLY"
+        assert desc["StreamDescription"]["TableName"] == table.name
+        assert desc["StreamDescription"].get("Shards")
+        assert desc["StreamDescription"]["Shards"][0].get("ShardId")
+        assert desc["StreamDescription"]["Shards"][0].get("SequenceNumberRange")
+        assert desc["StreamDescription"]["Shards"][0]["SequenceNumberRange"].get(
+            "StartingSequenceNumber"
+        )
         # We don't know what the sequence number is supposed to be, but the
         # DynamoDB documentation requires that it contains only numeric
         # characters and some libraries rely on this. Reproduces issue #7158:
-        assert desc['StreamDescription']['Shards'][0]['SequenceNumberRange']['StartingSequenceNumber'].isdecimal()
+        assert desc["StreamDescription"]["Shards"][0]["SequenceNumberRange"][
+            "StartingSequenceNumber"
+        ].isdecimal()
+
 
 @pytest.mark.xfail(reason="alternator does not have creation time on streams")
 def test_describe_stream_create_time(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
         streams = dynamodbstreams.list_streams(TableName=table.name)
-        arn = streams['Streams'][0]['StreamArn'];
+        arn = streams["Streams"][0]["StreamArn"]
         desc = dynamodbstreams.describe_stream(StreamArn=arn)
-        assert desc;
-        assert desc.get('StreamDescription')
+        assert desc
+        assert desc.get("StreamDescription")
         # note these are non-required attributes
-        assert 'CreationRequestDateTime' in desc['StreamDescription']
+        assert "CreationRequestDateTime" in desc["StreamDescription"]
+
 
 def test_describe_nonexistent_stream(dynamodb, dynamodbstreams):
-    with pytest.raises(ClientError, match='ResourceNotFoundException' if is_local_java(dynamodbstreams) else 'ValidationException'):
-        dynamodbstreams.describe_stream(StreamArn='sdfadfsdfnlfkajakfgjalksfgklasjklasdjfklasdfasdfgasf')
+    with pytest.raises(
+        ClientError,
+        match="ResourceNotFoundException"
+        if is_local_java(dynamodbstreams)
+        else "ValidationException",
+    ):
+        dynamodbstreams.describe_stream(
+            StreamArn="sdfadfsdfnlfkajakfgjalksfgklasjklasdjfklasdfasdfgasf"
+        )
+
 
 def test_describe_stream_with_nonexistent_last_shard(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
         streams = dynamodbstreams.list_streams(TableName=table.name)
-        arn = streams['Streams'][0]['StreamArn'];
+        arn = streams["Streams"][0]["StreamArn"]
         try:
-            desc = dynamodbstreams.describe_stream(StreamArn=arn, ExclusiveStartShardId='zzzzzzzzzzzzzzzzzzzzzzzzsfasdgagadfadfgagkjsdfsfsdjfjks')
-            assert not desc['StreamDescription']['Shards']
+            desc = dynamodbstreams.describe_stream(
+                StreamArn=arn,
+                ExclusiveStartShardId="zzzzzzzzzzzzzzzzzzzzzzzzsfasdgagadfadfgagkjsdfsfsdjfjks",
+            )
+            assert not desc["StreamDescription"]["Shards"]
         except:
-            # local java throws here. real does not. 
+            # local java throws here. real does not.
             ensure_java_server(dynamodbstreams, error=None)
 
+
 def test_get_shard_iterator(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
         streams = dynamodbstreams.list_streams(TableName=table.name)
-        arn = streams['Streams'][0]['StreamArn'];
+        arn = streams["Streams"][0]["StreamArn"]
         desc = dynamodbstreams.describe_stream(StreamArn=arn)
 
-        shard_id = desc['StreamDescription']['Shards'][0]['ShardId'];
-        seq = desc['StreamDescription']['Shards'][0]['SequenceNumberRange']['StartingSequenceNumber'];
-
+        shard_id = desc["StreamDescription"]["Shards"][0]["ShardId"]
+        seq = desc["StreamDescription"]["Shards"][0]["SequenceNumberRange"][
+            "StartingSequenceNumber"
+        ]
         # spec says shard_id must be 65 chars or less
         assert len(shard_id) <= 65
 
-        for type in ['AT_SEQUENCE_NUMBER', 'AFTER_SEQUENCE_NUMBER']: 
+        for type in ["AT_SEQUENCE_NUMBER", "AFTER_SEQUENCE_NUMBER"]:
             iter = dynamodbstreams.get_shard_iterator(
-                StreamArn=arn, ShardId=shard_id, ShardIteratorType=type, SequenceNumber=seq
+                StreamArn=arn,
+                ShardId=shard_id,
+                ShardIteratorType=type,
+                SequenceNumber=seq,
             )
-            assert iter.get('ShardIterator')
+            assert iter.get("ShardIterator")
 
-        for type in ['TRIM_HORIZON', 'LATEST']: 
+        for type in ["TRIM_HORIZON", "LATEST"]:
             iter = dynamodbstreams.get_shard_iterator(
                 StreamArn=arn, ShardId=shard_id, ShardIteratorType=type
             )
-            assert iter.get('ShardIterator')
+            assert iter.get("ShardIterator")
 
-        for type in ['AT_SEQUENCE_NUMBER', 'AFTER_SEQUENCE_NUMBER']: 
+        for type in ["AT_SEQUENCE_NUMBER", "AFTER_SEQUENCE_NUMBER"]:
             # must have seq in these modes
-            with pytest.raises(ClientError, match='ValidationException'):
+            with pytest.raises(ClientError, match="ValidationException"):
                 dynamodbstreams.get_shard_iterator(
                     StreamArn=arn, ShardId=shard_id, ShardIteratorType=type
                 )
 
-        for type in ['TRIM_HORIZON', 'LATEST']: 
+        for type in ["TRIM_HORIZON", "LATEST"]:
             # should not set "seq" in these modes
-            with pytest.raises(ClientError, match='ValidationException'):
+            with pytest.raises(ClientError, match="ValidationException"):
                 dynamodbstreams.get_shard_iterator(
-                    StreamArn=arn, ShardId=shard_id, ShardIteratorType=type, SequenceNumber=seq
+                    StreamArn=arn,
+                    ShardId=shard_id,
+                    ShardIteratorType=type,
+                    SequenceNumber=seq,
                 )
 
         # bad arn
-        with pytest.raises(ClientError, match='ValidationException'):
+        with pytest.raises(ClientError, match="ValidationException"):
             dynamodbstreams.get_shard_iterator(
-                StreamArn='sdfadsfsdfsdgdfsgsfdabadfbabdadsfsdfsdfsdfsdfsdfsdfdfdssdffbdfdf', ShardId=shard_id, ShardIteratorType=type, SequenceNumber=seq
+                StreamArn="sdfadsfsdfsdgdfsgsfdabadfbabdadsfsdfsdfsdfsdfsdfsdfdfdssdffbdfdf",
+                ShardId=shard_id,
+                ShardIteratorType=type,
+                SequenceNumber=seq,
             )
-        # bad shard id  
-        with pytest.raises(ClientError, match='ResourceNotFoundException'):
-            dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId='semprinidfaasdasfsdvacsdcfsdsvsdvsdvsdvsdvsdv', 
-                ShardIteratorType='LATEST'
-                )
+        # bad shard id
+        with pytest.raises(ClientError, match="ResourceNotFoundException"):
+            dynamodbstreams.get_shard_iterator(
+                StreamArn=arn,
+                ShardId="semprinidfaasdasfsdvacsdcfsdsvsdvsdvsdvsdvsdv",
+                ShardIteratorType="LATEST",
+            )
         # bad iter type
-        with pytest.raises(ClientError, match='ValidationException'):
-            dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=shard_id, 
-                ShardIteratorType='bulle', SequenceNumber=seq
-                )
-        # bad seq 
-        with pytest.raises(ClientError, match='ValidationException'):
-            dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=shard_id, 
-                ShardIteratorType='LATEST', SequenceNumber='sdfsafglldfngjdafnasdflgnaldklkafdsgklnasdlv'
-                )
+        with pytest.raises(ClientError, match="ValidationException"):
+            dynamodbstreams.get_shard_iterator(
+                StreamArn=arn,
+                ShardId=shard_id,
+                ShardIteratorType="bulle",
+                SequenceNumber=seq,
+            )
+        # bad seq
+        with pytest.raises(ClientError, match="ValidationException"):
+            dynamodbstreams.get_shard_iterator(
+                StreamArn=arn,
+                ShardId=shard_id,
+                ShardIteratorType="LATEST",
+                SequenceNumber="sdfsafglldfngjdafnasdflgnaldklkafdsgklnasdlv",
+            )
+
 
 def test_get_shard_iterator_for_nonexistent_stream(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
         (arn, label) = wait_for_active_stream(dynamodbstreams, table)
         desc = dynamodbstreams.describe_stream(StreamArn=arn)
-        shards = desc['StreamDescription']['Shards']
-        with pytest.raises(ClientError, match='ResourceNotFoundException' if is_local_java(dynamodbstreams) else 'ValidationException'):
+        shards = desc["StreamDescription"]["Shards"]
+        with pytest.raises(
+            ClientError,
+            match="ResourceNotFoundException"
+            if is_local_java(dynamodbstreams)
+            else "ValidationException",
+        ):
             dynamodbstreams.get_shard_iterator(
-                    StreamArn='sdfadfsddafgdafsgjnadflkgnalngalsdfnlkasnlkasdfasdfasf', ShardId=shards[0]['ShardId'], ShardIteratorType='LATEST'
-                )
+                StreamArn="sdfadfsddafgdafsgjnadflkgnalngalsdfnlkasnlkasdfasdfasf",
+                ShardId=shards[0]["ShardId"],
+                ShardIteratorType="LATEST",
+            )
+
 
 def test_get_shard_iterator_for_nonexistent_shard(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
         streams = dynamodbstreams.list_streams(TableName=table.name)
-        arn = streams['Streams'][0]['StreamArn'];
-        with pytest.raises(ClientError, match='ResourceNotFoundException'):
+        arn = streams["Streams"][0]["StreamArn"]
+        with pytest.raises(ClientError, match="ResourceNotFoundException"):
             dynamodbstreams.get_shard_iterator(
-                    StreamArn=arn, ShardId='adfasdasdasdasdasdasdasdasdasasdasd', ShardIteratorType='LATEST'
-                )
+                StreamArn=arn,
+                ShardId="adfasdasdasdasdasdasdasdasdasasdasd",
+                ShardIteratorType="LATEST",
+            )
+
 
 def test_get_records(dynamodb, dynamodbstreams):
     # TODO: add tests for storage/transactionable variations and global/local index
-    with create_stream_test_table(dynamodb, StreamViewType='NEW_AND_OLD_IMAGES') as table:
+    with create_stream_test_table(
+        dynamodb, StreamViewType="NEW_AND_OLD_IMAGES"
+    ) as table:
         (arn, label) = wait_for_active_stream(dynamodbstreams, table)
 
-        p = 'piglet'
-        c = 'ninja'
-        val = 'lucifers'
-        val2 = 'flowers'
-        table.put_item(Item={'p': p, 'c': c, 'a1': val, 'a2': val2})
+        p = "piglet"
+        c = "ninja"
+        val = "lucifers"
+        val2 = "flowers"
+        table.put_item(Item={"p": p, "c": c, "a1": val, "a2": val2})
 
-        nval = 'semprini'
-        nval2 = 'nudge'
-        table.update_item(Key={'p': p, 'c': c}, 
-            AttributeUpdates={ 'a1': {'Value': nval, 'Action': 'PUT'},
-                'a2': {'Value': nval2, 'Action': 'PUT'}
-            })
+        nval = "semprini"
+        nval2 = "nudge"
+        table.update_item(
+            Key={"p": p, "c": c},
+            AttributeUpdates={
+                "a1": {"Value": nval, "Action": "PUT"},
+                "a2": {"Value": nval2, "Action": "PUT"},
+            },
+        )
 
         has_insert = False
 
         # in truth, we should sleep already here, since at least scylla
-        # will not be able to produce any stream content until 
+        # will not be able to produce any stream content until
         # ~30s after insert/update (confidence iterval)
-        # but it is useful to see a working null-iteration as well, so 
+        # but it is useful to see a working null-iteration as well, so
         # lets go already.
         while True:
             desc = dynamodbstreams.describe_stream(StreamArn=arn)
             iterators = []
 
             while True:
-                shards = desc['StreamDescription']['Shards']
+                shards = desc["StreamDescription"]["Shards"]
 
                 for shard in shards:
-                    shard_id = shard['ShardId']
-                    start = shard['SequenceNumberRange']['StartingSequenceNumber']
-                    iter = dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='AT_SEQUENCE_NUMBER',SequenceNumber=start)['ShardIterator']
+                    shard_id = shard["ShardId"]
+                    start = shard["SequenceNumberRange"]["StartingSequenceNumber"]
+                    iter = dynamodbstreams.get_shard_iterator(
+                        StreamArn=arn,
+                        ShardId=shard_id,
+                        ShardIteratorType="AT_SEQUENCE_NUMBER",
+                        SequenceNumber=start,
+                    )["ShardIterator"]
                     iterators.append(iter)
 
                 last_shard = desc["StreamDescription"].get("LastEvaluatedShardId")
                 if not last_shard:
                     break
 
-                desc = dynamodbstreams.describe_stream(StreamArn=arn, ExclusiveStartShardId=last_shard)
+                desc = dynamodbstreams.describe_stream(
+                    StreamArn=arn, ExclusiveStartShardId=last_shard
+                )
 
             next_iterators = []
             while iterators:
                 iter = iterators.pop(0)
                 response = dynamodbstreams.get_records(ShardIterator=iter, Limit=1000)
-                if 'NextShardIterator' in response:
-                    next_iterators.append(response['NextShardIterator'])
+                if "NextShardIterator" in response:
+                    next_iterators.append(response["NextShardIterator"])
 
-                records = response.get('Records')
+                records = response.get("Records")
                 # print("Query {} -> {}".format(iter, records))
                 if records:
                     for record in records:
                         # print("Record: {}".format(record))
-                        type = record['eventName']
-                        dynamodb = record['dynamodb']
-                        keys = dynamodb['Keys']
-                        
-                        assert keys.get('p')
-                        assert keys.get('c')
-                        assert keys['p'].get('S')
-                        assert keys['p']['S'] == p
-                        assert keys['c'].get('S')
-                        assert keys['c']['S'] == c
+                        type = record["eventName"]
+                        dynamodb = record["dynamodb"]
+                        keys = dynamodb["Keys"]
 
-                        if type == 'MODIFY' or type == 'INSERT':
-                            assert dynamodb.get('NewImage')
-                            newimage = dynamodb['NewImage'];
-                            assert newimage.get('a1')
-                            assert newimage.get('a2')
+                        assert keys.get("p")
+                        assert keys.get("c")
+                        assert keys["p"].get("S")
+                        assert keys["p"]["S"] == p
+                        assert keys["c"].get("S")
+                        assert keys["c"]["S"] == c
 
-                        if type == 'INSERT' or (type == 'MODIFY' and not has_insert):
-                            assert newimage['a1']['S'] == val
-                            assert newimage['a2']['S'] == val2
+                        if type == "MODIFY" or type == "INSERT":
+                            assert dynamodb.get("NewImage")
+                            newimage = dynamodb["NewImage"]
+                            assert newimage.get("a1")
+                            assert newimage.get("a2")
+
+                        if type == "INSERT" or (type == "MODIFY" and not has_insert):
+                            assert newimage["a1"]["S"] == val
+                            assert newimage["a2"]["S"] == val2
                             has_insert = True
                             continue
-                        if type == 'MODIFY':
+                        if type == "MODIFY":
                             assert has_insert
-                            assert newimage['a1']['S'] == nval
-                            assert newimage['a2']['S'] == nval2
-                            assert dynamodb.get('OldImage')
-                            oldimage = dynamodb['OldImage'];
-                            assert oldimage.get('a1')
-                            assert oldimage.get('a2')
-                            assert oldimage['a1']['S'] == val
-                            assert oldimage['a2']['S'] == val2
+                            assert newimage["a1"]["S"] == nval
+                            assert newimage["a2"]["S"] == nval2
+                            assert dynamodb.get("OldImage")
+                            oldimage = dynamodb["OldImage"]
+                            assert oldimage.get("a1")
+                            assert oldimage.get("a2")
+                            assert oldimage["a1"]["S"] == val
+                            assert oldimage["a2"]["S"] == val2
                             return
             print("Not done. Sleep 10s...")
             time.sleep(10)
             iterators = next_iterators
 
+
 def test_get_records_nonexistent_iterator(dynamodbstreams):
-    with pytest.raises(ClientError, match='ValidationException'):
-        dynamodbstreams.get_records(ShardIterator='sdfsdfsgagaddafgagasgasgasdfasdfasdfasdfasdgasdasdgasdg', Limit=1000)
+    with pytest.raises(ClientError, match="ValidationException"):
+        dynamodbstreams.get_records(
+            ShardIterator="sdfsdfsgagaddafgagasgasgasdfasdfasdfasdfasdgasdasdgasdg",
+            Limit=1000,
+        )
+
 
 ##############################################################################
 
@@ -482,109 +595,154 @@ def test_get_records_nonexistent_iterator(dynamodbstreams):
 # and if in the future we can work around the DynamoDB problem, we can return
 # these fixtures to module scope.
 
+
 @contextmanager
 def create_table_ss(dynamodb, dynamodbstreams, type):
-    table = create_test_table(dynamodb,
+    table = create_test_table(
+        dynamodb,
         Tags=TAGS,
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'S' }],
-        StreamSpecification={ 'StreamEnabled': True, 'StreamViewType': type })
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
+        StreamSpecification={"StreamEnabled": True, "StreamViewType": type},
+    )
     (arn, label) = wait_for_active_stream(dynamodbstreams, table, timeout=60)
     yield table, arn
     table.delete()
+
 
 def create_table_sss_lsi(dynamodb, dynamodbstreams, type):
-    table = create_test_table(dynamodb,
+    table = create_test_table(
+        dynamodb,
         Tags=TAGS,
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'S' }, { 'AttributeName': 'a', 'AttributeType': 'S' }],
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "a", "AttributeType": "S"},
+        ],
         LocalSecondaryIndexes=[
             {
-                'IndexName': 'a_idx',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'a', 'KeyType': 'RANGE' }],
-                'Projection': {
-                    'ProjectionType': 'ALL',
-                }
+                "IndexName": "a_idx",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "a", "KeyType": "RANGE"},
+                ],
+                "Projection": {
+                    "ProjectionType": "ALL",
+                },
             }
         ],
-        StreamSpecification={ 'StreamEnabled': True, 'StreamViewType': type })
+        StreamSpecification={"StreamEnabled": True, "StreamViewType": type},
+    )
     (arn, label) = wait_for_active_stream(dynamodbstreams, table, timeout=60)
     yield table, arn
     table.delete()
 
+
 def create_table_s_no_ck(dynamodb, dynamodbstreams, type):
-    table = create_test_table(dynamodb,
+    table = create_test_table(
+        dynamodb,
         Tags=TAGS,
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
-        StreamSpecification={ 'StreamEnabled': True, 'StreamViewType': type })
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+        StreamSpecification={"StreamEnabled": True, "StreamViewType": type},
+    )
     (arn, label) = wait_for_active_stream(dynamodbstreams, table, timeout=60)
     yield table, arn
     table.delete()
+
 
 @pytest.fixture(scope="function")
 def test_table_sss_new_and_old_images_lsi(dynamodb, dynamodbstreams):
-    yield from create_table_sss_lsi(dynamodb, dynamodbstreams, 'NEW_AND_OLD_IMAGES')
+    yield from create_table_sss_lsi(dynamodb, dynamodbstreams, "NEW_AND_OLD_IMAGES")
+
 
 @pytest.fixture(scope="function")
 def test_table_ss_keys_only(dynamodb, dynamodbstreams):
-    with create_table_ss(dynamodb, dynamodbstreams, 'KEYS_ONLY') as stream:
+    with create_table_ss(dynamodb, dynamodbstreams, "KEYS_ONLY") as stream:
         yield stream
+
 
 @pytest.fixture(scope="function")
 def test_table_ss_new_image(dynamodb, dynamodbstreams):
-    with create_table_ss(dynamodb, dynamodbstreams, 'NEW_IMAGE') as stream:
+    with create_table_ss(dynamodb, dynamodbstreams, "NEW_IMAGE") as stream:
         yield stream
+
 
 @pytest.fixture(scope="function")
 def test_table_ss_old_image(dynamodb, dynamodbstreams):
-    with create_table_ss(dynamodb, dynamodbstreams, 'OLD_IMAGE') as stream:
+    with create_table_ss(dynamodb, dynamodbstreams, "OLD_IMAGE") as stream:
         yield stream
+
 
 @pytest.fixture(scope="function")
 def test_table_ss_new_and_old_images(dynamodb, dynamodbstreams):
-    with create_table_ss(dynamodb, dynamodbstreams, 'NEW_AND_OLD_IMAGES') as stream:
+    with create_table_ss(dynamodb, dynamodbstreams, "NEW_AND_OLD_IMAGES") as stream:
         yield stream
+
 
 @pytest.fixture(scope="function")
 def test_table_s_no_ck_keys_only(dynamodb, dynamodbstreams):
-    yield from create_table_s_no_ck(dynamodb, dynamodbstreams, 'KEYS_ONLY')
+    yield from create_table_s_no_ck(dynamodb, dynamodbstreams, "KEYS_ONLY")
+
 
 @pytest.fixture(scope="function")
 def test_table_s_no_ck_new_image(dynamodb, dynamodbstreams):
-    yield from create_table_s_no_ck(dynamodb, dynamodbstreams, 'NEW_IMAGE')
+    yield from create_table_s_no_ck(dynamodb, dynamodbstreams, "NEW_IMAGE")
+
 
 @pytest.fixture(scope="function")
 def test_table_s_no_ck_old_image(dynamodb, dynamodbstreams):
-    yield from create_table_s_no_ck(dynamodb, dynamodbstreams, 'OLD_IMAGE')
+    yield from create_table_s_no_ck(dynamodb, dynamodbstreams, "OLD_IMAGE")
+
 
 @pytest.fixture(scope="function")
 def test_table_s_no_ck_new_and_old_images(dynamodb, dynamodbstreams):
-    yield from create_table_s_no_ck(dynamodb, dynamodbstreams, 'NEW_AND_OLD_IMAGES')
+    yield from create_table_s_no_ck(dynamodb, dynamodbstreams, "NEW_AND_OLD_IMAGES")
+
 
 # Test that it is, sadly, not allowed to use UpdateTable on a table which
 # already has a stream enabled to change that stream's StreamViewType.
 # Relates to #6939
 def test_streams_change_type(test_table_ss_keys_only):
     table, arn = test_table_ss_keys_only
-    with pytest.raises(ClientError, match='ValidationException.*already'):
-        table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'OLD_IMAGE'});
+    with pytest.raises(ClientError, match="ValidationException.*already"):
+        table.update(
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "OLD_IMAGE"}
+        )
         # If the above change succeeded (because of issue #6939), switch it back :-)
-        table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'});
+        table.update(
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"}
+        )
+
 
 # It is not allowed to enable stream for a table that already has a stream,
 # even if of the same type.
 def test_streams_enable_on_enabled(test_table_ss_new_and_old_images):
     table, arn = test_table_ss_new_and_old_images
-    with pytest.raises(ClientError, match='ValidationException.*already.*enabled'):
-        table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'NEW_AND_OLD_IMAGES'});
+    with pytest.raises(ClientError, match="ValidationException.*already.*enabled"):
+        table.update(
+            StreamSpecification={
+                "StreamEnabled": True,
+                "StreamViewType": "NEW_AND_OLD_IMAGES",
+            }
+        )
+
 
 # It is not allowed to disbale stream on a table that does not have a stream.
 def test_streams_disable_on_disabled(test_table):
-    with pytest.raises(ClientError, match='ValidationException.*stream.*disable'):
-        test_table.update(StreamSpecification={'StreamEnabled': False});
+    with pytest.raises(ClientError, match="ValidationException.*stream.*disable"):
+        test_table.update(StreamSpecification={"StreamEnabled": False})
+
 
 # Utility function for listing all the shards of the given stream arn.
 # Implemented by multiple calls to DescribeStream, possibly several pages
@@ -599,18 +757,23 @@ def list_shards(dynamodbstreams, arn):
     # 32 (16 vnodes x 2 cpus), see issue #6979, so to still exercise this
     # paging feature, lets use a limit of 10.
     limit = 10
-    response = dynamodbstreams.describe_stream(StreamArn=arn, Limit=limit)['StreamDescription']
-    assert len(response['Shards']) <= limit
-    shards = [x['ShardId'] for x in response['Shards']]
-    while 'LastEvaluatedShardId' in response:
+    response = dynamodbstreams.describe_stream(StreamArn=arn, Limit=limit)[
+        "StreamDescription"
+    ]
+    assert len(response["Shards"]) <= limit
+    shards = [x["ShardId"] for x in response["Shards"]]
+    while "LastEvaluatedShardId" in response:
         # 7409 kinesis ignores LastEvaluatedShardId and just looks at last shard
-        assert shards[-1] == response['LastEvaluatedShardId']
-        response = dynamodbstreams.describe_stream(StreamArn=arn, Limit=limit,
-            ExclusiveStartShardId=response['LastEvaluatedShardId'])['StreamDescription']
-        assert len(response['Shards']) <= limit
-        shards.extend([x['ShardId'] for x in response['Shards']])
+        assert shards[-1] == response["LastEvaluatedShardId"]
+        response = dynamodbstreams.describe_stream(
+            StreamArn=arn,
+            Limit=limit,
+            ExclusiveStartShardId=response["LastEvaluatedShardId"],
+        )["StreamDescription"]
+        assert len(response["Shards"]) <= limit
+        shards.extend([x["ShardId"] for x in response["Shards"]])
 
-    print('Number of shards in stream: {}'.format(len(shards)))
+    print("Number of shards in stream: {}".format(len(shards)))
     assert len(set(shards)) == len(shards)
     # 7409 - kinesis required shards to be in lexical order.
     # verify.
@@ -618,30 +781,43 @@ def list_shards(dynamodbstreams, arn):
 
     # special test: ensure we get nothing more if we ask for starting at the last
     # of the last
-    response = dynamodbstreams.describe_stream(StreamArn=arn,
-        ExclusiveStartShardId=shards[-1])['StreamDescription']
-    assert len(response['Shards']) == 0
+    response = dynamodbstreams.describe_stream(
+        StreamArn=arn, ExclusiveStartShardId=shards[-1]
+    )["StreamDescription"]
+    assert len(response["Shards"]) == 0
 
     return shards
+
 
 # Utility function for getting shard iterators starting at "LATEST" for
 # all the shards of the given stream arn.
 def latest_iterators(dynamodbstreams, arn):
     iterators = []
     for shard_id in list_shards(dynamodbstreams, arn):
-        iterators.append(dynamodbstreams.get_shard_iterator(StreamArn=arn,
-            ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator'])
+        iterators.append(
+            dynamodbstreams.get_shard_iterator(
+                StreamArn=arn, ShardId=shard_id, ShardIteratorType="LATEST"
+            )["ShardIterator"]
+        )
     assert len(set(iterators)) == len(iterators)
     return iterators
+
 
 # Similar to latest_iterators(), just also returns the shard id which produced
 # each iterator.
 def shards_and_latest_iterators(dynamodbstreams, arn):
     shards_and_iterators = []
     for shard_id in list_shards(dynamodbstreams, arn):
-        shards_and_iterators.append((shard_id, dynamodbstreams.get_shard_iterator(StreamArn=arn,
-            ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']))
+        shards_and_iterators.append(
+            (
+                shard_id,
+                dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn, ShardId=shard_id, ShardIteratorType="LATEST"
+                )["ShardIterator"],
+            )
+        )
     return shards_and_iterators
+
 
 # Utility function for fetching more content from the stream (given its
 # array of iterators) into an "output" array. Call repeatedly to get more
@@ -653,22 +829,28 @@ def fetch_more(dynamodbstreams, iterators, output):
     new_iterators = []
     for iter in iterators:
         response = dynamodbstreams.get_records(ShardIterator=iter)
-        if 'NextShardIterator' in response:
-            new_iterators.append(response['NextShardIterator'])
-        output.extend(response['Records'])
+        if "NextShardIterator" in response:
+            new_iterators.append(response["NextShardIterator"])
+        output.extend(response["Records"])
     assert len(set(new_iterators)) == len(new_iterators)
     return new_iterators
 
+
 def print_events(expected_events, output, failed_at=None):
     if failed_at is None:
-        print(f'compare_events: timeouted')
+        print(f"compare_events: timeouted")
     else:
-        print(f'compare_events: failed at output event {failed_at}')
+        print(f"compare_events: failed at output event {failed_at}")
     for index, event in enumerate(expected_events):
         expected_type, expected_key, expected_old_image, expected_new_image = event
-        print(f'expected event {index}: type={expected_type}, key={expected_key}, old_image={expected_old_image}, new_image={expected_new_image}')
+        print(
+            f"expected event {index}: type={expected_type}, key={expected_key}, old_image={expected_old_image}, new_image={expected_new_image}"
+        )
     for index, event in enumerate(output):
-        print(f'output event {index}: type={event["eventName"]}, key={event["dynamodb"]["Keys"]}, old_image={event["dynamodb"].get("OldImage")}, new_image={event["dynamodb"].get("NewImage")}')
+        print(
+            f"output event {index}: type={event['eventName']}, key={event['dynamodb']['Keys']}, old_image={event['dynamodb'].get('OldImage')}, new_image={event['dynamodb'].get('NewImage')}"
+        )
+
 
 # Utility function for comparing "output" as fetched by fetch_more(), to a list
 # expected_events, each of which looks like:
@@ -706,71 +888,85 @@ def compare_events(expected_events, output, mode, expected_region):
         try:
             # In DynamoDB, eventSource is 'aws:dynamodb'. We decided to set it to
             # a *different* value - 'scylladb:alternator'. Issue #6931.
-            assert 'eventSource' in event
+            assert "eventSource" in event
             # For lack of a direct equivalent of a region, Alternator provides the
             # DC name instead. Reproduces #6931.
-            assert 'awsRegion' in event
-            assert event['awsRegion'] == expected_region
+            assert "awsRegion" in event
+            assert event["awsRegion"] == expected_region
             # Reproduces #6931.
-            assert 'eventVersion' in event
-            assert event['eventVersion'] in ['1.0', '1.1']
+            assert "eventVersion" in event
+            assert event["eventVersion"] in ["1.0", "1.1"]
             # Check that eventID appears, but can't check much on what it is.
-            assert 'eventID' in event
-            op = event['eventName']
-            record = event['dynamodb']
+            assert "eventID" in event
+            op = event["eventName"]
+            record = event["dynamodb"]
             # record['Keys'] is "serialized" JSON, ({'S', 'thestring'}), so we
             # want to deserialize it to match our expected_events content.
             deserializer = TypeDeserializer()
-            key = {x:deserializer.deserialize(y) for (x,y) in record['Keys'].items()}
-            expected_type, expected_key, expected_old_image, expected_new_image = expected_events_map[freeze(key)].pop(0)
+            key = {x: deserializer.deserialize(y) for (x, y) in record["Keys"].items()}
+            expected_type, expected_key, expected_old_image, expected_new_image = (
+                expected_events_map[freeze(key)].pop(0)
+            )
             assert op == expected_type
-            assert record['StreamViewType'] == mode
+            assert record["StreamViewType"] == mode
             # We don't know what ApproximateCreationDateTime should be, but we do
             # know it needs to be a timestamp - there is conflicting documentation
             # in what format (ISO 8601?). In any case, boto3 parses this timestamp
             # for us, so we can't check it here, beyond checking it exists.
-            assert 'ApproximateCreationDateTime' in record
+            assert "ApproximateCreationDateTime" in record
             # We don't know what SequenceNumber is supposed to be, but the DynamoDB
             # documentation requires that it contains only numeric characters and
             # some libraries rely on this. This reproduces issue #7158:
-            assert 'SequenceNumber' in record
-            assert record['SequenceNumber'].isdecimal()
+            assert "SequenceNumber" in record
+            assert record["SequenceNumber"].isdecimal()
             # Alternator doesn't set the SizeBytes member. Issue #6931.
-            #assert 'SizeBytes' in record
-            if mode == 'KEYS_ONLY':
-                assert not 'NewImage' in record
-                assert not 'OldImage' in record
-            elif mode == 'NEW_IMAGE':
-                assert not 'OldImage' in record
+            # assert 'SizeBytes' in record
+            if mode == "KEYS_ONLY":
+                assert not "NewImage" in record
+                assert not "OldImage" in record
+            elif mode == "NEW_IMAGE":
+                assert not "OldImage" in record
                 if expected_new_image == None:
-                    assert not 'NewImage' in record
+                    assert not "NewImage" in record
                 else:
-                    new_image = {x:deserializer.deserialize(y) for (x,y) in record['NewImage'].items()}
+                    new_image = {
+                        x: deserializer.deserialize(y)
+                        for (x, y) in record["NewImage"].items()
+                    }
                     assert expected_new_image == new_image
-            elif mode == 'OLD_IMAGE':
-                assert not 'NewImage' in record
+            elif mode == "OLD_IMAGE":
+                assert not "NewImage" in record
                 if expected_old_image == None:
-                    assert not 'OldImage' in record
+                    assert not "OldImage" in record
                 else:
-                    old_image = {x:deserializer.deserialize(y) for (x,y) in record['OldImage'].items()}
+                    old_image = {
+                        x: deserializer.deserialize(y)
+                        for (x, y) in record["OldImage"].items()
+                    }
                     assert expected_old_image == old_image
-            elif mode == 'NEW_AND_OLD_IMAGES':
+            elif mode == "NEW_AND_OLD_IMAGES":
                 if expected_new_image == None:
-                    assert not 'NewImage' in record
+                    assert not "NewImage" in record
                 else:
-                    new_image = {x:deserializer.deserialize(y) for (x,y) in record['NewImage'].items()}
+                    new_image = {
+                        x: deserializer.deserialize(y)
+                        for (x, y) in record["NewImage"].items()
+                    }
                     assert expected_new_image == new_image
                 if expected_old_image == None:
-                    assert not 'OldImage' in record
+                    assert not "OldImage" in record
                 else:
-                    old_image = {x:deserializer.deserialize(y) for (x,y) in record['OldImage'].items()}
+                    old_image = {
+                        x: deserializer.deserialize(y)
+                        for (x, y) in record["OldImage"].items()
+                    }
                     assert expected_old_image == old_image
             else:
-                pytest.fail('cannot happen')
+                pytest.fail("cannot happen")
         except AssertionError:
             print_events(expected_events, output, failed_at=e)
             raise
-            
+
     # After the above loop, expected_events_map should remain empty arrays.
     # If it isn't, one of the expected events did not yet happen. Return False.
     for entry in expected_events_map.values():
@@ -778,7 +974,10 @@ def compare_events(expected_events, output, mode, expected_region):
             return False
     return True
 
-def fetch_and_compare_events(dynamodb, dynamodbstreams, iterators, expected_events, mode):
+
+def fetch_and_compare_events(
+    dynamodb, dynamodbstreams, iterators, expected_events, mode
+):
     # Updating the stream is asynchronous. Moreover, it may even be delayed
     # artificially (see Alternator's alternator_streams_time_window_s config).
     # So if compare_events() reports the stream data is missing some of the
@@ -793,87 +992,163 @@ def fetch_and_compare_events(dynamodb, dynamodbstreams, iterators, expected_even
     output = []
     while time.time() < timeout:
         iterators = fetch_more(dynamodbstreams, iterators, output)
-        print("after fetch_more number expected_events={}, output={}".format(len(expected_events), len(output)))
+        print(
+            "after fetch_more number expected_events={}, output={}".format(
+                len(expected_events), len(output)
+            )
+        )
         if compare_events(expected_events, output, mode, region):
             # success!
             return
         time.sleep(0.5)
     # If we're still here, the last compare_events returned false.
     print_events(expected_events, output)
-    pytest.fail('missing events in output: {}'.format(output))
+    pytest.fail("missing events in output: {}".format(output))
+
 
 # Convenience function used to implement several tests below. It runs a given
 # function "updatefunc" which is supposed to do some updates to the table
 # and also return an expected_events list. do_test() then fetches the streams
 # data and compares it to the expected_events using compare_events().
-def do_test(test_table_ss_stream, dynamodb, dynamodbstreams, updatefunc, mode, p = random_string(), c = random_string()):
+def do_test(
+    test_table_ss_stream,
+    dynamodb,
+    dynamodbstreams,
+    updatefunc,
+    mode,
+    p=random_string(),
+    c=random_string(),
+):
     table, arn = test_table_ss_stream
     iterators = latest_iterators(dynamodbstreams, arn)
     expected_events = updatefunc(table, p, c)
-    fetch_and_compare_events(dynamodb, dynamodbstreams, iterators, expected_events, mode)
+    fetch_and_compare_events(
+        dynamodb, dynamodbstreams, iterators, expected_events, mode
+    )
 
-def do_batch_test(test_table_ss_stream, dynamodb, dynamodbstreams, updatefunc, mode, item_count = 3):
+
+def do_batch_test(
+    test_table_ss_stream, dynamodb, dynamodbstreams, updatefunc, mode, item_count=3
+):
     p = [random_string() for _ in range(item_count)]
     c = [f"ck_{i}" for i in range(item_count)]
 
     table, arn = test_table_ss_stream
     iterators = latest_iterators(dynamodbstreams, arn)
     expected_events = updatefunc(table, p, c)
-    fetch_and_compare_events(dynamodb, dynamodbstreams, iterators, expected_events, mode)
+    fetch_and_compare_events(
+        dynamodb, dynamodbstreams, iterators, expected_events, mode
+    )
+
 
 # Test a single PutItem of a new item. Should result in a single INSERT
 # event. Reproduces #6930.
 def test_streams_putitem_keys_only(test_table_ss_keys_only, dynamodb, dynamodbstreams):
     def do_updates(table, p, c):
         events = []
-        table.put_item(Item={'p': p, 'c': c, 'x': 2})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2}])
+        table.put_item(Item={"p": p, "c": c, "x": 2})
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2}])
         return events
-    do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
+
+    do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, "KEYS_ONLY")
+
 
 # Replacing an item should result in a MODIFY, rather than REMOVE and MODIFY.
 # Moreover, the old item should be visible in OldImage. Reproduces #6930.
-def test_streams_putitem_new_items_override_old(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+def test_streams_putitem_new_items_override_old(
+    test_table_ss_new_and_old_images, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, c):
         events = []
-        table.put_item(Item={'p': p, 'c': c, 'a': 1})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'a': 1}])
-        table.put_item(Item={'p': p, 'c': c, 'b': 2})
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'a': 1}, {'p': p, 'c': c, 'b': 2}])
-        table.put_item(Item={'p': p, 'c': c, 'a': 3, 'b': 4})
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'b': 2}, {'p': p, 'c': c, 'a': 3, 'b': 4}])
-        table.put_item(Item={'p': p, 'c': c})
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'a': 3, 'b': 4}, {'p': p, 'c': c}])
+        table.put_item(Item={"p": p, "c": c, "a": 1})
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "a": 1}])
+        table.put_item(Item={"p": p, "c": c, "b": 2})
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "a": 1},
+                {"p": p, "c": c, "b": 2},
+            ]
+        )
+        table.put_item(Item={"p": p, "c": c, "a": 3, "b": 4})
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "b": 2},
+                {"p": p, "c": c, "a": 3, "b": 4},
+            ]
+        )
+        table.put_item(Item={"p": p, "c": c})
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "a": 3, "b": 4},
+                {"p": p, "c": c},
+            ]
+        )
         return events
-    do_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    do_test(
+        test_table_ss_new_and_old_images,
+        dynamodb,
+        dynamodbstreams,
+        do_updates,
+        "NEW_AND_OLD_IMAGES",
+    )
+
 
 # Same as test_streams_putitem_new_items_overrides_old, but for a replaced
 # column is used in LSI. Reproduces #6930.
-def test_streams_putitem_new_item_overrides_old_lsi(test_table_sss_new_and_old_images_lsi, dynamodb, dynamodbstreams):
+def test_streams_putitem_new_item_overrides_old_lsi(
+    test_table_sss_new_and_old_images_lsi, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, c):
         events = []
-        table.put_item(Item={'p': p, 'c': c, 'a': '1'})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'a': '1'}])
-        table.put_item(Item={'p': p, 'c': c})
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'a': '1'}, {'p': p, 'c': c}])
-        assert len(full_scan(table, IndexName='a_idx')) == 0
+        table.put_item(Item={"p": p, "c": c, "a": "1"})
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "a": "1"}])
+        table.put_item(Item={"p": p, "c": c})
+        events.append(
+            ["MODIFY", {"p": p, "c": c}, {"p": p, "c": c, "a": "1"}, {"p": p, "c": c}]
+        )
+        assert len(full_scan(table, IndexName="a_idx")) == 0
         return events
-    do_test(test_table_sss_new_and_old_images_lsi, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    do_test(
+        test_table_sss_new_and_old_images_lsi,
+        dynamodb,
+        dynamodbstreams,
+        do_updates,
+        "NEW_AND_OLD_IMAGES",
+    )
+
 
 # Test PutItem streams in a table with no clustering key.
-def test_streams_putitem_no_ck_new_items_override_old(test_table_s_no_ck_new_and_old_images, dynamodb, dynamodbstreams):
+def test_streams_putitem_no_ck_new_items_override_old(
+    test_table_s_no_ck_new_and_old_images, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, _):
         events = []
-        table.put_item(Item={'p': p, 'a': 1})
-        events.append(['INSERT', {'p': p}, None, {'p': p, 'a': 1}])
-        table.put_item(Item={'p': p, 'b': 2})
-        events.append(['MODIFY', {'p': p}, {'p': p, 'a': 1}, {'p': p, 'b': 2}])
-        table.put_item(Item={'p': p, 'a': 3, 'b': 4})
-        events.append(['MODIFY', {'p': p}, {'p': p, 'b': 2}, {'p': p, 'a': 3, 'b': 4}])
-        table.put_item(Item={'p': p})
-        events.append(['MODIFY', {'p': p}, {'p': p, 'a': 3, 'b': 4}, {'p': p}])
+        table.put_item(Item={"p": p, "a": 1})
+        events.append(["INSERT", {"p": p}, None, {"p": p, "a": 1}])
+        table.put_item(Item={"p": p, "b": 2})
+        events.append(["MODIFY", {"p": p}, {"p": p, "a": 1}, {"p": p, "b": 2}])
+        table.put_item(Item={"p": p, "a": 3, "b": 4})
+        events.append(["MODIFY", {"p": p}, {"p": p, "b": 2}, {"p": p, "a": 3, "b": 4}])
+        table.put_item(Item={"p": p})
+        events.append(["MODIFY", {"p": p}, {"p": p, "a": 3, "b": 4}, {"p": p}])
         return events
-    do_test(test_table_s_no_ck_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    do_test(
+        test_table_s_no_ck_new_and_old_images,
+        dynamodb,
+        dynamodbstreams,
+        do_updates,
+        "NEW_AND_OLD_IMAGES",
+    )
+
 
 # In test_streams_new_and_old_images among other things we test that a
 # DeleteItem operation gives the correct old image. That test used a table
@@ -884,45 +1159,85 @@ def test_streams_putitem_no_ck_new_items_override_old(test_table_s_no_ck_new_and
 # differently by CDC. In issue #26382 - which this test reproduces - we
 # discovered that our implementation doesn't select a preimage for partition
 # deletions, resulting in a missing OldImage.
-def test_streams_deleteitem_old_image_no_ck(test_table_s_no_ck_new_and_old_images, test_table_s_no_ck_old_image, dynamodb, dynamodbstreams):
+def test_streams_deleteitem_old_image_no_ck(
+    test_table_s_no_ck_new_and_old_images,
+    test_table_s_no_ck_old_image,
+    dynamodb,
+    dynamodbstreams,
+):
     def do_updates(table, p, _):
         events = []
-        table.update_item(Key={'p': p},
-            AttributeUpdates={'x': {'Value': 1, 'Action': 'PUT'}})
-        events.append(['INSERT', {'p': p}, None, {'p': p, 'x': 1}])
-        table.delete_item(Key={'p': p})
-        events.append(['REMOVE', {'p': p}, {'p': p, 'x': 1}, None])
+        table.update_item(
+            Key={"p": p}, AttributeUpdates={"x": {"Value": 1, "Action": "PUT"}}
+        )
+        events.append(["INSERT", {"p": p}, None, {"p": p, "x": 1}])
+        table.delete_item(Key={"p": p})
+        events.append(["REMOVE", {"p": p}, {"p": p, "x": 1}, None])
         return events
-    do_test(test_table_s_no_ck_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
-    do_test(test_table_s_no_ck_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    do_test(
+        test_table_s_no_ck_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE"
+    )
+    do_test(
+        test_table_s_no_ck_new_and_old_images,
+        dynamodb,
+        dynamodbstreams,
+        do_updates,
+        "NEW_AND_OLD_IMAGES",
+    )
+
 
 # Test a single UpdateItem. Should result in a single INSERT event.
 # Reproduces #6918.
-def test_streams_updateitem_keys_only(test_table_ss_keys_only, dynamodb, dynamodbstreams):
+def test_streams_updateitem_keys_only(
+    test_table_ss_keys_only, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, c):
         events = []
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 2})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2}])
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET x = :val1",
+            ExpressionAttributeValues={":val1": 2},
+        )
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2}])
         return events
-    do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
+
+    do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, "KEYS_ONLY")
+
 
 # Test OLD_IMAGE using UpdateItem. Verify that the OLD_IMAGE indeed includes,
 # as needed, the entire old item and not just the modified columns.
 # Reproduces issue #6935
-def test_streams_updateitem_old_image(test_table_ss_old_image, dynamodb, dynamodbstreams):
+def test_streams_updateitem_old_image(
+    test_table_ss_old_image, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, c):
         events = []
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 2})
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET x = :val1",
+            ExpressionAttributeValues={":val1": 2},
+        )
         # Note: The "None" as OldImage here tests that the OldImage should be
         # missing because the item didn't exist. This reproduces issue #6933.
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2}])
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET y = :val1', ExpressionAttributeValues={':val1': 3})
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 2}, {'p': p, 'c': c, 'x': 2, 'y': 3}])
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2}])
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET y = :val1",
+            ExpressionAttributeValues={":val1": 3},
+        )
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "x": 2},
+                {"p": p, "c": c, "x": 2, "y": 3},
+            ]
+        )
         return events
-    do_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
+
+    do_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE")
+
 
 # Above we verified that if an item did not previously exist, the OLD_IMAGE
 # would be missing, but if the item did previously exist, OLD_IMAGE should
@@ -931,19 +1246,28 @@ def test_streams_updateitem_old_image(test_table_ss_old_image, dynamodb, dynamod
 # key - in this case since the item did exist, OLD_IMAGE should be returned -
 # and include just the key. This is a special case of reproducing #6935 -
 # the first patch for this issue failed in this special case.
-def test_streams_updateitem_old_image_empty_item(test_table_ss_old_image, dynamodb, dynamodbstreams):
+def test_streams_updateitem_old_image_empty_item(
+    test_table_ss_old_image, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, c):
         events = []
         # Create an *empty* item, with nothing except a key:
-        table.update_item(Key={'p': p, 'c': c})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c}])
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET y = :val1', ExpressionAttributeValues={':val1': 3})
+        table.update_item(Key={"p": p, "c": c})
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c}])
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET y = :val1",
+            ExpressionAttributeValues={":val1": 3},
+        )
         # Note that OLD_IMAGE should be present and be the empty item,
         # with just a key, not entirely missing.
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c}, {'p': p, 'c': c, 'y': 3}])
+        events.append(
+            ["MODIFY", {"p": p, "c": c}, {"p": p, "c": c}, {"p": p, "c": c, "y": 3}]
+        )
         return events
-    do_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
+
+    do_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE")
+
 
 # Test that OLD_IMAGE indeed includes the entire old item and not just the
 # modified attributes, in the special case of attributes which are a key of
@@ -958,62 +1282,116 @@ def test_streams_updateitem_old_image_empty_item(test_table_ss_old_image, dynamo
 # OldImage (#6935) and the LSI key is also missing (#7030).
 @pytest.fixture(scope="function")
 def test_table_ss_old_image_and_lsi(dynamodb, dynamodbstreams):
-    table = create_test_table(dynamodb,
+    table = create_test_table(
+        dynamodb,
         Tags=TAGS,
         KeySchema=[
-            {'AttributeName': 'p', 'KeyType': 'HASH'},
-            {'AttributeName': 'c', 'KeyType': 'RANGE'}],
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'c', 'AttributeType': 'S' },
-            { 'AttributeName': 'k', 'AttributeType': 'S' }],
-        LocalSecondaryIndexes=[{
-            'IndexName': 'index',
-            'KeySchema': [
-                {'AttributeName': 'p', 'KeyType': 'HASH'},
-                {'AttributeName': 'k', 'KeyType': 'RANGE'}],
-            'Projection': { 'ProjectionType': 'ALL' }
-        }],
-        StreamSpecification={ 'StreamEnabled': True, 'StreamViewType': 'OLD_IMAGE' })
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "k", "AttributeType": "S"},
+        ],
+        LocalSecondaryIndexes=[
+            {
+                "IndexName": "index",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "k", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        StreamSpecification={"StreamEnabled": True, "StreamViewType": "OLD_IMAGE"},
+    )
     (arn, label) = wait_for_active_stream(dynamodbstreams, table, timeout=60)
     yield table, arn
     table.delete()
 
-def test_streams_updateitem_old_image_lsi(test_table_ss_old_image_and_lsi, dynamodb, dynamodbstreams):
+
+def test_streams_updateitem_old_image_lsi(
+    test_table_ss_old_image_and_lsi, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, c):
         events = []
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET x = :x, k = :k',
-            ExpressionAttributeValues={':x': 2, ':k': 'dog'})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2, 'k': 'dog'}])
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET y = :y', ExpressionAttributeValues={':y': 3})
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET x = :x, k = :k",
+            ExpressionAttributeValues={":x": 2, ":k": "dog"},
+        )
+        events.append(
+            ["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2, "k": "dog"}]
+        )
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET y = :y",
+            ExpressionAttributeValues={":y": 3},
+        )
         # In issue #7030, the 'k' value was missing from the OldImage.
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 2, 'k': 'dog'}, {'p': p, 'c': c, 'x': 2, 'k': 'dog', 'y': 3}])
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "x": 2, "k": "dog"},
+                {"p": p, "c": c, "x": 2, "k": "dog", "y": 3},
+            ]
+        )
         return events
-    do_test(test_table_ss_old_image_and_lsi, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
+
+    do_test(
+        test_table_ss_old_image_and_lsi,
+        dynamodb,
+        dynamodbstreams,
+        do_updates,
+        "OLD_IMAGE",
+    )
+
 
 # This test is the same as the previous (test_streams_updateitem_old_image_lsi)
 # except that the *old* value of the LSI key k is missing. Since PR 8568, CDC
 # adds a special deleted$k marker for a missing column in the preimage, and
 # this test verifies that Alternator Streams doesn't put this extra marker in
 # its output.
-def test_streams_updateitem_old_image_lsi_missing_column(test_table_ss_old_image_and_lsi, dynamodb, dynamodbstreams):
+def test_streams_updateitem_old_image_lsi_missing_column(
+    test_table_ss_old_image_and_lsi, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, c):
         events = []
         # Note that we do *not* set the "k" attribute (the LSI key)
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET x = :x',
-            ExpressionAttributeValues={':x': 2})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2}])
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET y = :y', ExpressionAttributeValues={':y': 3})
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET x = :x",
+            ExpressionAttributeValues={":x": 2},
+        )
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2}])
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET y = :y",
+            ExpressionAttributeValues={":y": 3},
+        )
         # "k" should be missing from OldImage, because it wasn't set earlier.
         # Verify the events contain only the expected attributes - not some
         # internal markers like "deleted$k".
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 2}, {'p': p, 'c': c, 'x': 2, 'y': 3}])
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "x": 2},
+                {"p": p, "c": c, "x": 2, "y": 3},
+            ]
+        )
         return events
-    do_test(test_table_ss_old_image_and_lsi, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
+
+    do_test(
+        test_table_ss_old_image_and_lsi,
+        dynamodb,
+        dynamodbstreams,
+        do_updates,
+        "OLD_IMAGE",
+    )
+
 
 # In general, DynamoDB doesn't emit events if an operation is a nop. This test
 # test verifies that UpdateItem doesn't result in a log row when the updated
@@ -1021,27 +1399,59 @@ def test_streams_updateitem_old_image_lsi_missing_column(test_table_ss_old_image
 # Corresponding tests for PutItem are included in tests based on do_updates_1.
 # The case for a PutItem within a BatchWriteItem is tested in
 # test_streams_batch_overwrite_identical. Reproduces #6918.
-def test_streams_updateitem_identical(test_table_ss_keys_only, test_table_ss_new_image, test_table_ss_old_image, test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+def test_streams_updateitem_identical(
+    test_table_ss_keys_only,
+    test_table_ss_new_image,
+    test_table_ss_old_image,
+    test_table_ss_new_and_old_images,
+    dynamodb,
+    dynamodbstreams,
+):
     def do_updates(table, p, c):
         events = []
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET x = :x',
-            ExpressionAttributeValues={':x': 2})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2}])
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET x = :x",
+            ExpressionAttributeValues={":x": 2},
+        )
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2}])
         # Overwriting the old item with an identical new item shouldn't produce
         # any events.
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='ADD x :x',
-            ExpressionAttributeValues={':x': 0})
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET x = :x',
-            ExpressionAttributeValues={':x': 2})
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="ADD x :x",
+            ExpressionAttributeValues={":x": 0},
+        )
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET x = :x",
+            ExpressionAttributeValues={":x": 2},
+        )
         return events
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
-        do_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, 'NEW_IMAGE')
-        do_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
-        do_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, "KEYS_ONLY"
+        )
+        do_test(
+            test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, "NEW_IMAGE"
+        )
+        do_test(
+            test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE"
+        )
+        do_test(
+            test_table_ss_new_and_old_images,
+            dynamodb,
+            dynamodbstreams,
+            do_updates,
+            "NEW_AND_OLD_IMAGES",
+        )
+
 
 # The above test_streams_updateitem_identical tested that if we UpdateItem an
 # item changing an attribute to a value identical to the one it already has,
@@ -1050,62 +1460,144 @@ def test_streams_updateitem_identical(test_table_ss_keys_only, test_table_ss_new
 # different serialization (the map's elements are ordered differently).
 # Since the value is nevertheless the same, here too we expect not to see
 # a change event in the stream. Reproduces issue #27375.
-@pytest.mark.xfail(reason="issue #27375")
-def test_streams_updateitem_equal_but_not_identical(test_table_ss_keys_only, test_table_ss_new_image, test_table_ss_old_image, test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+@pytest.mark.xfail(
+    reason="Alternator streams may generate event even if item did not really change #27375"
+)
+def test_streams_updateitem_equal_but_not_identical(
+    test_table_ss_keys_only,
+    test_table_ss_new_image,
+    test_table_ss_old_image,
+    test_table_ss_new_and_old_images,
+    dynamodb,
+    dynamodbstreams,
+):
     def do_updates(table, p, c):
         events = []
         # We use manual_request() to let us be sure that we pass the JSON
         # values to the server in exactly the order we want to, without the
         # Python SDK possibly rearranging them.
         # Set x to be a map: {'dog': 1, 'cat': 2, 'mouse': 3}.
-        payload = '''{
-            "TableName": "''' + table.name + '''",
-            "Key": {"p": {"S": "''' + p + '''"}, "c": {"S": "''' + c + '''"}},
+        payload = (
+            '''{
+            "TableName": "'''
+            + table.name
+            + '''",
+            "Key": {"p": {"S": "'''
+            + p
+            + '''"}, "c": {"S": "'''
+            + c
+            + """"}},
             "UpdateExpression": "SET x = :x",
             "ExpressionAttributeValues": {":x": %s}
-            }'''
-        manual_request(dynamodb, 'UpdateItem',
-            payload % '{"M": {"dog": {"N": "1"}, "cat": {"N": "2"}, "mouse": {"N": "3"}}}')
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': {'dog': 1, 'cat': 2, 'mouse': 3}}])
+            }"""
+        )
+        manual_request(
+            dynamodb,
+            "UpdateItem",
+            payload
+            % '{"M": {"dog": {"N": "1"}, "cat": {"N": "2"}, "mouse": {"N": "3"}}}',
+        )
+        events.append(
+            [
+                "INSERT",
+                {"p": p, "c": c},
+                None,
+                {"p": p, "c": c, "x": {"dog": 1, "cat": 2, "mouse": 3}},
+            ]
+        )
         # Overwriting x an identical map item shouldn't produce any events,
         # so we won't add anything to the "events" list:
-        manual_request(dynamodb, 'UpdateItem',
-            payload % '{"M": {"dog": {"N": "1"}, "cat": {"N": "2"}, "mouse": {"N": "3"}}}')
+        manual_request(
+            dynamodb,
+            "UpdateItem",
+            payload
+            % '{"M": {"dog": {"N": "1"}, "cat": {"N": "2"}, "mouse": {"N": "3"}}}',
+        )
         # Now try to overwrite x with a map that has the same elements in
         # a different order. These two values, despite not being identical
         # in JSON form, should be considered equal and again no event should
         # be generated.
-        manual_request(dynamodb, 'UpdateItem',
-            payload % '{"M": {"cat": {"N": "2"}, "dog": {"N": "1"}, "mouse": {"N": "3"}}}')
+        manual_request(
+            dynamodb,
+            "UpdateItem",
+            payload
+            % '{"M": {"cat": {"N": "2"}, "dog": {"N": "1"}, "mouse": {"N": "3"}}}',
+        )
         return events
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
-        do_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, 'NEW_IMAGE')
-        do_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
-        do_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, "KEYS_ONLY"
+        )
+        do_test(
+            test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, "NEW_IMAGE"
+        )
+        do_test(
+            test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE"
+        )
+        do_test(
+            test_table_ss_new_and_old_images,
+            dynamodb,
+            dynamodbstreams,
+            do_updates,
+            "NEW_AND_OLD_IMAGES",
+        )
+
 
 # Tests that deleting a missing attribute with UpdateItem doesn't generate a
 # REMOVE event. Other cases are tested in test_streams_batch_delete_missing
 # and in tests based on do_updates_1. Reproduces #6918.
-def test_streams_updateitem_delete_missing(test_table_ss_keys_only, test_table_ss_new_image, test_table_ss_old_image, test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+def test_streams_updateitem_delete_missing(
+    test_table_ss_keys_only,
+    test_table_ss_new_image,
+    test_table_ss_old_image,
+    test_table_ss_new_and_old_images,
+    dynamodb,
+    dynamodbstreams,
+):
     def do_updates(table, p, c):
         events = []
         # Create an item
-        table.update_item(Key={'p': p, 'c': c},
-            AttributeUpdates={'x': {'Value': 1, 'Action': 'PUT'}})
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 1}])
+        table.update_item(
+            Key={"p": p, "c": c}, AttributeUpdates={"x": {"Value": 1, "Action": "PUT"}}
+        )
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 1}])
         # Deleting a missing attribute shouldn't produce any event for both
         # AttributeUpdates and UpdateExpression.
-        table.update_item(Key={'p': p, 'c': c},
-            AttributeUpdates={'y': {'Action': 'DELETE'}})
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='REMOVE z')
+        table.update_item(
+            Key={"p": p, "c": c}, AttributeUpdates={"y": {"Action": "DELETE"}}
+        )
+        table.update_item(Key={"p": p, "c": c}, UpdateExpression="REMOVE z")
         return events
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
-        do_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, 'NEW_IMAGE')
-        do_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
-        do_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, "KEYS_ONLY"
+        )
+        do_test(
+            test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, "NEW_IMAGE"
+        )
+        do_test(
+            test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE"
+        )
+        do_test(
+            test_table_ss_new_and_old_images,
+            dynamodb,
+            dynamodbstreams,
+            do_updates,
+            "NEW_AND_OLD_IMAGES",
+        )
+
 
 # Tests similar to the above tests for OLD_IMAGE, just for NEW_IMAGE mode.
 # Verify that the NEW_IMAGE includes the entire old item (including the key),
@@ -1115,26 +1607,47 @@ def test_streams_updateitem_delete_missing(test_table_ss_keys_only, test_table_s
 def test_streams_new_image(test_table_ss_new_image, dynamodb, dynamodbstreams):
     def do_updates(table, p, c):
         events = []
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 2})
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET x = :val1",
+            ExpressionAttributeValues={":val1": 2},
+        )
         # Confirm that when adding one attribute "x", the NewImage contains both
         # the new x, and the key columns (p and c).
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2}])
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2}])
         # Confirm that when adding just attribute "y", the NewImage will contain
         # all the attributes, including the old "x":
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET y = :val1', ExpressionAttributeValues={':val1': 3})
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 2}, {'p': p, 'c': c, 'x': 2, 'y': 3}])
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET y = :val1",
+            ExpressionAttributeValues={":val1": 3},
+        )
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "x": 2},
+                {"p": p, "c": c, "x": 2, "y": 3},
+            ]
+        )
         # Confirm that when deleting the columns x and y, the NewImage becomes
         # empty - but still exists and contains the key columns,
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='REMOVE x, y')
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 2, 'y': 3}, {'p': p, 'c': c}])
+        table.update_item(Key={"p": p, "c": c}, UpdateExpression="REMOVE x, y")
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "x": 2, "y": 3},
+                {"p": p, "c": c},
+            ]
+        )
         # Confirm that deleting the item results in a missing NewImage:
-        table.delete_item(Key={'p': p, 'c': c})
-        events.append(['REMOVE', {'p': p, 'c': c}, {'p': p, 'c': c}, None])
+        table.delete_item(Key={"p": p, "c": c})
+        events.append(["REMOVE", {"p": p, "c": c}, {"p": p, "c": c}, None])
         return events
-    do_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, 'NEW_IMAGE')
+
+    do_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, "NEW_IMAGE")
+
 
 # Test similar to the above test for NEW_IMAGE corner cases, but here for
 # NEW_AND_OLD_IMAGES mode.
@@ -1143,34 +1656,68 @@ def test_streams_new_image(test_table_ss_new_image, dynamodb, dynamodbstreams):
 # implementation of the combined mode has unique bugs, so it is worth testing
 # it separately.
 # Reproduces issue #7107.
-def test_streams_new_and_old_images(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+def test_streams_new_and_old_images(
+    test_table_ss_new_and_old_images, dynamodb, dynamodbstreams
+):
     def do_updates(table, p, c):
         events = []
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 2})
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET x = :val1",
+            ExpressionAttributeValues={":val1": 2},
+        )
         # The item doesn't yet exist, so OldImage is missing.
-        events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2}])
+        events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2}])
         # Confirm that when adding just attribute "y", the NewImage will contain
         # all the attributes, including the old "x". Also, OldImage contains the
         # key attributes, not just "x":
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET y = :val1', ExpressionAttributeValues={':val1': 3})
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 2}, {'p': p, 'c': c, 'x': 2, 'y': 3}])
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET y = :val1",
+            ExpressionAttributeValues={":val1": 3},
+        )
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "x": 2},
+                {"p": p, "c": c, "x": 2, "y": 3},
+            ]
+        )
         # Confirm that when deleting the attributes x and y, the NewImage becomes
         # empty - but still exists and contains the key attributes:
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='REMOVE x, y')
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 2, 'y': 3}, {'p': p, 'c': c}])
+        table.update_item(Key={"p": p, "c": c}, UpdateExpression="REMOVE x, y")
+        events.append(
+            [
+                "MODIFY",
+                {"p": p, "c": c},
+                {"p": p, "c": c, "x": 2, "y": 3},
+                {"p": p, "c": c},
+            ]
+        )
         # Confirm that when adding an attribute z to the empty item, OldItem is
         # not missing - it just contains only the key attributes:
-        table.update_item(Key={'p': p, 'c': c},
-            UpdateExpression='SET z = :val1', ExpressionAttributeValues={':val1': 4})
-        events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c}, {'p': p, 'c': c, 'z': 4}])
+        table.update_item(
+            Key={"p": p, "c": c},
+            UpdateExpression="SET z = :val1",
+            ExpressionAttributeValues={":val1": 4},
+        )
+        events.append(
+            ["MODIFY", {"p": p, "c": c}, {"p": p, "c": c}, {"p": p, "c": c, "z": 4}]
+        )
         # Confirm that deleting the item results in a missing NewImage:
-        table.delete_item(Key={'p': p, 'c': c})
-        events.append(['REMOVE', {'p': p, 'c': c}, {'p': p, 'c': c, 'z': 4}, None])
+        table.delete_item(Key={"p": p, "c": c})
+        events.append(["REMOVE", {"p": p, "c": c}, {"p": p, "c": c, "z": 4}, None])
         return events
-    do_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    do_test(
+        test_table_ss_new_and_old_images,
+        dynamodb,
+        dynamodbstreams,
+        do_updates,
+        "NEW_AND_OLD_IMAGES",
+    )
+
 
 # Test that when a stream shard has no data to read, GetRecords returns an
 # empty Records array - not a missing one. Reproduces issue #6926.
@@ -1178,14 +1725,22 @@ def test_streams_no_records(test_table_ss_keys_only, dynamodbstreams):
     table, arn = test_table_ss_keys_only
     # Get just one shard - any shard - and its LATEST iterator. Because it's
     # LATEST, there will be no data to read from this iterator.
-    shard = dynamodbstreams.describe_stream(StreamArn=arn, Limit=1)['StreamDescription']['Shards'][0]
-    shard_id = shard['ShardId']
-    iter = dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']
+    shard = dynamodbstreams.describe_stream(StreamArn=arn, Limit=1)[
+        "StreamDescription"
+    ]["Shards"][0]
+    shard_id = shard["ShardId"]
+    iter = dynamodbstreams.get_shard_iterator(
+        StreamArn=arn, ShardId=shard_id, ShardIteratorType="LATEST"
+    )["ShardIterator"]
     response = dynamodbstreams.get_records(ShardIterator=iter)
-    assert 'NextShardIterator' in response or 'EndingSequenceNumber' in shard['SequenceNumberRange']
-    assert 'Records' in response
+    assert (
+        "NextShardIterator" in response
+        or "EndingSequenceNumber" in shard["SequenceNumberRange"]
+    )
+    assert "Records" in response
     # We expect Records to be empty - there is no data at the LATEST iterator.
-    assert response['Records'] == []
+    assert response["Records"] == []
+
 
 # Test that after fetching the last result from a shard, we don't get it
 # yet again. Reproduces issue #6942.
@@ -1194,25 +1749,31 @@ def test_streams_last_result(test_table_ss_keys_only, dynamodbstreams):
     iterators = latest_iterators(dynamodbstreams, arn)
     # Do an UpdateItem operation that is expected to leave one event in the
     # stream.
-    table.update_item(Key={'p': random_string(), 'c': random_string()},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+    table.update_item(
+        Key={"p": random_string(), "c": random_string()},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
     # Eventually (we may need to retry this for a while), *one* of the
     # stream shards will return one event:
     timeout = time.time() + 15
     while time.time() < timeout:
         for iter in iterators:
             response = dynamodbstreams.get_records(ShardIterator=iter)
-            if 'Records' in response and response['Records'] != []:
+            if "Records" in response and response["Records"] != []:
                 # Found the shard with the data! Test that it only has
                 # one event and that if we try to read again, we don't
                 # get more data (this was issue #6942).
-                assert len(response['Records']) == 1
-                assert 'NextShardIterator' in response
-                response = dynamodbstreams.get_records(ShardIterator=response['NextShardIterator'])
-                assert response['Records'] == []
+                assert len(response["Records"]) == 1
+                assert "NextShardIterator" in response
+                response = dynamodbstreams.get_records(
+                    ShardIterator=response["NextShardIterator"]
+                )
+                assert response["Records"] == []
                 return
         time.sleep(0.5)
     pytest.fail("timed out")
+
 
 # In test_streams_last_result above we tested that there is no further events
 # after reading the only one. In this test we verify that if we *do* perform
@@ -1225,44 +1786,57 @@ def test_streams_another_result(test_table_ss_keys_only, dynamodbstreams):
     # stream.
     p = random_string()
     c = random_string()
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
     # Eventually, *one* of the stream shards will return one event:
     timeout = time.time() + 15
     while time.time() < timeout:
         for iter in iterators:
             response = dynamodbstreams.get_records(ShardIterator=iter)
-            if 'Records' in response and response['Records'] != []:
+            if "Records" in response and response["Records"] != []:
                 # Finally found the shard reporting the changes to this key
-                assert len(response['Records']) == 1
-                assert response['Records'][0]['dynamodb']['Keys']== {'p': {'S': p}, 'c': {'S': c}}
-                assert 'NextShardIterator' in response
-                iter = response['NextShardIterator']
+                assert len(response["Records"]) == 1
+                assert response["Records"][0]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert "NextShardIterator" in response
+                iter = response["NextShardIterator"]
                 # Found the shard with the data. It only has one event so if
                 # we try to read again, we find nothing (this is the same as
                 # what test_streams_last_result tests).
                 response = dynamodbstreams.get_records(ShardIterator=iter)
-                assert response['Records'] == []
-                assert 'NextShardIterator' in response
-                iter = response['NextShardIterator']
+                assert response["Records"] == []
+                assert "NextShardIterator" in response
+                iter = response["NextShardIterator"]
                 # Do another UpdateItem operation to the same key, so it is
                 # expected to write to the *same* shard:
-                table.update_item(Key={'p': p, 'c': c},
-                    UpdateExpression='SET x = :val2', ExpressionAttributeValues={':val2': 7})
+                table.update_item(
+                    Key={"p": p, "c": c},
+                    UpdateExpression="SET x = :val2",
+                    ExpressionAttributeValues={":val2": 7},
+                )
                 # Again we may need to wait for the event to appear on the stream:
                 timeout = time.time() + 15
                 while time.time() < timeout:
                     response = dynamodbstreams.get_records(ShardIterator=iter)
-                    if 'Records' in response and response['Records'] != []:
-                        assert len(response['Records']) == 1
-                        assert response['Records'][0]['dynamodb']['Keys']== {'p': {'S': p}, 'c': {'S': c}}
-                        assert 'NextShardIterator' in response
+                    if "Records" in response and response["Records"] != []:
+                        assert len(response["Records"]) == 1
+                        assert response["Records"][0]["dynamodb"]["Keys"] == {
+                            "p": {"S": p},
+                            "c": {"S": c},
+                        }
+                        assert "NextShardIterator" in response
                         # The test is done, successfully.
                         return
                     time.sleep(0.5)
                 pytest.fail("timed out")
         time.sleep(0.5)
     pytest.fail("timed out")
+
 
 # Test the SequenceNumber attribute returned for stream events, and the
 # "AT_SEQUENCE_NUMBER" iterator that can be used to re-read from the same
@@ -1274,41 +1848,57 @@ def test_streams_at_sequence_number(test_table_ss_keys_only, dynamodbstreams):
     # stream.
     p = random_string()
     c = random_string()
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
     # Eventually, *one* of the stream shards will return the one event:
     timeout = time.time() + 15
     while time.time() < timeout:
-        for (shard_id, iter) in shards_and_iterators:
+        for shard_id, iter in shards_and_iterators:
             response = dynamodbstreams.get_records(ShardIterator=iter)
-            if 'Records' in response and response['Records'] != []:
+            if "Records" in response and response["Records"] != []:
                 # Finally found the shard reporting the changes to this key:
-                assert len(response['Records']) == 1
-                assert response['Records'][0]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                assert 'NextShardIterator' in response
-                sequence_number = response['Records'][0]['dynamodb']['SequenceNumber']
+                assert len(response["Records"]) == 1
+                assert response["Records"][0]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert "NextShardIterator" in response
+                sequence_number = response["Records"][0]["dynamodb"]["SequenceNumber"]
                 # Found the shard with the data. It only has one event so if
                 # we try to read again, we find nothing (this is the same as
                 # what test_streams_last_result tests).
-                iter = response['NextShardIterator']
+                iter = response["NextShardIterator"]
                 response = dynamodbstreams.get_records(ShardIterator=iter)
-                assert response['Records'] == []
-                assert 'NextShardIterator' in response
+                assert response["Records"] == []
+                assert "NextShardIterator" in response
                 # If we use the SequenceNumber of the first event to create an
                 # AT_SEQUENCE_NUMBER iterator, we can read the same event again.
                 # We don't need a loop and a timeout, because this event is already
                 # available.
-                iter = dynamodbstreams.get_shard_iterator(StreamArn=arn,
-                    ShardId=shard_id, ShardIteratorType='AT_SEQUENCE_NUMBER',
-                    SequenceNumber=sequence_number)['ShardIterator']
+                iter = dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn,
+                    ShardId=shard_id,
+                    ShardIteratorType="AT_SEQUENCE_NUMBER",
+                    SequenceNumber=sequence_number,
+                )["ShardIterator"]
                 response = dynamodbstreams.get_records(ShardIterator=iter)
-                assert 'Records' in response
-                assert len(response['Records']) == 1
-                assert response['Records'][0]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                assert response['Records'][0]['dynamodb']['SequenceNumber'] == sequence_number
+                assert "Records" in response
+                assert len(response["Records"]) == 1
+                assert response["Records"][0]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert (
+                    response["Records"][0]["dynamodb"]["SequenceNumber"]
+                    == sequence_number
+                )
                 return
         time.sleep(0.5)
     pytest.fail("timed out")
+
 
 # Test the SequenceNumber attribute returned for stream events, and the
 # "AFTER_SEQUENCE_NUMBER" iterator that can be used to re-read *after* the same
@@ -1320,20 +1910,32 @@ def test_streams_after_sequence_number(test_table_ss_keys_only, dynamodbstreams)
     # two events in the stream.
     p = random_string()
     c = random_string()
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 3})
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 3},
+    )
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
     # Eventually, *one* of the stream shards will return the two events:
     timeout = time.time() + 15
     while time.time() < timeout:
-        for (shard_id, iter) in shards_and_iterators:
+        for shard_id, iter in shards_and_iterators:
             response = dynamodbstreams.get_records(ShardIterator=iter)
-            if 'Records' in response and len(response['Records']) == 2:
-                assert response['Records'][0]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                assert response['Records'][1]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                sequence_number_1 = response['Records'][0]['dynamodb']['SequenceNumber']
-                sequence_number_2 = response['Records'][1]['dynamodb']['SequenceNumber']
+            if "Records" in response and len(response["Records"]) == 2:
+                assert response["Records"][0]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert response["Records"][1]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                sequence_number_1 = response["Records"][0]["dynamodb"]["SequenceNumber"]
+                sequence_number_2 = response["Records"][1]["dynamodb"]["SequenceNumber"]
 
                 # #7424 - AWS sdk assumes sequence numbers can be compared
                 # as bigints, and are monotonically growing.
@@ -1343,17 +1945,27 @@ def test_streams_after_sequence_number(test_table_ss_keys_only, dynamodbstreams)
                 # AFTER_SEQUENCE_NUMBER iterator, we can read the second event
                 # (only) again. We don't need a loop and a timeout, because this
                 # event is already available.
-                iter = dynamodbstreams.get_shard_iterator(StreamArn=arn,
-                    ShardId=shard_id, ShardIteratorType='AFTER_SEQUENCE_NUMBER',
-                    SequenceNumber=sequence_number_1)['ShardIterator']
+                iter = dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn,
+                    ShardId=shard_id,
+                    ShardIteratorType="AFTER_SEQUENCE_NUMBER",
+                    SequenceNumber=sequence_number_1,
+                )["ShardIterator"]
                 response = dynamodbstreams.get_records(ShardIterator=iter)
-                assert 'Records' in response
-                assert len(response['Records']) == 1
-                assert response['Records'][0]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                assert response['Records'][0]['dynamodb']['SequenceNumber'] == sequence_number_2
+                assert "Records" in response
+                assert len(response["Records"]) == 1
+                assert response["Records"][0]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert (
+                    response["Records"][0]["dynamodb"]["SequenceNumber"]
+                    == sequence_number_2
+                )
                 return
         time.sleep(0.5)
     pytest.fail("timed out")
+
 
 # Test the "TRIM_HORIZON" iterator, which can be used to re-read *all* the
 # previously-read events of the stream shard again.
@@ -1367,20 +1979,32 @@ def test_streams_trim_horizon(test_table_ss_keys_only, dynamodbstreams):
     # two events in the stream.
     p = random_string()
     c = random_string()
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 3})
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 3},
+    )
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
     # Eventually, *one* of the stream shards will return the two events:
     timeout = time.time() + 15
     while time.time() < timeout:
-        for (shard_id, iter) in shards_and_iterators:
+        for shard_id, iter in shards_and_iterators:
             response = dynamodbstreams.get_records(ShardIterator=iter)
-            if 'Records' in response and len(response['Records']) == 2:
-                assert response['Records'][0]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                assert response['Records'][1]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                sequence_number_1 = response['Records'][0]['dynamodb']['SequenceNumber']
-                sequence_number_2 = response['Records'][1]['dynamodb']['SequenceNumber']
+            if "Records" in response and len(response["Records"]) == 2:
+                assert response["Records"][0]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert response["Records"][1]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                sequence_number_1 = response["Records"][0]["dynamodb"]["SequenceNumber"]
+                sequence_number_2 = response["Records"][1]["dynamodb"]["SequenceNumber"]
                 # If we use the TRIM_HORIZON iterator, we should receive the
                 # same two events again, in the same order.
                 # Note that we assume that the fixture gave us a brand new
@@ -1388,18 +2012,32 @@ def test_streams_trim_horizon(test_table_ss_keys_only, dynamodbstreams):
                 # couldn't assume this, this test would need to become much
                 # more complex, and would need to read from this shard until
                 # we find the two events we are looking for.
-                iter = dynamodbstreams.get_shard_iterator(StreamArn=arn,
-                    ShardId=shard_id, ShardIteratorType='TRIM_HORIZON')['ShardIterator']
+                iter = dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON"
+                )["ShardIterator"]
                 response = dynamodbstreams.get_records(ShardIterator=iter)
-                assert 'Records' in response
-                assert len(response['Records']) == 2
-                assert response['Records'][0]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                assert response['Records'][1]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                assert response['Records'][0]['dynamodb']['SequenceNumber'] == sequence_number_1
-                assert response['Records'][1]['dynamodb']['SequenceNumber'] == sequence_number_2
+                assert "Records" in response
+                assert len(response["Records"]) == 2
+                assert response["Records"][0]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert response["Records"][1]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert (
+                    response["Records"][0]["dynamodb"]["SequenceNumber"]
+                    == sequence_number_1
+                )
+                assert (
+                    response["Records"][1]["dynamodb"]["SequenceNumber"]
+                    == sequence_number_2
+                )
                 return
         time.sleep(0.5)
     pytest.fail("timed out")
+
 
 # Test the StartingSequenceNumber information returned by DescribeStream.
 # The DynamoDB documentation explains that StartingSequenceNumber is
@@ -1420,39 +2058,59 @@ def test_streams_starting_sequence_number(test_table_ss_keys_only, dynamodbstrea
     # two events in the stream.
     p = random_string()
     c = random_string()
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 3})
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 3},
+    )
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
     # Get for all the stream shards the iterator starting at the shard's
     # StartingSequenceNumber:
     response = dynamodbstreams.describe_stream(StreamArn=arn)
-    shards = response['StreamDescription']['Shards']
-    while 'LastEvaluatedShardId' in response['StreamDescription']:
-        response = dynamodbstreams.describe_stream(StreamArn=arn,
-            ExclusiveStartShardId=response['StreamDescription']['LastEvaluatedShardId'])
-        shards.extend(response['StreamDescription']['Shards'])
+    shards = response["StreamDescription"]["Shards"]
+    while "LastEvaluatedShardId" in response["StreamDescription"]:
+        response = dynamodbstreams.describe_stream(
+            StreamArn=arn,
+            ExclusiveStartShardId=response["StreamDescription"]["LastEvaluatedShardId"],
+        )
+        shards.extend(response["StreamDescription"]["Shards"])
     iterators = []
     for shard in shards:
-        shard_id = shard['ShardId']
-        start = shard['SequenceNumberRange']['StartingSequenceNumber']
+        shard_id = shard["ShardId"]
+        start = shard["SequenceNumberRange"]["StartingSequenceNumber"]
         assert start.isdecimal()
-        iterators.append(dynamodbstreams.get_shard_iterator(StreamArn=arn,
-            ShardId=shard_id, ShardIteratorType='AT_SEQUENCE_NUMBER',
-            SequenceNumber=start)['ShardIterator'])
+        iterators.append(
+            dynamodbstreams.get_shard_iterator(
+                StreamArn=arn,
+                ShardId=shard_id,
+                ShardIteratorType="AT_SEQUENCE_NUMBER",
+                SequenceNumber=start,
+            )["ShardIterator"]
+        )
 
     # Eventually, *one* of the stream shards will return the two events:
     timeout = time.time() + 15
     while time.time() < timeout:
         for iter in iterators:
             response = dynamodbstreams.get_records(ShardIterator=iter)
-            if 'Records' in response and len(response['Records']) == 2:
-                assert response['Records'][0]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
-                assert response['Records'][1]['dynamodb']['Keys'] == {'p': {'S': p}, 'c': {'S': c}}
+            if "Records" in response and len(response["Records"]) == 2:
+                assert response["Records"][0]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
+                assert response["Records"][1]["dynamodb"]["Keys"] == {
+                    "p": {"S": p},
+                    "c": {"S": c},
+                }
                 return
         time.sleep(0.5)
 
     pytest.fail("timed out")
+
 
 # Above we tested some specific operations in small tests aimed to reproduce
 # a specific bug, in the following tests we do a all the different operations,
@@ -1464,161 +2122,415 @@ def test_streams_starting_sequence_number(test_table_ss_keys_only, dynamodbstrea
 def do_updates_1(table, p, c):
     events = []
     # a first put_item appears as an INSERT event. Note also empty old_image.
-    table.put_item(Item={'p': p, 'c': c, 'x': 2})
-    events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 2}])
+    table.put_item(Item={"p": p, "c": c, "x": 2})
+    events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 2}])
     # a second put_item of the *same* key and same value, doesn't appear in the log at all!
-    table.put_item(Item={'p': p, 'c': c, 'x': 2})
+    table.put_item(Item={"p": p, "c": c, "x": 2})
     # a second put_item of the *same* key and different value, appears as a MODIFY event
-    table.put_item(Item={'p': p, 'c': c, 'y': 3})
-    events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 2}, {'p': p, 'c': c, 'y': 3}])
+    table.put_item(Item={"p": p, "c": c, "y": 3})
+    events.append(
+        ["MODIFY", {"p": p, "c": c}, {"p": p, "c": c, "x": 2}, {"p": p, "c": c, "y": 3}]
+    )
     # deleting an item appears as a REMOVE event. Note no new_image at all, but there is an old_image.
-    table.delete_item(Key={'p': p, 'c': c})
-    events.append(['REMOVE', {'p': p, 'c': c}, {'p': p, 'c': c, 'y': 3}, None])
+    table.delete_item(Key={"p": p, "c": c})
+    events.append(["REMOVE", {"p": p, "c": c}, {"p": p, "c": c, "y": 3}, None])
     # deleting a non-existent item doesn't appear in the log at all.
-    table.delete_item(Key={'p': p, 'c': c})
+    table.delete_item(Key={"p": p, "c": c})
     # If update_item creates an item, the event is INSERT as well.
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET b = :val1',
-        ExpressionAttributeValues={':val1': 4})
-    events.append(['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'b': 4}])
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET b = :val1",
+        ExpressionAttributeValues={":val1": 4},
+    )
+    events.append(["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "b": 4}])
     # If update_item modifies the item, note how old and new image includes both old and new columns
-    table.update_item(Key={'p': p, 'c': c},
-        UpdateExpression='SET x = :val1',
-        ExpressionAttributeValues={':val1': 5})
-    events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'b': 4}, {'p': p, 'c': c, 'b': 4, 'x': 5}])
+    table.update_item(
+        Key={"p": p, "c": c},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
+    events.append(
+        [
+            "MODIFY",
+            {"p": p, "c": c},
+            {"p": p, "c": c, "b": 4},
+            {"p": p, "c": c, "b": 4, "x": 5},
+        ]
+    )
     # TODO: incredibly, if we uncomment the "REMOVE b" update below, it will be
     # completely missing from the DynamoDB stream - the test continues to
     # pass even though we didn't add another expected event, and even though
     # the preimage in the following expected event includes this "b" we will
     # remove. I couldn't reproduce this apparent DynamoDB bug in a smaller test.
-    #table.update_item(Key={'p': p, 'c': c}, UpdateExpression='REMOVE b')
+    # table.update_item(Key={'p': p, 'c': c}, UpdateExpression='REMOVE b')
     # Test BatchWriteItem as well. This modifies the item, so will be a MODIFY event.
-    table.meta.client.batch_write_item(RequestItems = {table.name: [{'PutRequest': {'Item': {'p': p, 'c': c, 'x': 5}}}]})
-    events.append(['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'b': 4, 'x': 5}, {'p': p, 'c': c, 'x': 5}])
+    table.meta.client.batch_write_item(
+        RequestItems={table.name: [{"PutRequest": {"Item": {"p": p, "c": c, "x": 5}}}]}
+    )
+    events.append(
+        [
+            "MODIFY",
+            {"p": p, "c": c},
+            {"p": p, "c": c, "b": 4, "x": 5},
+            {"p": p, "c": c, "x": 5},
+        ]
+    )
     return events
+
 
 # The tested events are the same as in do_updates_1, but the table doesn't have
 # a clustering key.
 def do_updates_1_no_ck(table, p, _):
     events = []
     # a first put_item appears as an INSERT event. Note also empty old_image.
-    table.put_item(Item={'p': p, 'x': 2})
-    events.append(['INSERT', {'p': p}, None, {'p': p, 'x': 2}])
+    table.put_item(Item={"p": p, "x": 2})
+    events.append(["INSERT", {"p": p}, None, {"p": p, "x": 2}])
     # a second put_item of the *same* key and same value, doesn't appear in the log at all!
-    table.put_item(Item={'p': p, 'x': 2})
+    table.put_item(Item={"p": p, "x": 2})
     # a second put_item of the *same* key and different value, appears as a MODIFY event
-    table.put_item(Item={'p': p, 'y': 3})
-    events.append(['MODIFY', {'p': p}, {'p': p, 'x': 2}, {'p': p, 'y': 3}])
+    table.put_item(Item={"p": p, "y": 3})
+    events.append(["MODIFY", {"p": p}, {"p": p, "x": 2}, {"p": p, "y": 3}])
     # deleting an item appears as a REMOVE event. Note no new_image at all, but there is an old_image.
-    table.delete_item(Key={'p': p})
-    events.append(['REMOVE', {'p': p}, {'p': p, 'y': 3}, None])
+    table.delete_item(Key={"p": p})
+    events.append(["REMOVE", {"p": p}, {"p": p, "y": 3}, None])
     # deleting a non-existent item doesn't appear in the log at all.
-    table.delete_item(Key={'p': p})
+    table.delete_item(Key={"p": p})
     # If update_item creates an item, the event is INSERT as well.
-    table.update_item(Key={'p': p},
-        UpdateExpression='SET b = :val1',
-        ExpressionAttributeValues={':val1': 4})
-    events.append(['INSERT', {'p': p}, None, {'p': p, 'b': 4}])
+    table.update_item(
+        Key={"p": p},
+        UpdateExpression="SET b = :val1",
+        ExpressionAttributeValues={":val1": 4},
+    )
+    events.append(["INSERT", {"p": p}, None, {"p": p, "b": 4}])
     # If update_item modifies the item, note how old and new image includes both old and new columns
-    table.update_item(Key={'p': p},
-        UpdateExpression='SET x = :val1',
-        ExpressionAttributeValues={':val1': 5})
-    events.append(['MODIFY', {'p': p}, {'p': p, 'b': 4}, {'p': p, 'b': 4, 'x': 5}])
+    table.update_item(
+        Key={"p": p},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
+    events.append(["MODIFY", {"p": p}, {"p": p, "b": 4}, {"p": p, "b": 4, "x": 5}])
     # Test BatchWriteItem as well. This modifies the item, so will be a MODIFY event.
-    table.meta.client.batch_write_item(RequestItems = {table.name: [{'PutRequest': {'Item': {'p': p, 'x': 5}}}]})
-    events.append(['MODIFY', {'p': p}, {'p': p, 'b': 4, 'x': 5}, {'p': p, 'x': 5}])
+    table.meta.client.batch_write_item(
+        RequestItems={table.name: [{"PutRequest": {"Item": {"p": p, "x": 5}}}]}
+    )
+    events.append(["MODIFY", {"p": p}, {"p": p, "b": 4, "x": 5}, {"p": p, "x": 5}])
     return events
 
+
 def test_streams_1_keys_only(test_table_ss_keys_only, dynamodb, dynamodbstreams):
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates_1, 'KEYS_ONLY')
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_ss_keys_only,
+            dynamodb,
+            dynamodbstreams,
+            do_updates_1,
+            "KEYS_ONLY",
+        )
+
 
 def test_streams_1_new_image(test_table_ss_new_image, dynamodb, dynamodbstreams):
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates_1, 'NEW_IMAGE')
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_ss_new_image,
+            dynamodb,
+            dynamodbstreams,
+            do_updates_1,
+            "NEW_IMAGE",
+        )
+
 
 def test_streams_1_old_image(test_table_ss_old_image, dynamodb, dynamodbstreams):
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates_1, 'OLD_IMAGE')
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_ss_old_image,
+            dynamodb,
+            dynamodbstreams,
+            do_updates_1,
+            "OLD_IMAGE",
+        )
 
-def test_streams_1_new_and_old_images(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates_1, 'NEW_AND_OLD_IMAGES')
 
-def test_streams_1_no_ck_keys_only(test_table_s_no_ck_keys_only, dynamodb, dynamodbstreams):
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_s_no_ck_keys_only, dynamodb, dynamodbstreams, do_updates_1_no_ck, 'KEYS_ONLY')
+def test_streams_1_new_and_old_images(
+    test_table_ss_new_and_old_images, dynamodb, dynamodbstreams
+):
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_ss_new_and_old_images,
+            dynamodb,
+            dynamodbstreams,
+            do_updates_1,
+            "NEW_AND_OLD_IMAGES",
+        )
 
-def test_streams_1_no_ck_new_image(test_table_s_no_ck_new_image, dynamodb, dynamodbstreams):
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_s_no_ck_new_image, dynamodb, dynamodbstreams, do_updates_1_no_ck, 'NEW_IMAGE')
 
-def test_streams_1_no_ck_old_image(test_table_s_no_ck_old_image, dynamodb, dynamodbstreams):
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_s_no_ck_old_image, dynamodb, dynamodbstreams, do_updates_1_no_ck, 'OLD_IMAGE')
+def test_streams_1_no_ck_keys_only(
+    test_table_s_no_ck_keys_only, dynamodb, dynamodbstreams
+):
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_s_no_ck_keys_only,
+            dynamodb,
+            dynamodbstreams,
+            do_updates_1_no_ck,
+            "KEYS_ONLY",
+        )
 
-def test_streams_1_no_ck_new_and_old_images(test_table_s_no_ck_new_and_old_images, dynamodb, dynamodbstreams):
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_test(test_table_s_no_ck_new_and_old_images, dynamodb, dynamodbstreams, do_updates_1_no_ck, 'NEW_AND_OLD_IMAGES')
+
+def test_streams_1_no_ck_new_image(
+    test_table_s_no_ck_new_image, dynamodb, dynamodbstreams
+):
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_s_no_ck_new_image,
+            dynamodb,
+            dynamodbstreams,
+            do_updates_1_no_ck,
+            "NEW_IMAGE",
+        )
+
+
+def test_streams_1_no_ck_old_image(
+    test_table_s_no_ck_old_image, dynamodb, dynamodbstreams
+):
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_s_no_ck_old_image,
+            dynamodb,
+            dynamodbstreams,
+            do_updates_1_no_ck,
+            "OLD_IMAGE",
+        )
+
+
+def test_streams_1_no_ck_new_and_old_images(
+    test_table_s_no_ck_new_and_old_images, dynamodb, dynamodbstreams
+):
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_test(
+            test_table_s_no_ck_new_and_old_images,
+            dynamodb,
+            dynamodbstreams,
+            do_updates_1_no_ck,
+            "NEW_AND_OLD_IMAGES",
+        )
+
 
 # Tests that a DeleteItem within a BatchWriteItem that tries to remove a
-# missing item doesn't generate a REMOVE event. 
+# missing item doesn't generate a REMOVE event.
 # Reproduces #6918.
-def test_streams_batch_delete_missing(test_table_ss_keys_only, test_table_ss_new_image, test_table_ss_old_image, test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+def test_streams_batch_delete_missing(
+    test_table_ss_keys_only,
+    test_table_ss_new_image,
+    test_table_ss_old_image,
+    test_table_ss_new_and_old_images,
+    dynamodb,
+    dynamodbstreams,
+):
     def do_updates(table, ps, cs):
         # Deleting items that don't exist shouldn't produce any events.
-        table.meta.client.batch_write_item(RequestItems = {
-            table.name: [{'DeleteRequest': {'Key': {'p': p, 'c': c}}} for p, c in zip(ps, cs)]
-        })
+        table.meta.client.batch_write_item(
+            RequestItems={
+                table.name: [
+                    {"DeleteRequest": {"Key": {"p": p, "c": c}}} for p, c in zip(ps, cs)
+                ]
+            }
+        )
         return []
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_batch_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
-        do_batch_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, 'NEW_IMAGE')
-        do_batch_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
-        do_batch_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_batch_test(
+            test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, "KEYS_ONLY"
+        )
+        do_batch_test(
+            test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, "NEW_IMAGE"
+        )
+        do_batch_test(
+            test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE"
+        )
+        do_batch_test(
+            test_table_ss_new_and_old_images,
+            dynamodb,
+            dynamodbstreams,
+            do_updates,
+            "NEW_AND_OLD_IMAGES",
+        )
+
 
 # This test verifies that a PutItem within a BatchWriteItem generates no event
 # when it replaces an item with an identical one. This no-op behaviour is also
 # tested for a standard PutItem (see tests based on do_updates_1), and an
 # UpdateItem (see test_streams_updateitem_overwrite_identical). Reproduces
 # #6918.
-def test_streams_batch_overwrite_identical(test_table_ss_keys_only, test_table_ss_new_image, test_table_ss_old_image, test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+def test_streams_batch_overwrite_identical(
+    test_table_ss_keys_only,
+    test_table_ss_new_image,
+    test_table_ss_old_image,
+    test_table_ss_new_and_old_images,
+    dynamodb,
+    dynamodbstreams,
+):
     # Batch PutItem identical items
     def do_updates(table, ps, cs):
         # Emit a separate event for each item in the batch.
-        table.meta.client.batch_write_item(RequestItems = {
-            table.name: [{'PutRequest': {'Item': {'p': p, 'c': c, 'x': i}}} for p, c, i in zip(ps, cs, range(1, len(ps) + 1))]
-        })
-        events = [['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': i}] for p, c, i in zip(ps, cs, range(1, len(ps) + 1))]
+        table.meta.client.batch_write_item(
+            RequestItems={
+                table.name: [
+                    {"PutRequest": {"Item": {"p": p, "c": c, "x": i}}}
+                    for p, c, i in zip(ps, cs, range(1, len(ps) + 1))
+                ]
+            }
+        )
+        events = [
+            ["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": i}]
+            for p, c, i in zip(ps, cs, range(1, len(ps) + 1))
+        ]
         # Overwriting with identical items shouldn't produce any events
-        table.meta.client.batch_write_item(RequestItems = {
-            table.name: [{'PutRequest': {'Item': {'p': p, 'c': c, 'x': i}}} for p, c, i in zip(ps, cs, range(1, len(ps) + 1))]
-        })
+        table.meta.client.batch_write_item(
+            RequestItems={
+                table.name: [
+                    {"PutRequest": {"Item": {"p": p, "c": c, "x": i}}}
+                    for p, c, i in zip(ps, cs, range(1, len(ps) + 1))
+                ]
+            }
+        )
         return events
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_batch_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
-        do_batch_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, 'NEW_IMAGE')
-        do_batch_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
-        do_batch_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
 
-def test_streams_batch_overwrite_different(test_table_ss_keys_only, test_table_ss_new_image, test_table_ss_old_image, test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_batch_test(
+            test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, "KEYS_ONLY"
+        )
+        do_batch_test(
+            test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, "NEW_IMAGE"
+        )
+        do_batch_test(
+            test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE"
+        )
+        do_batch_test(
+            test_table_ss_new_and_old_images,
+            dynamodb,
+            dynamodbstreams,
+            do_updates,
+            "NEW_AND_OLD_IMAGES",
+        )
+
+
+def test_streams_batch_overwrite_different(
+    test_table_ss_keys_only,
+    test_table_ss_new_image,
+    test_table_ss_old_image,
+    test_table_ss_new_and_old_images,
+    dynamodb,
+    dynamodbstreams,
+):
     def do_updates(table, ps, cs):
         # Emit a separate event for each item in the batch.
-        table.meta.client.batch_write_item(RequestItems = {
-            table.name: [{'PutRequest': {'Item': {'p': p, 'c': c, 'x': 1}}} for p, c in zip(ps, cs)]
-        })
-        events = [['INSERT', {'p': p, 'c': c}, None, {'p': p, 'c': c, 'x': 1}] for p, c in zip(ps, cs)]
+        table.meta.client.batch_write_item(
+            RequestItems={
+                table.name: [
+                    {"PutRequest": {"Item": {"p": p, "c": c, "x": 1}}}
+                    for p, c in zip(ps, cs)
+                ]
+            }
+        )
+        events = [
+            ["INSERT", {"p": p, "c": c}, None, {"p": p, "c": c, "x": 1}]
+            for p, c in zip(ps, cs)
+        ]
         # ... but overwriting with different items should be reported as MODIFY.
-        table.meta.client.batch_write_item(RequestItems = {
-            table.name: [{'PutRequest': {'Item': {'p': p, 'c': c, 'x': 2}}} for p, c in zip(ps, cs)]
-        })
-        events.extend([['MODIFY', {'p': p, 'c': c}, {'p': p, 'c': c, 'x': 1}, {'p': p, 'c': c, 'x': 2}] for p, c in zip(ps, cs)])
+        table.meta.client.batch_write_item(
+            RequestItems={
+                table.name: [
+                    {"PutRequest": {"Item": {"p": p, "c": c, "x": 2}}}
+                    for p, c in zip(ps, cs)
+                ]
+            }
+        )
+        events.extend(
+            [
+                [
+                    "MODIFY",
+                    {"p": p, "c": c},
+                    {"p": p, "c": c, "x": 1},
+                    {"p": p, "c": c, "x": 2},
+                ]
+                for p, c in zip(ps, cs)
+            ]
+        )
         return events
-    with scylla_config_temporary(dynamodb, 'alternator_streams_increased_compatibility', 'true', nop=is_aws(dynamodb)):
-        do_batch_test(test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, 'KEYS_ONLY')
-        do_batch_test(test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, 'NEW_IMAGE')
-        do_batch_test(test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, 'OLD_IMAGE')
-        do_batch_test(test_table_ss_new_and_old_images, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+    with scylla_config_temporary(
+        dynamodb,
+        "alternator_streams_increased_compatibility",
+        "true",
+        nop=is_aws(dynamodb),
+    ):
+        do_batch_test(
+            test_table_ss_keys_only, dynamodb, dynamodbstreams, do_updates, "KEYS_ONLY"
+        )
+        do_batch_test(
+            test_table_ss_new_image, dynamodb, dynamodbstreams, do_updates, "NEW_IMAGE"
+        )
+        do_batch_test(
+            test_table_ss_old_image, dynamodb, dynamodbstreams, do_updates, "OLD_IMAGE"
+        )
+        do_batch_test(
+            test_table_ss_new_and_old_images,
+            dynamodb,
+            dynamodbstreams,
+            do_updates,
+            "NEW_AND_OLD_IMAGES",
+        )
+
 
 # A fixture which creates a test table with a stream enabled, and returns a
 # bunch of interesting information collected from the CreateTable response.
@@ -1628,18 +2540,21 @@ def test_streams_batch_overwrite_different(test_table_ss_keys_only, test_table_s
 @pytest.fixture(scope="module")
 def test_table_stream_with_result(dynamodb, dynamodbstreams):
     tablename = unique_table_name()
-    result = dynamodb.meta.client.create_table(TableName=tablename,
+    result = dynamodb.meta.client.create_table(
+        TableName=tablename,
         Tags=TAGS,
-        BillingMode='PAY_PER_REQUEST',
-        StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+        BillingMode="PAY_PER_REQUEST",
+        StreamSpecification={"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"},
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-        ])
-    waiter = dynamodb.meta.client.get_waiter('table_exists')
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+        ],
+    )
+    waiter = dynamodb.meta.client.get_waiter("table_exists")
     waiter.config.delay = 1
     waiter.config.max_attempts = 200
     waiter.wait(TableName=tablename)
@@ -1652,11 +2567,12 @@ def test_table_stream_with_result(dynamodb, dynamodbstreams):
         except ClientError as ce:
             # if the table has a stream currently being created we cannot
             # delete the table immediately. Again, only with real dynamo
-            if ce.response['Error']['Code'] == 'ResourceInUseException':
-                print('Could not delete table yet. Sleeping 5s.')
+            if ce.response["Error"]["Code"] == "ResourceInUseException":
+                print("Could not delete table yet. Sleeping 5s.")
                 time.sleep(5)
-                continue;
+                continue
             raise
+
 
 # Wait for a table to return to "ACTIVE" status. We need to call this after
 # doing an UpdateTable to a table - because before this wait finishes we are
@@ -1664,73 +2580,80 @@ def test_table_stream_with_result(dynamodb, dynamodbstreams):
 def wait_for_status_active(table):
     for i in range(60):
         desc = table.meta.client.describe_table(TableName=table.name)
-        if desc['Table']['TableStatus'] == 'ACTIVE':
+        if desc["Table"]["TableStatus"] == "ACTIVE":
             return
         time.sleep(1)
     pytest.fail("wait_for_status_active() timed out")
+
 
 # Test that in a table with Streams enabled, LatestStreamArn is returned
 # by CreateTable, DescribeTable and UpdateTable, and is the same ARN as
 # returned by ListStreams. Reproduces issue #7157.
 def test_latest_stream_arn(test_table_stream_with_result, dynamodbstreams):
     (result, table) = test_table_stream_with_result
-    assert 'LatestStreamArn' in result['TableDescription']
-    arn_in_create_table = result['TableDescription']['LatestStreamArn']
+    assert "LatestStreamArn" in result["TableDescription"]
+    arn_in_create_table = result["TableDescription"]["LatestStreamArn"]
     # Check that ListStreams returns the same stream ARN as returned
     # by the original CreateTable
     (arn_in_list_streams, label) = wait_for_active_stream(dynamodbstreams, table)
     assert arn_in_create_table == arn_in_list_streams
     # Check that DescribeTable also includes the same LatestStreamArn:
-    desc = table.meta.client.describe_table(TableName=table.name)['Table']
-    assert 'LatestStreamArn' in desc
-    assert desc['LatestStreamArn'] == arn_in_create_table
+    desc = table.meta.client.describe_table(TableName=table.name)["Table"]
+    assert "LatestStreamArn" in desc
+    assert desc["LatestStreamArn"] == arn_in_create_table
     # Check that UpdateTable also includes the same LatestStreamArn.
     # The "update" changes nothing (it just sets BillingMode to what it was).
-    desc = table.meta.client.update_table(TableName=table.name,
-            BillingMode='PAY_PER_REQUEST')['TableDescription']
-    assert desc['LatestStreamArn'] == arn_in_create_table
+    desc = table.meta.client.update_table(
+        TableName=table.name, BillingMode="PAY_PER_REQUEST"
+    )["TableDescription"]
+    assert desc["LatestStreamArn"] == arn_in_create_table
     wait_for_status_active(table)
+
 
 # Test that in a table with Streams enabled, LatestStreamLabel is returned
 # by CreateTable, DescribeTable and UpdateTable, and is the same "label" as
 # returned by ListStreams. Reproduces issue #7162.
 def test_latest_stream_label(test_table_stream_with_result, dynamodbstreams):
     (result, table) = test_table_stream_with_result
-    assert 'LatestStreamLabel' in result['TableDescription']
-    label_in_create_table = result['TableDescription']['LatestStreamLabel']
+    assert "LatestStreamLabel" in result["TableDescription"]
+    label_in_create_table = result["TableDescription"]["LatestStreamLabel"]
     # Check that ListStreams returns the same stream label as returned
     # by the original CreateTable
     (arn, label) = wait_for_active_stream(dynamodbstreams, table)
     assert label_in_create_table == label
     # Check that DescribeTable also includes the same LatestStreamLabel:
-    desc = table.meta.client.describe_table(TableName=table.name)['Table']
-    assert 'LatestStreamLabel' in desc
-    assert desc['LatestStreamLabel'] == label_in_create_table
+    desc = table.meta.client.describe_table(TableName=table.name)["Table"]
+    assert "LatestStreamLabel" in desc
+    assert desc["LatestStreamLabel"] == label_in_create_table
     # Check that UpdateTable also includes the same LatestStreamLabel.
     # The "update" changes nothing (it just sets BillingMode to what it was).
-    desc = table.meta.client.update_table(TableName=table.name,
-            BillingMode='PAY_PER_REQUEST')['TableDescription']
-    assert desc['LatestStreamLabel'] == label_in_create_table
+    desc = table.meta.client.update_table(
+        TableName=table.name, BillingMode="PAY_PER_REQUEST"
+    )["TableDescription"]
+    assert desc["LatestStreamLabel"] == label_in_create_table
     wait_for_status_active(table)
+
 
 # Test that in a table with Streams enabled, StreamSpecification is returned
 # by CreateTable, DescribeTable and UpdateTable. Reproduces issue #7163.
 def test_stream_specification(test_table_stream_with_result, dynamodbstreams):
     # StreamSpecification as set in test_table_stream_with_result:
-    stream_specification = {'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'}
+    stream_specification = {"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"}
     (result, table) = test_table_stream_with_result
-    assert 'StreamSpecification' in result['TableDescription']
-    assert stream_specification == result['TableDescription']['StreamSpecification']
+    assert "StreamSpecification" in result["TableDescription"]
+    assert stream_specification == result["TableDescription"]["StreamSpecification"]
     # Check that DescribeTable also includes the same StreamSpecification:
-    desc = table.meta.client.describe_table(TableName=table.name)['Table']
-    assert 'StreamSpecification' in desc
-    assert stream_specification == desc['StreamSpecification']
+    desc = table.meta.client.describe_table(TableName=table.name)["Table"]
+    assert "StreamSpecification" in desc
+    assert stream_specification == desc["StreamSpecification"]
     # Check that UpdateTable also includes the same StreamSpecification.
     # The "update" changes nothing (it just sets BillingMode to what it was).
-    desc = table.meta.client.update_table(TableName=table.name,
-            BillingMode='PAY_PER_REQUEST')['TableDescription']
-    assert stream_specification == desc['StreamSpecification']
+    desc = table.meta.client.update_table(
+        TableName=table.name, BillingMode="PAY_PER_REQUEST"
+    )["TableDescription"]
+    assert stream_specification == desc["StreamSpecification"]
     wait_for_status_active(table)
+
 
 # The following test checks the behavior of *closed* shards.
 # We achieve a closed shard by disabling the stream - the DynamoDB
@@ -1751,8 +2674,11 @@ def test_streams_closed_read(test_table_ss_keys_only, dynamodbstreams):
     shards_and_iterators = shards_and_latest_iterators(dynamodbstreams, arn)
     # Do an UpdateItem operation that is expected to leave one event in the
     # stream.
-    table.update_item(Key={'p': random_string(), 'c': random_string()},
-        UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+    table.update_item(
+        Key={"p": random_string(), "c": random_string()},
+        UpdateExpression="SET x = :val1",
+        ExpressionAttributeValues={":val1": 5},
+    )
     # Disable streaming for this table. Note that the test_table_ss_keys_only
     # fixture has "function" scope so it is fine to ruin table, it will not
     # be used in other tests.
@@ -1764,9 +2690,9 @@ def test_streams_closed_read(test_table_ss_keys_only, dynamodbstreams):
     # eventually *one* of the stream shards will return one event:
     timeout = time.time() + 15
     while time.time() < timeout:
-        for (shard_id, iter) in shards_and_iterators:
+        for shard_id, iter in shards_and_iterators:
             response = dynamodbstreams.get_records(ShardIterator=iter)
-            if 'Records' in response and response['Records'] != []:
+            if "Records" in response and response["Records"] != []:
                 # Found the shard with the data! Test that it only has
                 # one event. NextShardIterator should either be missing now,
                 # indicating that it is a closed shard (DynamoDB does this),
@@ -1774,22 +2700,26 @@ def test_streams_closed_read(test_table_ss_keys_only, dynamodbstreams):
                 # and reading from *that* iterator should then tell us that
                 # we reached the end of the shard (i.e., zero results and
                 # missing NextShardIterator).
-                assert len(response['Records']) == 1
-                if 'NextShardIterator' in response:
-                    response = dynamodbstreams.get_records(ShardIterator=response['NextShardIterator'])
-                    assert len(response['Records']) == 0
-                    assert not 'NextShardIterator' in response
+                assert len(response["Records"]) == 1
+                if "NextShardIterator" in response:
+                    response = dynamodbstreams.get_records(
+                        ShardIterator=response["NextShardIterator"]
+                    )
+                    assert len(response["Records"]) == 0
+                    assert not "NextShardIterator" in response
                 # Until now we verified that we can read the closed shard
                 # using an old iterator. Let's test now that the closed
                 # shard id is also still valid, and a new iterator can be
                 # created for it, and the old data can be read from it:
-                iter = dynamodbstreams.get_shard_iterator(StreamArn=arn,
-                    ShardId=shard_id, ShardIteratorType='TRIM_HORIZON')['ShardIterator']
+                iter = dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON"
+                )["ShardIterator"]
                 response = dynamodbstreams.get_records(ShardIterator=iter)
-                assert len(response['Records']) == 1
+                assert len(response["Records"]) == 1
                 return
         time.sleep(0.5)
     pytest.fail("timed out")
+
 
 # In the above test (test_streams_closed_read) we used a disabled stream as
 # a means to generate a closed shard, and tested the behavior of that closed
@@ -1805,8 +2735,11 @@ def test_streams_disabled_stream(test_table_ss_keys_only, dynamodbstreams):
     iterators = latest_iterators(dynamodbstreams, arn)
     # Do an UpdateItem operation that is expected to leave one event in the
     # stream.
-    table.update_item(Key={'p': random_string(), 'c': random_string()},
-        UpdateExpression='SET x = :x', ExpressionAttributeValues={':x': 5})
+    table.update_item(
+        Key={"p": random_string(), "c": random_string()},
+        UpdateExpression="SET x = :x",
+        ExpressionAttributeValues={":x": 5},
+    )
 
     # Wait for this one update to become available in the stream before we
     # disable the stream. Otherwise, theoretically (although unlikely in
@@ -1816,7 +2749,7 @@ def test_streams_disabled_stream(test_table_ss_keys_only, dynamodbstreams):
     while time.time() < timeout and not found:
         for iter in iterators:
             response = dynamodbstreams.get_records(ShardIterator=iter)
-            if 'Records' in response and len(response['Records']) > 0:
+            if "Records" in response and len(response["Records"]) > 0:
                 found = True
                 break
         time.sleep(0.5)
@@ -1829,55 +2762,68 @@ def test_streams_disabled_stream(test_table_ss_keys_only, dynamodbstreams):
 
     # Check that the stream ARN which we previously got for the disabled
     # stream is still listed by ListStreams
-    arns = [stream['StreamArn'] for stream in dynamodbstreams.list_streams(TableName=table.name)['Streams']]
+    arns = [
+        stream["StreamArn"]
+        for stream in dynamodbstreams.list_streams(TableName=table.name)["Streams"]
+    ]
     assert arn in arns
 
     # DescribeStream on the disabled stream still works and lists its shards.
     # All these shards are listed as being closed (i.e., should have
     # EndingSequenceNumber). The basic details of the stream (e.g., the view
     # type) are available and the status of the stream is DISABLED.
-    response = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
-    assert response['StreamStatus'] == 'DISABLED'
-    assert response['StreamViewType'] == 'KEYS_ONLY'
-    assert response['TableName'] == table.name
-    shards_info = response['Shards']
-    while 'LastEvaluatedShardId' in response:
-        response = dynamodbstreams.describe_stream(StreamArn=arn, ExclusiveStartShardId=response['LastEvaluatedShardId'])['StreamDescription']
-        assert response['StreamStatus'] == 'DISABLED'
-        assert response['StreamViewType'] == 'KEYS_ONLY'
-        assert response['TableName'] == table.name
-        shards_info.extend(response['Shards'])
-    print('Number of shards in stream: {}'.format(len(shards_info)))
+    response = dynamodbstreams.describe_stream(StreamArn=arn)["StreamDescription"]
+    assert response["StreamStatus"] == "DISABLED"
+    assert response["StreamViewType"] == "KEYS_ONLY"
+    assert response["TableName"] == table.name
+    shards_info = response["Shards"]
+    while "LastEvaluatedShardId" in response:
+        response = dynamodbstreams.describe_stream(
+            StreamArn=arn, ExclusiveStartShardId=response["LastEvaluatedShardId"]
+        )["StreamDescription"]
+        assert response["StreamStatus"] == "DISABLED"
+        assert response["StreamViewType"] == "KEYS_ONLY"
+        assert response["TableName"] == table.name
+        shards_info.extend(response["Shards"])
+    print("Number of shards in stream: {}".format(len(shards_info)))
     for shard in shards_info:
-        assert 'EndingSequenceNumber' in shard['SequenceNumberRange']
-        assert shard['SequenceNumberRange']['EndingSequenceNumber'].isdecimal()
+        assert "EndingSequenceNumber" in shard["SequenceNumberRange"]
+        assert shard["SequenceNumberRange"]["EndingSequenceNumber"].isdecimal()
 
     # We can get TRIM_HORIZON iterators for all these shards, to read all
     # the old data they still have (this data should be saved for 24 hours
     # after the stream was disabled)
     iterators = []
     for shard in shards_info:
-        iterators.append(dynamodbstreams.get_shard_iterator(StreamArn=arn,
-            ShardId=shard['ShardId'], ShardIteratorType='TRIM_HORIZON')['ShardIterator'])
+        iterators.append(
+            dynamodbstreams.get_shard_iterator(
+                StreamArn=arn,
+                ShardId=shard["ShardId"],
+                ShardIteratorType="TRIM_HORIZON",
+            )["ShardIterator"]
+        )
 
     # We can read the one change we did in one of these iterators. The data
     # should be available immediately - no need for retries with timeout.
     nrecords = 0
     for iter in iterators:
         response = dynamodbstreams.get_records(ShardIterator=iter)
-        if 'Records' in response:
-            nrecords += len(response['Records'])
+        if "Records" in response:
+            nrecords += len(response["Records"])
         # The shard is closed, so NextShardIterator should either be missing
         # now,  indicating that it is a closed shard (DynamoDB does this),
         # or, it may (and currently does in Alternator) return an iterator
         # and reading from *that* iterator should then tell us that
         # we reached the end of the shard (i.e., zero results and
         # missing NextShardIterator).
-        if 'NextShardIterator' in response:
-            response = dynamodbstreams.get_records(ShardIterator=response['NextShardIterator'])
-            assert len(response['Records']) == 0
-            assert not 'NextShardIterator' in response
+        if "NextShardIterator" in response:
+            response = dynamodbstreams.get_records(
+                ShardIterator=response["NextShardIterator"]
+            )
+            assert len(response["Records"]) == 0
+            assert not "NextShardIterator" in response
     assert nrecords == 1
+
 
 # When streams are enabled for a table, we get a unique ARN which should be
 # unique but not change unless streams are eventually disabled for this table.
@@ -1886,16 +2832,21 @@ def test_streams_disabled_stream(test_table_ss_keys_only, dynamodbstreams):
 # issue #12601 that changes to the version of the schema lead to a change of
 # the ARN. In this test we show that it doesn't happen.
 def test_stream_arn_unchanging(dynamodb, dynamodbstreams):
-    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+    with create_stream_test_table(dynamodb, StreamViewType="KEYS_ONLY") as table:
         (arn, label) = wait_for_active_stream(dynamodbstreams, table)
         # Change a tag on the table. This changes its schema.
-        table_arn = table.meta.client.describe_table(TableName=table.name)['Table']['TableArn']
-        table.meta.client.tag_resource(ResourceArn=table_arn, Tags=[{'Key': 'animal', 'Value': 'dog' }])
+        table_arn = table.meta.client.describe_table(TableName=table.name)["Table"][
+            "TableArn"
+        ]
+        table.meta.client.tag_resource(
+            ResourceArn=table_arn, Tags=[{"Key": "animal", "Value": "dog"}]
+        )
         # The change in the table's schema should not change its stream ARN
         streams = dynamodbstreams.list_streams(TableName=table.name)
-        assert 'Streams' in streams
-        assert len(streams['Streams']) == 1
-        assert streams['Streams'][0]['StreamArn'] == arn
+        assert "Streams" in streams
+        assert len(streams["Streams"]) == 1
+        assert streams["Streams"][0]["StreamArn"] == arn
+
 
 # Enabling a stream shouldn't cause any extra table to appear in ListTables.
 # In issue #19911, enabling streams on a table called xyz caused the name
@@ -1905,20 +2856,24 @@ def test_stream_arn_unchanging(dynamodb, dynamodbstreams):
 # In test_gsi.py and test_lsi.py we have similar tests for GSI and LSI.
 # Reproduces #19911
 def test_stream_list_tables(dynamodb):
-    with new_test_table(dynamodb,
+    with new_test_table(
+        dynamodb,
         Tags=TAGS,
-        StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, ]
+        StreamSpecification={"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"},
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+        ],
     ) as table:
-            # Check that the test table is listed by ListTable, but its long
-            # and unique name (created by unique_table_name()) isn't a proper
-            # substring of any other table's name.
-            tables = list_tables(dynamodb)
-            assert table.name in tables
-            for listed_name in tables:
-                if table.name != listed_name:
-                    assert table.name not in listed_name
+        # Check that the test table is listed by ListTable, but its long
+        # and unique name (created by unique_table_name()) isn't a proper
+        # substring of any other table's name.
+        tables = list_tables(dynamodb)
+        assert table.name in tables
+        for listed_name in tables:
+            if table.name != listed_name:
+                assert table.name not in listed_name
+
 
 # The DynamoDB documentation for GetRecords says that "GetRecords can retrieve
 # a maximum of 1 MB of data or 1000 stream records, whichever comes first.",
@@ -1934,26 +2889,32 @@ def test_get_records_too_high_limit(test_table_ss_keys_only, dynamodbstreams):
     # LATEST, there will be no data to read from this iterator, but we don't
     # care, we just want to run the GetRecords request, we don't care what
     # is returned.
-    shard = dynamodbstreams.describe_stream(StreamArn=arn, Limit=1)['StreamDescription']['Shards'][0]
-    shard_id = shard['ShardId']
-    iter = dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']
+    shard = dynamodbstreams.describe_stream(StreamArn=arn, Limit=1)[
+        "StreamDescription"
+    ]["Shards"][0]
+    shard_id = shard["ShardId"]
+    iter = dynamodbstreams.get_shard_iterator(
+        StreamArn=arn, ShardId=shard_id, ShardIteratorType="LATEST"
+    )["ShardIterator"]
     # Limit=1000 should be allowed:
     dynamodbstreams.get_records(ShardIterator=iter, Limit=1000)
     # Limit=1001 should NOT be allowed
-    with pytest.raises(ClientError, match='ValidationException.*[Ll]imit'):
+    with pytest.raises(ClientError, match="ValidationException.*[Ll]imit"):
         dynamodbstreams.get_records(ShardIterator=iter, Limit=1001)
     # Limit must be >= 0:
-    with pytest.raises(ClientError, match='ValidationException.*[Ll]imit'):
+    with pytest.raises(ClientError, match="ValidationException.*[Ll]imit"):
         dynamodbstreams.get_records(ShardIterator=iter, Limit=0)
-    with pytest.raises(ClientError, match='ValidationException.*[Ll]imit'):
+    with pytest.raises(ClientError, match="ValidationException.*[Ll]imit"):
         dynamodbstreams.get_records(ShardIterator=iter, Limit=-1)
+
 
 # padded_name() creates a unique name of given length by taking the
 # output of unique_table_name() and padding it with extra 'x' characters:
 def padded_name(length):
     u = unique_table_name()
     assert length >= len(u)
-    return u + 'x'*(length-len(u))
+    return u + "x" * (length - len(u))
+
 
 # When Alternator enables streams, CDC creates a new table whose name is the
 # same as the existing table with the suffix "_scylla_cdc_log". In issue
@@ -1966,55 +2927,82 @@ def padded_name(length):
 # Reproduces #24598
 def test_stream_table_name_length_222_create(dynamodb):
     try:
-        with new_test_table(dynamodb, name=padded_name(222),
+        with new_test_table(
+            dynamodb,
+            name=padded_name(222),
             Tags=TAGS,
-            StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, ]
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"},
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "p", "AttributeType": "S"},
+            ],
         ) as table:
             pass
     except ClientError as e:
         # In Alternator, we may decide that 222 is too long to create a table,
         # or too long to create the stream. But if we reached here, at least
         # it didn't crash.
-        assert 'table name is longer than' in str(e) or 'TableName must be' in str(e)
+        assert "table name is longer than" in str(e) or "TableName must be" in str(e)
+
 
 # Reproduces #24598
 def test_stream_table_name_length_222_update(dynamodb, dynamodbstreams):
     try:
-        with new_test_table(dynamodb, name=padded_name(222),
+        with new_test_table(
+            dynamodb,
+            name=padded_name(222),
             Tags=TAGS,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, ]
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "p", "AttributeType": "S"},
+            ],
         ) as table:
-            table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'});
+            table.update(
+                StreamSpecification={
+                    "StreamEnabled": True,
+                    "StreamViewType": "KEYS_ONLY",
+                }
+            )
             # DynamoDB doesn't allow deleting the base table while the stream
             # is in the process of being added
             wait_for_active_stream(dynamodbstreams, table)
     except ClientError as e:
-        assert 'table name is longer than' in str(e) or 'TableName must be' in str(e)
+        assert "table name is longer than" in str(e) or "TableName must be" in str(e)
+
 
 # When the table has a shorter name length, like 192, we should be able to
 # create both the table and streams, with no problems.
 def test_stream_table_name_length_192_create(dynamodb):
-    with new_test_table(dynamodb, name=padded_name(192),
+    with new_test_table(
+        dynamodb,
+        name=padded_name(192),
         Tags=TAGS,
-        StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, ]
+        StreamSpecification={"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"},
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+        ],
     ) as table:
         pass
 
+
 def test_stream_table_name_length_192_update(dynamodb, dynamodbstreams):
-    with new_test_table(dynamodb, name=padded_name(192),
+    with new_test_table(
+        dynamodb,
+        name=padded_name(192),
         Tags=TAGS,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, ]
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+        ],
     ) as table:
-        table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'});
+        table.update(
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "KEYS_ONLY"}
+        )
         # DynamoDB doesn't allow deleting the base table while the stream
         # is in the process of being added
         wait_for_active_stream(dynamodbstreams, table)
+
 
 # In earlier tests, we tested the stream events logged for BatchWriteItem,
 # but it was usually a single item in the batch or in do_batch_test(),
@@ -2027,21 +3015,53 @@ def test_stream_table_name_length_192_update(dynamodb, dynamodbstreams):
 # modes, and reproduces #28439 when it failed only in always_use_lwt mode.
 # This is a Scylla-only test because it checks write isolation modes, which
 # don't exist in DynamoDB.
-@pytest.mark.parametrize('mode', ['only_rmw_uses_lwt', pytest.param('always_use_lwt', marks=pytest.mark.xfail(reason='#28439')), 'unsafe_rmw', 'forbid_rmw'])
-def test_streams_multiple_items_one_partition(dynamodb, dynamodbstreams, scylla_only, mode):
-    with create_table_ss(dynamodb, dynamodbstreams, 'NEW_AND_OLD_IMAGES') as stream:
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "only_rmw_uses_lwt",
+        pytest.param(
+            "always_use_lwt",
+            marks=pytest.mark.xfail(
+                reason="Streams will output wrong log, when BatchWriteItem is used to update multiple items from the same partition #28439"
+            ),
+        ),
+        "unsafe_rmw",
+        "forbid_rmw",
+    ],
+)
+def test_streams_multiple_items_one_partition(
+    dynamodb, dynamodbstreams, scylla_only, mode
+):
+    with create_table_ss(dynamodb, dynamodbstreams, "NEW_AND_OLD_IMAGES") as stream:
         table, stream_arn = stream
         # Set write isolation mode on the table to the chosen "mode":
-        table_arn = table.meta.client.describe_table(TableName=table.name)['Table']['TableArn']
-        table.meta.client.tag_resource(ResourceArn=table_arn, Tags=[{'Key': 'system:write_isolation', 'Value': mode}])
+        table_arn = table.meta.client.describe_table(TableName=table.name)["Table"][
+            "TableArn"
+        ]
+        table.meta.client.tag_resource(
+            ResourceArn=table_arn,
+            Tags=[{"Key": "system:write_isolation", "Value": mode}],
+        )
+
         # Now try the test, a single BatchWriteItem writing three different
         # items in the same partition p:
         def do_updates(table, p, c):
-            cs = [c + '1', c + '2', c + '3']
-            table.meta.client.batch_write_item(RequestItems = {
-                table.name: [{'PutRequest': {'Item': {'p': p, 'c': cc, 'x': cc}}} for cc in cs]})
-            return [['INSERT', {'p': p, 'c': cc}, None, {'p': p, 'c': cc, 'x': cc}] for cc in cs]
-        do_test(stream, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+            cs = [c + "1", c + "2", c + "3"]
+            table.meta.client.batch_write_item(
+                RequestItems={
+                    table.name: [
+                        {"PutRequest": {"Item": {"p": p, "c": cc, "x": cc}}}
+                        for cc in cs
+                    ]
+                }
+            )
+            return [
+                ["INSERT", {"p": p, "c": cc}, None, {"p": p, "c": cc, "x": cc}]
+                for cc in cs
+            ]
+
+        do_test(stream, dynamodb, dynamodbstreams, do_updates, "NEW_AND_OLD_IMAGES")
+
 
 # TODO: tests on multiple partitions
 # TODO: write a test that disabling the stream and re-enabling it works, but

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -14,38 +14,35 @@ from re import fullmatch
 import pytest
 from botocore.exceptions import ClientError
 
-from .util import list_tables, unique_table_name, create_test_table, random_string, new_test_table, is_aws, scylla_config_read
+from .util import (
+    list_tables,
+    unique_table_name,
+    create_test_table,
+    random_string,
+    new_test_table,
+    is_aws,
+    scylla_config_read,
+)
 
 
 # Utility function for create a table with a given name and some valid
 # schema.. This function initiates the table's creation, but doesn't
 # wait for the table to actually become ready.
-def create_table(dynamodb, name, BillingMode='PAY_PER_REQUEST', **kwargs):
+def create_table(dynamodb, name, BillingMode="PAY_PER_REQUEST", **kwargs):
     return dynamodb.create_table(
         TableName=name,
         BillingMode=BillingMode,
         KeySchema=[
-            {
-                'AttributeName': 'p',
-                'KeyType': 'HASH'
-            },
-            {
-                'AttributeName': 'c',
-                'KeyType': 'RANGE'
-            }
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
-            {
-                'AttributeName': 'p',
-                'AttributeType': 'S'
-            },
-            {
-                'AttributeName': 'c',
-                'AttributeType': 'S'
-            },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
         ],
-        **kwargs
+        **kwargs,
     )
+
 
 # Utility function for creating a table with a given name, and then deleting
 # it immediately, waiting for these operations to complete. Since the wait
@@ -55,11 +52,13 @@ def create_table(dynamodb, name, BillingMode='PAY_PER_REQUEST', **kwargs):
 # successfully using this function are very slow.
 def create_and_delete_table(dynamodb, name, **kwargs):
     table = create_table(dynamodb, name, **kwargs)
-    table.meta.client.get_waiter('table_exists').wait(TableName=name)
+    table.meta.client.get_waiter("table_exists").wait(TableName=name)
     table.delete()
-    table.meta.client.get_waiter('table_not_exists').wait(TableName=name)
+    table.meta.client.get_waiter("table_not_exists").wait(TableName=name)
+
 
 ##############################################################################
+
 
 # Test creating a table, and then deleting it, waiting for each operation
 # to have completed before proceeding. Since the wait uses DescribeTable,
@@ -68,30 +67,34 @@ def create_and_delete_table(dynamodb, name, **kwargs):
 # Unfortunately, this test is extremely slow with DynamoDB because deleting
 # a table is extremely slow until it really happens.
 def test_create_and_delete_table(dynamodb):
-    create_and_delete_table(dynamodb, 'alternator_test')
+    create_and_delete_table(dynamodb, "alternator_test")
+
 
 # Test that recreating a table right after deleting it works without issues
 def test_recreate_table(dynamodb):
-    create_and_delete_table(dynamodb, 'alternator_recr_test')
-    create_and_delete_table(dynamodb, 'alternator_recr_test')
+    create_and_delete_table(dynamodb, "alternator_recr_test")
+    create_and_delete_table(dynamodb, "alternator_recr_test")
+
 
 # DynamoDB documentation specifies that table names must be 3-255 characters,
 # and match the regex [a-zA-Z0-9._-]+. Names not matching these rules should
 # be rejected, and no table be created.
 def test_create_table_unsupported_names(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, 'n')
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, 'nn')
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, 'n' * 256)
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, 'nyh@test')
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_table(dynamodb, "n")
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_table(dynamodb, "nn")
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_table(dynamodb, "n" * 256)
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_table(dynamodb, "nyh@test")
+
 
 # On the other hand, names following the above rules should be accepted. Even
 # names which the Scylla rules forbid, such as a name starting with .
 def test_create_and_delete_table_non_scylla_name(dynamodb):
-    create_and_delete_table(dynamodb, '.alternator_test')
+    create_and_delete_table(dynamodb, ".alternator_test")
+
 
 # names with 255 characters are allowed in Dynamo, but they are not currently
 # supported in Scylla because we create a directory whose name is the table's
@@ -99,110 +102,111 @@ def test_create_and_delete_table_non_scylla_name(dynamodb):
 # we only support names with length up to 192.
 @pytest.mark.xfail(reason="Alternator limits table name length to 192")
 def test_create_and_delete_table_255(dynamodb):
-    create_and_delete_table(dynamodb, 'n' * 255)
+    create_and_delete_table(dynamodb, "n" * 255)
+
+
 def test_create_and_delete_table_256(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException'):
-       create_and_delete_table(dynamodb, 'n' * 256)
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_and_delete_table(dynamodb, "n" * 256)
+
+
 def test_create_and_delete_table_192(dynamodb):
-    create_and_delete_table(dynamodb, 'n' * 192)
+    create_and_delete_table(dynamodb, "n" * 192)
+
 
 # Tests creating a table with an invalid schema should return a
 # ValidationException error.
 def test_create_table_invalid_schema(dynamodb):
     # The name of the table "created" by this test shouldn't matter, the
     # creation should not succeed anyway.
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="ValidationException"):
         dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[
-                { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                { 'AttributeName': 'c', 'KeyType': 'HASH' }
+                {"AttributeName": "p", "KeyType": "HASH"},
+                {"AttributeName": "c", "KeyType": "HASH"},
             ],
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'c', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
             ],
         )
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="ValidationException"):
         dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[
-                { 'AttributeName': 'p', 'KeyType': 'RANGE' },
-                { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+                {"AttributeName": "p", "KeyType": "RANGE"},
+                {"AttributeName": "c", "KeyType": "RANGE"},
             ],
             AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'c', 'AttributeType': 'S' },
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
             ],
         )
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="ValidationException"):
         dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
+            KeySchema=[{"AttributeName": "c", "KeyType": "RANGE"}],
+            AttributeDefinitions=[
+                {"AttributeName": "c", "AttributeType": "S"},
+            ],
+        )
+    with pytest.raises(ClientError, match="ValidationException"):
+        dynamodb.create_table(
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[
-                { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+                {"AttributeName": "c", "KeyType": "HASH"},
+                {"AttributeName": "p", "KeyType": "RANGE"},
+                {"AttributeName": "z", "KeyType": "RANGE"},
             ],
             AttributeDefinitions=[
-                { 'AttributeName': 'c', 'AttributeType': 'S' },
+                {"AttributeName": "c", "AttributeType": "S"},
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "z", "AttributeType": "S"},
             ],
         )
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="ValidationException"):
         dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[
-                { 'AttributeName': 'c', 'KeyType': 'HASH' },
-                { 'AttributeName': 'p', 'KeyType': 'RANGE' },
-                { 'AttributeName': 'z', 'KeyType': 'RANGE' }
+                {"AttributeName": "c", "KeyType": "HASH"},
             ],
-            AttributeDefinitions=[
-                { 'AttributeName': 'c', 'AttributeType': 'S' },
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'z', 'AttributeType': 'S' }
-            ],
+            AttributeDefinitions=[{"AttributeName": "z", "AttributeType": "S"}],
         )
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="ValidationException"):
         dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[
-                { 'AttributeName': 'c', 'KeyType': 'HASH' },
+                {"AttributeName": "k", "KeyType": "HASH"},
             ],
-            AttributeDefinitions=[
-                { 'AttributeName': 'z', 'AttributeType': 'S' }
-            ],
+            AttributeDefinitions=[{"AttributeName": "k", "AttributeType": "Q"}],
         )
-    with pytest.raises(ClientError, match='ValidationException'):
-        dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
-            KeySchema=[
-                { 'AttributeName': 'k', 'KeyType': 'HASH' },
-            ],
-            AttributeDefinitions=[
-                { 'AttributeName': 'k', 'AttributeType': 'Q' }
-            ],
-        )
+
 
 # Another case of an invalid schema is repeating the same AttributeName
 # twice in AttributeDefinitions. DynamoDB has no way of knowing which of
 # the two definitions was intended.
 # Reproduces #13870
 def test_create_table_duplicate_attribute_name(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*uplicate.*xyz'):
+    with pytest.raises(ClientError, match="ValidationException.*uplicate.*xyz"):
         dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[
-                { 'AttributeName': 'xyz', 'KeyType': 'HASH' },
+                {"AttributeName": "xyz", "KeyType": "HASH"},
             ],
             AttributeDefinitions=[
-                { 'AttributeName': 'xyz', 'AttributeType': 'S' },
-                { 'AttributeName': 'xyz', 'AttributeType': 'N' }
+                {"AttributeName": "xyz", "AttributeType": "S"},
+                {"AttributeName": "xyz", "AttributeType": "N"},
             ],
         )
+
 
 # In addition to the specific AttributeDefinitions error reported in
 # issue #13870, there are other ways which AttributeDefinitions can be
@@ -212,27 +216,27 @@ def test_create_table_invalid_attribute_definitions(dynamodb):
     # DynamoDB prints a rather ugly error message: "1 validation error
     # detected: Value null at 'attributeDefinitions.1.member.attributeName'
     # failed to satisfy constraint: Member must not be null".
-    with pytest.raises(ClientError, match='ValidationException.*ttributeName'):
+    with pytest.raises(ClientError, match="ValidationException.*ttributeName"):
         dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[
-                { 'AttributeName': 'xyz', 'KeyType': 'HASH' },
+                {"AttributeName": "xyz", "KeyType": "HASH"},
             ],
             AttributeDefinitions=[
-                { 'AttributeType': 'S' }, # missing AttributeName
+                {"AttributeType": "S"},  # missing AttributeName
             ],
         )
     # Missing "AttributeType" in one of the members of AttributeDefinitions.
-    with pytest.raises(ClientError, match='ValidationException.*ttributeType'):
+    with pytest.raises(ClientError, match="ValidationException.*ttributeType"):
         dynamodb.create_table(
-            TableName='name_doesnt_matter',
-            BillingMode='PAY_PER_REQUEST',
+            TableName="name_doesnt_matter",
+            BillingMode="PAY_PER_REQUEST",
             KeySchema=[
-                { 'AttributeName': 'xyz', 'KeyType': 'HASH' },
+                {"AttributeName": "xyz", "KeyType": "HASH"},
             ],
             AttributeDefinitions=[
-                { 'AttributeName': 'xyz' }, # missing AttributeType
+                {"AttributeName": "xyz"},  # missing AttributeType
             ],
         )
 
@@ -240,18 +244,27 @@ def test_create_table_invalid_attribute_definitions(dynamodb):
     # validation in conftest.py, boto3 still doesn't us test the case of
     # extra fields in AttributeDefinitions, and catches such errors itself.
 
+
 # Creation of a table without AttributeDefinitions is illegal
 # Reproduces #23043
 def test_create_table_lacking_attribute_definitions(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*[aA]ttributeDefinitions'):
-        with new_test_table(dynamodb, KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }]) as table:
+    with pytest.raises(
+        ClientError, match="ValidationException.*[aA]ttributeDefinitions"
+    ):
+        with new_test_table(
+            dynamodb, KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}]
+        ) as table:
             pass
+
 
 # Test that trying to create a table that already exists fails in the
 # appropriate way (ResourceInUseException)
 def test_create_table_already_exists(dynamodb, test_table):
-    with pytest.raises(ClientError, match='ResourceInUseException.*Table.*already exists'):
+    with pytest.raises(
+        ClientError, match="ResourceInUseException.*Table.*already exists"
+    ):
         create_table(dynamodb, test_table.name)
+
 
 # Test that BillingMode error path works as expected - only the values
 # PROVISIONED or PAY_PER_REQUEST are allowed. The former requires
@@ -259,28 +272,35 @@ def test_create_table_already_exists(dynamodb, test_table):
 # If BillingMode is outright missing, it defaults (as original
 # DynamoDB did) to PROVISIONED so ProvisionedThroughput is allowed.
 def test_create_table_billing_mode_errors(dynamodb, test_table):
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, unique_table_name(), BillingMode='unknown')
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_table(dynamodb, unique_table_name(), BillingMode="unknown")
     # billing mode is case-sensitive
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, unique_table_name(), BillingMode='pay_per_request')
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_table(dynamodb, unique_table_name(), BillingMode="pay_per_request")
     # PAY_PER_REQUEST cannot come with a ProvisionedThroughput:
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, unique_table_name(),
-            BillingMode='PAY_PER_REQUEST', ProvisionedThroughput={'ReadCapacityUnits': 10, 'WriteCapacityUnits': 10})
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_table(
+            dynamodb,
+            unique_table_name(),
+            BillingMode="PAY_PER_REQUEST",
+            ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+        )
     # On the other hand, PROVISIONED requires ProvisionedThroughput:
     # By the way, ProvisionedThroughput not only needs to appear, it must
     # have both ReadCapacityUnits and WriteCapacityUnits - but we can't test
     # this with boto3, because boto3 has its own verification that if
     # ProvisionedThroughput is given, it must have the correct form.
-    with pytest.raises(ClientError, match='ValidationException'):
-        create_table(dynamodb, unique_table_name(), BillingMode='PROVISIONED')
+    with pytest.raises(ClientError, match="ValidationException"):
+        create_table(dynamodb, unique_table_name(), BillingMode="PROVISIONED")
     # If BillingMode is completely missing, it defaults to PROVISIONED, so
     # ProvisionedThroughput is required
-    with pytest.raises(ClientError, match='ValidationException'):
-        dynamodb.create_table(TableName=unique_table_name(),
-            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }])
+    with pytest.raises(ClientError, match="ValidationException"):
+        dynamodb.create_table(
+            TableName=unique_table_name(),
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+        )
+
 
 # Even before Alternator gains full support for the DynamoDB stream API
 # and CreateTable's StreamSpecification option, we should support the
@@ -288,23 +308,29 @@ def test_create_table_billing_mode_errors(dynamodb, test_table):
 def test_table_streams_off(dynamodb):
     # If StreamSpecification is given, but has StreamEnabled=false, it's as
     # if StreamSpecification was missing. StreamViewType isn't needed.
-    table = create_test_table(dynamodb, StreamSpecification={'StreamEnabled': False},
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
-    table.delete();
-    # DynamoDB doesn't allow StreamSpecification to be empty map - if it
-    # exists, it must have a StreamEnabled
-    # Unfortunately, new versions of boto3 doesn't let us pass this...
-    #with pytest.raises(ClientError, match='ValidationException'):
-    #    table = create_test_table(dynamodb, StreamSpecification={},
-    #        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-    #        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
-    #    table.delete();
-    # Unfortunately, boto3 doesn't allow us to pass StreamSpecification=None.
-    # This is what we had in issue #5796.
+    table = create_test_table(
+        dynamodb,
+        StreamSpecification={"StreamEnabled": False},
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+    )
+    table.delete()
+
+
+# DynamoDB doesn't allow StreamSpecification to be empty map - if it
+# exists, it must have a StreamEnabled
+# Unfortunately, new versions of boto3 doesn't let us pass this...
+# with pytest.raises(ClientError, match='ValidationException'):
+#    table = create_test_table(dynamodb, StreamSpecification={},
+#        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+#        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
+#    table.delete();
+# Unfortunately, boto3 doesn't allow us to pass StreamSpecification=None.
+# This is what we had in issue #5796.
 
 # For tests with 'StreamEnabled': True, and different 'StreamViewType', see
 # test_streams.py.
+
 
 # Our first implementation had a special column name called "attrs" where
 # we stored a map for all non-key columns. If the user tried to name one
@@ -314,28 +340,42 @@ def test_table_streams_off(dynamodb):
 # the result was no longer a disaster, but is still an error from CreateTable
 # saying that the column name ':attrs' is reserved.
 # Reproduces #5009
-@pytest.mark.xfail(reason="#5009: name ':attrs' not allowed for key column")
+@pytest.mark.xfail(
+    reason='Alternator: don\'t forbid attribute name ":attrs" as a key #5009'
+)
 def test_create_table_special_column_name(dynamodb):
-    for c in ['attrs', ':attrs']:
+    for c in ["attrs", ":attrs"]:
         # Try the suspicious attribute name as a partition key:
-        with new_test_table(dynamodb,
-            KeySchema=[{ 'AttributeName': c, 'KeyType': 'HASH' }],
-            AttributeDefinitions=[{ 'AttributeName': c, 'AttributeType': 'S' }]) as table:
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": c, "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": c, "AttributeType": "S"}],
+        ) as table:
             s = random_string()
-            expected = {c: s, 'hello': random_string()}
+            expected = {c: s, "hello": random_string()}
             table.put_item(Item=expected)
-            assert expected == table.get_item(Key={c: s}, ConsistentRead=True)['Item']
+            assert expected == table.get_item(Key={c: s}, ConsistentRead=True)["Item"]
         # Try the suspicious attribute name as a clustering key:
-        with new_test_table(dynamodb,
-            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' },
-                       { 'AttributeName': c, 'KeyType': 'RANGE' }],
-            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' },
-                                  { 'AttributeName': c, 'AttributeType': 'S' }]) as table:
+        with new_test_table(
+            dynamodb,
+            KeySchema=[
+                {"AttributeName": "p", "KeyType": "HASH"},
+                {"AttributeName": c, "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": c, "AttributeType": "S"},
+            ],
+        ) as table:
             p = random_string()
             s = random_string()
-            expected = {'p': p, c: s, 'hello': random_string()}
+            expected = {"p": p, c: s, "hello": random_string()}
             table.put_item(Item=expected)
-            assert expected == table.get_item(Key={'p': p, c: s}, ConsistentRead=True)['Item']
+            assert (
+                expected
+                == table.get_item(Key={"p": p, c: s}, ConsistentRead=True)["Item"]
+            )
+
 
 # Whereas test_create_table_special_column_name above tests what happen when
 # the name ":attrs" is used for a key column (partition key or sort key), in
@@ -346,64 +386,100 @@ def test_create_table_special_column_name(dynamodb):
 # these tests used to crash Scylla or otherwise fail.
 def test_special_attribute_name_putitem(test_table_s):
     p = random_string()
-    expected = {'p': p, ':attrs': random_string()}
+    expected = {"p": p, ":attrs": random_string()}
     test_table_s.put_item(Item=expected)
-    assert expected == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert expected == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+
 
 def test_special_attribute_name_updateitem_put(test_table_s):
     p = random_string()
     s = random_string()
-    test_table_s.update_item(Key={'p': p},
-        AttributeUpdates={':attrs': {'Value': s, 'Action': 'PUT'}})
-    assert {'p': p, ':attrs': s} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_s.update_item(
+        Key={"p": p}, AttributeUpdates={":attrs": {"Value": s, "Action": "PUT"}}
+    )
+    assert {"p": p, ":attrs": s} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+
 
 def test_special_attribute_name_updateitem_delete(test_table_s):
     p = random_string()
     s = random_string()
-    test_table_s.put_item(Item={'p': p, ':attrs': s, 'animal': 'dog'})
-    assert {'p': p, ':attrs': s, 'animal': 'dog'} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    test_table_s.update_item(Key={'p': p},
-        AttributeUpdates={':attrs': {'Action': 'DELETE'}})
-    assert {'p': p, 'animal': 'dog'} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_s.put_item(Item={"p": p, ":attrs": s, "animal": "dog"})
+    assert {"p": p, ":attrs": s, "animal": "dog"} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+    test_table_s.update_item(
+        Key={"p": p}, AttributeUpdates={":attrs": {"Action": "DELETE"}}
+    )
+    assert {"p": p, "animal": "dog"} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+
 
 def test_special_attribute_name_updateitem_rmw(test_table_s):
     p = random_string()
-    test_table_s.put_item(Item={'p': p, ':attrs': 7})
-    assert {'p': p, ':attrs': 7} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    test_table_s.update_item(Key={'p': p},
-        UpdateExpression='SET #a = #a + :one',
-        ExpressionAttributeValues={':one': 1},
-        ExpressionAttributeNames={'#a': ':attrs'})
-    assert {'p': p, ':attrs': 8} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_s.put_item(Item={"p": p, ":attrs": 7})
+    assert {"p": p, ":attrs": 7} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression="SET #a = #a + :one",
+        ExpressionAttributeValues={":one": 1},
+        ExpressionAttributeNames={"#a": ":attrs"},
+    )
+    assert {"p": p, ":attrs": 8} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+
 
 def test_special_attribute_name_updateitem_expected(test_table_s):
     p = random_string()
-    test_table_s.put_item(Item={'p': p, ':attrs': 7})
-    assert {'p': p, ':attrs': 7} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    test_table_s.update_item(Key={'p': p},
-        AttributeUpdates={'animal': {'Value': 'dog', 'Action': 'PUT'}},
-        Expected={':attrs': {'ComparisonOperator': 'EQ', 'AttributeValueList': [7]}})
-    assert {'p': p, ':attrs': 7, 'animal': 'dog'} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_s.put_item(Item={"p": p, ":attrs": 7})
+    assert {"p": p, ":attrs": 7} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+    test_table_s.update_item(
+        Key={"p": p},
+        AttributeUpdates={"animal": {"Value": "dog", "Action": "PUT"}},
+        Expected={":attrs": {"ComparisonOperator": "EQ", "AttributeValueList": [7]}},
+    )
+    assert {"p": p, ":attrs": 7, "animal": "dog"} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+
 
 def test_special_attribute_name_updateitem_condition(test_table_s):
     p = random_string()
-    test_table_s.put_item(Item={'p': p, ':attrs': 7})
-    assert {'p': p, ':attrs': 7} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    test_table_s.update_item(Key={'p': p},
-        UpdateExpression='SET #b = :val',
-        ExpressionAttributeValues={':val': 'dog', ':seven': 7},
-        ExpressionAttributeNames={'#a': ':attrs', '#b': 'animal'},
-        ConditionExpression='#a = :seven')
-    assert {'p': p, ':attrs': 7, 'animal': 'dog'} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_s.put_item(Item={"p": p, ":attrs": 7})
+    assert {"p": p, ":attrs": 7} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+    test_table_s.update_item(
+        Key={"p": p},
+        UpdateExpression="SET #b = :val",
+        ExpressionAttributeValues={":val": "dog", ":seven": 7},
+        ExpressionAttributeNames={"#a": ":attrs", "#b": "animal"},
+        ConditionExpression="#a = :seven",
+    )
+    assert {"p": p, ":attrs": 7, "animal": "dog"} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+
 
 def test_special_attribute_name_getitem_projection(test_table_s):
     p = random_string()
-    test_table_s.put_item(Item={'p': p, ':attrs': 7, 'animal': 'dog'})
-    assert {'p': p, ':attrs': 7, 'animal': 'dog'} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    assert {':attrs': 7} == test_table_s.get_item(Key={'p': p},
-        ProjectionExpression='#a',
-        ExpressionAttributeNames={'#a': ':attrs'},
-        ConsistentRead=True)['Item']
+    test_table_s.put_item(Item={"p": p, ":attrs": 7, "animal": "dog"})
+    assert {"p": p, ":attrs": 7, "animal": "dog"} == test_table_s.get_item(
+        Key={"p": p}, ConsistentRead=True
+    )["Item"]
+    assert {":attrs": 7} == test_table_s.get_item(
+        Key={"p": p},
+        ProjectionExpression="#a",
+        ExpressionAttributeNames={"#a": ":attrs"},
+        ConsistentRead=True,
+    )["Item"]
 
 
 # Test that all tables we create are listed, and pagination works properly.
@@ -417,11 +493,13 @@ def test_list_tables_paginated(dynamodb, test_table, test_table_s, test_table_b)
         list_tables_set = set(list_tables(dynamodb, limit))
         assert my_tables_set.issubset(list_tables_set)
 
+
 # Test that pagination limit is validated
 def test_list_tables_wrong_limit(dynamodb):
     # lower limit (min. 1) is imposed by boto3 library checks
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="ValidationException"):
         dynamodb.meta.client.list_tables(Limit=101)
+
 
 # Even before Alternator gains support for configuring server-side encryption
 # ("encryption at rest") with CreateTable's SSESpecification option, we should
@@ -432,24 +510,30 @@ def test_table_sse_off(dynamodb):
     # If StreamSpecification is given, but has StreamEnabled=false, it's as
     # if StreamSpecification was missing, and fine. No other attributes are
     # necessary.
-    table = create_test_table(dynamodb, SSESpecification = {'Enabled': False},
-        KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-        AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }]);
-    table.delete();
+    table = create_test_table(
+        dynamodb,
+        SSESpecification={"Enabled": False},
+        KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+    )
+    table.delete()
+
 
 # Test that trying to delete a table that doesn't exist fails in the
 # appropriate way (ResourceNotFoundException)
 def test_delete_table_non_existent(dynamodb, test_table):
     client = dynamodb.meta.client
-    with pytest.raises(ClientError, match='ResourceNotFoundException'):
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
         client.delete_table(TableName=random_string(20))
+
 
 # Test that trying to update a table that doesn't exist fails in the
 # appropriate way (ResourceNotFoundException)
 def test_update_table_non_existent(dynamodb, test_table):
     client = dynamodb.meta.client
-    with pytest.raises(ClientError, match='ResourceNotFoundException'):
-        client.update_table(TableName=random_string(20), BillingMode='PAY_PER_REQUEST')
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
+        client.update_table(TableName=random_string(20), BillingMode="PAY_PER_REQUEST")
+
 
 # Test for reproducing issues #6391 and #9868 - where CreateTable did not
 # *atomically* perform all the schema modifications - creating a keyspace,
@@ -474,46 +558,53 @@ def test_update_table_non_existent(dynamodb, test_table):
 # But even on one coordinator this test can already reproduce the bugs
 # described in #6391 and #9868, so it's worth having this single-node test
 # as well.
-@pytest.mark.parametrize("table_def", [
-    # A table without a secondary index - requiring the creation of
-    # a keyspace and a table in it.
-    {   'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [
-            { 'AttributeName': 'p', 'AttributeType': 'S' }]
-    },
-    # Reproducer for #9868 - CreateTable needs to create a keyspace,
-    # a table, and a materialized view.
-    {   'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'c', 'KeyType': 'RANGE' }
-        ],
-        'AttributeDefinitions': [
-            { 'AttributeName': 'p', 'AttributeType': 'S' },
-            { 'AttributeName': 'c', 'AttributeType': 'S' },
-        ],
-        'GlobalSecondaryIndexes': [
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'c', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'p', 'KeyType': 'RANGE' },
-                ],
-                'Projection': { 'ProjectionType': 'ALL' }
-            }
-        ]
-    },
-    # Reproducer for #6391, a table with tags - which we used to add
-    # non-atomically after having already created the table.
-    {   'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [
-            { 'AttributeName': 'p', 'AttributeType': 'S' }],
-        'Tags': [{'Key': 'k1', 'Value': 'v1'}]
-    }
-])
+@pytest.mark.parametrize(
+    "table_def",
+    [
+        # A table without a secondary index - requiring the creation of
+        # a keyspace and a table in it.
+        {
+            "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
+        },
+        # Reproducer for #9868 - CreateTable needs to create a keyspace,
+        # a table, and a materialized view.
+        {
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"},
+                {"AttributeName": "c", "KeyType": "RANGE"},
+            ],
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+            ],
+            "GlobalSecondaryIndexes": [
+                {
+                    "IndexName": "hello",
+                    "KeySchema": [
+                        {"AttributeName": "c", "KeyType": "HASH"},
+                        {"AttributeName": "p", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        },
+        # Reproducer for #6391, a table with tags - which we used to add
+        # non-atomically after having already created the table.
+        {
+            "KeySchema": [{"AttributeName": "p", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "p", "AttributeType": "S"}],
+            "Tags": [{"Key": "k1", "Value": "v1"}],
+        },
+    ],
+)
 def test_concurrent_create_and_delete_table(dynamodb, table_def):
     # According to boto3 documentation, "Unlike Resources and Sessions,
     # clients are generally thread-safe.". So because we have two threads
     # in this test, we must not use "dynamodb" (containing the boto3
     # "resource") - we should only the boto3 "client":
     client = dynamodb.meta.client
+
     # Unfortunately by default Python threads print their exceptions
     # (e.g., assertion failures) but don't propagate them to the join(),
     # so the overall test doesn't fail. The following Thread wrapper
@@ -524,9 +615,10 @@ def test_concurrent_create_and_delete_table(dynamodb, table_def):
                 self.ret = self._target(*self._args, **self._kwargs)
             except BaseException as e:
                 self.exception = e
+
         def join(self, timeout=None):
             super().join(timeout)
-            if hasattr(self, 'exception'):
+            if hasattr(self, "exception"):
                 raise self.exception
             return self.ret
 
@@ -536,6 +628,7 @@ def test_concurrent_create_and_delete_table(dynamodb, table_def):
     # Lower numbers have some chance of not catching the bug. If this
     # issue starts to xpass, we may need to increase the count.
     count = 10
+
     def deletes():
         for i in range(count):
             try:
@@ -547,22 +640,25 @@ def test_concurrent_create_and_delete_table(dynamodb, table_def):
                 # of being created.
                 # Anything else (e.g., InternalServerError) is a bug.
                 assert isinstance(e, ClientError) and (
-                    'ResourceNotFoundException' in str(e) or
-                    'ResourceInUseException' in str(e))
+                    "ResourceNotFoundException" in str(e)
+                    or "ResourceInUseException" in str(e)
+                )
             else:
                 print("delete successful")
+
     def creates():
         for i in range(count):
             try:
-                client.create_table(TableName=table_name,
-                    BillingMode='PAY_PER_REQUEST',
-                    **table_def)
+                client.create_table(
+                    TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_def
+                )
             except Exception as e:
                 # Expect either success or a ResourceInUseException.
                 # Anything else (e.g., InternalServerError) is a bug.
-                assert isinstance(e, ClientError) and 'ResourceInUseException' in str(e)
+                assert isinstance(e, ClientError) and "ResourceInUseException" in str(e)
             else:
                 print("create successful")
+
     t1 = ThreadWrapper(target=deletes)
     t2 = ThreadWrapper(target=creates)
     t1.start()
@@ -581,56 +677,61 @@ def test_concurrent_create_and_delete_table(dynamodb, table_def):
                 client.delete_table(TableName=table_name)
                 break
             except ClientError as e:
-                if 'ResourceNotFoundException' in str(e):
+                if "ResourceNotFoundException" in str(e):
                     # The table was already deleted by the deletion thread,
                     # nothing left to do :-)
                     break
-                if 'ResourceInUseException' in str(e):
+                if "ResourceInUseException" in str(e):
                     # A CreateTable opereration is still in progress,
                     # we can't delete the table yet.
                     time.sleep(1)
                     continue
                 raise
 
+
 # Test that DeleteTable returns correct TableDescription (issue #11472)
 def test_delete_table_description(dynamodb):
     table_name = unique_table_name()
 
     table = create_table(dynamodb, table_name)
-    table.meta.client.get_waiter('table_exists').wait(TableName=table_name)
-    got = table.delete()['TableDescription']
+    table.meta.client.get_waiter("table_exists").wait(TableName=table_name)
+    got = table.delete()["TableDescription"]
 
-    assert got['TableName'] == table_name
-    assert got['TableStatus'] == 'DELETING'
-    assert 'TableId' in got
-    assert fullmatch('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', got['TableId'])
+    assert got["TableName"] == table_name
+    assert got["TableStatus"] == "DELETING"
+    assert "TableId" in got
+    assert fullmatch(
+        "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", got["TableId"]
+    )
 
-    assert 'TableArn' in got and got['TableArn'].startswith('arn:')
+    assert "TableArn" in got and got["TableArn"].startswith("arn:")
 
-    assert not 'CreationDateTime' in got
-    assert not 'KeySchema' in got 
-    assert not 'AttributeDefinitions' in got
+    assert not "CreationDateTime" in got
+    assert not "KeySchema" in got
+    assert not "AttributeDefinitions" in got
 
-    assert got['BillingModeSummary']['BillingMode'] == 'PAY_PER_REQUEST'
-    assert 'LastUpdateToPayPerRequestDateTime' in got['BillingModeSummary']
-    assert got['BillingModeSummary']['LastUpdateToPayPerRequestDateTime'] != None
+    assert got["BillingModeSummary"]["BillingMode"] == "PAY_PER_REQUEST"
+    assert "LastUpdateToPayPerRequestDateTime" in got["BillingModeSummary"]
+    assert got["BillingModeSummary"]["LastUpdateToPayPerRequestDateTime"] != None
 
-    assert got['ProvisionedThroughput']['NumberOfDecreasesToday'] == 0
-    assert got['ProvisionedThroughput']['WriteCapacityUnits'] == 0
-    assert got['ProvisionedThroughput']['ReadCapacityUnits'] == 0
+    assert got["ProvisionedThroughput"]["NumberOfDecreasesToday"] == 0
+    assert got["ProvisionedThroughput"]["WriteCapacityUnits"] == 0
+    assert got["ProvisionedThroughput"]["ReadCapacityUnits"] == 0
+
 
 # Test that DeleteTable returns correct TableDescription (issue #11472) and has no not implemented fields (see #5026 issue)
 # after any field implementation move its testing code to the 'test_delete_table_description' test
-@pytest.mark.xfail(reason="#5026: TableDescription still doesn't implement these fields")
+@pytest.mark.xfail(reason="Alternator: missing fields in return of DescribeTable #5026")
 def test_delete_table_description_missing_fields(dynamodb):
     table_name = unique_table_name()
 
     table = create_table(dynamodb, table_name)
-    table.meta.client.get_waiter('table_exists').wait(TableName=table_name)
-    got = table.delete()['TableDescription']
+    table.meta.client.get_waiter("table_exists").wait(TableName=table_name)
+    got = table.delete()["TableDescription"]
 
-    assert 'TableSizeBytes' in got
-    assert 'ItemCount' in got    
+    assert "TableSizeBytes" in got
+    assert "ItemCount" in got
+
 
 # Above in test_delete_table_description() we tested the correctness of the
 # return value of DeleteTable, and in particular that it doesn't include all
@@ -640,45 +741,67 @@ def test_delete_table_description_missing_fields(dynamodb):
 # returns a description of the indexes (in fields "GlobalSecondaryIndexes"
 # and "LocalSecondaryIndexes"), DeleteTable doesn't.
 def test_delete_table_description_with_si(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'},
-                   {'AttributeName': 'c', 'KeyType': 'RANGE'}],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' },
-                               { 'AttributeName': 'c', 'AttributeType': 'S' },
-                               { 'AttributeName': 'x', 'AttributeType': 'S' }],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x", "AttributeType": "S"},
+        ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'hello',
-                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
-                'Projection': { 'ProjectionType': 'ALL' }
-            }],
+            {
+                "IndexName": "hello",
+                "KeySchema": [{"AttributeName": "x", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'hithere',
-                'KeySchema': [{'AttributeName': 'p', 'KeyType': 'HASH'},
-                              {'AttributeName': 'x', 'KeyType': 'RANGE'}],
-                'Projection': { 'ProjectionType': 'ALL' }
-            }]
+            {
+                "IndexName": "hithere",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
     )
     # Check that DescribeTable returns the table's KeySchema,
     # AttributeDefinitions, GlobalSecondaryIndexes and LocalSecondaryIndexes,
     # but DeleteTable does *not* return those, even though it could.
-    got_describe = table.meta.client.describe_table(TableName=table.name)['Table']
-    got_delete = table.delete()['TableDescription']
-    assert got_describe['TableName'] == table.name
-    assert got_delete['TableName'] == table.name
-    for i in ['KeySchema', 'AttributeDefinitions', 'GlobalSecondaryIndexes', 'LocalSecondaryIndexes']:
+    got_describe = table.meta.client.describe_table(TableName=table.name)["Table"]
+    got_delete = table.delete()["TableDescription"]
+    assert got_describe["TableName"] == table.name
+    assert got_delete["TableName"] == table.name
+    for i in [
+        "KeySchema",
+        "AttributeDefinitions",
+        "GlobalSecondaryIndexes",
+        "LocalSecondaryIndexes",
+    ]:
         assert i in got_describe
         assert not i in got_delete
+
 
 # Test that CreateTable rejects spurious entries in AttributeDefinitions
 # (entries which aren't used as a key of the table or any GSI or LSI).
 # Reproduces issue #19784.
 def test_create_table_spurious_attribute_definitions(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*AttributeDefinitions'):
-        with new_test_table(dynamodb,
-            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' },
-                                  { 'AttributeName': 'c', 'AttributeType': 'S' }]) as table:
-                pass
+    with pytest.raises(ClientError, match="ValidationException.*AttributeDefinitions"):
+        with new_test_table(
+            dynamodb,
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"},
+            ],
+        ) as table:
+            pass
+
 
 # DynamoDB supports many different types, but the documentation claims that
 # for keys, "The only data types allowed for primary key attributes are
@@ -689,23 +812,32 @@ def test_create_table_spurious_attribute_definitions(dynamodb):
 # See also test_gsi.py::test_gsi_invalid_key_types which checks that the
 # same types are also forbidden as GSI keys.
 def test_forbidden_key_types(dynamodb):
-    for t in ['BOOL', 'BS', 'L', 'M', 'NS', 'NULL', 'SS']:
+    for t in ["BOOL", "BS", "L", "M", "NS", "NULL", "SS"]:
         # Check that partition key of type t is forbidden.
         # The specific error message is different in DynamoDB and Alternator,
         # but both mention the requested type in the message in single quotes.
         with pytest.raises(ClientError, match=f"ValidationException.*'{t}'"):
-            with new_test_table(dynamodb,
-                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
-                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': t}]):
-                    pass
+            with new_test_table(
+                dynamodb,
+                KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+                AttributeDefinitions=[{"AttributeName": "p", "AttributeType": t}],
+            ):
+                pass
         # Check that sort key of type t is forbidden.
         with pytest.raises(ClientError, match=f"ValidationException.*'{t}'"):
-            with new_test_table(dynamodb,
-                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'},
-                           {'AttributeName': 'c', 'KeyType': 'RANGE'}],
-                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'},
-                                      {'AttributeName': 'c', 'AttributeType': t}]):
-                    pass
+            with new_test_table(
+                dynamodb,
+                KeySchema=[
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "c", "KeyType": "RANGE"},
+                ],
+                AttributeDefinitions=[
+                    {"AttributeName": "p", "AttributeType": "S"},
+                    {"AttributeName": "c", "AttributeType": t},
+                ],
+            ):
+                pass
+
 
 # Although as we tested in the previous test (test_forbidden_key_types) most
 # DynamoDB types are not allowed as key types (only S, B and N are allowed),
@@ -717,10 +849,18 @@ def test_forbidden_key_types(dynamodb):
 # because we can't create a table with these types, GetItem with those
 # types is bound to fail.
 def test_forbidden_key_types_getitem(test_table_s):
-    for p in [False, {b'hi', b'there'}, ['hi',3], {'hi': 3}, {1,2}, None, {'hi', 'there'}]:
+    for p in [
+        False,
+        {b"hi", b"there"},
+        ["hi", 3],
+        {"hi": 3},
+        {1, 2},
+        None,
+        {"hi", "there"},
+    ]:
         # Unfortunately the error message in DynamoDB ("The provided key
         # element does not match the schema") and Alternator ("Type mismatch:
         # expected type S for key column p, got type "BOOL") doesn't have
         # anything in common except the word "match".
-        with pytest.raises(ClientError, match='ValidationException.*match'):
-            test_table_s.get_item(Key={'p': p})
+        with pytest.raises(ClientError, match="ValidationException.*match"):
+            test_table_s.get_item(Key={"p": p})

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -15,7 +15,12 @@ import pytest
 from botocore.exceptions import ClientError
 from packaging.version import Version
 
-from test.alternator.util import multiset, create_test_table, unique_table_name, random_string
+from test.alternator.util import (
+    multiset,
+    create_test_table,
+    unique_table_name,
+    random_string,
+)
 
 # Until August 2024, TagResource was a synchronous operation in DynamoDB -
 # when it returned, the new tags were readable by ListTagsOfResource.
@@ -33,104 +38,108 @@ from test.alternator.util import multiset, create_test_table, unique_table_name,
 # actually happened. Of course, this means the following functions must not
 # be called in parallel on the same table.
 
+
 def tags_array_to_dict(tags_array):
     # Convert [{'Key': 'k', 'Value': 'v'}, ...] into {'k': 'v', ...}
-    return {tag_item['Key']: tag_item['Value'] for tag_item in tags_array}
+    return {tag_item["Key"]: tag_item["Value"] for tag_item in tags_array}
+
 
 def wait_for_tags_dict(table, arn, expected, timeout=30):
     deadline = time.time() + timeout
     while time.time() < deadline:
-        after = tags_array_to_dict(table.meta.client.list_tags_of_resource(ResourceArn=arn)['Tags'])
+        after = tags_array_to_dict(
+            table.meta.client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+        )
         if expected == after:
             return
         time.sleep(0.1)
-    assert expected == tags_array_to_dict(table.meta.client.list_tags_of_resource(ResourceArn=arn)['Tags'])
+    assert expected == tags_array_to_dict(
+        table.meta.client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    )
+
 
 def tag_resource(table, arn, tags):
-    expected = tags_array_to_dict(table.meta.client.list_tags_of_resource(ResourceArn=arn)['Tags'])
+    expected = tags_array_to_dict(
+        table.meta.client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    )
     expected.update(tags_array_to_dict(tags))
     table.meta.client.tag_resource(ResourceArn=arn, Tags=tags)
     wait_for_tags_dict(table, arn, expected)
 
+
 def untag_resource(table, arn, tagkeys):
-    expected = tags_array_to_dict(table.meta.client.list_tags_of_resource(ResourceArn=arn)['Tags'])
+    expected = tags_array_to_dict(
+        table.meta.client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    )
     expected = {k: v for k, v in expected.items() if k not in tagkeys}
     table.meta.client.untag_resource(ResourceArn=arn, TagKeys=tagkeys)
     wait_for_tags_dict(table, arn, expected)
 
+
 def delete_tags(table, arn):
     got = table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    if len(got['Tags']):
-        untag_resource(table, arn, [tag['Key'] for tag in got['Tags']])
+    if len(got["Tags"]):
+        untag_resource(table, arn, [tag["Key"] for tag in got["Tags"]])
+
 
 # Test checking that tagging and untagging is correctly handled
 def test_tag_resource_basic(test_table):
-    got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
-    arn =  got['TableArn']
+    got = test_table.meta.client.describe_table(TableName=test_table.name)["Table"]
+    arn = got["TableArn"]
     tags = [
-        {
-            'Key': 'string',
-            'Value': 'string'
-        },
-        {
-            'Key': 'string2',
-            'Value': 'string4'
-        },
-        {
-            'Key': '7',
-            'Value': ' '
-        },
-        {
-            'Key': ' ',
-            'Value': '9'
-        },
+        {"Key": "string", "Value": "string"},
+        {"Key": "string2", "Value": "string4"},
+        {"Key": "7", "Value": " "},
+        {"Key": " ", "Value": "9"},
     ]
 
     delete_tags(test_table, arn)
     got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert len(got['Tags']) == 0
+    assert len(got["Tags"]) == 0
     tag_resource(test_table, arn, tags)
     got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert 'Tags' in got
-    assert multiset(got['Tags']) == multiset(tags)
+    assert "Tags" in got
+    assert multiset(got["Tags"]) == multiset(tags)
 
     # Removing non-existent tags is legal
-    untag_resource(test_table, arn, ['string2', 'non-nexistent', 'zzz2'])
-    tags.remove({'Key': 'string2', 'Value': 'string4'})
+    untag_resource(test_table, arn, ["string2", "non-nexistent", "zzz2"])
+    tags.remove({"Key": "string2", "Value": "string4"})
     got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert 'Tags' in got
-    assert multiset(got['Tags']) == multiset(tags)
+    assert "Tags" in got
+    assert multiset(got["Tags"]) == multiset(tags)
 
     delete_tags(test_table, arn)
     got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert len(got['Tags']) == 0
+    assert len(got["Tags"]) == 0
+
 
 def test_tag_resource_overwrite(test_table):
-    got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
-    arn =  got['TableArn']
+    got = test_table.meta.client.describe_table(TableName=test_table.name)["Table"]
+    arn = got["TableArn"]
     tags = [
-        {
-            'Key': 'string',
-            'Value': 'string'
-        },
+        {"Key": "string", "Value": "string"},
     ]
     delete_tags(test_table, arn)
     tag_resource(test_table, arn, tags)
     got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert 'Tags' in got
-    assert multiset(got['Tags']) == multiset(tags)
+    assert "Tags" in got
+    assert multiset(got["Tags"]) == multiset(tags)
     tags = [
-        {
-            'Key': 'string',
-            'Value': 'different_string_value'
-        },
+        {"Key": "string", "Value": "different_string_value"},
     ]
     tag_resource(test_table, arn, tags)
     got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert 'Tags' in got
-    assert multiset(got['Tags']) == multiset(tags)
+    assert "Tags" in got
+    assert multiset(got["Tags"]) == multiset(tags)
 
-PREDEFINED_TAGS = [{'Key': 'str1', 'Value': 'str2'}, {'Key': 'kkk', 'Value': 'vv'}, {'Key': 'keykey', 'Value': 'valvalvalval'}]
+
+PREDEFINED_TAGS = [
+    {"Key": "str1", "Value": "str2"},
+    {"Key": "kkk", "Value": "vv"},
+    {"Key": "keykey", "Value": "valvalvalval"},
+]
+
+
 @pytest.fixture(scope="module")
 def test_table_tags(dynamodb):
     # The feature of creating a table already with tags was only added to
@@ -138,78 +147,134 @@ def test_table_tags(dynamodb):
     # https://aws.amazon.com/about-aws/whats-new/2019/04/now-you-can-tag-amazon-dynamodb-tables-when-you-create-them/
     # so older versions of the library cannot run this test.
     import botocore
-    if (Version(botocore.__version__) < Version('1.12.136')):
+
+    if Version(botocore.__version__) < Version("1.12.136"):
         pytest.skip("Botocore version 1.12.136 or above required to run this test")
 
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'N' } ],
-        Tags=PREDEFINED_TAGS)
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "N"},
+        ],
+        Tags=PREDEFINED_TAGS,
+    )
     yield table
     table.delete()
 
+
 # Test checking that tagging works during table creation
 def test_list_tags_from_creation(test_table_tags):
-    got = test_table_tags.meta.client.describe_table(TableName=test_table_tags.name)['Table']
-    arn =  got['TableArn']
+    got = test_table_tags.meta.client.describe_table(TableName=test_table_tags.name)[
+        "Table"
+    ]
+    arn = got["TableArn"]
     got = test_table_tags.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert multiset(got['Tags']) == multiset(PREDEFINED_TAGS)
+    assert multiset(got["Tags"]) == multiset(PREDEFINED_TAGS)
+
 
 # Test checking that incorrect parameters return proper error codes
 def test_tag_resource_incorrect(test_table):
-    got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
-    arn =  got['TableArn']
+    got = test_table.meta.client.describe_table(TableName=test_table.name)["Table"]
+    arn = got["TableArn"]
     delete_tags(test_table, arn)
     # Note: Tags must have two entries in the map: Key and Value, and their values
     # must be at least 1 character long, but these are validated on boto3 level
     # Older DynamoDB returned AccessDeniedException for this case, newer one
     # returns ValidationException saying "ARNs must start with 'arn:'".
-    with pytest.raises(ClientError, match='AccessDeniedException|ARNs'):
-        test_table.meta.client.tag_resource(ResourceArn='I_do_not_exist', Tags=[{'Key': '7', 'Value': '8'}])
-    with pytest.raises(ClientError, match='ValidationException'):
+    with pytest.raises(ClientError, match="AccessDeniedException|ARNs"):
+        test_table.meta.client.tag_resource(
+            ResourceArn="I_do_not_exist", Tags=[{"Key": "7", "Value": "8"}]
+        )
+    with pytest.raises(ClientError, match="ValidationException"):
         test_table.meta.client.tag_resource(ResourceArn=arn, Tags=[])
-    tag_resource(test_table, arn, [{'Key': str(i), 'Value': str(i)} for i in range(30)])
-    tag_resource(test_table, arn, [{'Key': str(i), 'Value': str(i)} for i in range(20, 40)])
-    with pytest.raises(ClientError, match='ValidationException'):
-        test_table.meta.client.tag_resource(ResourceArn=arn, Tags=[{'Key': str(i), 'Value': str(i)} for i in range(40, 60)])
-    for incorrect_arn in ['arn:not/a/good/format', 'x'*125, 'arn:'+'scylla/'*15, ':/'*30, ' ', 'незаконные буквы']:
-        with pytest.raises(ClientError, match='.*Exception'):
-            test_table.meta.client.tag_resource(ResourceArn=incorrect_arn, Tags=[{'Key':'x', 'Value':'y'}])
-    for incorrect_tag in [('ok', '#!%%^$$&'), ('->>;-)])', 'ok'), ('!!!\\|','<><')]:
-        with pytest.raises(ClientError, match='ValidationException'):
-            test_table.meta.client.tag_resource(ResourceArn=arn, Tags=[{'Key':incorrect_tag[0],'Value':incorrect_tag[1]}])
+    tag_resource(test_table, arn, [{"Key": str(i), "Value": str(i)} for i in range(30)])
+    tag_resource(
+        test_table, arn, [{"Key": str(i), "Value": str(i)} for i in range(20, 40)]
+    )
+    with pytest.raises(ClientError, match="ValidationException"):
+        test_table.meta.client.tag_resource(
+            ResourceArn=arn,
+            Tags=[{"Key": str(i), "Value": str(i)} for i in range(40, 60)],
+        )
+    for incorrect_arn in [
+        "arn:not/a/good/format",
+        "x" * 125,
+        "arn:" + "scylla/" * 15,
+        ":/" * 30,
+        " ",
+        "незаконные буквы",
+    ]:
+        with pytest.raises(ClientError, match=".*Exception"):
+            test_table.meta.client.tag_resource(
+                ResourceArn=incorrect_arn, Tags=[{"Key": "x", "Value": "y"}]
+            )
+    for incorrect_tag in [("ok", "#!%%^$$&"), ("->>;-)])", "ok"), ("!!!\\|", "<><")]:
+        with pytest.raises(ClientError, match="ValidationException"):
+            test_table.meta.client.tag_resource(
+                ResourceArn=arn,
+                Tags=[{"Key": incorrect_tag[0], "Value": incorrect_tag[1]}],
+            )
+
 
 # The previous test, test_tag_resource_incorrect, tried several cases of
 # misformatted or obviously incorrect ARNs and checked the appropriate
 # errors. Here we try a more subtle error - an ARN that looks like it could
 # have been a real one - it's close to an existing table's ARN - but isn't.
 def test_tag_resource_subtly_incorrect_arn(test_table):
-    arn = test_table.meta.client.describe_table(TableName=test_table.name)['Table']['TableArn']
+    arn = test_table.meta.client.describe_table(TableName=test_table.name)["Table"][
+        "TableArn"
+    ]
     # The very last component of the ARN, on both Alternator and DynamoDB,
     # is the table's name. If we add one character at the end of the ARN,
     # it will look like it might be correct, but the table would not found.
-    incorrect_arn = arn + 'x'
+    incorrect_arn = arn + "x"
     # In this case, where the ARN is well-formatted but refers to a non-
     # existent table, DynamoDB returns ResourceNotFoundException and not
     # AccessDeniedException or ValidationException as in other cases.
-    with pytest.raises(ClientError, match='ResourceNotFoundException'):
-        test_table.meta.client.tag_resource(ResourceArn=incorrect_arn, Tags=[{'Key':'x', 'Value':'y'}])
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
+        test_table.meta.client.tag_resource(
+            ResourceArn=incorrect_arn, Tags=[{"Key": "x", "Value": "y"}]
+        )
+
 
 # Test that only specific values are allowed for write isolation (system:write_isolation tag)
 def test_tag_resource_write_isolation_values(scylla_only, test_table):
-    got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
-    arn =  got['TableArn']
-    for i in ['f', 'forbid', 'forbid_rmw', 'a', 'always', 'always_use_lwt', 'o', 'only_rmw_uses_lwt', 'u', 'unsafe', 'unsafe_rmw']:
-        tag_resource(test_table, arn, [{'Key':'system:write_isolation', 'Value':i}])
-    with pytest.raises(ClientError, match='ValidationException'):
-        test_table.meta.client.tag_resource(ResourceArn=arn, Tags=[{'Key':'system:write_isolation', 'Value':'bah'}])
+    got = test_table.meta.client.describe_table(TableName=test_table.name)["Table"]
+    arn = got["TableArn"]
+    for i in [
+        "f",
+        "forbid",
+        "forbid_rmw",
+        "a",
+        "always",
+        "always_use_lwt",
+        "o",
+        "only_rmw_uses_lwt",
+        "u",
+        "unsafe",
+        "unsafe_rmw",
+    ]:
+        tag_resource(test_table, arn, [{"Key": "system:write_isolation", "Value": i}])
+    with pytest.raises(ClientError, match="ValidationException"):
+        test_table.meta.client.tag_resource(
+            ResourceArn=arn, Tags=[{"Key": "system:write_isolation", "Value": "bah"}]
+        )
     # Verify that reading system:write_isolation is possible (we didn't
     # accidentally prevent it while fixing #24098)
-    keys = [tag['Key'] for tag in test_table.meta.client.list_tags_of_resource(ResourceArn=arn)['Tags']]
-    assert 'system:write_isolation' in keys
+    keys = [
+        tag["Key"]
+        for tag in test_table.meta.client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    ]
+    assert "system:write_isolation" in keys
     # Finally remove the system:write_isolation tag so to not modify the
     # default behavior of test_table.
-    untag_resource(test_table, arn, ['system:write_isolation'])
+    untag_resource(test_table, arn, ["system:write_isolation"])
+
 
 # Test that if trying to create a table with forbidden tags (in this test,
 # a list of tags longer than the maximum allowed of 50 tags), the table
@@ -219,19 +284,23 @@ def test_too_long_tags_from_creation(dynamodb):
     # DynamoDB in April 2019, and to the botocore library in version 1.12.136
     # so older versions of the library cannot run this test.
     import botocore
-    if (Version(botocore.__version__) < Version('1.12.136')):
+
+    if Version(botocore.__version__) < Version("1.12.136"):
         pytest.skip("Botocore version 1.12.136 or above required to run this test")
     name = unique_table_name()
     # Setting 100 tags is not allowed, the following table creation should fail:
-    with pytest.raises(ClientError, match='ValidationException'):
-        dynamodb.create_table(TableName=name,
-            BillingMode='PAY_PER_REQUEST',
-            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
-            Tags=[{'Key': str(i), 'Value': str(i)} for i in range(100)])
+    with pytest.raises(ClientError, match="ValidationException"):
+        dynamodb.create_table(
+            TableName=name,
+            BillingMode="PAY_PER_REQUEST",
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+            Tags=[{"Key": str(i), "Value": str(i)} for i in range(100)],
+        )
     # After the table creation failed, the table should not exist.
-    with pytest.raises(ClientError, match='ResourceNotFoundException'):
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
         dynamodb.meta.client.describe_table(TableName=name)
+
 
 # This test is similar to the above, but uses another case of forbidden tags -
 # here an illegal value for the system:write_isolation tag. This is a
@@ -244,93 +313,94 @@ def test_forbidden_tags_from_creation(scylla_only, dynamodb):
     # DynamoDB in April 2019, and to the botocore library in version 1.12.136
     # so older versions of the library cannot run this test.
     import botocore
-    if (Version(botocore.__version__) < Version('1.12.136')):
+
+    if Version(botocore.__version__) < Version("1.12.136"):
         pytest.skip("Botocore version 1.12.136 or above required to run this test")
     name = unique_table_name()
     # It is not allowed to set the system:write_isolation to "dog", so the
     # following table creation should fail:
-    with pytest.raises(ClientError, match='ValidationException'):
-        dynamodb.create_table(TableName=name,
-            BillingMode='PAY_PER_REQUEST',
-            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
-            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
-            Tags=[{'Key': 'system:write_isolation', 'Value': 'dog'}])
+    with pytest.raises(ClientError, match="ValidationException"):
+        dynamodb.create_table(
+            TableName=name,
+            BillingMode="PAY_PER_REQUEST",
+            KeySchema=[{"AttributeName": "p", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "p", "AttributeType": "S"}],
+            Tags=[{"Key": "system:write_isolation", "Value": "dog"}],
+        )
     # After the table creation failed, the table should not exist.
-    with pytest.raises(ClientError, match='ResourceNotFoundException'):
+    with pytest.raises(ClientError, match="ResourceNotFoundException"):
         dynamodb.meta.client.describe_table(TableName=name)
+
 
 # Test checking that unicode tags are allowed
 @pytest.mark.xfail(reason="unicode tags not yet supported")
 def test_tag_resource_unicode(test_table):
-    got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
-    arn =  got['TableArn']
+    got = test_table.meta.client.describe_table(TableName=test_table.name)["Table"]
+    arn = got["TableArn"]
     tags = [
-        {
-            'Key': 'законные буквы',
-            'Value': 'string'
-        },
-        {
-            'Key': 'ѮѮ Ѯ',
-            'Value': 'string4'
-        },
-        {
-            'Key': 'ѮѮ',
-            'Value': 'ѮѮѮѮѮѮѮѮѮѮѮѮѮѮ'
-        },
-        {
-            'Key': 'keyѮѮѮ',
-            'Value': 'ѮѮѮvalue'
-        },
+        {"Key": "законные буквы", "Value": "string"},
+        {"Key": "ѮѮ Ѯ", "Value": "string4"},
+        {"Key": "ѮѮ", "Value": "ѮѮѮѮѮѮѮѮѮѮѮѮѮѮ"},
+        {"Key": "keyѮѮѮ", "Value": "ѮѮѮvalue"},
     ]
 
     delete_tags(test_table, arn)
     got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert len(got['Tags']) == 0
+    assert len(got["Tags"]) == 0
     tag_resource(test_table, arn, tags)
     got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)
-    assert 'Tags' in got
-    assert multiset(got['Tags']) == multiset(tags)
+    assert "Tags" in got
+    assert multiset(got["Tags"]) == multiset(tags)
+
 
 # Test that the Tags option of TagResource is required
 def test_tag_resource_missing_tags(test_table):
     client = test_table.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
-    with pytest.raises(ClientError, match='ValidationException'):
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
+    with pytest.raises(ClientError, match="ValidationException"):
         client.tag_resource(ResourceArn=arn)
+
 
 # A simple table with both gsi and lsi (which happen to be the same), which
 # we'll use for testing tagging of GSIs and LSIs
 # Use a function-scoped fixture to get a fresh untagged table in each test.
 @pytest.fixture(scope="function")
 def table_lsi_gsi(dynamodb):
-    table = create_test_table(dynamodb,
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+    table = create_test_table(
+        dynamodb,
+        KeySchema=[
+            {"AttributeName": "p", "KeyType": "HASH"},
+            {"AttributeName": "c", "KeyType": "RANGE"},
+        ],
         AttributeDefinitions=[
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'c', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x1', 'AttributeType': 'S' },
+            {"AttributeName": "p", "AttributeType": "S"},
+            {"AttributeName": "c", "AttributeType": "S"},
+            {"AttributeName": "x1", "AttributeType": "S"},
         ],
         GlobalSecondaryIndexes=[
-            {   'IndexName': 'gsi',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'x1', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "gsi",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x1", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
             }
         ],
         LocalSecondaryIndexes=[
-            {   'IndexName': 'lsi',
-                'KeySchema': [
-                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
-                    { 'AttributeName': 'x1', 'KeyType': 'RANGE' }
+            {
+                "IndexName": "lsi",
+                "KeySchema": [
+                    {"AttributeName": "p", "KeyType": "HASH"},
+                    {"AttributeName": "x1", "KeyType": "RANGE"},
                 ],
-                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
             }
-        ])
+        ],
+    )
     yield table
     table.delete()
+
 
 # Although GSIs and LSIs have their own ARN (listed by DescribeTable), it
 # turns out that they cannot be used to retrieve or set tags on the GSI or
@@ -349,21 +419,39 @@ def table_lsi_gsi(dynamodb):
 # DynamoDB here, and to *allow* tagging GSIs and LSIs separately. But until
 # then, this test verifies that we don't allow it - just like DynamoDB.
 def test_tag_lsi_gsi(table_lsi_gsi):
-    table_desc = table_lsi_gsi.meta.client.describe_table(TableName=table_lsi_gsi.name)['Table']
-    table_arn =  table_desc['TableArn']
-    gsi_arn =  table_desc['GlobalSecondaryIndexes'][0]['IndexArn']
-    lsi_arn =  table_desc['LocalSecondaryIndexes'][0]['IndexArn']
-    assert [] == table_lsi_gsi.meta.client.list_tags_of_resource(ResourceArn=table_arn)['Tags']
-    with pytest.raises(ClientError, match='ValidationException.*[Rr]esource ?[Aa]rn'):
-        assert [] == table_lsi_gsi.meta.client.list_tags_of_resource(ResourceArn=gsi_arn)['Tags']
-    with pytest.raises(ClientError, match='ValidationException.*[Rr]esource ?[Aa]rn'):
-        assert [] == table_lsi_gsi.meta.client.list_tags_of_resource(ResourceArn=lsi_arn)['Tags']
-    tags = [ { 'Key': 'hi', 'Value': 'hello' } ]
+    table_desc = table_lsi_gsi.meta.client.describe_table(TableName=table_lsi_gsi.name)[
+        "Table"
+    ]
+    table_arn = table_desc["TableArn"]
+    gsi_arn = table_desc["GlobalSecondaryIndexes"][0]["IndexArn"]
+    lsi_arn = table_desc["LocalSecondaryIndexes"][0]["IndexArn"]
+    assert (
+        []
+        == table_lsi_gsi.meta.client.list_tags_of_resource(ResourceArn=table_arn)[
+            "Tags"
+        ]
+    )
+    with pytest.raises(ClientError, match="ValidationException.*[Rr]esource ?[Aa]rn"):
+        assert (
+            []
+            == table_lsi_gsi.meta.client.list_tags_of_resource(ResourceArn=gsi_arn)[
+                "Tags"
+            ]
+        )
+    with pytest.raises(ClientError, match="ValidationException.*[Rr]esource ?[Aa]rn"):
+        assert (
+            []
+            == table_lsi_gsi.meta.client.list_tags_of_resource(ResourceArn=lsi_arn)[
+                "Tags"
+            ]
+        )
+    tags = [{"Key": "hi", "Value": "hello"}]
     tag_resource(table_lsi_gsi, table_arn, tags)
-    with pytest.raises(ClientError, match='ValidationException.*[Rr]esource ?[Aa]rn'):
+    with pytest.raises(ClientError, match="ValidationException.*[Rr]esource ?[Aa]rn"):
         table_lsi_gsi.meta.client.tag_resource(ResourceArn=gsi_arn, Tags=tags)
-    with pytest.raises(ClientError, match='ValidationException.*[Rr]esource ?[Aa]rn'):
+    with pytest.raises(ClientError, match="ValidationException.*[Rr]esource ?[Aa]rn"):
         table_lsi_gsi.meta.client.tag_resource(ResourceArn=lsi_arn, Tags=tags)
+
 
 # Test that if we concurrently add tags A and B to a table, both survive.
 # If the process of adding tag A involved reading the current tags, adding
@@ -374,7 +462,8 @@ def test_tag_lsi_gsi(table_lsi_gsi):
 @pytest.mark.veryslow
 def test_concurrent_tag(dynamodb, test_table):
     client = test_table.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
+
     # Unfortunately by default Python threads print their exceptions
     # (e.g., assertion failures) but don't propagate them to the join(),
     # so the overall test doesn't fail. The following Thread wrapper
@@ -385,110 +474,139 @@ def test_concurrent_tag(dynamodb, test_table):
                 self.ret = self._target(*self._args, **self._kwargs)
             except BaseException as e:
                 self.exception = e
+
         def join(self, timeout=None):
             super().join(timeout)
-            if hasattr(self, 'exception'):
+            if hasattr(self, "exception"):
                 raise self.exception
             return self.ret
 
     def tag_untag_once(tag):
-        tag_resource(test_table, arn, [{'Key': tag, 'Value': 'Hello'}])
+        tag_resource(test_table, arn, [{"Key": tag, "Value": "Hello"}])
         # Check that the tag that we just added is still on the table (and
         # wasn't overwritten by a concurrent addition of a different tag):
-        got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)['Tags']
-        assert [x['Value'] for x in got if x['Key']==tag] == ['Hello']
+        got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+        assert [x["Value"] for x in got if x["Key"] == tag] == ["Hello"]
         untag_resource(test_table, arn, [tag])
-        got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)['Tags']
-        assert [x['Value'] for x in got if x['Key']==tag] == []
+        got = test_table.meta.client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+        assert [x["Value"] for x in got if x["Key"] == tag] == []
+
     def tag_loop(tag, count):
         for i in range(count):
             tag_untag_once(tag)
+
     # The more iterations we do, the higher the chance of reproducing
     # this issue. On my laptop, count = 100 reproduces the bug every time.
     # Lower numbers have some chance of not catching the bug. If this
     # issue starts to xpass, we may need to increase the count.
     count = 200
-    t1 = ThreadWrapper(target=lambda: tag_loop('A', count))
-    t2 = ThreadWrapper(target=lambda: tag_loop('B', count))
+    t1 = ThreadWrapper(target=lambda: tag_loop("A", count))
+    t2 = ThreadWrapper(target=lambda: tag_loop("B", count))
     t1.start()
     t2.start()
     t1.join()
     t2.join()
 
+
 # An empty string is allowed as a tag's value
 # Reproduces #16904.
 def test_empty_tag_value(dynamodb, test_table):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
     tag = random_string()
-    tag_resource(test_table, arn, [{'Key': tag, 'Value': ''}])
+    tag_resource(test_table, arn, [{"Key": tag, "Value": ""}])
     # Verify that the tag with the empty value was correctly saved:
-    tags = client.list_tags_of_resource(ResourceArn=arn)['Tags']
-    assert {'Key': tag, 'Value': ''} in tags
+    tags = client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    assert {"Key": tag, "Value": ""} in tags
     # Clean up the tag we just added
     untag_resource(test_table, arn, [tag])
+
 
 # However, an empty string is NOT allowed as a tag's key
 def test_empty_tag_key(dynamodb, test_table):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
-    with pytest.raises(ClientError, match='ValidationException'):
-        client.tag_resource(ResourceArn=arn, Tags=[{'Key': '', 'Value': 'dog'}])
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
+    with pytest.raises(ClientError, match="ValidationException"):
+        client.tag_resource(ResourceArn=arn, Tags=[{"Key": "", "Value": "dog"}])
+
 
 # Although an empty Value is allowed for a tag, a *missing* Value is not
 # allowed:
 def test_missing_tag_value(dynamodb, test_table):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
-    with pytest.raises(ClientError, match='ValidationException'):
-        client.tag_resource(ResourceArn=arn, Tags=[{'Key': 'dog'}])
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
+    with pytest.raises(ClientError, match="ValidationException"):
+        client.tag_resource(ResourceArn=arn, Tags=[{"Key": "dog"}])
+
 
 # According to the DynamoDB documentation, the maximum tag key length allowed
 # is 128 characters. Actually, it's 128 *unicode* characters which are
 # allowed, not 128 bytes.
 # Reproduces #16908
-@pytest.mark.parametrize("is_ascii", [
+@pytest.mark.parametrize(
+    "is_ascii",
+    [
         True,
-        pytest.param(False, marks=pytest.mark.xfail(reason="#16908"))])
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                reason="Alternator TagResource should allow (and count) unicode characters #16908"
+            ),
+        ),
+    ],
+)
 def test_tag_key_length_128_allowed(dynamodb, test_table, is_ascii):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
-    tag = ('x' if is_ascii else 'א') * 128
-    tag_resource(test_table, arn, [{'Key': tag, 'Value': 'dog'}])
-    tags = client.list_tags_of_resource(ResourceArn=arn)['Tags']
-    assert {'Key': tag, 'Value': 'dog'} in tags
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
+    tag = ("x" if is_ascii else "א") * 128
+    tag_resource(test_table, arn, [{"Key": tag, "Value": "dog"}])
+    tags = client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    assert {"Key": tag, "Value": "dog"} in tags
     untag_resource(test_table, arn, [tag])
+
 
 def test_tag_key_length_129_forbidden(dynamodb, test_table):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
-    tag = 'x'*129
-    with pytest.raises(ClientError, match='ValidationException'):
-        client.tag_resource(ResourceArn=arn, Tags=[{'Key': tag, 'Value': 'dog'}])
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
+    tag = "x" * 129
+    with pytest.raises(ClientError, match="ValidationException"):
+        client.tag_resource(ResourceArn=arn, Tags=[{"Key": tag, "Value": "dog"}])
+
 
 # According to the DynamoDB documentation, the maximum tag value length
 # allowed is 256 characters. Actually, it's 256 *unicode* characters which
 # are allowed, not 256 bytes.
 # Reproduces #16908
-@pytest.mark.parametrize("is_ascii", [
+@pytest.mark.parametrize(
+    "is_ascii",
+    [
         True,
-        pytest.param(False, marks=pytest.mark.xfail(reason="#16908"))])
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                reason="Alternator TagResource should allow (and count) unicode characters #16908"
+            ),
+        ),
+    ],
+)
 def test_tag_value_length_256_allowed(dynamodb, test_table, is_ascii):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
     tag = random_string()
-    value = ('x' if is_ascii else 'א') * 256
-    tag_resource(test_table, arn, [{'Key': tag, 'Value': value}])
-    tags = client.list_tags_of_resource(ResourceArn=arn)['Tags']
-    assert {'Key': tag, 'Value': value} in tags
+    value = ("x" if is_ascii else "א") * 256
+    tag_resource(test_table, arn, [{"Key": tag, "Value": value}])
+    tags = client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    assert {"Key": tag, "Value": value} in tags
     untag_resource(test_table, arn, [tag])
+
 
 def test_tag_value_length_257_forbidden(dynamodb, test_table):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
-    value = 'x'*257
-    with pytest.raises(ClientError, match='ValidationException'):
-        client.tag_resource(ResourceArn=arn, Tags=[{'Key': 'dog', 'Value': value}])
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
+    value = "x" * 257
+    with pytest.raises(ClientError, match="ValidationException"):
+        client.tag_resource(ResourceArn=arn, Tags=[{"Key": "dog", "Value": value}])
+
 
 # According to the DynamoDB documentation, only letters, whitespace, numbers,
 # and the characters [+-=._:/] are allowed in both tag keys or values.
@@ -496,24 +614,25 @@ def test_tag_value_length_257_forbidden(dynamodb, test_table):
 # key or value.
 def test_tag_forbidden_chars(dynamodb, test_table):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
-    for x in ['hi!', 'd%g', '"hello"']:
-        with pytest.raises(ClientError, match='ValidationException'):
-            client.tag_resource(ResourceArn=arn, Tags=[{'Key': x, 'Value': 'dog'}])
-        with pytest.raises(ClientError, match='ValidationException'):
-            client.tag_resource(ResourceArn=arn, Tags=[{'Key': 'dog', 'Value': x}])
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
+    for x in ["hi!", "d%g", '"hello"']:
+        with pytest.raises(ClientError, match="ValidationException"):
+            client.tag_resource(ResourceArn=arn, Tags=[{"Key": x, "Value": "dog"}])
+        with pytest.raises(ClientError, match="ValidationException"):
+            client.tag_resource(ResourceArn=arn, Tags=[{"Key": "dog", "Value": x}])
+
 
 # Check that's it's allowed to reassign a new value to an existing tag.
 def test_tag_reassign(dynamodb, test_table):
     client = dynamodb.meta.client
-    arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
+    arn = client.describe_table(TableName=test_table.name)["Table"]["TableArn"]
     tag = random_string()
     value1 = random_string()
     value2 = random_string()
-    tag_resource(test_table, arn, [{'Key': tag, 'Value': value1}])
-    tags = client.list_tags_of_resource(ResourceArn=arn)['Tags']
-    assert {'Key': tag, 'Value': value1} in tags
-    tag_resource(test_table, arn, [{'Key': tag, 'Value': value2}])
-    tags = client.list_tags_of_resource(ResourceArn=arn)['Tags']
-    assert {'Key': tag, 'Value': value2} in tags
+    tag_resource(test_table, arn, [{"Key": tag, "Value": value1}])
+    tags = client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    assert {"Key": tag, "Value": value1} in tags
+    tag_resource(test_table, arn, [{"Key": tag, "Value": value2}])
+    tags = client.list_tags_of_resource(ResourceArn=arn)["Tags"]
+    assert {"Key": tag, "Value": value2} in tags
     untag_resource(test_table, arn, [tag])

--- a/test/alternator/test_transact.py
+++ b/test/alternator/test_transact.py
@@ -24,269 +24,336 @@ from .util import random_string
 # A ClientRequestToken is not passed in these basic tests.
 ##########################################################################
 
+
 # Single Put action without a condition
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_put_unconditional(test_table_s):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x}
-    test_table_s.meta.client.transact_write_items(TransactItems=[{
-        'Put': {
-            'TableName': test_table_s.name,
-            'Item': item
-        }}])
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    item = {"p": p, "x": x}
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[{"Put": {"TableName": test_table_s.name, "Item": item}}]
+    )
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+
 
 # Single Put action with a true condition - succeeds
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_put_true(test_table_s):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x}
-    test_table_s.meta.client.transact_write_items(TransactItems=[{
-        'Put': {
-            'TableName': test_table_s.name,
-            'Item': item,
-            # The condition attribute_not_exists(p) is true for an
-            # item that doesn't exist
-            'ConditionExpression': 'attribute_not_exists(p)'
-        }}])
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    item = {"p": p, "x": x}
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            {
+                "Put": {
+                    "TableName": test_table_s.name,
+                    "Item": item,
+                    # The condition attribute_not_exists(p) is true for an
+                    # item that doesn't exist
+                    "ConditionExpression": "attribute_not_exists(p)",
+                }
+            }
+        ]
+    )
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+
 
 # Single Put action with a false condition fails with a
 # TransactionCanceledException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_put_false(test_table_s):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x}
-    with pytest.raises(ClientError, match='TransactionCanceledException'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[{
-            'Put': {
-                'TableName': test_table_s.name,
-                'Item': item,
-                # The condition attribute_exists(p) is false for an
-                # item that doesn't exist
-                'ConditionExpression': 'attribute_exists(p)'
-            }}])
+    item = {"p": p, "x": x}
+    with pytest.raises(ClientError, match="TransactionCanceledException"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": item,
+                        # The condition attribute_exists(p) is false for an
+                        # item that doesn't exist
+                        "ConditionExpression": "attribute_exists(p)",
+                    }
+                }
+            ]
+        )
     # The transaction failed, so the item didn't go in:
-    assert 'Item' not in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+    assert "Item" not in test_table_s.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 # Verify that a transaction's Put action, behaves like a PutItem request,
 # and not like a CQL Insert, in that it completely replaces an existing item -
 # it doesn't merge the new data into the existing item.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_put_replaces(test_table_s):
     p = random_string()
     x = random_string()
     y = random_string()
-    test_table_s.put_item(Item={'p': p, 'x': x})
-    assert {'p': p, 'x': x} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    test_table_s.meta.client.transact_write_items(TransactItems=[{
-        'Put': {
-            'TableName': test_table_s.name,
-            'Item': {'p': p, 'y': y}
-        }}])
-    assert {'p': p, 'y': y} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_s.put_item(Item={"p": p, "x": x})
+    assert {"p": p, "x": x} == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)[
+        "Item"
+    ]
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            {"Put": {"TableName": test_table_s.name, "Item": {"p": p, "y": y}}}
+        ]
+    )
+    assert {"p": p, "y": y} == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)[
+        "Item"
+    ]
+
 
 # Single Delete action without a condition
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_delete_unconditional(test_table_s):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x}
+    item = {"p": p, "x": x}
     test_table_s.put_item(Item=item)
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    test_table_s.meta.client.transact_write_items(TransactItems=[{
-        'Delete': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p}
-        }}])
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[{"Delete": {"TableName": test_table_s.name, "Key": {"p": p}}}]
+    )
     # Item should be gone
-    assert 'Item' not in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+    assert "Item" not in test_table_s.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 # Single Delete action with a true condition succeeds
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_delete_true(test_table_s):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x}
+    item = {"p": p, "x": x}
     test_table_s.put_item(Item=item)
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
-    test_table_s.meta.client.transact_write_items(TransactItems=[{
-        'Delete': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p},
-            # The condition attribute_exists(p) is true for an
-            # item that exists
-            'ConditionExpression': 'attribute_exists(p)'
-        }}])
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            {
+                "Delete": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p},
+                    # The condition attribute_exists(p) is true for an
+                    # item that exists
+                    "ConditionExpression": "attribute_exists(p)",
+                }
+            }
+        ]
+    )
     # Item should be gone
-    assert 'Item' not in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+    assert "Item" not in test_table_s.get_item(Key={"p": p}, ConsistentRead=True)
+
 
 # Single Delete action with a false condition fails with a
 # TransactionCanceledException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_delete_false(test_table_s):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x}
+    item = {"p": p, "x": x}
     test_table_s.put_item(Item=item)
-    with pytest.raises(ClientError, match='TransactionCanceledException'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[{
-            'Delete': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p},
-                # The condition attribute_not_exists(p) is false for an
-                # item that does exist
-                'ConditionExpression': 'attribute_not_exists(p)'
-            }}])
+    with pytest.raises(ClientError, match="TransactionCanceledException"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Delete": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p},
+                        # The condition attribute_not_exists(p) is false for an
+                        # item that does exist
+                        "ConditionExpression": "attribute_not_exists(p)",
+                    }
+                }
+            ]
+        )
     # The transaction failed, so the item wasn't deleted
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+
 
 # Single ConditionCheck action without a condition is, unsurprisingly,
 # not allowed - resulting in ValidationException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_conditioncheck_unconditional(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*[cC]onditionExpression'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[{
-            'ConditionCheck': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p}
-            }}])
+    with pytest.raises(
+        ClientError, match="ValidationException.*[cC]onditionExpression"
+    ):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {"ConditionCheck": {"TableName": test_table_s.name, "Key": {"p": p}}}
+            ]
+        )
+
 
 # Single ConditionCheck action with a true condition succeeds, but
 # doesn't do anything (since it's just a condition check, not a write)
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_conditioncheck_true(test_table_s):
     p = random_string()
-    test_table_s.meta.client.transact_write_items(TransactItems=[{
-        'ConditionCheck': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p},
-            # The condition attribute_not_exists(p) is true for an
-            # item that doesn't exist
-            'ConditionExpression': 'attribute_not_exists(p)'
-        }}])
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            {
+                "ConditionCheck": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p},
+                    # The condition attribute_not_exists(p) is true for an
+                    # item that doesn't exist
+                    "ConditionExpression": "attribute_not_exists(p)",
+                }
+            }
+        ]
+    )
+
 
 # Single ConditionCheck action with a false condition fails with a
 # TransactionCanceledException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_conditioncheck_false(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='TransactionCanceledException'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[{
-            'ConditionCheck': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p},
-                # The condition attribute_exists(p) is false for an item that
-                # doesn't exist
-                'ConditionExpression': 'attribute_exists(p)'
-            }}])
+    with pytest.raises(ClientError, match="TransactionCanceledException"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "ConditionCheck": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p},
+                        # The condition attribute_exists(p) is false for an item that
+                        # doesn't exist
+                        "ConditionExpression": "attribute_exists(p)",
+                    }
+                }
+            ]
+        )
+
 
 # Unlike the previous test_transact_write_items_single_* tests which used
 # trivial conditions without ExpressionAttributeNames and
 # ExpressionAttributeValues, the following tests for Update actions do use
 # those in UpdateExpression and/or ConditionExpression.
 
+
 # Single Update action without a condition
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_update_unconditional(test_table_s):
     p = random_string()
-    item = {'p': p, 'x': 42}
+    item = {"p": p, "x": 42}
     test_table_s.put_item(Item=item)
-    test_table_s.meta.client.transact_write_items(TransactItems=[{
-        'Update': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p},
-            'UpdateExpression': 'SET #var = #var + :one',
-            'ExpressionAttributeNames': {'#var': 'x'},
-            'ExpressionAttributeValues': {':one': 1},
-        }}])
-    item['x'] += 1
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            {
+                "Update": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p},
+                    "UpdateExpression": "SET #var = #var + :one",
+                    "ExpressionAttributeNames": {"#var": "x"},
+                    "ExpressionAttributeValues": {":one": 1},
+                }
+            }
+        ]
+    )
+    item["x"] += 1
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+
 
 # Single Update action with a true condition succeeds
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_update_true(test_table_s):
     p = random_string()
-    item = {'p': p, 'x': 42}
+    item = {"p": p, "x": 42}
     test_table_s.put_item(Item=item)
-    test_table_s.meta.client.transact_write_items(TransactItems=[{
-        'Update': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p},
-            # x is really 42, so this condition is true
-            'ConditionExpression': '#var = :fourtytwo',
-            'UpdateExpression': 'SET #var = #var + :one',
-            'ExpressionAttributeNames': {'#var': 'x'},
-            'ExpressionAttributeValues': {':one': 1, ':fourtytwo': 42},
-        }}])
-    item['x'] += 1
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            {
+                "Update": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p},
+                    # x is really 42, so this condition is true
+                    "ConditionExpression": "#var = :fourtytwo",
+                    "UpdateExpression": "SET #var = #var + :one",
+                    "ExpressionAttributeNames": {"#var": "x"},
+                    "ExpressionAttributeValues": {":one": 1, ":fourtytwo": 42},
+                }
+            }
+        ]
+    )
+    item["x"] += 1
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+
 
 # Single Update action with a false condition fails with a
 # TransactionCanceledException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_update_false(test_table_s):
     p = random_string()
-    item = {'p': p, 'x': 42}
+    item = {"p": p, "x": 42}
     test_table_s.put_item(Item=item)
-    with pytest.raises(ClientError, match='TransactionCanceledException'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[{
-            'Update': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p},
-                # x is really 42, not 43, so this condition is false
-                'ConditionExpression': '#var = :fourtythree',
-                'UpdateExpression': 'SET #var = #var + :one',
-                'ExpressionAttributeNames': {'#var': 'x'},
-                'ExpressionAttributeValues': {':one': 1, ':fourtythree': 43},
-            }}])
+    with pytest.raises(ClientError, match="TransactionCanceledException"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Update": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p},
+                        # x is really 42, not 43, so this condition is false
+                        "ConditionExpression": "#var = :fourtythree",
+                        "UpdateExpression": "SET #var = #var + :one",
+                        "ExpressionAttributeNames": {"#var": "x"},
+                        "ExpressionAttributeValues": {":one": 1, ":fourtythree": 43},
+                    }
+                }
+            ]
+        )
     # Since the condition failed, the item remains unchanged
-    assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]
+
 
 ##########################################################################
 # Additional tests for less basic TransactWriteItems functionality
 ##########################################################################
 
+
 # Check that without ClientRequestToken, a request is not idempotent -
 # if we increment the same counter twice it happens twice. But if we do
 # use ClientRequestToken and pass the same one twice, only the first increment
 # happens.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_clientrequesttoken(test_table_s):
     p = random_string()
-    item = {'p': p, 'x': 42}
+    item = {"p": p, "x": 42}
     test_table_s.put_item(Item=item)
 
-    increment_x = [{
-        'Update': {
-            'TableName': test_table_s.name, 'Key': {'p': p},
-            'UpdateExpression': 'SET x = x + :one',
-            'ExpressionAttributeValues': {':one': 1},
+    increment_x = [
+        {
+            "Update": {
+                "TableName": test_table_s.name,
+                "Key": {"p": p},
+                "UpdateExpression": "SET x = x + :one",
+                "ExpressionAttributeValues": {":one": 1},
+            }
         }
-    }]
+    ]
 
     # Doing two transactions each incrementing x without ClientRequestToken,
     # both happen:
-    test_table_s.meta.client.transact_write_items(
-        TransactItems=increment_x)
-    assert 43 == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']['x']
-    test_table_s.meta.client.transact_write_items(
-        TransactItems=increment_x)
-    assert 44 == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']['x']
+    test_table_s.meta.client.transact_write_items(TransactItems=increment_x)
+    assert 43 == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]["x"]
+    test_table_s.meta.client.transact_write_items(TransactItems=increment_x)
+    assert 44 == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]["x"]
     # But if we pass a ClientRequestToken and attempt the same transaction
     # twice, only one is performed. The second transaction succeeds - it
     # just has no affect.
     token = random_string()
     test_table_s.meta.client.transact_write_items(
-        ClientRequestToken=token, TransactItems=increment_x)
-    assert 45 == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']['x']
+        ClientRequestToken=token, TransactItems=increment_x
+    )
+    assert 45 == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]["x"]
     test_table_s.meta.client.transact_write_items(
-        ClientRequestToken=token, TransactItems=increment_x)
-    assert 45 == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']['x']
+        ClientRequestToken=token, TransactItems=increment_x
+    )
+    assert 45 == test_table_s.get_item(Key={"p": p}, ConsistentRead=True)["Item"]["x"]
+
 
 # Check that ClientRequestToken can be a string between 1 and 36 characters,
 # anything else is rejected.
@@ -295,216 +362,259 @@ def test_transact_write_items_clientrequesttoken(test_table_s):
 # table name, we can't reuse the same ClientRequestToken or we'll get a
 # IdempotentParameterMismatch error. We must use a random token - and
 # a random one-character string is not enough to avoid test flakiness.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_clientrequesttoken_length(test_table_s):
     p = random_string()
-    item = {'p': p}
-    transaction = [{'Put': {'TableName': test_table_s.name, 'Item': item}}]
+    item = {"p": p}
+    transaction = [{"Put": {"TableName": test_table_s.name, "Item": item}}]
     # 36 characters work
     test_table_s.meta.client.transact_write_items(
-        ClientRequestToken=random_string(length=36),
-        TransactItems=transaction)
+        ClientRequestToken=random_string(length=36), TransactItems=transaction
+    )
     # 37 characters is too long for ClientRequestToken, a ValidationException
     # results:
-    with pytest.raises(ClientError, match='ValidationException.*[cC]lientRequestToken'):
+    with pytest.raises(ClientError, match="ValidationException.*[cC]lientRequestToken"):
         test_table_s.meta.client.transact_write_items(
-            ClientRequestToken=random_string(length=37),
-            TransactItems=transaction)
+            ClientRequestToken=random_string(length=37), TransactItems=transaction
+        )
+
 
 # Check that if the same ClientRequestToken is used for two transactions,
 # but they are different, an IdempotentParameterMismatch error is thrown.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_clientrequesttoken_mismatch(test_table_s):
-    transaction1 = [{'Put': {'TableName': test_table_s.name, 'Item': {'p': random_string()}}}]
-    transaction2 = [{'Put': {'TableName': test_table_s.name, 'Item': {'p': random_string()}}}]
+    transaction1 = [
+        {"Put": {"TableName": test_table_s.name, "Item": {"p": random_string()}}}
+    ]
+    transaction2 = [
+        {"Put": {"TableName": test_table_s.name, "Item": {"p": random_string()}}}
+    ]
     token = random_string()
     test_table_s.meta.client.transact_write_items(
-        ClientRequestToken=token, TransactItems=transaction1)
-    with pytest.raises(ClientError, match='IdempotentParameterMismatchException'):
+        ClientRequestToken=token, TransactItems=transaction1
+    )
+    with pytest.raises(ClientError, match="IdempotentParameterMismatchException"):
         test_table_s.meta.client.transact_write_items(
-            ClientRequestToken=token, TransactItems=transaction2)
+            ClientRequestToken=token, TransactItems=transaction2
+        )
+
 
 # All tests above involved a transaction with a single action. Here
 # we finally begin to check trasactions with multiple actions. Let's
 # begin with a successful TransactWriteItems transaction, where some of
 # the actions have successful conditions, and some don't have conditions
 # at all, and all the actions are performed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_multi_action_true(test_table_s):
     p1 = random_string()
     p2 = random_string()
     p3 = random_string()
-    item1 = {'p': p1, 'x': 'dog'}
-    item2 = {'p': p2, 'x': 'cat'}
-    test_table_s.meta.client.transact_write_items(TransactItems=[
-        # unconditional Put
-        { 'Put': {
-            'TableName': test_table_s.name,
-            'Item': item1
-        }},
-        # Put with true condition (attribute_not_exists(p) is true
-        # when the item doesn't exist).
-        { 'Put': {
-            'TableName': test_table_s.name,
-            'Item': item2,
-            'ConditionExpression': 'attribute_not_exists(p)'
-        }},
-        # ConditionCheck with true condition. It is true, but doesn't
-        # cause anything to be written for key p3.
-        { 'ConditionCheck': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p3},
-            'ConditionExpression': 'attribute_not_exists(p)'
-        }},
-        ])
+    item1 = {"p": p1, "x": "dog"}
+    item2 = {"p": p2, "x": "cat"}
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            # unconditional Put
+            {"Put": {"TableName": test_table_s.name, "Item": item1}},
+            # Put with true condition (attribute_not_exists(p) is true
+            # when the item doesn't exist).
+            {
+                "Put": {
+                    "TableName": test_table_s.name,
+                    "Item": item2,
+                    "ConditionExpression": "attribute_not_exists(p)",
+                }
+            },
+            # ConditionCheck with true condition. It is true, but doesn't
+            # cause anything to be written for key p3.
+            {
+                "ConditionCheck": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p3},
+                    "ConditionExpression": "attribute_not_exists(p)",
+                }
+            },
+        ]
+    )
     # p1 and p2 supposed to have been written by the transaction, but p3
     # wasn't because it was only involved in a ConditionCheck.
-    assert item1 == test_table_s.get_item(Key={'p': p1}, ConsistentRead=True)['Item']
-    assert item2 == test_table_s.get_item(Key={'p': p2}, ConsistentRead=True)['Item']
-    assert 'Item' not in test_table_s.get_item(Key={'p': p3}, ConsistentRead=True)
+    assert item1 == test_table_s.get_item(Key={"p": p1}, ConsistentRead=True)["Item"]
+    assert item2 == test_table_s.get_item(Key={"p": p2}, ConsistentRead=True)["Item"]
+    assert "Item" not in test_table_s.get_item(Key={"p": p3}, ConsistentRead=True)
+
 
 # Test a transaction with several actions, one of which has a false
 # condition. The entire transaction should fail, and none of its actions
 # (not even those with true conditions or no conditions) should be performed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_multi_action_false(test_table_s):
     p1 = random_string()
     p2 = random_string()
     p3 = random_string()
-    item1 = {'p': p1, 'x': 'dog'}
-    item2 = {'p': p2, 'x': 'cat'}
-    with pytest.raises(ClientError, match='TransactionCanceledException'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            # unconditional Put
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': item1
-            }},
-            # Put with true condition (attribute_not_exists(p) is true
-            # when the item doesn't exist).
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': item2,
-                'ConditionExpression': 'attribute_not_exists(p)'
-            }},
-            # ConditionCheck with a *false* condition. It should cause the
-            # entire transaction to be rejected.
-            { 'ConditionCheck': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p3},
-                'ConditionExpression': 'attribute_exists(p)'
-            }},
-            ])
+    item1 = {"p": p1, "x": "dog"}
+    item2 = {"p": p2, "x": "cat"}
+    with pytest.raises(ClientError, match="TransactionCanceledException"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                # unconditional Put
+                {"Put": {"TableName": test_table_s.name, "Item": item1}},
+                # Put with true condition (attribute_not_exists(p) is true
+                # when the item doesn't exist).
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": item2,
+                        "ConditionExpression": "attribute_not_exists(p)",
+                    }
+                },
+                # ConditionCheck with a *false* condition. It should cause the
+                # entire transaction to be rejected.
+                {
+                    "ConditionCheck": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p3},
+                        "ConditionExpression": "attribute_exists(p)",
+                    }
+                },
+            ]
+        )
     # Because the entire transaction was rejected, none of its actions
     # should have been done. Items for p1, p2 and p3 should all not exist.
-    assert 'Item' not in test_table_s.get_item(Key={'p': p1}, ConsistentRead=True)
-    assert 'Item' not in test_table_s.get_item(Key={'p': p2}, ConsistentRead=True)
-    assert 'Item' not in test_table_s.get_item(Key={'p': p3}, ConsistentRead=True)
+    assert "Item" not in test_table_s.get_item(Key={"p": p1}, ConsistentRead=True)
+    assert "Item" not in test_table_s.get_item(Key={"p": p2}, ConsistentRead=True)
+    assert "Item" not in test_table_s.get_item(Key={"p": p3}, ConsistentRead=True)
+
 
 # Test that it's not allowed for two actions in the same transaction to
 # target the same item (this limitation also includes ConditionCheck
 # actions).
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_multi_action_conflict(test_table_s):
     p1 = random_string()
     p2 = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*one item'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p1}
-            }},
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p1}
-            }}])
-    with pytest.raises(ClientError, match='ValidationException.*one item'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p1}
-            }},
-            { 'ConditionCheck': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p1},
-                'ConditionExpression': 'attribute_not_exists(p)'
-            }}])
-    with pytest.raises(ClientError, match='ValidationException.*one item'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p1}
-            }},
-            { 'ConditionCheck': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p2},
-                'ConditionExpression': 'attribute_not_exists(p)'
-            }},
-            { 'ConditionCheck': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p2},
-                'ConditionExpression': 'attribute_not_exists(p)'
-            }}])
+    with pytest.raises(ClientError, match="ValidationException.*one item"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {"Put": {"TableName": test_table_s.name, "Item": {"p": p1}}},
+                {"Put": {"TableName": test_table_s.name, "Item": {"p": p1}}},
+            ]
+        )
+    with pytest.raises(ClientError, match="ValidationException.*one item"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {"Put": {"TableName": test_table_s.name, "Item": {"p": p1}}},
+                {
+                    "ConditionCheck": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p1},
+                        "ConditionExpression": "attribute_not_exists(p)",
+                    }
+                },
+            ]
+        )
+    with pytest.raises(ClientError, match="ValidationException.*one item"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {"Put": {"TableName": test_table_s.name, "Item": {"p": p1}}},
+                {
+                    "ConditionCheck": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p2},
+                        "ConditionExpression": "attribute_not_exists(p)",
+                    }
+                },
+                {
+                    "ConditionCheck": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p2},
+                        "ConditionExpression": "attribute_not_exists(p)",
+                    }
+                },
+            ]
+        )
+
 
 # Test that a transaction may involve more than one table, not just more than
 # one item.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_multi_table_true(test_table_s, test_table_ss):
     p1 = random_string()
     p2 = random_string()
     c2 = random_string()
-    item1 = {'p': p1, 'x': 'dog'}
-    item2 = {'p': p2, 'c': c2, 'x': 'cat'}
-    test_table_s.meta.client.transact_write_items(TransactItems=[
-        # unconditional Put on the first table
-        { 'Put': {
-            'TableName': test_table_s.name,
-            'Item': item1
-        }},
-        # Put with true condition on the second table
-        { 'Put': {
-            'TableName': test_table_ss.name,
-            'Item': item2,
-            'ConditionExpression': 'attribute_not_exists(p)'
-        }}
-        ])
+    item1 = {"p": p1, "x": "dog"}
+    item2 = {"p": p2, "c": c2, "x": "cat"}
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            # unconditional Put on the first table
+            {"Put": {"TableName": test_table_s.name, "Item": item1}},
+            # Put with true condition on the second table
+            {
+                "Put": {
+                    "TableName": test_table_ss.name,
+                    "Item": item2,
+                    "ConditionExpression": "attribute_not_exists(p)",
+                }
+            },
+        ]
+    )
     # p1 and p2 supposed to have been written by the transaction on the
     # two different tables
-    assert item1 == test_table_s.get_item(Key={'p': p1}, ConsistentRead=True)['Item']
-    assert item2 == test_table_ss.get_item(Key={'p': p2, 'c': c2}, ConsistentRead=True)['Item']
+    assert item1 == test_table_s.get_item(Key={"p": p1}, ConsistentRead=True)["Item"]
+    assert (
+        item2
+        == test_table_ss.get_item(Key={"p": p2, "c": c2}, ConsistentRead=True)["Item"]
+    )
+
 
 # Check that a TransactWriteItems with zero items is not allowed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_empty(test_table_s):
-    with pytest.raises(ClientError, match='ValidationException.*[tT]ransactItems'):
+    with pytest.raises(ClientError, match="ValidationException.*[tT]ransactItems"):
         test_table_s.meta.client.transact_write_items(TransactItems=[])
+
 
 # Check that a TransactWriteItems with 100 items is allowed. The limit
 # used to be just 25 items, but it was increased to 100 in September 2022.
 # The next test will check that *more* than 100 items is not allowed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_100(test_table_s):
     p = random_string()
-    items = [{'p': p + str(i), 'x': i} for i in range(100)]
-    test_table_s.meta.client.transact_write_items(TransactItems=[
-        { 'Put': {
-            'TableName': test_table_s.name,
-            'Item': item,
-        }} for item in items])
+    items = [{"p": p + str(i), "x": i} for i in range(100)]
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            {
+                "Put": {
+                    "TableName": test_table_s.name,
+                    "Item": item,
+                }
+            }
+            for item in items
+        ]
+    )
     # verify that all 100 items went in
     for item in items:
-        assert item == test_table_s.get_item(Key={'p': item['p']}, ConsistentRead=True)['Item']
+        assert (
+            item
+            == test_table_s.get_item(Key={"p": item["p"]}, ConsistentRead=True)["Item"]
+        )
+
 
 # Check that a transaction with 101 (>100) items is rejected.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_101(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*[tT]ransactItems.*100'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p + str(i)},
-            }} for i in range(101)])
+    with pytest.raises(ClientError, match="ValidationException.*[tT]ransactItems.*100"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p + str(i)},
+                    }
+                }
+                for i in range(101)
+            ]
+        )
+
 
 # Beyond limiting a TransactWriteItems to 100 items (verified in tests above)
 # DynamoDB has an aditional limit that "the aggregate size of the items in the
@@ -515,18 +625,25 @@ def test_transact_write_items_101(test_table_s):
 # new item in the transaction - so the transaction itself reaches 5MB in
 # size. In the next test we will check what happens for Update or Delete
 # actions which may themselves have small size but refer to large items.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_put_5MB(test_table_s):
     p = random_string()
     # We will write 50 items of roughly 100KB each, reaching around 5MB
-    long = 'x'*100000
-    items = [{'p': p + str(i), 'x': long} for i in range(50)]
-    with pytest.raises(ClientError, match='ValidationException.*size cannot exceed'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': item,
-            }} for item in items])
+    long = "x" * 100000
+    items = [{"p": p + str(i), "x": long} for i in range(50)]
+    with pytest.raises(ClientError, match="ValidationException.*size cannot exceed"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": item,
+                    }
+                }
+                for item in items
+            ]
+        )
+
 
 # In the previous test (test_transact_write_items_put_5MB) we saw that we
 # can't have over 4 MB of new data in a transaction. But the DynamoDB
@@ -541,13 +658,13 @@ def test_transact_write_items_put_5MB(test_table_s):
 # (DynamoDB refers to it as "transaction payload" in the error messages) is
 # what matters, not the size of the items. A delete transaction that deletes
 # 5 MB of items but the transaction itself is small - is allowed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_delete_5MB(test_table_s):
     p = random_string()
     # Write (not in a transaction) 50 items of roughly 100 KB each, so their
     # total size is roughly 5 MB.
-    long = 'x'*100000
-    items = [{'p': p + str(i), 'x': long} for i in range(50)]
+    long = "x" * 100000
+    items = [{"p": p + str(i), "x": long} for i in range(50)]
     with test_table_s.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
@@ -557,42 +674,60 @@ def test_transact_write_items_delete_5MB(test_table_s):
     # limit is really on the transaction size, not the "aggregate size of the
     # items" mentioned in the documentation.
     try:
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Delete': {
-                'TableName': test_table_s.name,
-                'Key': {'p': item['p']},
-            }} for item in items])
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Delete": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": item["p"]},
+                    }
+                }
+                for item in items
+            ]
+        )
         # Verify the deletes worked
         for item in items:
-            assert 'Item' not in test_table_s.get_item(Key={'p': item['p']}, ConsistentRead=True)
+            assert "Item" not in test_table_s.get_item(
+                Key={"p": item["p"]}, ConsistentRead=True
+            )
     except ClientError as e:
         # A 5 MB write transaction takes roughly 10,000 WCUs, which DynamoDB
         # sometimes refuses to do on a brand-new on-demand table, so the
         # transaction gets rejected. But if this happens, it's an expected
         # failure. It's not a real failure (a real failure would have been
         # the transaction failing on something other than ThrottlingException).
-        if e.response['Error']['Code'] == 'ThrottlingException':
+        if e.response["Error"]["Code"] == "ThrottlingException":
             pytest.xfail()
         else:
             raise
 
+
 # But verify that aggregate transaction size of 3MB is fine. Note that
 # individual items are limited to 400KB, so we must a transaction with
 # several smaller items.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_put_3MB(test_table_s):
     p = random_string()
     # We will write 30 items of roughly 100KB each, reaching around 3MB
-    long = 'x'*100000
-    items = [{'p': p + str(i), 'x': long} for i in range(30)]
-    test_table_s.meta.client.transact_write_items(TransactItems=[
-        { 'Put': {
-            'TableName': test_table_s.name,
-            'Item': item,
-        }} for item in items])
+    long = "x" * 100000
+    items = [{"p": p + str(i), "x": long} for i in range(30)]
+    test_table_s.meta.client.transact_write_items(
+        TransactItems=[
+            {
+                "Put": {
+                    "TableName": test_table_s.name,
+                    "Item": item,
+                }
+            }
+            for item in items
+        ]
+    )
     # verify that all 30 items went in
     for item in items:
-        assert item == test_table_s.get_item(Key={'p': item['p']}, ConsistentRead=True)['Item']
+        assert (
+            item
+            == test_table_s.get_item(Key={"p": item["p"]}, ConsistentRead=True)["Item"]
+        )
 
 
 # In various tests above we checked that failed conditions result in a
@@ -611,28 +746,33 @@ def test_transact_write_items_put_3MB(test_table_s):
 #    tests.
 # 4. ThrottlingError - similar, for on-demand tables that haven't scaled
 #    enough yet.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_cancellation_reasons_conditionalcheckfailed(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='TransactionCanceledException') as e:
-        test_table_s.meta.client.transact_write_items(TransactItems=[{
-            'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p},
-                # The condition attribute_exists(p) is false for an
-                # item that doesn't exist
-                'ConditionExpression': 'attribute_exists(p)'
-            }}])
+    with pytest.raises(ClientError, match="TransactionCanceledException") as e:
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p},
+                        # The condition attribute_exists(p) is false for an
+                        # item that doesn't exist
+                        "ConditionExpression": "attribute_exists(p)",
+                    }
+                }
+            ]
+        )
     # The error object should have a CancellationReasons member. Our
     # transaction has one item, and one failure, so the CancellationReasons
     # should be a one-member array. This member has a code, and a message.
-    assert 'CancellationReasons' in e.value.response
-    reasons = e.value.response['CancellationReasons']
+    assert "CancellationReasons" in e.value.response
+    reasons = e.value.response["CancellationReasons"]
     assert len(reasons) == 1
-    assert reasons[0]['Code'] == 'ConditionalCheckFailed'
+    assert reasons[0]["Code"] == "ConditionalCheckFailed"
     # The Message is a user-readable message like "The conditional request
     # failed". We'll assert it exists, but not insist what the text is
-    assert 'Message' in reasons[0]
+    assert "Message" in reasons[0]
 
     # Now do the same thing with a transaction with multiple actions, some
     # with failed conditions so the entire transaction gets canceled.
@@ -642,52 +782,58 @@ def test_transact_write_cancellation_reasons_conditionalcheckfailed(test_table_s
     p2 = random_string()
     p3 = random_string()
     p4 = random_string()
-    with pytest.raises(ClientError, match='TransactionCanceledException') as e:
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            # Unconditional Put
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p1}
-            }},
-            # Put with true condition (attribute_not_exists(p) is true
-            # when the item doesn't exist).
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p2},
-                'ConditionExpression': 'attribute_not_exists(p)'
-            }},
-            # ConditionCheck with a *false* condition. It should cause the
-            # entire transaction to be rejected.
-            { 'ConditionCheck': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p3},
-                'ConditionExpression': 'attribute_exists(p)'
-            }},
-            # Another false condition, on a Put action:
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p4},
-                'ConditionExpression': 'attribute_exists(p)'
-            }},
-            ])
-    assert 'CancellationReasons' in e.value.response
-    reasons = e.value.response['CancellationReasons']
+    with pytest.raises(ClientError, match="TransactionCanceledException") as e:
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                # Unconditional Put
+                {"Put": {"TableName": test_table_s.name, "Item": {"p": p1}}},
+                # Put with true condition (attribute_not_exists(p) is true
+                # when the item doesn't exist).
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p2},
+                        "ConditionExpression": "attribute_not_exists(p)",
+                    }
+                },
+                # ConditionCheck with a *false* condition. It should cause the
+                # entire transaction to be rejected.
+                {
+                    "ConditionCheck": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p3},
+                        "ConditionExpression": "attribute_exists(p)",
+                    }
+                },
+                # Another false condition, on a Put action:
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p4},
+                        "ConditionExpression": "attribute_exists(p)",
+                    }
+                },
+            ]
+        )
+    assert "CancellationReasons" in e.value.response
+    reasons = e.value.response["CancellationReasons"]
     # The CancellationReasons are listed in the same order of the actions
     # in the transaction - we expect the first two actions to have not
     # failed, so they have Code="None", and the third and forth both failed.
     # It's interesting that DynamoDB does report both failures - and doesn't
     # "short circuit" after the first one.
     assert len(reasons) == 4
-    assert reasons[0]['Code'] == 'None'
-    assert reasons[1]['Code'] == 'None'
-    assert reasons[2]['Code'] == 'ConditionalCheckFailed'
-    assert reasons[3]['Code'] == 'ConditionalCheckFailed'
+    assert reasons[0]["Code"] == "None"
+    assert reasons[1]["Code"] == "None"
+    assert reasons[2]["Code"] == "ConditionalCheckFailed"
+    assert reasons[3]["Code"] == "ConditionalCheckFailed"
     # Actions "None" reason don't come with a user-readable message,
     # but others do.
-    assert 'Message' not in reasons[0]
-    assert 'Message' not in reasons[1]
-    assert 'Message' in reasons[2]
-    assert 'Message' in reasons[3]
+    assert "Message" not in reasons[0]
+    assert "Message" not in reasons[1]
+    assert "Message" in reasons[2]
+    assert "Message" in reasons[3]
+
 
 # Another possible cancellation reason is a ValidationError in one of the
 # actions - for example an attempt to write a wrong type into a key or
@@ -710,46 +856,55 @@ def test_transact_write_cancellation_reasons_conditionalcheckfailed(test_table_s
 # It's not clear how DynamoDB decided which case will return a
 # ValidationException and which a ValidationError, but let's be compatible
 # with what DynamoDB does.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_cancellation_reasons_validationerror(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='TransactionCanceledException') as e:
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                # The key p should be a string, not a number, so this
-                # item has a validation error.
-                'Item': {'p': 7}
-            }},
-            { 'Put': {
-                'TableName': test_table_s.name,
-                # A second validation error. As explained above, as soon
-                # as the first validation error was found above, this action
-                # will not be reached and its validation error will not be
-                # detected. So we expect "None" reason on this action.
-                'Item': {'p': 8}
-            }},
-            { 'Put': {
-                'TableName': test_table_s.name,
-                # This condition is false (the item does *not* exist yet),
-                # and would have failed the tranaction, but the server won't
-                # even get around to checking that because of the validation
-                # error in the other actions. So we will expect to get a
-                # "None" reason on this action.
-                'ConditionExpression': 'attribute_exists(p)',
-                'Item': {'p': p}
-            }},
-            ])
-    assert 'CancellationReasons' in e.value.response
-    reasons = e.value.response['CancellationReasons']
+    with pytest.raises(ClientError, match="TransactionCanceledException") as e:
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        # The key p should be a string, not a number, so this
+                        # item has a validation error.
+                        "Item": {"p": 7},
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        # A second validation error. As explained above, as soon
+                        # as the first validation error was found above, this action
+                        # will not be reached and its validation error will not be
+                        # detected. So we expect "None" reason on this action.
+                        "Item": {"p": 8},
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        # This condition is false (the item does *not* exist yet),
+                        # and would have failed the tranaction, but the server won't
+                        # even get around to checking that because of the validation
+                        # error in the other actions. So we will expect to get a
+                        # "None" reason on this action.
+                        "ConditionExpression": "attribute_exists(p)",
+                        "Item": {"p": p},
+                    }
+                },
+            ]
+        )
+    assert "CancellationReasons" in e.value.response
+    reasons = e.value.response["CancellationReasons"]
     assert len(reasons) == 3
-    assert reasons[0]['Code'] == 'ValidationError'
-    assert reasons[1]['Code'] == 'None'
-    assert reasons[2]['Code'] == 'None'
-    assert 'Message' in reasons[0]
+    assert reasons[0]["Code"] == "ValidationError"
+    assert reasons[1]["Code"] == "None"
+    assert reasons[2]["Code"] == "None"
+    assert "Message" in reasons[0]
     # "None" reason doesn't come with a message:
-    assert 'Message' not in reasons[1]
-    assert 'Message' not in reasons[2]
+    assert "Message" not in reasons[1]
+    assert "Message" not in reasons[2]
+
 
 # Verify that even if there is just *one* action in the transaction,
 # on certain types of errors like the incorrect key type we used above
@@ -758,73 +913,89 @@ def test_transact_write_cancellation_reasons_validationerror(test_table_s):
 # ValidationException. Below we'll see in other tests that this is not
 # always true - in some other types of errors, we actually do get a
 # ValidationException.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_cancellation_reasons_validationerror_one(test_table_s):
-    with pytest.raises(ClientError, match='TransactionCanceledException') as e:
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                # The key p should be a string, not a number, so this
-                # item has a validation error.
-                'Item': {'p': 7}
-            }}])
-    reasons = e.value.response['CancellationReasons']
-    assert reasons[0]['Code'] == 'ValidationError'
-    assert 'Message' in reasons[0]
+    with pytest.raises(ClientError, match="TransactionCanceledException") as e:
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        # The key p should be a string, not a number, so this
+                        # item has a validation error.
+                        "Item": {"p": 7},
+                    }
+                }
+            ]
+        )
+    reasons = e.value.response["CancellationReasons"]
+    assert reasons[0]["Code"] == "ValidationError"
+    assert "Message" in reasons[0]
+
 
 # Check the ReturnValuesOnConditionCheckFailure parameter, which allows
 # the user to retrieve the content of the item that caused a specific
 # condition to fail.
 # Note that ReturnValuesOnConditionCheckFailure is specified for a
 # specific action, not for the entire transaction.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_returnvaluesonconditioncheckfailure(test_table_s):
     p = random_string()
-    item = {'p': p, 'x': 42, 'y': 'dog'}
+    item = {"p": p, "x": 42, "y": "dog"}
     test_table_s.put_item(Item=item)
     # Check ReturnValuesOnConditionCheckFailure="ALL_OLD"
-    with pytest.raises(ClientError, match='TransactionCanceledException') as e:
-        test_table_s.meta.client.transact_write_items(TransactItems=[{
-            'Update': {
-                'ReturnValuesOnConditionCheckFailure': 'ALL_OLD',
-                'TableName': test_table_s.name,
-                'Key': {'p': p},
-                # x is really 42, not 43, so this condition is false
-                'ConditionExpression': 'x = :fourtythree',
-                'UpdateExpression': 'SET x = x + :one',
-                'ExpressionAttributeValues': {':one': 1, ':fourtythree': 43},
-            }}])
+    with pytest.raises(ClientError, match="TransactionCanceledException") as e:
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Update": {
+                        "ReturnValuesOnConditionCheckFailure": "ALL_OLD",
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p},
+                        # x is really 42, not 43, so this condition is false
+                        "ConditionExpression": "x = :fourtythree",
+                        "UpdateExpression": "SET x = x + :one",
+                        "ExpressionAttributeValues": {":one": 1, ":fourtythree": 43},
+                    }
+                }
+            ]
+        )
     # The relevant CancellationReasons will now have an "Item".
     # The returned reasons[0]['Item'] has DynamoDB JSON encoding, and in
     # this specific place (inside the error object) boto3 forgot to
     # deserialize the JSON encoding for us (like it does automatically
     # in other place) - so we need to do this deserialization manually
     # with TypeDeserializer before we can compare it to the expected "item".
-    assert 'CancellationReasons' in e.value.response
-    reasons = e.value.response['CancellationReasons']
+    assert "CancellationReasons" in e.value.response
+    reasons = e.value.response["CancellationReasons"]
     assert len(reasons) == 1
-    assert reasons[0]['Code'] == 'ConditionalCheckFailed'
-    assert 'Message' in reasons[0]
+    assert reasons[0]["Code"] == "ConditionalCheckFailed"
+    assert "Message" in reasons[0]
     deserializer = TypeDeserializer()
-    got_item = {x:deserializer.deserialize(y) for (x,y) in reasons[0]['Item'].items()}
+    got_item = {x: deserializer.deserialize(y) for (x, y) in reasons[0]["Item"].items()}
     assert item == got_item
 
     # The same transaction with  ReturnValuesOnConditionCheckFailure="NONE"
     # doesn't return the Item:
-    with pytest.raises(ClientError, match='TransactionCanceledException') as e:
-        test_table_s.meta.client.transact_write_items(TransactItems=[{
-            'Update': {
-                'ReturnValuesOnConditionCheckFailure': 'NONE',
-                'TableName': test_table_s.name,
-                'Key': {'p': p},
-                'ConditionExpression': 'x = :fourtythree',
-                'UpdateExpression': 'SET x = x + :one',
-                'ExpressionAttributeValues': {':one': 1, ':fourtythree': 43},
-            }}])
-    reasons = e.value.response['CancellationReasons']
+    with pytest.raises(ClientError, match="TransactionCanceledException") as e:
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Update": {
+                        "ReturnValuesOnConditionCheckFailure": "NONE",
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p},
+                        "ConditionExpression": "x = :fourtythree",
+                        "UpdateExpression": "SET x = x + :one",
+                        "ExpressionAttributeValues": {":one": 1, ":fourtythree": 43},
+                    }
+                }
+            ]
+        )
+    reasons = e.value.response["CancellationReasons"]
     assert len(reasons) == 1
-    assert reasons[0]['Code'] == 'ConditionalCheckFailed'
-    assert 'Item' not in reasons[0]
+    assert reasons[0]["Code"] == "ConditionalCheckFailed"
+    assert "Item" not in reasons[0]
 
     # Setting ReturnValuesOnConditionCheckFailure to anything else, e.g.,
     # lowercase 'none', or 'dog', is a validation error. Surprisingly,
@@ -832,17 +1003,29 @@ def test_transact_write_items_returnvaluesonconditioncheckfailure(test_table_s):
     # DynamoDB can return TransactionCanceledException with a per-action
     # ValidationError, in this case it doesn't do that - it returns a
     # ValidationException for the entire request.
-    for option in ['none', 'dog']:
-        with pytest.raises(ClientError, match='ValidationException.*[rR]eturnValuesOnConditionCheckFailure'):
-            test_table_s.meta.client.transact_write_items(TransactItems=[{
-                'Update': {
-                    'ReturnValuesOnConditionCheckFailure': option,
-                    'TableName': test_table_s.name,
-                    'Key': {'p': p},
-                    'ConditionExpression': 'x = :fourtythree',
-                    'UpdateExpression': 'SET x = x + :one',
-                    'ExpressionAttributeValues': {':one': 1, ':fourtythree': 43},
-                }}])
+    for option in ["none", "dog"]:
+        with pytest.raises(
+            ClientError,
+            match="ValidationException.*[rR]eturnValuesOnConditionCheckFailure",
+        ):
+            test_table_s.meta.client.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "ReturnValuesOnConditionCheckFailure": option,
+                            "TableName": test_table_s.name,
+                            "Key": {"p": p},
+                            "ConditionExpression": "x = :fourtythree",
+                            "UpdateExpression": "SET x = x + :one",
+                            "ExpressionAttributeValues": {
+                                ":one": 1,
+                                ":fourtythree": 43,
+                            },
+                        }
+                    }
+                ]
+            )
+
 
 # Various checks for ExpressionAttributeValues and ExpressionAttributeNames
 # in a ConditionExpression, such as missing or unused entries in those arrays.
@@ -853,73 +1036,104 @@ def test_transact_write_items_returnvaluesonconditioncheckfailure(test_table_s):
 # ValidationException on the entire transaction. It turns out that it's
 # the latter.
 
+
 # Check ConditionExpression reference to missing ExpressionAttributeNames
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_missing_name(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*#xyz'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p},
-                # The reference "#xyz" is missing in ExpressionAttributeNames
-                'ConditionExpression': 'attribute_exists(#xyz)'
-            }}])
+    with pytest.raises(ClientError, match="ValidationException.*#xyz"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p},
+                        # The reference "#xyz" is missing in ExpressionAttributeNames
+                        "ConditionExpression": "attribute_exists(#xyz)",
+                    }
+                }
+            ]
+        )
+
 
 # Check ConditionExpression value missing in ExpressionAttributeValues
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_missing_value(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*:xyz'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p},
-                # The reference ":xyz" is missing in ExpressionAttributeValues
-                'ConditionExpression': 'p = :xyz'
-            }}])
+    with pytest.raises(ClientError, match="ValidationException.*:xyz"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p},
+                        # The reference ":xyz" is missing in ExpressionAttributeValues
+                        "ConditionExpression": "p = :xyz",
+                    }
+                }
+            ]
+        )
+
 
 # Check unused name in ExpressionAttributeName
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_unused_name(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*unused.*#xyz'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p},
-                'ConditionExpression': 'attribute_exists(p)',
-                # The name "#xyz" isn't used in in any expression
-                'ExpressionAttributeNames': {'#xyz': 'x'}
-            }}])
+    with pytest.raises(ClientError, match="ValidationException.*unused.*#xyz"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p},
+                        "ConditionExpression": "attribute_exists(p)",
+                        # The name "#xyz" isn't used in in any expression
+                        "ExpressionAttributeNames": {"#xyz": "x"},
+                    }
+                }
+            ]
+        )
+
 
 # Check unused value in ExpressionAttributeValues
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_unused_value(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*unused.*:xyz'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p},
-                'ConditionExpression': 'attribute_exists(p)',
-                # The value ":xyz" isn't used in in any expression
-                'ExpressionAttributeValues': {':xyz': 7}
-            }}])
+    with pytest.raises(ClientError, match="ValidationException.*unused.*:xyz"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p},
+                        "ConditionExpression": "attribute_exists(p)",
+                        # The value ":xyz" isn't used in in any expression
+                        "ExpressionAttributeValues": {":xyz": 7},
+                    }
+                }
+            ]
+        )
+
 
 # Syntax error in a ConditionExpression in one action also returns a
 # ValidationException for the entire transaction, not per item:
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_syntax_error(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*Syntax error'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p},
-                # "hello!" is a syntax error as an expression
-                'ConditionExpression': 'hello!',
-            }}])
+    with pytest.raises(ClientError, match="ValidationException.*Syntax error"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p},
+                        # "hello!" is a syntax error as an expression
+                        "ConditionExpression": "hello!",
+                    }
+                }
+            ]
+        )
+
 
 # Some other errors in a ConditionExpression, like an ExpressionAttributeNames
 # with an integer instead of a string (an attribute name), can generate a
@@ -928,152 +1142,215 @@ def test_transact_write_items_syntax_error(test_table_s):
 # return a ValidationException here and we change the test to accept both.
 # But the important point is that the single exception is returned for the
 # entire transaction - not per item.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_serialization_exception(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='SerializationException'):
-        test_table_s.meta.client.transact_write_items(TransactItems=[
-            { 'Put': {
-                'TableName': test_table_s.name,
-                'Item': {'p': p},
-                'ConditionExpression': 'attribute_exists(p)',
-                # ExpressionAttributeNames expects strings (names of
-                # attributes), not the integer 7.
-                'ExpressionAttributeNames': {'#xyz': 7}
-            }}])
+    with pytest.raises(ClientError, match="SerializationException"):
+        test_table_s.meta.client.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": test_table_s.name,
+                        "Item": {"p": p},
+                        "ConditionExpression": "attribute_exists(p)",
+                        # ExpressionAttributeNames expects strings (names of
+                        # attributes), not the integer 7.
+                        "ExpressionAttributeNames": {"#xyz": 7},
+                    }
+                }
+            ]
+        )
+
 
 ##########################################################################
 # Tests for TransactGetItems functionality
 ##########################################################################
 
+
 # Test basic transaction with one "Get" action
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_one(test_table_s):
     p = random_string()
     x = random_string()
-    item = {'p': p, 'x': x}
+    item = {"p": p, "x": x}
     test_table_s.put_item(Item=item)
-    ret = test_table_s.meta.client.transact_get_items(TransactItems=[
-        { 'Get': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p},
-            }}])
-    assert 'Responses' in ret
-    assert len(ret['Responses']) == 1
-    assert 'Item' in ret['Responses'][0]
-    assert item == ret['Responses'][0]['Item']
+    ret = test_table_s.meta.client.transact_get_items(
+        TransactItems=[
+            {
+                "Get": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p},
+                }
+            }
+        ]
+    )
+    assert "Responses" in ret
+    assert len(ret["Responses"]) == 1
+    assert "Item" in ret["Responses"][0]
+    assert item == ret["Responses"][0]["Item"]
+
 
 # If a Get transaction can't find an item with the given key, it's not
 # an error - one of the Responses entries will just not have an "Item":
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_missing(test_table_s):
     p = random_string()
-    ret = test_table_s.meta.client.transact_get_items(TransactItems=[
-        { 'Get': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p},
-            }}])
-    assert 'Responses' in ret
-    assert len(ret['Responses']) == 1
-    assert 'Item' not in ret['Responses'][0]
+    ret = test_table_s.meta.client.transact_get_items(
+        TransactItems=[
+            {
+                "Get": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p},
+                }
+            }
+        ]
+    )
+    assert "Responses" in ret
+    assert len(ret["Responses"]) == 1
+    assert "Item" not in ret["Responses"][0]
+
 
 # Test the ProjectionExpression parameter for a Get action, asking not to
 # get the entire item and rather just get specific attributes. See more
 # extensive tests for ProjectionExpression in test_projection_expression.py.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_projection_expression(test_table_s):
     p = random_string()
-    item = {'p': p, 'x': 1, 'y': 2, 'z': 3}
+    item = {"p": p, "x": 1, "y": 2, "z": 3}
     test_table_s.put_item(Item=item)
-    ret = test_table_s.meta.client.transact_get_items(TransactItems=[
-        { 'Get': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p},
-            'ProjectionExpression': 'x,z'
-            }}])
-    assert 'Responses' in ret
-    assert len(ret['Responses']) == 1
-    assert 'Item' in ret['Responses'][0]
-    assert {'x': item['x'], 'z': item['z']} == ret['Responses'][0]['Item']
+    ret = test_table_s.meta.client.transact_get_items(
+        TransactItems=[
+            {
+                "Get": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p},
+                    "ProjectionExpression": "x,z",
+                }
+            }
+        ]
+    )
+    assert "Responses" in ret
+    assert len(ret["Responses"]) == 1
+    assert "Item" in ret["Responses"][0]
+    assert {"x": item["x"], "z": item["z"]} == ret["Responses"][0]["Item"]
+
 
 # ProjectionExpression also supports ExpressionAttributeNames.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_projection_expression_attribute_names(test_table_s):
     p = random_string()
-    item = {'p': p, 'x': 1, 'y': 2, 'z': 3}
+    item = {"p": p, "x": 1, "y": 2, "z": 3}
     test_table_s.put_item(Item=item)
-    ret = test_table_s.meta.client.transact_get_items(TransactItems=[
-        { 'Get': {
-            'TableName': test_table_s.name,
-            'Key': {'p': p},
-            'ProjectionExpression': '#xx,#zz',
-            'ExpressionAttributeNames': {'#xx': 'x', '#zz': 'z'}
-            }}])
-    assert 'Responses' in ret
-    assert len(ret['Responses']) == 1
-    assert 'Item' in ret['Responses'][0]
-    assert {'x': item['x'], 'z': item['z']} == ret['Responses'][0]['Item']
+    ret = test_table_s.meta.client.transact_get_items(
+        TransactItems=[
+            {
+                "Get": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": p},
+                    "ProjectionExpression": "#xx,#zz",
+                    "ExpressionAttributeNames": {"#xx": "x", "#zz": "z"},
+                }
+            }
+        ]
+    )
+    assert "Responses" in ret
+    assert len(ret["Responses"]) == 1
+    assert "Item" in ret["Responses"][0]
+    assert {"x": item["x"], "z": item["z"]} == ret["Responses"][0]["Item"]
+
 
 # If ExpressionAttributeNames is missing a name, or has an unused name,
 # it's an error. As we saw above in other cases, it's a ValidationException
 # for the entire transaction - not a TransactionCanceledException.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_unused_expressionattributenames(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*unused.*#qq'):
-        test_table_s.meta.client.transact_get_items(TransactItems=[
-            { 'Get': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p},
-                'ProjectionExpression': '#xx,#zz',
-                # The reference "#qq" isn't used in the ProjectionExpression
-                'ExpressionAttributeNames': {'#xx': 'x', '#zz': 'z', '#qq': 'q'}
-            }}])
+    with pytest.raises(ClientError, match="ValidationException.*unused.*#qq"):
+        test_table_s.meta.client.transact_get_items(
+            TransactItems=[
+                {
+                    "Get": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p},
+                        "ProjectionExpression": "#xx,#zz",
+                        # The reference "#qq" isn't used in the ProjectionExpression
+                        "ExpressionAttributeNames": {
+                            "#xx": "x",
+                            "#zz": "z",
+                            "#qq": "q",
+                        },
+                    }
+                }
+            ]
+        )
 
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_missing_expressionattributenames(test_table_s):
     p = random_string()
-    with pytest.raises(ClientError, match='ValidationException.*#zz'):
-        test_table_s.meta.client.transact_get_items(TransactItems=[
-            { 'Get': {
-                'TableName': test_table_s.name,
-                'Key': {'p': p},
-                'ProjectionExpression': '#xx,#zz',
-                # The reference "#zz" is missing in ExpressionAttributeNames
-                'ExpressionAttributeNames': {'#xx': 'x'}
-            }}])
+    with pytest.raises(ClientError, match="ValidationException.*#zz"):
+        test_table_s.meta.client.transact_get_items(
+            TransactItems=[
+                {
+                    "Get": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": p},
+                        "ProjectionExpression": "#xx,#zz",
+                        # The reference "#zz" is missing in ExpressionAttributeNames
+                        "ExpressionAttributeNames": {"#xx": "x"},
+                    }
+                }
+            ]
+        )
+
 
 # Test the ability to read multiple items in one transaction. We can actually
 # read 100 small items in one transaction - the limit used to be just 25
 # items, but it was increased to 100 in September 2022 so let's verify that
 # it works.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_100(test_table_s):
     p = random_string()
-    items = [{'p': p + str(i), 'x': i} for i in range(100)]
+    items = [{"p": p + str(i), "x": i} for i in range(100)]
     with test_table_s.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
-    ret = test_table_s.meta.client.transact_get_items(TransactItems=[
-        { 'Get': {
-            'TableName': test_table_s.name,
-            'Key': {'p': item['p']},
-        }} for item in items])
+    ret = test_table_s.meta.client.transact_get_items(
+        TransactItems=[
+            {
+                "Get": {
+                    "TableName": test_table_s.name,
+                    "Key": {"p": item["p"]},
+                }
+            }
+            for item in items
+        ]
+    )
     # verify that all 100 items were read
     for item in items:
-        assert item == test_table_s.get_item(Key={'p': item['p']}, ConsistentRead=True)['Item']
-    assert 'Responses' in ret
-    assert len(ret['Responses']) == 100
-    for i, response in enumerate(ret['Responses']):
-        assert 'Item' in response
-        assert response['Item'] == items[i]
+        assert (
+            item
+            == test_table_s.get_item(Key={"p": item["p"]}, ConsistentRead=True)["Item"]
+        )
+    assert "Responses" in ret
+    assert len(ret["Responses"]) == 100
+    for i, response in enumerate(ret["Responses"]):
+        assert "Item" in response
+        assert response["Item"] == items[i]
+
 
 # A transaction with 100 read actions is the limit, and 101 are not allowed:
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_101(test_table_s):
-    with pytest.raises(ClientError, match='ValidationException.*[tT]ransactItems.*100'):
-        test_table_s.meta.client.transact_get_items(TransactItems=[
-            { 'Get': {
-                'TableName': test_table_s.name,
-                'Key': {'p': str(i)},
-            }} for i in range(101)])
+    with pytest.raises(ClientError, match="ValidationException.*[tT]ransactItems.*100"):
+        test_table_s.meta.client.transact_get_items(
+            TransactItems=[
+                {
+                    "Get": {
+                        "TableName": test_table_s.name,
+                        "Key": {"p": str(i)},
+                    }
+                }
+                for i in range(101)
+            ]
+        )

--- a/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
+++ b/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
@@ -10,25 +10,56 @@
 
 from .porting import *
 
+
 # Migrated from cql_tests.py:TestCQL.test_select_distinct()
 def testSelectDistinct(cql, test_keyspace):
     # Test a regular (CQL3) table.
-    with create_table(cql, test_keyspace, "(pk0 int, pk1 int, ck0 int, val int, PRIMARY KEY ((pk0, pk1), ck0))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk0 int, pk1 int, ck0 int, val int, PRIMARY KEY ((pk0, pk1), ck0))",
+    ) as table:
         for i in range(3):
-            execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 0, 0)", i, i)
-            execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 1, 1)", i, i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 0, 0)",
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 1, 1)",
+                i,
+                i,
+            )
 
-        assertRows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 1"),
-                   row(0, 0))
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 1"), row(0, 0)
+        )
 
-        assertRows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 3"),
-                   row(0, 0),
-                   row(2, 2),
-                   row(1, 1))
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 3"),
+            row(0, 0),
+            row(2, 2),
+            row(1, 1),
+        )
 
         # Test selection validation.
-        assertInvalidMessage(cql, table, "queries must request all the partition key columns", "SELECT DISTINCT pk0 FROM %s")
-        assertInvalidMessage(cql, table, "queries must only request partition key columns", "SELECT DISTINCT pk0, pk1, ck0 FROM %s")
+        assertInvalidMessage(
+            cql,
+            table,
+            "queries must request all the partition key columns",
+            "SELECT DISTINCT pk0 FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "queries must only request partition key columns",
+            "SELECT DISTINCT pk0, pk1, ck0 FROM %s",
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.test_select_distinct_with_deletions()
 def testSelectDistinctWithDeletions(cql, test_keyspace):
@@ -51,113 +82,256 @@ def testSelectDistinctWithDeletions(cql, test_keyspace):
         rows = getRows(execute(cql, table, "SELECT DISTINCT k FROM %s"))
         assert len(rows) == 9
 
+
 # Reproduces issue #10354
-@pytest.mark.xfail(reason="#10354 - we forgot to allow SELECT DISTINCT filtering on static column")
+@pytest.mark.xfail(
+    reason="SELECT DISTINCT should allow filter on static columns, not just partition keys #10354"
+)
 def testSelectDistinctWithWhereClause(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, a int, b int, PRIMARY KEY (k, a))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, a int, b int, PRIMARY KEY (k, a))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
 
         for i in range(10):
             execute(cql, table, "INSERT INTO %s (k, a, b) VALUES (?, ?, ?)", i, i, i)
-            execute(cql, table, "INSERT INTO %s (k, a, b) VALUES (?, ?, ?)", i, i * 10, i * 10)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b) VALUES (?, ?, ?)",
+                i,
+                i * 10,
+                i * 10,
+            )
 
         # In issue #10354, Scylla forgot the "and/or static columns" part.
         distinctQueryErrorMsg = "SELECT DISTINCT with WHERE clause only supports restriction by partition key and/or static columns."
-        assertInvalidMessage(cql, table, distinctQueryErrorMsg,
-                             "SELECT DISTINCT k FROM %s WHERE a >= 80 ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            distinctQueryErrorMsg,
+            "SELECT DISTINCT k FROM %s WHERE a >= 80 ALLOW FILTERING",
+        )
 
-        assertInvalidMessage(cql, table, distinctQueryErrorMsg,
-                             "SELECT DISTINCT k FROM %s WHERE k IN (1, 2, 3) AND a = 10")
+        assertInvalidMessage(
+            cql,
+            table,
+            distinctQueryErrorMsg,
+            "SELECT DISTINCT k FROM %s WHERE k IN (1, 2, 3) AND a = 10",
+        )
 
-        assertInvalidMessage(cql, table, distinctQueryErrorMsg,
-                             "SELECT DISTINCT k FROM %s WHERE b = 5")
+        assertInvalidMessage(
+            cql, table, distinctQueryErrorMsg, "SELECT DISTINCT k FROM %s WHERE b = 5"
+        )
 
-        assertRows(execute(cql, table, "SELECT DISTINCT k FROM %s WHERE k = 1"),
-                   row(1))
-        assertRows(execute(cql, table, "SELECT DISTINCT k FROM %s WHERE k IN (5, 6, 7)"),
-                   row(5),
-                   row(6),
-                   row(7))
+        assertRows(execute(cql, table, "SELECT DISTINCT k FROM %s WHERE k = 1"), row(1))
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT k FROM %s WHERE k IN (5, 6, 7)"),
+            row(5),
+            row(6),
+            row(7),
+        )
 
     # With static columns
-    with create_table(cql, test_keyspace, "(k int, a int, s int static, b int, PRIMARY KEY (k, a))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, a int, s int static, b int, PRIMARY KEY (k, a))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
         for i in range(10):
-            execute(cql, table, "INSERT INTO %s (k, a, b, s) VALUES (?, ?, ?, ?)", i, i, i, i)
-            execute(cql, table, "INSERT INTO %s (k, a, b, s) VALUES (?, ?, ?, ?)", i, i * 10, i * 10, i * 10)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b, s) VALUES (?, ?, ?, ?)",
+                i,
+                i,
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b, s) VALUES (?, ?, ?, ?)",
+                i,
+                i * 10,
+                i * 10,
+                i * 10,
+            )
 
-        assertRows(execute(cql, table, "SELECT DISTINCT s FROM %s WHERE k = 5"),
-                   row(50))
-        assertRows(execute(cql, table, "SELECT DISTINCT s FROM %s WHERE k IN (5, 6, 7)"),
-                   row(50),
-                   row(60),
-                   row(70))
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT s FROM %s WHERE k = 5"), row(50)
+        )
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT s FROM %s WHERE k IN (5, 6, 7)"),
+            row(50),
+            row(60),
+            row(70),
+        )
+
 
 # Reproduces issue #10354
-@pytest.mark.xfail(reason="#10354 - we forgot to allow SELECT DISTINCT filtering on static column")
+@pytest.mark.xfail(
+    reason="SELECT DISTINCT should allow filter on static columns, not just partition keys #10354"
+)
 def testSelectDistinctWithWhereClauseOnStaticColumn(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, a int, s int static, s1 int static, b int, PRIMARY KEY (k, a))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, a int, s int static, s1 int static, b int, PRIMARY KEY (k, a))",
+    ) as table:
         for i in range(10):
-            execute(cql, table, "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)", i, i, i, i, i)
-            execute(cql, table, "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)", i, i * 10, i * 10, i * 10, i * 10)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)",
+                i,
+                i,
+                i,
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)",
+                i,
+                i * 10,
+                i * 10,
+                i * 10,
+                i * 10,
+            )
 
-        execute(cql, table, "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)", 2, 10, 10, 10, 10)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)",
+            2,
+            10,
+            10,
+            10,
+            10,
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assertRows(execute(cql, table, "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 90 AND s1 = 90 ALLOW FILTERING"),
-                       row(9, 90, 90))
+            assertRows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 90 AND s1 = 90 ALLOW FILTERING",
+                ),
+                row(9, 90, 90),
+            )
 
-            assertRows(execute(cql, table, "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 90 AND s1 = 90 ALLOW FILTERING"),
-                       row(9, 90, 90))
+            assertRows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 90 AND s1 = 90 ALLOW FILTERING",
+                ),
+                row(9, 90, 90),
+            )
 
-            assertRows(execute(cql, table, "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 10 AND s1 = 10 ALLOW FILTERING"),
-                       row(1, 10, 10),
-                       row(2, 10, 10))
+            assertRows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 10 AND s1 = 10 ALLOW FILTERING",
+                ),
+                row(1, 10, 10),
+                row(2, 10, 10),
+            )
 
-            assertRows(execute(cql, table, "SELECT DISTINCT k, s, s1 FROM %s WHERE k = 1 AND s = 10 AND s1 = 10 ALLOW FILTERING"),
-                       row(1, 10, 10))
+            assertRows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT k, s, s1 FROM %s WHERE k = 1 AND s = 10 AND s1 = 10 ALLOW FILTERING",
+                ),
+                row(1, 10, 10),
+            )
+
 
 def _testSelectDistinctWithPaging(cql, table):
-    for pageSize in range(1,7):
+    for pageSize in range(1, 7):
         # Range query
-        assert_rows(execute_with_paging(cql, table, "SELECT DISTINCT a, s FROM %s", pageSize),
-                          row(1, 1),
-                          row(0, 0),
-                          row(2, 2),
-                          row(4, 4),
-                          row(3, 3))
+        assert_rows(
+            execute_with_paging(cql, table, "SELECT DISTINCT a, s FROM %s", pageSize),
+            row(1, 1),
+            row(0, 0),
+            row(2, 2),
+            row(4, 4),
+            row(3, 3),
+        )
 
-        assert_rows(execute_with_paging(cql, table, "SELECT DISTINCT a, s FROM %s LIMIT 3", pageSize),
-                          row(1, 1),
-                          row(0, 0),
-                          row(2, 2))
+        assert_rows(
+            execute_with_paging(
+                cql, table, "SELECT DISTINCT a, s FROM %s LIMIT 3", pageSize
+            ),
+            row(1, 1),
+            row(0, 0),
+            row(2, 2),
+        )
 
-        assert_rows(execute_with_paging(cql, table, "SELECT DISTINCT a, s FROM %s WHERE s >= 2 ALLOW FILTERING", pageSize),
-                          row(2, 2),
-                          row(4, 4),
-                          row(3, 3))
+        assert_rows(
+            execute_with_paging(
+                cql,
+                table,
+                "SELECT DISTINCT a, s FROM %s WHERE s >= 2 ALLOW FILTERING",
+                pageSize,
+            ),
+            row(2, 2),
+            row(4, 4),
+            row(3, 3),
+        )
 
         # Multi partition query
-        assert_rows(execute_with_paging(cql, table, "SELECT DISTINCT a, s FROM %s WHERE a IN (1, 2, 3, 4);", pageSize),
-                          row(1, 1),
-                          row(2, 2),
-                          row(3, 3),
-                          row(4, 4))
+        assert_rows(
+            execute_with_paging(
+                cql,
+                table,
+                "SELECT DISTINCT a, s FROM %s WHERE a IN (1, 2, 3, 4);",
+                pageSize,
+            ),
+            row(1, 1),
+            row(2, 2),
+            row(3, 3),
+            row(4, 4),
+        )
 
-        assert_rows(execute_with_paging(cql, table, "SELECT DISTINCT a, s FROM %s WHERE a IN (1, 2, 3, 4) LIMIT 3;", pageSize),
-                          row(1, 1),
-                          row(2, 2),
-                          row(3, 3))
+        assert_rows(
+            execute_with_paging(
+                cql,
+                table,
+                "SELECT DISTINCT a, s FROM %s WHERE a IN (1, 2, 3, 4) LIMIT 3;",
+                pageSize,
+            ),
+            row(1, 1),
+            row(2, 2),
+            row(3, 3),
+        )
 
-        assert_rows(execute_with_paging(cql, table, "SELECT DISTINCT a, s FROM %s WHERE a IN (1, 2, 3, 4) AND s >= 2 ALLOW FILTERING;", pageSize),
-                          row(2, 2),
-                          row(3, 3),
-                          row(4, 4))
+        assert_rows(
+            execute_with_paging(
+                cql,
+                table,
+                "SELECT DISTINCT a, s FROM %s WHERE a IN (1, 2, 3, 4) AND s >= 2 ALLOW FILTERING;",
+                pageSize,
+            ),
+            row(2, 2),
+            row(3, 3),
+            row(4, 4),
+        )
+
 
 # Reproduces issue #10354
-@pytest.mark.xfail(reason="#10354 - we forgot to allow SELECT DISTINCT filtering on static column")
+@pytest.mark.xfail(
+    reason="SELECT DISTINCT should allow filter on static columns, not just partition keys #10354"
+)
 def testSelectDistinctWithStaticColumnsAndPaging(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))",
+    ) as table:
         # Test with only static data
         for i in range(5):
             execute(cql, table, "INSERT INTO %s (a, s) VALUES (?, ?)", i, i)
@@ -167,14 +341,30 @@ def testSelectDistinctWithStaticColumnsAndPaging(cql, test_keyspace):
         # Test with a mix of partition with rows and partitions without rows
         for i in range(5):
             if i % 2 == 0:
-                for j in range(1,4):
-                    execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", i, j, j, i + j)
+                for j in range(1, 4):
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+                        i,
+                        j,
+                        j,
+                        i + j,
+                    )
 
         _testSelectDistinctWithPaging(cql, table)
 
         # Test with all partition with rows
         for i in range(5):
-            for j in range(1,4):
-                execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", i, j, j, i + j)
+            for j in range(1, 4):
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+                    i,
+                    j,
+                    j,
+                    i + j,
+                )
 
         _testSelectDistinctWithPaging(cql, table)

--- a/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
@@ -14,88 +14,161 @@ from ctypes import c_float
 from datetime import datetime
 from cassandra.util import Date, uuid_from_time
 
+
 def testInvalidQueries(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int primary key, b text, c double)") as table:
-        assertInvalidMessage(cql, table, "cannot be cast to", "SELECT CAST(a AS boolean) FROM %s")
+    with create_table(
+        cql, test_keyspace, "(a int primary key, b text, c double)"
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "cannot be cast to", "SELECT CAST(a AS boolean) FROM %s"
+        )
+
 
 def testNumericCastsInSelectionClause(cql, test_keyspace, cassandra_bug):
-    with create_table(cql, test_keyspace, "(a tinyint primary key, b smallint, c int, d bigint, e float, f double, g decimal, h varint, i int)") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                1, 2, 3, 4, 5.2, 6.3, Decimal("6.3"), 4)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a tinyint primary key, b smallint, c int, d bigint, e float, f double, g decimal, h varint, i int)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            1,
+            2,
+            3,
+            4,
+            5.2,
+            6.3,
+            Decimal("6.3"),
+            4,
+        )
 
         # Reproduces #14508:
-        assertColumnNames(execute(cql, table, "SELECT CAST(b AS int), CAST(c AS int), CAST(d AS double) FROM %s"),
-                          # The original names unmanipulated by the Python
-                          # driver are cast(b as int).
-                          "cast_b_as_int",
-                          "c",
-                          "cast_d_as_double")
+        assertColumnNames(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(b AS int), CAST(c AS int), CAST(d AS double) FROM %s",
+            ),
+            # The original names unmanipulated by the Python
+            # driver are cast(b as int).
+            "cast_b_as_int",
+            "c",
+            "cast_d_as_double",
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS tinyint), " +
-                "CAST(b AS tinyint), " +
-                "CAST(c AS tinyint), " +
-                "CAST(d AS tinyint), " +
-                "CAST(e AS tinyint), " +
-                "CAST(f AS tinyint), " +
-                "CAST(g AS tinyint), " +
-                "CAST(h AS tinyint), " +
-                "CAST(i AS tinyint) FROM %s"),
-                   row(1, 2, 3, 4, 5, 6, 6, 4, None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS tinyint), "
+                + "CAST(b AS tinyint), "
+                + "CAST(c AS tinyint), "
+                + "CAST(d AS tinyint), "
+                + "CAST(e AS tinyint), "
+                + "CAST(f AS tinyint), "
+                + "CAST(g AS tinyint), "
+                + "CAST(h AS tinyint), "
+                + "CAST(i AS tinyint) FROM %s",
+            ),
+            row(1, 2, 3, 4, 5, 6, 6, 4, None),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS smallint), " +
-                "CAST(b AS smallint), " +
-                "CAST(c AS smallint), " +
-                "CAST(d AS smallint), " +
-                "CAST(e AS smallint), " +
-                "CAST(f AS smallint), " +
-                "CAST(g AS smallint), " +
-                "CAST(h AS smallint), " +
-                "CAST(i AS smallint) FROM %s"),
-                   row(1, 2, 3, 4, 5, 6, 6, 4, None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS smallint), "
+                + "CAST(b AS smallint), "
+                + "CAST(c AS smallint), "
+                + "CAST(d AS smallint), "
+                + "CAST(e AS smallint), "
+                + "CAST(f AS smallint), "
+                + "CAST(g AS smallint), "
+                + "CAST(h AS smallint), "
+                + "CAST(i AS smallint) FROM %s",
+            ),
+            row(1, 2, 3, 4, 5, 6, 6, 4, None),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS int), " +
-                "CAST(b AS int), " +
-                "CAST(c AS int), " +
-                "CAST(d AS int), " +
-                "CAST(e AS int), " +
-                "CAST(f AS int), " +
-                "CAST(g AS int), " +
-                "CAST(h AS int), " +
-                "CAST(i AS int) FROM %s"),
-                   row(1, 2, 3, 4, 5, 6, 6, 4, None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS int), "
+                + "CAST(b AS int), "
+                + "CAST(c AS int), "
+                + "CAST(d AS int), "
+                + "CAST(e AS int), "
+                + "CAST(f AS int), "
+                + "CAST(g AS int), "
+                + "CAST(h AS int), "
+                + "CAST(i AS int) FROM %s",
+            ),
+            row(1, 2, 3, 4, 5, 6, 6, 4, None),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS bigint), " +
-                "CAST(b AS bigint), " +
-                "CAST(c AS bigint), " +
-                "CAST(d AS bigint), " +
-                "CAST(e AS bigint), " +
-                "CAST(f AS bigint), " +
-                "CAST(g AS bigint), " +
-                "CAST(h AS bigint), " +
-                "CAST(i AS bigint) FROM %s"),
-                   row(1, 2, 3, 4, 5, 6, 6, 4, None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS bigint), "
+                + "CAST(b AS bigint), "
+                + "CAST(c AS bigint), "
+                + "CAST(d AS bigint), "
+                + "CAST(e AS bigint), "
+                + "CAST(f AS bigint), "
+                + "CAST(g AS bigint), "
+                + "CAST(h AS bigint), "
+                + "CAST(i AS bigint) FROM %s",
+            ),
+            row(1, 2, 3, 4, 5, 6, 6, 4, None),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS float), " +
-                "CAST(b AS float), " +
-                "CAST(c AS float), " +
-                "CAST(d AS float), " +
-                "CAST(e AS float), " +
-                "CAST(f AS float), " +
-                "CAST(g AS float), " +
-                "CAST(h AS float), " +
-                "CAST(i AS float) FROM %s"),
-                   row(1.0, 2.0, 3.0, 4.0, c_float(5.2).value, c_float(6.3).value, c_float(6.3).value, 4.0, None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS float), "
+                + "CAST(b AS float), "
+                + "CAST(c AS float), "
+                + "CAST(d AS float), "
+                + "CAST(e AS float), "
+                + "CAST(f AS float), "
+                + "CAST(g AS float), "
+                + "CAST(h AS float), "
+                + "CAST(i AS float) FROM %s",
+            ),
+            row(
+                1.0,
+                2.0,
+                3.0,
+                4.0,
+                c_float(5.2).value,
+                c_float(6.3).value,
+                c_float(6.3).value,
+                4.0,
+                None,
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS double), " +
-                "CAST(b AS double), " +
-                "CAST(c AS double), " +
-                "CAST(d AS double), " +
-                "CAST(e AS double), " +
-                "CAST(f AS double), " +
-                "CAST(g AS double), " +
-                "CAST(h AS double), " +
-                "CAST(i AS double) FROM %s"),
-                   row(1.0, 2.0, 3.0, 4.0, c_float(5.2).value, 6.3, 6.3, 4.0, None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS double), "
+                + "CAST(b AS double), "
+                + "CAST(c AS double), "
+                + "CAST(d AS double), "
+                + "CAST(e AS double), "
+                + "CAST(f AS double), "
+                + "CAST(g AS double), "
+                + "CAST(h AS double), "
+                + "CAST(i AS double) FROM %s",
+            ),
+            row(1.0, 2.0, 3.0, 4.0, c_float(5.2).value, 6.3, 6.3, 4.0, None),
+        )
 
         # Cassandra has a bug here (CASSANDRA-18647), so this test was modified
         # from the original and fails on Cassandra and marked cassandra_bug:
@@ -104,164 +177,254 @@ def testNumericCastsInSelectionClause(cql, test_keyspace, cassandra_bug):
         # and only then converted to decimal with all those silly extra digits.
         # Scylla, correctly, only keeps the relevant digits for the original
         # float - 5.2.
-        assertRows(execute(cql, table, "SELECT CAST(a AS decimal), " +
-                "CAST(b AS decimal), " +
-                "CAST(c AS decimal), " +
-                "CAST(d AS decimal), " +
-                "CAST(e AS decimal), " +
-                "CAST(f AS decimal), " +
-                "CAST(g AS decimal), " +
-                "CAST(h AS decimal), " +
-                "CAST(i AS decimal) FROM %s"),
-                   row(Decimal("1"),
-                       Decimal("2"),
-                       Decimal("3"),
-                       Decimal("4"),
-                       # this fails in Cassandra. In Cassandra, we get
-                       # Decimal(str(c_float(5.2).value))
-                       Decimal("5.2"),
-                       Decimal("6.3"),
-                       Decimal("6.3"),
-                       Decimal("4"),
-                       None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS decimal), "
+                + "CAST(b AS decimal), "
+                + "CAST(c AS decimal), "
+                + "CAST(d AS decimal), "
+                + "CAST(e AS decimal), "
+                + "CAST(f AS decimal), "
+                + "CAST(g AS decimal), "
+                + "CAST(h AS decimal), "
+                + "CAST(i AS decimal) FROM %s",
+            ),
+            row(
+                Decimal("1"),
+                Decimal("2"),
+                Decimal("3"),
+                Decimal("4"),
+                # this fails in Cassandra. In Cassandra, we get
+                # Decimal(str(c_float(5.2).value))
+                Decimal("5.2"),
+                Decimal("6.3"),
+                Decimal("6.3"),
+                Decimal("4"),
+                None,
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS ascii), " +
-                "CAST(b AS ascii), " +
-                "CAST(c AS ascii), " +
-                "CAST(d AS ascii), " +
-                "CAST(e AS ascii), " +
-                "CAST(f AS ascii), " +
-                "CAST(g AS ascii), " +
-                "CAST(h AS ascii), " +
-                "CAST(i AS ascii) FROM %s"),
-                   row("1",
-                       "2",
-                       "3",
-                       "4",
-                       "5.2",
-                       "6.3",
-                       "6.3",
-                       "4",
-                       None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS ascii), "
+                + "CAST(b AS ascii), "
+                + "CAST(c AS ascii), "
+                + "CAST(d AS ascii), "
+                + "CAST(e AS ascii), "
+                + "CAST(f AS ascii), "
+                + "CAST(g AS ascii), "
+                + "CAST(h AS ascii), "
+                + "CAST(i AS ascii) FROM %s",
+            ),
+            row("1", "2", "3", "4", "5.2", "6.3", "6.3", "4", None),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS text), " +
-                "CAST(b AS text), " +
-                "CAST(c AS text), " +
-                "CAST(d AS text), " +
-                "CAST(e AS text), " +
-                "CAST(f AS text), " +
-                "CAST(g AS text), " +
-                "CAST(h AS text), " +
-                "CAST(i AS text) FROM %s"),
-                   row("1",
-                       "2",
-                       "3",
-                       "4",
-                       "5.2",
-                       "6.3",
-                       "6.3",
-                       "4",
-                       None))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS text), "
+                + "CAST(b AS text), "
+                + "CAST(c AS text), "
+                + "CAST(d AS text), "
+                + "CAST(e AS text), "
+                + "CAST(f AS text), "
+                + "CAST(g AS text), "
+                + "CAST(h AS text), "
+                + "CAST(i AS text) FROM %s",
+            ),
+            row("1", "2", "3", "4", "5.2", "6.3", "6.3", "4", None),
+        )
+
 
 def testNoLossOfPrecisionForCastToDecimal(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int primary key, bigint_clmn bigint, varint_clmn varint)") as table:
-        execute(cql, table, "INSERT INTO %s(k, bigint_clmn, varint_clmn) VALUES(2, 9223372036854775807, 1234567890123456789)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int primary key, bigint_clmn bigint, varint_clmn varint)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(k, bigint_clmn, varint_clmn) VALUES(2, 9223372036854775807, 1234567890123456789)",
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(bigint_clmn AS decimal), CAST(varint_clmn AS decimal) FROM %s"),
-                   row(Decimal("9223372036854775807"), Decimal("1234567890123456789")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(bigint_clmn AS decimal), CAST(varint_clmn AS decimal) FROM %s",
+            ),
+            row(Decimal("9223372036854775807"), Decimal("1234567890123456789")),
+        )
+
 
 def testTimeCastsInSelectionClause(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a timeuuid primary key, b timestamp, c date, d time)") as table:
+    with create_table(
+        cql, test_keyspace, "(a timeuuid primary key, b timestamp, c date, d time)"
+    ) as table:
         yearMonthDay = "2015-05-21"
         dateNoTime = datetime(2015, 5, 21, 0, 0, 0)
         dateTime = datetime(2015, 5, 21, 11, 3, 2)
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, '" + yearMonthDay + " 11:03:02+00', '2015-05-21', '11:03:02')",
-                uuid_from_time(dateTime))
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, '"
+            + yearMonthDay
+            + " 11:03:02+00', '2015-05-21', '11:03:02')",
+            uuid_from_time(dateTime),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS timestamp), " +
-                           "CAST(b AS timestamp), " +
-                           "CAST(c AS timestamp) FROM %s"),
-                   row(dateTime, dateTime, dateNoTime))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS timestamp), "
+                + "CAST(b AS timestamp), "
+                + "CAST(c AS timestamp) FROM %s",
+            ),
+            row(dateTime, dateTime, dateNoTime),
+        )
 
         date = Date(yearMonthDay)
-        assertRows(execute(cql, table, "SELECT CAST(a AS date), " +
-                           "CAST(b AS date), " +
-                           "CAST(c AS date) FROM %s"),
-                   row(date, date, date))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS date), "
+                + "CAST(b AS date), "
+                + "CAST(c AS date) FROM %s",
+            ),
+            row(date, date, date),
+        )
 
         # Reproduces #14518:
-        assertRows(execute(cql, table, "SELECT CAST(b AS text), " +
-                           "CAST(c AS text), " +
-                           "CAST(d AS text) FROM %s"),
-                   row(yearMonthDay + "T11:03:02.000Z", yearMonthDay, "11:03:02.000000000"))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(b AS text), "
+                + "CAST(c AS text), "
+                + "CAST(d AS text) FROM %s",
+            ),
+            row(yearMonthDay + "T11:03:02.000Z", yearMonthDay, "11:03:02.000000000"),
+        )
+
 
 def testOtherTypeCastsInSelectionClause(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a ascii primary key, b inet, c boolean)") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, '127.0.0.1', ?)",
-                "test", True)
+    with create_table(
+        cql, test_keyspace, "(a ascii primary key, b inet, c boolean)"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, '127.0.0.1', ?)",
+            "test",
+            True,
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS text), " +
-                "CAST(b AS text), " +
-                "CAST(c AS text) FROM %s"),
-                   row("test", "127.0.0.1", "true"))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS text), "
+                + "CAST(b AS text), "
+                + "CAST(c AS text) FROM %s",
+            ),
+            row("test", "127.0.0.1", "true"),
+        )
+
 
 def testCastsWithReverseOrder(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b smallint, c double, primary key (a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
-                1, 2, 6.3)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b smallint, c double, primary key (a, b)) WITH CLUSTERING ORDER BY (b DESC)",
+    ) as table:
+        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 2, 6.3)
 
-        assertRows(execute(cql, table, "SELECT CAST(a AS tinyint), " +
-                "CAST(b AS tinyint), " +
-                "CAST(c AS tinyint) FROM %s"),
-                   row(1, 2, 6))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(a AS tinyint), "
+                + "CAST(b AS tinyint), "
+                + "CAST(c AS tinyint) FROM %s",
+            ),
+            row(1, 2, 6),
+        )
 
-        assertRows(execute(cql, table, "SELECT CAST(CAST(a AS tinyint) AS smallint), " +
-                "CAST(CAST(b AS tinyint) AS smallint), " +
-                "CAST(CAST(c AS tinyint) AS smallint) FROM %s"),
-                   row(1, 2, 6))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(CAST(a AS tinyint) AS smallint), "
+                + "CAST(CAST(b AS tinyint) AS smallint), "
+                + "CAST(CAST(c AS tinyint) AS smallint) FROM %s",
+            ),
+            row(1, 2, 6),
+        )
 
         # In Cassandra, doubles cast to text always get a decimal point
         # (e.g., "1.0") but Scylla may yield just "1". Both are fine.
-        assert_rows2(execute(cql, table, "SELECT CAST(CAST(CAST(a AS tinyint) AS double) AS text), " +
-                "CAST(CAST(CAST(b AS tinyint) AS double) AS text), " +
-                "CAST(CAST(CAST(c AS tinyint) AS double) AS text) FROM %s"),
-                   [row("1.0", "2.0", "6.0")],
-                   [row("1", "2", "6")])
+        assert_rows2(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(CAST(CAST(a AS tinyint) AS double) AS text), "
+                + "CAST(CAST(CAST(b AS tinyint) AS double) AS text), "
+                + "CAST(CAST(CAST(c AS tinyint) AS double) AS text) FROM %s",
+            ),
+            [row("1.0", "2.0", "6.0")],
+            [row("1", "2", "6")],
+        )
 
         # FIXME: I commented out this test for UDF because of laziness to
         # translate it to Lua for Scylla :-( Bring it back.
-        #String f = createFunction(KEYSPACE, "int",
+        # String f = createFunction(KEYSPACE, "int",
         #                          "CREATE FUNCTION %s(val int) " +
         #                                  "RETURNS NULL ON NULL INPUT " +
         #                                  "RETURNS double " +
         #                                  "LANGUAGE java " +
         #                                  "AS 'return (double)val;'")
         #
-        #assertRows(execute(cql, table, "SELECT " + f + "(CAST(b AS int)) FROM %s"),
+        # assertRows(execute(cql, table, "SELECT " + f + "(CAST(b AS int)) FROM %s"),
         #           row((double) 2))
         #
-                #assertRows(execute(cql, table, "SELECT CAST(" + f + "(CAST(b AS int)) AS text) FROM %s"),
+        # assertRows(execute(cql, table, "SELECT CAST(" + f + "(CAST(b AS int)) AS text) FROM %s"),
         #           row("2.0"))
+
 
 # Reproduces #14501:
 def testCounterCastsInSelectionClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int primary key, b counter)") as table:
         execute(cql, table, "UPDATE %s SET b = b + 2 WHERE a = 1")
 
-        assertRows(execute(cql, table, "SELECT CAST(b AS tinyint), " +
-                "CAST(b AS smallint), " +
-                "CAST(b AS int), " +
-                "CAST(b AS bigint), " +
-                "CAST(b AS float), " +
-                "CAST(b AS double), " +
-                "CAST(b AS decimal), " +
-                "CAST(b AS ascii), " +
-                "CAST(b AS text) FROM %s"),
-                   row(2, 2, 2, 2, 2.0, 2.0, Decimal("2"), "2", "2"))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT CAST(b AS tinyint), "
+                + "CAST(b AS smallint), "
+                + "CAST(b AS int), "
+                + "CAST(b AS bigint), "
+                + "CAST(b AS float), "
+                + "CAST(b AS double), "
+                + "CAST(b AS decimal), "
+                + "CAST(b AS ascii), "
+                + "CAST(b AS text) FROM %s",
+            ),
+            row(2, 2, 2, 2, 2.0, 2.0, Decimal("2"), "2", "2"),
+        )
+
 
 # Verifies that the {@code CAST} function can be used in the values of {@code INSERT INTO} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInInsertIntoValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         # Simple cast
@@ -269,16 +432,27 @@ def testCastsInInsertIntoValues(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT v FROM %s"), row(1))
 
         # Nested casts
-        execute(cql, table, "INSERT INTO %s (k, v) VALUES (1, CAST(CAST(CAST(2.3 AS int) AS float) AS int))")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v) VALUES (1, CAST(CAST(CAST(2.3 AS int) AS float) AS int))",
+        )
         assertRows(execute(cql, table, "SELECT v FROM %s"), row(2))
 
         # Cast of placeholder with type hint
-        execute(cql, table, "INSERT INTO %s (k, v) VALUES (1, CAST((float) ? AS int))", 3.4)
+        execute(
+            cql, table, "INSERT INTO %s (k, v) VALUES (1, CAST((float) ? AS int))", 3.4
+        )
         assertRows(execute(cql, table, "SELECT v FROM %s"), row(3))
 
         # Cast of placeholder without type hint
-        assertInvalidMessage(cql, table, "Ambiguous call to function system.castAsInt",
-                                    "INSERT INTO %s (k, v) VALUES (1, CAST(? AS int))", 3.4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous call to function system.castAsInt",
+            "INSERT INTO %s (k, v) VALUES (1, CAST(? AS int))",
+            3.4,
+        )
 
         # Type hint of cast
         execute(cql, table, "INSERT INTO %s (k, v) VALUES (1, (int) CAST(4.9 AS int))")
@@ -288,15 +462,16 @@ def testCastsInInsertIntoValues(cql, test_keyspace):
         # translate it to Lua for Scylla :-( Bring it back.
 
         # Function of cast
-        #execute(cql, table, String.format("INSERT INTO %%s (k, v) VALUES (1, %s(CAST(5 AS float)))", floatToInt()))
-        #assertRows(execute(cql, table, "SELECT v FROM %s"), row(5))
+        # execute(cql, table, String.format("INSERT INTO %%s (k, v) VALUES (1, %s(CAST(5 AS float)))", floatToInt()))
+        # assertRows(execute(cql, table, "SELECT v FROM %s"), row(5))
 
         # Cast of function
-        #execute(cql, table, String.format("INSERT INTO %%s (k, v) VALUES (1, CAST(%s(6) AS int))", intToFloat()))
-        #assertRows(execute(cql, table, "SELECT v FROM %s"), row(6))
+        # execute(cql, table, String.format("INSERT INTO %%s (k, v) VALUES (1, CAST(%s(6) AS int))", intToFloat()))
+        # assertRows(execute(cql, table, "SELECT v FROM %s"), row(6))
+
 
 # Verifies that the {@code CAST} function can be used in the values of {@code UPDATE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInUpdateValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         # Simple cast
@@ -304,7 +479,11 @@ def testCastsInUpdateValues(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT v FROM %s"), row(1))
 
         # Nested casts
-        execute(cql, table, "UPDATE %s SET v = CAST(CAST(CAST(2.3 AS int) AS float) AS int) WHERE k = 1")
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET v = CAST(CAST(CAST(2.3 AS int) AS float) AS int) WHERE k = 1",
+        )
         assertRows(execute(cql, table, "SELECT v FROM %s"), row(2))
 
         # Cast of placeholder with type hint
@@ -312,8 +491,13 @@ def testCastsInUpdateValues(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT v FROM %s"), row(3))
 
         # Cast of placeholder without type hint
-        assertInvalidMessage(cql, table, "Ambiguous call to function system.castAsInt",
-                                    "UPDATE %s SET v = CAST(? AS int) WHERE k = 1", 3.4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous call to function system.castAsInt",
+            "UPDATE %s SET v = CAST(? AS int) WHERE k = 1",
+            3.4,
+        )
 
         # Type hint of cast
         execute(cql, table, "UPDATE %s SET v = (int) CAST(4.9 AS int) WHERE k = 1")
@@ -322,19 +506,20 @@ def testCastsInUpdateValues(cql, test_keyspace):
         # FIXME: I commented out these tests for UDF because of laziness to
         # translate it to Lua for Scylla :-( Bring it back.
 
-        #// Function of cast
-        #execute(cql, table, String.format("UPDATE %%s SET v = %s(CAST(5 AS float)) WHERE k = 1", floatToInt()))
-        #assertRows(execute(cql, table, "SELECT v FROM %s"), row(5))
+        # // Function of cast
+        # execute(cql, table, String.format("UPDATE %%s SET v = %s(CAST(5 AS float)) WHERE k = 1", floatToInt()))
+        # assertRows(execute(cql, table, "SELECT v FROM %s"), row(5))
 
-        #// Cast of function
-        #execute(cql, table, String.format("UPDATE %%s SET v = CAST(%s(6) AS int) WHERE k = 1", intToFloat()))
-        #assertRows(execute(cql, table, "SELECT v FROM %s"), row(6))
+        # // Cast of function
+        # execute(cql, table, String.format("UPDATE %%s SET v = CAST(%s(6) AS int) WHERE k = 1", intToFloat()))
+        # assertRows(execute(cql, table, "SELECT v FROM %s"), row(6))
+
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code UPDATE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInUpdateWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
-        for i in range(1,7):
+        for i in range(1, 7):
             execute(cql, table, "INSERT INTO %s (k) VALUES (?)", i)
 
         # Simple cast
@@ -342,16 +527,29 @@ def testCastsInUpdateWhereClause(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 1), row(1))
 
         # Nested casts
-        execute(cql, table, "UPDATE %s SET v = ? WHERE k = CAST(CAST(CAST(2.3 AS int) AS float) AS int)", 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET v = ? WHERE k = CAST(CAST(CAST(2.3 AS int) AS float) AS int)",
+            2,
+        )
         assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 2), row(2))
 
         # Cast of placeholder with type hint
-        execute(cql, table, "UPDATE %s SET v = ? WHERE k = CAST((float) ? AS int)", 3, 3.4)
+        execute(
+            cql, table, "UPDATE %s SET v = ? WHERE k = CAST((float) ? AS int)", 3, 3.4
+        )
         assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 3), row(3))
 
         # Cast of placeholder without type hint
-        assertInvalidMessage(cql, table, "Ambiguous call to function system.castAsInt",
-                                    "UPDATE %s SET v = ? WHERE k = CAST(? AS int)", 3, 3.4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous call to function system.castAsInt",
+            "UPDATE %s SET v = ? WHERE k = CAST(? AS int)",
+            3,
+            3.4,
+        )
 
         # Type hint of cast
         execute(cql, table, "UPDATE %s SET v = ? WHERE k = (int) CAST(4.9 AS int)", 4)
@@ -360,48 +558,72 @@ def testCastsInUpdateWhereClause(cql, test_keyspace):
         # FIXME: I commented out these tests for UDF because of laziness to
         # translate it to Lua for Scylla :-( Bring it back.
 
-        #// Function of cast
-        #execute(cql, table, String.format("UPDATE %%s SET v = ? WHERE k = %s(CAST(5 AS float))", floatToInt()), 5)
-        #assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 5), row(5))
+        # // Function of cast
+        # execute(cql, table, String.format("UPDATE %%s SET v = ? WHERE k = %s(CAST(5 AS float))", floatToInt()), 5)
+        # assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 5), row(5))
 
-        #// Cast of function
-        #execute(cql, table, String.format("UPDATE %%s SET v = ? WHERE k = CAST(%s(6) AS int)", intToFloat()), 6)
-        #assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 6), row(6))
+        # // Cast of function
+        # execute(cql, table, String.format("UPDATE %%s SET v = ? WHERE k = CAST(%s(6) AS int)", intToFloat()), 6)
+        # assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 6), row(6))
+
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code SELECT} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInSelectWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key)") as table:
-        for i in range(1,7):
+        for i in range(1, 7):
             execute(cql, table, "INSERT INTO %s (k) VALUES (?)", i)
 
         # Simple cast
-        assertRows(execute(cql, table, "SELECT k FROM %s WHERE k = CAST(1.3 AS int)"), row(1))
+        assertRows(
+            execute(cql, table, "SELECT k FROM %s WHERE k = CAST(1.3 AS int)"), row(1)
+        )
 
         # Nested casts
-        assertRows(execute(cql, table, "SELECT k FROM %s WHERE k = CAST(CAST(CAST(2.3 AS int) AS float) AS int)"), row(2))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT k FROM %s WHERE k = CAST(CAST(CAST(2.3 AS int) AS float) AS int)",
+            ),
+            row(2),
+        )
 
         # Cast of placeholder with type hint
-        assertRows(execute(cql, table, "SELECT k FROM %s WHERE k = CAST((float) ? AS int)", 3.4), row(3))
+        assertRows(
+            execute(
+                cql, table, "SELECT k FROM %s WHERE k = CAST((float) ? AS int)", 3.4
+            ),
+            row(3),
+        )
 
         # Cast of placeholder without type hint
-        assertInvalidMessage(cql, table, "Ambiguous call to function system.castAsInt",
-                                    "SELECT k FROM %s WHERE k = CAST(? AS int)", 3.4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous call to function system.castAsInt",
+            "SELECT k FROM %s WHERE k = CAST(? AS int)",
+            3.4,
+        )
 
         # Type hint of cast
-        assertRows(execute(cql, table, "SELECT k FROM %s WHERE k = (int) CAST(4.9 AS int)"), row(4))
+        assertRows(
+            execute(cql, table, "SELECT k FROM %s WHERE k = (int) CAST(4.9 AS int)"),
+            row(4),
+        )
 
         # FIXME: I commented out these tests for UDF because of laziness to
         # translate it to Lua for Scylla :-( Bring it back.
 
-        #// Function of cast
-        #assertRows(execute(cql, table, String.format("SELECT k FROM %%s WHERE k = %s(CAST(5 AS float))", floatToInt())), row(5))
+        # // Function of cast
+        # assertRows(execute(cql, table, String.format("SELECT k FROM %%s WHERE k = %s(CAST(5 AS float))", floatToInt())), row(5))
 
-        #// Cast of function
-        #assertRows(execute(cql, table, String.format("SELECT k FROM %%s WHERE k = CAST(%s(6) AS int)", intToFloat())), row(6))
+        # // Cast of function
+        # assertRows(execute(cql, table, String.format("SELECT k FROM %%s WHERE k = CAST(%s(6) AS int)", intToFloat())), row(6))
+
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code DELETE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInDeleteWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key)") as table:
         for i in range(1, 7):
@@ -412,7 +634,11 @@ def testCastsInDeleteWhereClause(cql, test_keyspace):
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 1))
 
         # Nested casts
-        execute(cql, table, "DELETE FROM %s WHERE k = CAST(CAST(CAST(2.3 AS int) AS float) AS int)")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE k = CAST(CAST(CAST(2.3 AS int) AS float) AS int)",
+        )
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 2))
 
         # Cast of placeholder with type hint
@@ -420,8 +646,13 @@ def testCastsInDeleteWhereClause(cql, test_keyspace):
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 3))
 
         # Cast of placeholder without type hint
-        assertInvalidMessage(cql, table, "Ambiguous call to function system.castAsInt",
-                                    "DELETE FROM %s WHERE k = CAST(? AS int)", 3.4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous call to function system.castAsInt",
+            "DELETE FROM %s WHERE k = CAST(? AS int)",
+            3.4,
+        )
 
         # Type hint of cast
         execute(cql, table, "DELETE FROM %s WHERE k = (int) CAST(4.9 AS int)")
@@ -430,13 +661,14 @@ def testCastsInDeleteWhereClause(cql, test_keyspace):
         # FIXME: I commented out these tests for UDF because of laziness to
         # translate it to Lua for Scylla :-( Bring it back.
 
-        #// Function of cast
-        #execute(cql, table, String.format("DELETE FROM %%s WHERE k = %s(CAST(5 AS float))", floatToInt()))
-        #assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 5))
+        # // Function of cast
+        # execute(cql, table, String.format("DELETE FROM %%s WHERE k = %s(CAST(5 AS float))", floatToInt()))
+        # assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 5))
 
-        #// Cast of function
-        #execute(cql, table, String.format("DELETE FROM %%s WHERE k = CAST(%s(6) AS int)", intToFloat()))
-        #assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 6))
+        # // Cast of function
+        # execute(cql, table, String.format("DELETE FROM %%s WHERE k = CAST(%s(6) AS int)", intToFloat()))
+        # assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 6))
+
 
 # FIXME: I commented out these utility functions for UDF because of laziness to
 # translate it to Lua for Scylla :-( Bring it back.
@@ -472,17 +704,24 @@ def testCastsInDeleteWhereClause(cql, test_keyspace):
 #                              "AS 'return (float) x;'")
 #    }
 
+
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code CREATE MATERIALIZED
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInCreateViewWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         viewName = test_keyspace + ".mv_with_cast"
-        execute(cql, table, f"CREATE MATERIALIZED VIEW {viewName} AS SELECT * FROM {table} WHERE k < CAST(3.14 AS int) AND v IS NOT NULL PRIMARY KEY (v, k)")
+        execute(
+            cql,
+            table,
+            f"CREATE MATERIALIZED VIEW {viewName} AS SELECT * FROM {table} WHERE k < CAST(3.14 AS int) AND v IS NOT NULL PRIMARY KEY (v, k)",
+        )
 
         execute(cql, table, "INSERT INTO %s (k, v) VALUES (1, 10)")
         execute(cql, table, "INSERT INTO %s (k, v) VALUES (2, 20)")
         execute(cql, table, "INSERT INTO %s (k, v) VALUES (3, 30)")
 
-        assertRows(execute(cql, table, f"SELECT * FROM {viewName}"), row(10, 1), row(20, 2))
+        assertRows(
+            execute(cql, table, f"SELECT * FROM {viewName}"), row(10, 1), row(20, 2)
+        )
 
         execute(cql, table, "DROP MATERIALIZED VIEW " + viewName)

--- a/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
@@ -16,491 +16,1378 @@ from cassandra.protocol import FunctionFailure
 from cassandra.util import Date
 from datetime import datetime
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testStringConcatenation(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b ascii, c text, PRIMARY KEY(a, b, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(a text, b ascii, c text, PRIMARY KEY(a, b, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('जॉन', 'Doe', 'जॉन Doe')")
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a + a, a + b, b + a, b + b FROM %s WHERE a = 'जॉन' AND b = 'Doe' AND c = 'जॉन Doe'"),
-                "a + a", "a + b", "b + a", "b + b")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a + a, a + b, b + a, b + b FROM %s WHERE a = 'जॉन' AND b = 'Doe' AND c = 'जॉन Doe'",
+                ),
+                "a + a",
+                "a + b",
+                "b + a",
+                "b + b",
+            )
 
-        assertRows(execute(cql, table, "SELECT a + ' ' + a, a + ' ' + b, b + ' ' + a, b + ' ' + b FROM %s WHERE a = 'जॉन' AND b = 'Doe' AND c = 'जॉन Doe'"),
-            row("जॉन जॉन", "जॉन Doe", "Doe जॉन", "Doe Doe"))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + ' ' + a, a + ' ' + b, b + ' ' + a, b + ' ' + b FROM %s WHERE a = 'जॉन' AND b = 'Doe' AND c = 'जॉन Doe'",
+            ),
+            row("जॉन जॉन", "जॉन Doe", "Doe जॉन", "Doe Doe"),
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testSingleOperations(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY(a, b, c))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (1, 2, 3, 4, 5.5, 6.5, 7, 8.5)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY(a, b, c))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (1, 2, 3, 4, 5.5, 6.5, 7, 8.5)",
+        )
 
         # Test additions
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a + a, b + a, c + a, d + a, e + a, f + a, g + a, h + a FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                          "a + a", "b + a", "c + a", "d + a", "e + a", "f + a", "g + a", "h + a")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a + a, b + a, c + a, d + a, e + a, f + a, g + a, h + a FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+                ),
+                "a + a",
+                "b + a",
+                "c + a",
+                "d + a",
+                "e + a",
+                "f + a",
+                "g + a",
+                "h + a",
+            )
 
-        assertRows(execute(cql, table, "SELECT a + a, b + a, c + a, d + a, e + a, f + a, g + a, h + a FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                   row(2, 3, 4, 5, 6.5, 7.5, 8, Decimal("9.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + a, b + a, c + a, d + a, e + a, f + a, g + a, h + a FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+            ),
+            row(2, 3, 4, 5, 6.5, 7.5, 8, Decimal("9.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + b, b + b, c + b, d + b, e + b, f + b, g + b, h + b FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                   row(3, 4, 5, 6, c_float(7.5).value, 8.5, 9, Decimal("10.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + b, b + b, c + b, d + b, e + b, f + b, g + b, h + b FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+            ),
+            row(3, 4, 5, 6, c_float(7.5).value, 8.5, 9, Decimal("10.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + c, b + c, c + c, d + c, e + c, f + c, g + c, h + c FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                   row(4, 5, 6, 7, c_float(8.5).value, 9.5, 10, Decimal("11.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + c, b + c, c + c, d + c, e + c, f + c, g + c, h + c FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+            ),
+            row(4, 5, 6, 7, c_float(8.5).value, 9.5, 10, Decimal("11.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + d, b + d, c + d, d + d, e + d, f + d, g + d, h + d FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                   row(5, 6, 7, 8, 9.5, 10.5, 11, Decimal("12.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + d, b + d, c + d, d + d, e + d, f + d, g + d, h + d FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+            ),
+            row(5, 6, 7, 8, 9.5, 10.5, 11, Decimal("12.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + e, b + e, c + e, d + e, e + e, f + e, g + e, h + e FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                   row(c_float(6.5).value, c_float(7.5).value, c_float(8.5).value, 9.5, c_float(11.0).value, 12.0, Decimal("12.5"), Decimal("14.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + e, b + e, c + e, d + e, e + e, f + e, g + e, h + e FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+            ),
+            row(
+                c_float(6.5).value,
+                c_float(7.5).value,
+                c_float(8.5).value,
+                9.5,
+                c_float(11.0).value,
+                12.0,
+                Decimal("12.5"),
+                Decimal("14.0"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + f, b + f, c + f, d + f, e + f, f + f, g + f, h + f FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                   row(7.5, 8.5, 9.5, 10.5, 12.0, 13.0, Decimal("13.5"), Decimal("15.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + f, b + f, c + f, d + f, e + f, f + f, g + f, h + f FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+            ),
+            row(7.5, 8.5, 9.5, 10.5, 12.0, 13.0, Decimal("13.5"), Decimal("15.0")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + g, b + g, c + g, d + g, e + g, f + g, g + g, h + g FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                   row(8, 9, 10, 11, Decimal("12.5"), Decimal("13.5"), 14, Decimal("15.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + g, b + g, c + g, d + g, e + g, f + g, g + g, h + g FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+            ),
+            row(8, 9, 10, 11, Decimal("12.5"), Decimal("13.5"), 14, Decimal("15.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + h, b + h, c + h, d + h, e + h, f + h, g + h, h + h FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2"),
-                   row(Decimal("9.5"),
-                       Decimal("10.5"),
-                       Decimal("11.5"),
-                       Decimal("12.5"),
-                       Decimal("14.0"),
-                       Decimal("15.0"),
-                       Decimal("15.5"),
-                       Decimal("17.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + h, b + h, c + h, d + h, e + h, f + h, g + h, h + h FROM %s WHERE a = 1 AND b = 2 AND c = 1 + 2",
+            ),
+            row(
+                Decimal("9.5"),
+                Decimal("10.5"),
+                Decimal("11.5"),
+                Decimal("12.5"),
+                Decimal("14.0"),
+                Decimal("15.0"),
+                Decimal("15.5"),
+                Decimal("17.0"),
+            ),
+        )
 
         # Test substractions
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a - a, b - a, c - a, d - a, e - a, f - a, g - a, h - a FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                          "a - a", "b - a", "c - a", "d - a", "e - a", "f - a", "g - a", "h - a")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a - a, b - a, c - a, d - a, e - a, f - a, g - a, h - a FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+                ),
+                "a - a",
+                "b - a",
+                "c - a",
+                "d - a",
+                "e - a",
+                "f - a",
+                "g - a",
+                "h - a",
+            )
 
-        assertRows(execute(cql, table, "SELECT a - a, b - a, c - a, d - a, e - a, f - a, g - a, h - a FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                   row(0, 1, 2, 3, c_float(4.5).value, 5.5, 6, Decimal("7.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - a, b - a, c - a, d - a, e - a, f - a, g - a, h - a FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+            ),
+            row(0, 1, 2, 3, c_float(4.5).value, 5.5, 6, Decimal("7.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - b, b - b, c - b, d - b, e - b, f - b, g - b, h - b FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                   row(-1, 0, 1, 2, c_float(3.5).value, 4.5, 5, Decimal("6.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - b, b - b, c - b, d - b, e - b, f - b, g - b, h - b FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+            ),
+            row(-1, 0, 1, 2, c_float(3.5).value, 4.5, 5, Decimal("6.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - c, b - c, c - c, d - c, e - c, f - c, g - c, h - c FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                   row(-2, -1, 0, 1, c_float(2.5).value, 3.5, 4, Decimal("5.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - c, b - c, c - c, d - c, e - c, f - c, g - c, h - c FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+            ),
+            row(-2, -1, 0, 1, c_float(2.5).value, 3.5, 4, Decimal("5.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - d, b - d, c - d, d - d, e - d, f - d, g - d, h - d FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                   row(-3, -2, -1, 0, 1.5, 2.5, 3, Decimal("4.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - d, b - d, c - d, d - d, e - d, f - d, g - d, h - d FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+            ),
+            row(-3, -2, -1, 0, 1.5, 2.5, 3, Decimal("4.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - e, b - e, c - e, d - e, e - e, f - e, g - e, h - e FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                   row(c_float(-4.5).value, c_float(-3.5).value, c_float(-2.5).value, -1.5, c_float(0.0).value, 1.0, Decimal("1.5"), Decimal("3.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - e, b - e, c - e, d - e, e - e, f - e, g - e, h - e FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+            ),
+            row(
+                c_float(-4.5).value,
+                c_float(-3.5).value,
+                c_float(-2.5).value,
+                -1.5,
+                c_float(0.0).value,
+                1.0,
+                Decimal("1.5"),
+                Decimal("3.0"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - f, b - f, c - f, d - f, e - f, f - f, g - f, h - f FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                   row(-5.5, -4.5, -3.5, -2.5, -1.0, 0.0, Decimal("0.5"), Decimal("2.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - f, b - f, c - f, d - f, e - f, f - f, g - f, h - f FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+            ),
+            row(-5.5, -4.5, -3.5, -2.5, -1.0, 0.0, Decimal("0.5"), Decimal("2.0")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - g, b - g, c - g, d - g, e - g, f - g, g - g, h - g FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                   row(-6, -5, -4, -3, Decimal("-1.5"), Decimal("-0.5"), 0, Decimal("1.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - g, b - g, c - g, d - g, e - g, f - g, g - g, h - g FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+            ),
+            row(-6, -5, -4, -3, Decimal("-1.5"), Decimal("-0.5"), 0, Decimal("1.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - h, b - h, c - h, d - h, e - h, f - h, g - h, h - h FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1"),
-                   row(Decimal("-7.5"),
-                       Decimal("-6.5"),
-                       Decimal("-5.5"),
-                       Decimal("-4.5"),
-                       Decimal("-3.0"),
-                       Decimal("-2.0"),
-                       Decimal("-1.5"),
-                       Decimal("0.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - h, b - h, c - h, d - h, e - h, f - h, g - h, h - h FROM %s WHERE a = 1 AND b = 2 AND c = 4 - 1",
+            ),
+            row(
+                Decimal("-7.5"),
+                Decimal("-6.5"),
+                Decimal("-5.5"),
+                Decimal("-4.5"),
+                Decimal("-3.0"),
+                Decimal("-2.0"),
+                Decimal("-1.5"),
+                Decimal("0.0"),
+            ),
+        )
 
         # Test multiplications
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a * a, b * a, c * a, d * a, e * a, f * a, g * a, h * a FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                          "a * a", "b * a", "c * a", "d * a", "e * a", "f * a", "g * a", "h * a")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a * a, b * a, c * a, d * a, e * a, f * a, g * a, h * a FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+                ),
+                "a * a",
+                "b * a",
+                "c * a",
+                "d * a",
+                "e * a",
+                "f * a",
+                "g * a",
+                "h * a",
+            )
 
-        assertRows(execute(cql, table, "SELECT a * a, b * a, c * a, d * a, e * a, f * a, g * a, h * a FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                   row(1, 2, 3, 4, c_float(5.5).value, 6.5, 7, Decimal("8.50")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * a, b * a, c * a, d * a, e * a, f * a, g * a, h * a FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+            ),
+            row(1, 2, 3, 4, c_float(5.5).value, 6.5, 7, Decimal("8.50")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * b, b * b, c * b, d * b, e * b, f * b, g * b, h * b FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                   row(2, 4, 6, 8, c_float(11.0).value, 13.0, 14, Decimal("17.00")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * b, b * b, c * b, d * b, e * b, f * b, g * b, h * b FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+            ),
+            row(2, 4, 6, 8, c_float(11.0).value, 13.0, 14, Decimal("17.00")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * c, b * c, c * c, d * c, e * c, f * c, g * c, h * c FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                   row(3, 6, 9, 12, c_float(16.5).value, 19.5, 21, Decimal("25.50")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * c, b * c, c * c, d * c, e * c, f * c, g * c, h * c FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+            ),
+            row(3, 6, 9, 12, c_float(16.5).value, 19.5, 21, Decimal("25.50")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * d, b * d, c * d, d * d, e * d, f * d, g * d, h * d FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                   row(4, 8, 12, 16, 22.0, 26.0, 28, Decimal("34.00")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * d, b * d, c * d, d * d, e * d, f * d, g * d, h * d FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+            ),
+            row(4, 8, 12, 16, 22.0, 26.0, 28, Decimal("34.00")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * e, b * e, c * e, d * e, e * e, f * e, g * e, h * e FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                   row(c_float(5.5).value, c_float(11.0).value, c_float(16.5).value, 22.0, c_float(30.25).value, 35.75, Decimal("38.5"), Decimal("46.75")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * e, b * e, c * e, d * e, e * e, f * e, g * e, h * e FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+            ),
+            row(
+                c_float(5.5).value,
+                c_float(11.0).value,
+                c_float(16.5).value,
+                22.0,
+                c_float(30.25).value,
+                35.75,
+                Decimal("38.5"),
+                Decimal("46.75"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * f, b * f, c * f, d * f, e * f, f * f, g * f, h * f FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                   row(6.5, 13.0, 19.5, 26.0, 35.75, 42.25, Decimal("45.5"), Decimal("55.25")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * f, b * f, c * f, d * f, e * f, f * f, g * f, h * f FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+            ),
+            row(6.5, 13.0, 19.5, 26.0, 35.75, 42.25, Decimal("45.5"), Decimal("55.25")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * g, b * g, c * g, d * g, e * g, f * g, g * g, h * g FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                   row(7, 14, 21, 28, Decimal("38.5"), Decimal("45.5"), 49, Decimal("59.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * g, b * g, c * g, d * g, e * g, f * g, g * g, h * g FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+            ),
+            row(7, 14, 21, 28, Decimal("38.5"), Decimal("45.5"), 49, Decimal("59.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * h, b * h, c * h, d * h, e * h, f * h, g * h, h * h FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1"),
-                   row(Decimal("8.50"),
-                       Decimal("17.00"),
-                       Decimal("25.50"),
-                       Decimal("34.00"),
-                       Decimal("46.75"),
-                       Decimal("55.25"),
-                       Decimal("59.5"),
-                       Decimal("72.25")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * h, b * h, c * h, d * h, e * h, f * h, g * h, h * h FROM %s WHERE a = 1 AND b = 2 AND c = 3 * 1",
+            ),
+            row(
+                Decimal("8.50"),
+                Decimal("17.00"),
+                Decimal("25.50"),
+                Decimal("34.00"),
+                Decimal("46.75"),
+                Decimal("55.25"),
+                Decimal("59.5"),
+                Decimal("72.25"),
+            ),
+        )
 
         # Test divisions
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a / a, b / a, c / a, d / a, e / a, f / a, g / a, h / a FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                          "a / a", "b / a", "c / a", "d / a", "e / a", "f / a", "g / a", "h / a")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a / a, b / a, c / a, d / a, e / a, f / a, g / a, h / a FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+                ),
+                "a / a",
+                "b / a",
+                "c / a",
+                "d / a",
+                "e / a",
+                "f / a",
+                "g / a",
+                "h / a",
+            )
 
-        assertRows(execute(cql, table, "SELECT a / a, b / a, c / a, d / a, e / a, f / a, g / a, h / a FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                   row(1, 2, 3, 4, c_float(5.5).value, 6.5, 7, Decimal("8.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / a, b / a, c / a, d / a, e / a, f / a, g / a, h / a FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+            ),
+            row(1, 2, 3, 4, c_float(5.5).value, 6.5, 7, Decimal("8.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / b, b / b, c / b, d / b, e / b, f / b, g / b, h / b FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                   row(0, 1, 1, 2, c_float(2.75).value, 3.25, 3, Decimal("4.25")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / b, b / b, c / b, d / b, e / b, f / b, g / b, h / b FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+            ),
+            row(0, 1, 1, 2, c_float(2.75).value, 3.25, 3, Decimal("4.25")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / c, b / c, c / c, d / c, e / c, f / c, g / c, h / c FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                   row(0, 0, 1, 1, c_float(1.8333334).value, 2.1666666666666665, 2, Decimal("2.83333333333333333333333333333333")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / c, b / c, c / c, d / c, e / c, f / c, g / c, h / c FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+            ),
+            row(
+                0,
+                0,
+                1,
+                1,
+                c_float(1.8333334).value,
+                2.1666666666666665,
+                2,
+                Decimal("2.83333333333333333333333333333333"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / d, b / d, c / d, d / d, e / d, f / d, g / d, h / d FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                   row(0, 0, 0, 1, 1.375, 1.625, 1, Decimal("2.125")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / d, b / d, c / d, d / d, e / d, f / d, g / d, h / d FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+            ),
+            row(0, 0, 0, 1, 1.375, 1.625, 1, Decimal("2.125")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / e, b / e, c / e, d / e, e / e, f / e, g / e, h / e FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                   row(c_float(0.18181819).value, c_float(0.36363637).value, c_float(0.54545456).value, 0.7272727272727273, c_float(1.0).value, 1.1818181818181819, Decimal("1.27272727272727272727272727272727"), Decimal("1.54545454545454545454545454545455")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / e, b / e, c / e, d / e, e / e, f / e, g / e, h / e FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+            ),
+            row(
+                c_float(0.18181819).value,
+                c_float(0.36363637).value,
+                c_float(0.54545456).value,
+                0.7272727272727273,
+                c_float(1.0).value,
+                1.1818181818181819,
+                Decimal("1.27272727272727272727272727272727"),
+                Decimal("1.54545454545454545454545454545455"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / f, b / f, c / f, d / f, e / f, f / f, g / f, h / f FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                   row(0.15384615384615385, 0.3076923076923077, 0.46153846153846156, 0.6153846153846154, 0.8461538461538461, 1.0, Decimal("1.07692307692307692307692307692308"), Decimal("1.30769230769230769230769230769231")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / f, b / f, c / f, d / f, e / f, f / f, g / f, h / f FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+            ),
+            row(
+                0.15384615384615385,
+                0.3076923076923077,
+                0.46153846153846156,
+                0.6153846153846154,
+                0.8461538461538461,
+                1.0,
+                Decimal("1.07692307692307692307692307692308"),
+                Decimal("1.30769230769230769230769230769231"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / g, b / g, c / g, d / g, e / g, f / g, g / g, h / g FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                   row(0, 0, 0, 0,
-                       Decimal("0.78571428571428571428571428571429"),
-                       Decimal("0.92857142857142857142857142857143"),
-                       1,
-                       Decimal("1.21428571428571428571428571428571")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / g, b / g, c / g, d / g, e / g, f / g, g / g, h / g FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+            ),
+            row(
+                0,
+                0,
+                0,
+                0,
+                Decimal("0.78571428571428571428571428571429"),
+                Decimal("0.92857142857142857142857142857143"),
+                1,
+                Decimal("1.21428571428571428571428571428571"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / h, b / h, c / h, d / h, e / h, f / h, g / h, h / h FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1"),
-                   row(Decimal("0.11764705882352941176470588235294"),
-                       Decimal("0.23529411764705882352941176470588"),
-                       Decimal("0.35294117647058823529411764705882"),
-                       Decimal("0.47058823529411764705882352941176"),
-                       Decimal("0.64705882352941176470588235294118"),
-                       Decimal("0.76470588235294117647058823529412"),
-                       Decimal("0.82352941176470588235294117647059"),
-                       Decimal("1")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / h, b / h, c / h, d / h, e / h, f / h, g / h, h / h FROM %s WHERE a = 1 AND b = 2 AND c = 3 / 1",
+            ),
+            row(
+                Decimal("0.11764705882352941176470588235294"),
+                Decimal("0.23529411764705882352941176470588"),
+                Decimal("0.35294117647058823529411764705882"),
+                Decimal("0.47058823529411764705882352941176"),
+                Decimal("0.64705882352941176470588235294118"),
+                Decimal("0.76470588235294117647058823529412"),
+                Decimal("0.82352941176470588235294117647059"),
+                Decimal("1"),
+            ),
+        )
 
         # Test modulo operations
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a % a, b % a, c % a, d % a, e % a, f % a, g % a, h % a FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                          "a % a", "b % a", "c % a", "d % a", "e % a", "f % a", "g % a", "h % a")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a % a, b % a, c % a, d % a, e % a, f % a, g % a, h % a FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+                ),
+                "a % a",
+                "b % a",
+                "c % a",
+                "d % a",
+                "e % a",
+                "f % a",
+                "g % a",
+                "h % a",
+            )
 
-        assertRows(execute(cql, table, "SELECT a % a, b % a, c % a, d % a, e % a, f % a, g % a, h % a FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                   row(0, 0, 0, 0, c_float(0.5).value, 0.5, 0, Decimal("0.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % a, b % a, c % a, d % a, e % a, f % a, g % a, h % a FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+            ),
+            row(0, 0, 0, 0, c_float(0.5).value, 0.5, 0, Decimal("0.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % b, b % b, c % b, d % b, e % b, f % b, g % b, h % b FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                   row(1, 0, 1, 0, c_float(1.5).value, 0.5, 1, Decimal("0.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % b, b % b, c % b, d % b, e % b, f % b, g % b, h % b FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+            ),
+            row(1, 0, 1, 0, c_float(1.5).value, 0.5, 1, Decimal("0.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % c, b % c, c % c, d % c, e % c, f % c, g % c, h % c FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                   row(1, 2, 0, 1, c_float(2.5).value, 0.5, 1, Decimal("2.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % c, b % c, c % c, d % c, e % c, f % c, g % c, h % c FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+            ),
+            row(1, 2, 0, 1, c_float(2.5).value, 0.5, 1, Decimal("2.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % d, b % d, c % d, d % d, e % d, f % d, g % d, h % d FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                   row(1, 2, 3, 0, 1.5, 2.5, 3, Decimal("0.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % d, b % d, c % d, d % d, e % d, f % d, g % d, h % d FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+            ),
+            row(1, 2, 3, 0, 1.5, 2.5, 3, Decimal("0.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % e, b % e, c % e, d % e, e % e, f % e, g % e, h % e FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                   row(c_float(1.0).value, c_float(2.0).value, c_float(3.0).value, 4.0, c_float(0.0).value, 1.0, Decimal("1.5"), Decimal("3.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % e, b % e, c % e, d % e, e % e, f % e, g % e, h % e FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+            ),
+            row(
+                c_float(1.0).value,
+                c_float(2.0).value,
+                c_float(3.0).value,
+                4.0,
+                c_float(0.0).value,
+                1.0,
+                Decimal("1.5"),
+                Decimal("3.0"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % f, b % f, c % f, d % f, e % f, f % f, g % f, h % f FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                   row(1.0, 2.0, 3.0, 4.0, 5.5, 0.0, Decimal("0.5"), Decimal("2.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % f, b % f, c % f, d % f, e % f, f % f, g % f, h % f FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+            ),
+            row(1.0, 2.0, 3.0, 4.0, 5.5, 0.0, Decimal("0.5"), Decimal("2.0")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % g, b % g, c % g, d % g, e % g, f % g, g % g, h % g FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                   row(1,2,3,4, Decimal("5.5"), Decimal("6.5"), 0, Decimal("1.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % g, b % g, c % g, d % g, e % g, f % g, g % g, h % g FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+            ),
+            row(1, 2, 3, 4, Decimal("5.5"), Decimal("6.5"), 0, Decimal("1.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % h, b % h, c % h, d % h, e % h, f % h, g % h, h % h FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5"),
-                   row(Decimal("1.0"),
-                       Decimal("2.0"),
-                       Decimal("3.0"),
-                       Decimal("4.0"),
-                       Decimal("5.5"),
-                       Decimal("6.5"),
-                       Decimal("7"),
-                       Decimal("0.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % h, b % h, c % h, d % h, e % h, f % h, g % h, h % h FROM %s WHERE a = 1 AND b = 2 AND c = 23 % 5",
+            ),
+            row(
+                Decimal("1.0"),
+                Decimal("2.0"),
+                Decimal("3.0"),
+                Decimal("4.0"),
+                Decimal("5.5"),
+                Decimal("6.5"),
+                Decimal("7"),
+                Decimal("0.0"),
+            ),
+        )
 
         # Test negation
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT -a, -b, -c, -d, -e, -f, -g, -h FROM %s WHERE a = 1 AND b = 2"),
-                          "-a", "-b", "-c", "-d", "-e", "-f", "-g", "-h")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT -a, -b, -c, -d, -e, -f, -g, -h FROM %s WHERE a = 1 AND b = 2",
+                ),
+                "-a",
+                "-b",
+                "-c",
+                "-d",
+                "-e",
+                "-f",
+                "-g",
+                "-h",
+            )
 
-        assertRows(execute(cql, table, "SELECT -a, -b, -c, -d, -e, -f, -g, -h FROM %s WHERE a = 1 AND b = 2"),
-                   row(-1, -2, -3, -4, c_float(-5.5).value, -6.5, -7, Decimal("-8.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT -a, -b, -c, -d, -e, -f, -g, -h FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(-1, -2, -3, -4, c_float(-5.5).value, -6.5, -7, Decimal("-8.5")),
+        )
 
         # Test with null
-        execute(cql, table, "UPDATE %s SET d = ? WHERE a = ? AND b = ? AND c = ?", None, 1, 2, 3)
-        assertRows(execute(cql, table, "SELECT a + d, b + d, c + d, d + d, e + d, f + d, g + d, h + d FROM %s WHERE a = 1 AND b = 2"),
-                   row(None, None, None, None, None, None, None, None))
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET d = ? WHERE a = ? AND b = ? AND c = ?",
+            None,
+            1,
+            2,
+            3,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + d, b + d, c + d, d + d, e + d, f + d, g + d, h + d FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(None, None, None, None, None, None, None, None),
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testModuloWithDecimals(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(numerator decimal, dec_mod decimal, int_mod int, bigint_mod bigint, PRIMARY KEY(numerator, dec_mod))") as table:
-        execute(cql, table, "INSERT INTO %s (numerator, dec_mod, int_mod, bigint_mod) VALUES (123456789112345678921234567893123456, 2, 2, 2)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(numerator decimal, dec_mod decimal, int_mod int, bigint_mod bigint, PRIMARY KEY(numerator, dec_mod))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (numerator, dec_mod, int_mod, bigint_mod) VALUES (123456789112345678921234567893123456, 2, 2, 2)",
+        )
 
-        assertRows(execute(cql, table, "SELECT numerator % dec_mod, numerator % int_mod, numerator % bigint_mod from %s"),
-                   row(Decimal("0"), Decimal("0.0"), Decimal("0.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT numerator % dec_mod, numerator % int_mod, numerator % bigint_mod from %s",
+            ),
+            row(Decimal("0"), Decimal("0.0"), Decimal("0.0")),
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testSingleOperationsWithLiterals(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int, c1 tinyint, c2 smallint, v text, PRIMARY KEY(pk, c1, c2))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk int, c1 tinyint, c2 smallint, v text, PRIMARY KEY(pk, c1, c2))",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (2, 2, 2, 'test')")
 
         # There is only one function outputing tinyint
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 2 AND c1 = 1 + 1"),
-                   row(2, 2, 2, "test"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE pk = 2 AND c1 = 1 + 1"),
+            row(2, 2, 2, "test"),
+        )
 
         # As the operation can only be a sum between tinyints the expected type is tinyint
-        #(cannot be reproduced in Python which sends the right type)
-        #assertInvalidMessage(cql, table, "Expected 1 byte for a tinyint (4)",
+        # (cannot be reproduced in Python which sends the right type)
+        # assertInvalidMessage(cql, table, "Expected 1 byte for a tinyint (4)",
         #                     "SELECT * FROM %s WHERE pk = 2 AND c1 = 1 + ?", 1)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 2 AND c1 = 1 + ?", 1),
-                   row(2, 2, 2, "test"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE pk = 2 AND c1 = 1 + ?", 1),
+            row(2, 2, 2, "test"),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 + 1 AND c1 = 2"),
-                   row(2, 2, 2, "test"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE pk = 1 + 1 AND c1 = 2"),
+            row(2, 2, 2, "test"),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 2 AND c1 = 2 AND c2 = 1 + 1"),
-                   row(2, 2, 2, "test"))
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE pk = 2 AND c1 = 2 AND c2 = 1 + 1"
+            ),
+            row(2, 2, 2, "test"),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 2 AND c1 = 2 AND c2 = 1 * (1 + 1)"),
-                   row(2, 2, 2, "test"))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = 2 AND c1 = 2 AND c2 = 1 * (1 + 1)",
+            ),
+            row(2, 2, 2, "test"),
+        )
 
         # tinyint, smallint and int could be used there so we need to disambiguate
-        assertInvalidMessage(cql, table, "Ambiguous '+' operation with args ? and 1: use type hint to disambiguate, example '(int) ?'",
-                             "SELECT * FROM %s WHERE pk = ? + 1 AND c1 = 2", 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous '+' operation with args ? and 1: use type hint to disambiguate, example '(int) ?'",
+            "SELECT * FROM %s WHERE pk = ? + 1 AND c1 = 2",
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "Ambiguous '+' operation with args ? and 1: use type hint to disambiguate, example '(int) ?'",
-                             "SELECT * FROM %s WHERE pk = 2 AND c1 = 2 AND c2 = 1 * (? + 1)", 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous '+' operation with args ? and 1: use type hint to disambiguate, example '(int) ?'",
+            "SELECT * FROM %s WHERE pk = 2 AND c1 = 2 AND c2 = 1 * (? + 1)",
+            1,
+        )
 
-        assertRows(execute(cql, table, "SELECT 1 + 1, v FROM %s WHERE pk = 2 AND c1 = 2"),
-                   row(2, "test"))
+        assertRows(
+            execute(cql, table, "SELECT 1 + 1, v FROM %s WHERE pk = 2 AND c1 = 2"),
+            row(2, "test"),
+        )
 
         # As the output type is unknown the ? type cannot be determined
-        assertInvalidMessage(cql, table, "Ambiguous '+' operation with args 1 and ?: use type hint to disambiguate, example '(int) ?'",
-                             "SELECT 1 + ?, v FROM %s WHERE pk = 2 AND c1 = 2", 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous '+' operation with args 1 and ?: use type hint to disambiguate, example '(int) ?'",
+            "SELECT 1 + ?, v FROM %s WHERE pk = 2 AND c1 = 2",
+            1,
+        )
 
         # As the prefered type for the constants is int, the returned type will be int
-        assertRows(execute(cql, table, "SELECT 100 + 50, v FROM %s WHERE pk = 2 AND c1 = 2"),
-                   row(150, "test"))
+        assertRows(
+            execute(cql, table, "SELECT 100 + 50, v FROM %s WHERE pk = 2 AND c1 = 2"),
+            row(150, "test"),
+        )
 
         # As the output type is unknown the ? type cannot be determined
-        assertInvalidMessage(cql, table, "Ambiguous '+' operation with args ? and 50: use type hint to disambiguate, example '(int) ?'",
-                             "SELECT ? + 50, v FROM %s WHERE pk = 2 AND c1 = 2", 100)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous '+' operation with args ? and 50: use type hint to disambiguate, example '(int) ?'",
+            "SELECT ? + 50, v FROM %s WHERE pk = 2 AND c1 = 2",
+            100,
+        )
 
-    with create_table(cql, test_keyspace, "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY(a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table: #// Make sure we test with ReversedTypes
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (1, 2, 3, 4, 5.5, 6.5, 7, 8.5)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY(a, b)) WITH CLUSTERING ORDER BY (b DESC)",
+    ) as table:  # // Make sure we test with ReversedTypes
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (1, 2, 3, 4, 5.5, 6.5, 7, 8.5)",
+        )
 
         # Test additions
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a + 1, b + 1, c + 1, d + 1, e + 1, f + 1, g + 1, h + 1 FROM %s WHERE a = 1 AND b = 2"),
-                          "a + 1", "b + 1", "c + 1", "d + 1", "e + 1", "f + 1", "g + 1", "h + 1")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a + 1, b + 1, c + 1, d + 1, e + 1, f + 1, g + 1, h + 1 FROM %s WHERE a = 1 AND b = 2",
+                ),
+                "a + 1",
+                "b + 1",
+                "c + 1",
+                "d + 1",
+                "e + 1",
+                "f + 1",
+                "g + 1",
+                "h + 1",
+            )
 
-        assertRows(execute(cql, table, "SELECT a + 1, b + 1, c + 1, d + 1, e + 1, f + 1, g + 1, h + 1 FROM %s WHERE a = 1 AND b = 2"),
-                   row(2, 3, 4, 5, c_float(6.5).value, 7.5, 8, Decimal("9.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + 1, b + 1, c + 1, d + 1, e + 1, f + 1, g + 1, h + 1 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(2, 3, 4, 5, c_float(6.5).value, 7.5, 8, Decimal("9.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT 2 + a, 2 + b, 2 + c, 2 + d, 2 + e, 2 + f, 2 + g, 2 + h FROM %s WHERE a = 1 AND b = 2"),
-                   row(3, 4, 5, 6, c_float(7.5).value, 8.5, 9, Decimal("10.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT 2 + a, 2 + b, 2 + c, 2 + d, 2 + e, 2 + f, 2 + g, 2 + h FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(3, 4, 5, 6, c_float(7.5).value, 8.5, 9, Decimal("10.5")),
+        )
 
         bigInt = 2147483647 + 10
 
-        assertRows(execute(cql, table, "SELECT a + " + str(bigInt) + ","
-                               + " b + " + str(bigInt) + ","
-                               + " c + " + str(bigInt) + ","
-                               + " d + " + str(bigInt) + ","
-                               + " e + " + str(bigInt) + ","
-                               + " f + " + str(bigInt) + ","
-                               + " g + " + str(bigInt) + ","
-                               + " h + " + str(bigInt) + " FROM %s WHERE a = 1 AND b = 2"),
-                   row(1 + bigInt,
-                       2 + bigInt,
-                       3 + bigInt,
-                       4 + bigInt,
-                       5.5 + bigInt,
-                       6.5 + bigInt,
-                       bigInt + 7,
-                       Decimal(bigInt + 8.5)))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + "
+                + str(bigInt)
+                + ","
+                + " b + "
+                + str(bigInt)
+                + ","
+                + " c + "
+                + str(bigInt)
+                + ","
+                + " d + "
+                + str(bigInt)
+                + ","
+                + " e + "
+                + str(bigInt)
+                + ","
+                + " f + "
+                + str(bigInt)
+                + ","
+                + " g + "
+                + str(bigInt)
+                + ","
+                + " h + "
+                + str(bigInt)
+                + " FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(
+                1 + bigInt,
+                2 + bigInt,
+                3 + bigInt,
+                4 + bigInt,
+                5.5 + bigInt,
+                6.5 + bigInt,
+                bigInt + 7,
+                Decimal(bigInt + 8.5),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + 5.5, b + 5.5, c + 5.5, d + 5.5, e + 5.5, f + 5.5, g + 5.5, h + 5.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(6.5, 7.5, 8.5, 9.5, 11.0, 12.0, Decimal("12.5"), Decimal("14.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + 5.5, b + 5.5, c + 5.5, d + 5.5, e + 5.5, f + 5.5, g + 5.5, h + 5.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(6.5, 7.5, 8.5, 9.5, 11.0, 12.0, Decimal("12.5"), Decimal("14.0")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + 6.5, b + 6.5, c + 6.5, d + 6.5, e + 6.5, f + 6.5, g + 6.5, h + 6.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(7.5, 8.5, 9.5, 10.5, 12.0, 13.0, Decimal("13.5"), Decimal("15.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + 6.5, b + 6.5, c + 6.5, d + 6.5, e + 6.5, f + 6.5, g + 6.5, h + 6.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(7.5, 8.5, 9.5, 10.5, 12.0, 13.0, Decimal("13.5"), Decimal("15.0")),
+        )
 
         # Test substractions
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a - 1, b - 1, c - 1, d - 1, e - 1, f - 1, g - 1, h - 1 FROM %s WHERE a = 1 AND b = 2"),
-                          "a - 1", "b - 1", "c - 1", "d - 1", "e - 1", "f - 1", "g - 1", "h - 1")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a - 1, b - 1, c - 1, d - 1, e - 1, f - 1, g - 1, h - 1 FROM %s WHERE a = 1 AND b = 2",
+                ),
+                "a - 1",
+                "b - 1",
+                "c - 1",
+                "d - 1",
+                "e - 1",
+                "f - 1",
+                "g - 1",
+                "h - 1",
+            )
 
-        assertRows(execute(cql, table, "SELECT a - 1, b - 1, c - 1, d - 1, e - 1, f - 1, g - 1, h - 1 FROM %s WHERE a = 1 AND b = 2"),
-                   row(0, 1, 2, 3, c_float(4.5).value, 5.5, 6, Decimal("7.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - 1, b - 1, c - 1, d - 1, e - 1, f - 1, g - 1, h - 1 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(0, 1, 2, 3, c_float(4.5).value, 5.5, 6, Decimal("7.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - 2, b - 2, c - 2, d - 2, e - 2, f - 2, g - 2, h - 2 FROM %s WHERE a = 1 AND b = 2"),
-                   row(-1, 0, 1, 2, c_float(3.5).value, 4.5, 5, Decimal("6.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - 2, b - 2, c - 2, d - 2, e - 2, f - 2, g - 2, h - 2 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(-1, 0, 1, 2, c_float(3.5).value, 4.5, 5, Decimal("6.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - 3, b - 3, 3 - 3, d - 3, e - 3, f - 3, g - 3, h - 3 FROM %s WHERE a = 1 AND b = 2"),
-                   row(-2, -1, 0, 1, c_float(2.5).value, 3.5, 4, Decimal("5.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - 3, b - 3, 3 - 3, d - 3, e - 3, f - 3, g - 3, h - 3 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(-2, -1, 0, 1, c_float(2.5).value, 3.5, 4, Decimal("5.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - " + str(bigInt) + ","
-                               + " b - " + str(bigInt) + ","
-                               + " c - " + str(bigInt) + ","
-                               + " d - " + str(bigInt) + ","
-                               + " e - " + str(bigInt) + ","
-                               + " f - " + str(bigInt) + ","
-                               + " g - " + str(bigInt) + ","
-                               + " h - " + str(bigInt) + " FROM %s WHERE a = 1 AND b = 2"),
-                   row(1 - bigInt,
-                       2 - bigInt,
-                       3 - bigInt,
-                       4 - bigInt,
-                       5.5 - bigInt,
-                       6.5 - bigInt,
-                       7 - bigInt,
-                       Decimal(8.5 - bigInt)))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - "
+                + str(bigInt)
+                + ","
+                + " b - "
+                + str(bigInt)
+                + ","
+                + " c - "
+                + str(bigInt)
+                + ","
+                + " d - "
+                + str(bigInt)
+                + ","
+                + " e - "
+                + str(bigInt)
+                + ","
+                + " f - "
+                + str(bigInt)
+                + ","
+                + " g - "
+                + str(bigInt)
+                + ","
+                + " h - "
+                + str(bigInt)
+                + " FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(
+                1 - bigInt,
+                2 - bigInt,
+                3 - bigInt,
+                4 - bigInt,
+                5.5 - bigInt,
+                6.5 - bigInt,
+                7 - bigInt,
+                Decimal(8.5 - bigInt),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - 5.5, b - 5.5, c - 5.5, d - 5.5, e - 5.5, f - 5.5, g - 5.5, h - 5.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(-4.5, -3.5, -2.5, -1.5, 0.0, 1.0, Decimal("1.5"), Decimal("3.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - 5.5, b - 5.5, c - 5.5, d - 5.5, e - 5.5, f - 5.5, g - 5.5, h - 5.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(-4.5, -3.5, -2.5, -1.5, 0.0, 1.0, Decimal("1.5"), Decimal("3.0")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a - 6.5, b - 6.5, c - 6.5, d - 6.5, e - 6.5, f - 6.5, g - 6.5, h - 6.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(-5.5, -4.5, -3.5, -2.5, -1.0, 0.0, Decimal("0.5"), Decimal("2.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a - 6.5, b - 6.5, c - 6.5, d - 6.5, e - 6.5, f - 6.5, g - 6.5, h - 6.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(-5.5, -4.5, -3.5, -2.5, -1.0, 0.0, Decimal("0.5"), Decimal("2.0")),
+        )
 
         # Test multiplications
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a * 1, b * 1, c * 1, d * 1, e * 1, f * 1, g * 1, h * 1 FROM %s WHERE a = 1 AND b = 2"),
-                          "a * 1", "b * 1", "c * 1", "d * 1", "e * 1", "f * 1", "g * 1", "h * 1")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a * 1, b * 1, c * 1, d * 1, e * 1, f * 1, g * 1, h * 1 FROM %s WHERE a = 1 AND b = 2",
+                ),
+                "a * 1",
+                "b * 1",
+                "c * 1",
+                "d * 1",
+                "e * 1",
+                "f * 1",
+                "g * 1",
+                "h * 1",
+            )
 
-        assertRows(execute(cql, table, "SELECT a * 1, b * 1, c * 1, d * 1, e * 1, f * 1, g * 1, h * 1 FROM %s WHERE a = 1 AND b = 2"),
-                   row(1, 2, 3, 4, c_float(5.5).value, 6.5, 7, Decimal("8.50")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * 1, b * 1, c * 1, d * 1, e * 1, f * 1, g * 1, h * 1 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(1, 2, 3, 4, c_float(5.5).value, 6.5, 7, Decimal("8.50")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * 2, b * 2, c * 2, d * 2, e * 2, f * 2, g * 2, h * 2 FROM %s WHERE a = 1 AND b = 2"),
-                   row(2, 4, 6, 8, c_float(11.0).value, 13.0, 14, Decimal("17.00")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * 2, b * 2, c * 2, d * 2, e * 2, f * 2, g * 2, h * 2 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(2, 4, 6, 8, c_float(11.0).value, 13.0, 14, Decimal("17.00")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * 3, b * 3, c * 3, d * 3, e * 3, f * 3, g * 3, h * 3 FROM %s WHERE a = 1 AND b = 2"),
-                   row(3, 6, 9, 12, c_float(16.5).value, 19.5, 21, Decimal("25.50")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * 3, b * 3, c * 3, d * 3, e * 3, f * 3, g * 3, h * 3 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(3, 6, 9, 12, c_float(16.5).value, 19.5, 21, Decimal("25.50")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * " + str(bigInt) + ","
-                            + " b * " + str(bigInt) + ","
-                            + " c * " + str(bigInt) + ","
-                            + " d * " + str(bigInt) + ","
-                            + " e * " + str(bigInt) + ","
-                            + " f * " + str(bigInt) + ","
-                            + " g * " + str(bigInt) + ","
-                            + " h * " + str(bigInt) + " FROM %s WHERE a = 1 AND b = 2"),
-                               row(1 * bigInt,
-                                   2 * bigInt,
-                                   3 * bigInt,
-                                   4 * bigInt,
-                                   5.5 * bigInt,
-                                   6.5 * bigInt,
-                                   7 * bigInt,
-                                   Decimal(8.5 * bigInt)))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * "
+                + str(bigInt)
+                + ","
+                + " b * "
+                + str(bigInt)
+                + ","
+                + " c * "
+                + str(bigInt)
+                + ","
+                + " d * "
+                + str(bigInt)
+                + ","
+                + " e * "
+                + str(bigInt)
+                + ","
+                + " f * "
+                + str(bigInt)
+                + ","
+                + " g * "
+                + str(bigInt)
+                + ","
+                + " h * "
+                + str(bigInt)
+                + " FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(
+                1 * bigInt,
+                2 * bigInt,
+                3 * bigInt,
+                4 * bigInt,
+                5.5 * bigInt,
+                6.5 * bigInt,
+                7 * bigInt,
+                Decimal(8.5 * bigInt),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * 5.5, b * 5.5, c * 5.5, d * 5.5, e * 5.5, f * 5.5, g * 5.5, h * 5.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(5.5, 11.0, 16.5, 22.0, 30.25, 35.75, Decimal("38.5"), Decimal("46.75")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * 5.5, b * 5.5, c * 5.5, d * 5.5, e * 5.5, f * 5.5, g * 5.5, h * 5.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(5.5, 11.0, 16.5, 22.0, 30.25, 35.75, Decimal("38.5"), Decimal("46.75")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a * 6.5, b * 6.5, c * 6.5, d * 6.5, e * 6.5, 6.5 * f, g * 6.5, h * 6.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(6.5, 13.0, 19.5, 26.0, 35.75, 42.25, Decimal("45.5"), Decimal("55.25")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a * 6.5, b * 6.5, c * 6.5, d * 6.5, e * 6.5, 6.5 * f, g * 6.5, h * 6.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(6.5, 13.0, 19.5, 26.0, 35.75, 42.25, Decimal("45.5"), Decimal("55.25")),
+        )
 
         # Test divisions
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a / 1, b / 1, c / 1, d / 1, e / 1, f / 1, g / 1, h / 1 FROM %s WHERE a = 1 AND b = 2"),
-                          "a / 1", "b / 1", "c / 1", "d / 1", "e / 1", "f / 1", "g / 1", "h / 1")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a / 1, b / 1, c / 1, d / 1, e / 1, f / 1, g / 1, h / 1 FROM %s WHERE a = 1 AND b = 2",
+                ),
+                "a / 1",
+                "b / 1",
+                "c / 1",
+                "d / 1",
+                "e / 1",
+                "f / 1",
+                "g / 1",
+                "h / 1",
+            )
 
-        assertRows(execute(cql, table, "SELECT a / 1, b / 1, c / 1, d / 1, e / 1, f / 1, g / 1, h / 1 FROM %s WHERE a = 1 AND b = 2"),
-                   row(1, 2, 3, 4, c_float(5.5).value, 6.5, 7, Decimal("8.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / 1, b / 1, c / 1, d / 1, e / 1, f / 1, g / 1, h / 1 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(1, 2, 3, 4, c_float(5.5).value, 6.5, 7, Decimal("8.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / 2, b / 2, c / 2, d / 2, e / 2, f / 2, g / 2, h / 2 FROM %s WHERE a = 1 AND b = 2"),
-                   row(0, 1, 1, 2, c_float(2.75).value, 3.25, 3, Decimal("4.25")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / 2, b / 2, c / 2, d / 2, e / 2, f / 2, g / 2, h / 2 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(0, 1, 1, 2, c_float(2.75).value, 3.25, 3, Decimal("4.25")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / 3, b / 3, c / 3, d / 3, e / 3, f / 3, g / 3, h / 3 FROM %s WHERE a = 1 AND b = 2"),
-                   row(0, 0, 1, 1, c_float(1.8333334).value, 2.1666666666666665, 2, Decimal("2.83333333333333333333333333333333")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / 3, b / 3, c / 3, d / 3, e / 3, f / 3, g / 3, h / 3 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(
+                0,
+                0,
+                1,
+                1,
+                c_float(1.8333334).value,
+                2.1666666666666665,
+                2,
+                Decimal("2.83333333333333333333333333333333"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / " + str(bigInt) + ","
-                + " b / " + str(bigInt) + ","
-                + " c / " + str(bigInt) + ","
-                + " d / " + str(bigInt) + ","
-                + " e / " + str(bigInt) + ","
-                + " f / " + str(bigInt) + ","
-                + " g / " + str(bigInt) + " FROM %s WHERE a = 1 AND b = 2"),
-                   row(1 // bigInt,
-                       2 // bigInt,
-                       3 // bigInt,
-                       4 // bigInt,
-                       5.5 / bigInt,
-                       6.5 / bigInt,
-                       7 // bigInt))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / "
+                + str(bigInt)
+                + ","
+                + " b / "
+                + str(bigInt)
+                + ","
+                + " c / "
+                + str(bigInt)
+                + ","
+                + " d / "
+                + str(bigInt)
+                + ","
+                + " e / "
+                + str(bigInt)
+                + ","
+                + " f / "
+                + str(bigInt)
+                + ","
+                + " g / "
+                + str(bigInt)
+                + " FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(
+                1 // bigInt,
+                2 // bigInt,
+                3 // bigInt,
+                4 // bigInt,
+                5.5 / bigInt,
+                6.5 / bigInt,
+                7 // bigInt,
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / 5.5, b / 5.5, c / 5.5, d / 5.5, e / 5.5, f / 5.5, g / 5.5, h / 5.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(0.18181818181818182, 0.36363636363636365, 0.5454545454545454, 0.7272727272727273, 1.0, 1.1818181818181819, Decimal("1.27272727272727272727272727272727"), Decimal("1.54545454545454545454545454545455")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / 5.5, b / 5.5, c / 5.5, d / 5.5, e / 5.5, f / 5.5, g / 5.5, h / 5.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(
+                0.18181818181818182,
+                0.36363636363636365,
+                0.5454545454545454,
+                0.7272727272727273,
+                1.0,
+                1.1818181818181819,
+                Decimal("1.27272727272727272727272727272727"),
+                Decimal("1.54545454545454545454545454545455"),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a / 6.5, b / 6.5, c / 6.5, d / 6.5, e / 6.5, f / 6.5, g / 6.5, h / 6.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(0.15384615384615385, 0.3076923076923077, 0.46153846153846156, 0.6153846153846154, 0.8461538461538461, 1.0, Decimal("1.07692307692307692307692307692308"), Decimal("1.30769230769230769230769230769231")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a / 6.5, b / 6.5, c / 6.5, d / 6.5, e / 6.5, f / 6.5, g / 6.5, h / 6.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(
+                0.15384615384615385,
+                0.3076923076923077,
+                0.46153846153846156,
+                0.6153846153846154,
+                0.8461538461538461,
+                1.0,
+                Decimal("1.07692307692307692307692307692308"),
+                Decimal("1.30769230769230769230769230769231"),
+            ),
+        )
 
         # Test modulo operations
 
         with original_column_names(cql) as cql:
-            assertColumnNames(execute(cql, table, "SELECT a % 1, b % 1, c % 1, d % 1, e % 1, f % 1, g % 1, h % 1 FROM %s WHERE a = 1 AND b = 2"),
-                          "a % 1", "b % 1", "c % 1", "d % 1", "e % 1", "f % 1", "g % 1", "h % 1")
+            assertColumnNames(
+                execute(
+                    cql,
+                    table,
+                    "SELECT a % 1, b % 1, c % 1, d % 1, e % 1, f % 1, g % 1, h % 1 FROM %s WHERE a = 1 AND b = 2",
+                ),
+                "a % 1",
+                "b % 1",
+                "c % 1",
+                "d % 1",
+                "e % 1",
+                "f % 1",
+                "g % 1",
+                "h % 1",
+            )
 
-        assertRows(execute(cql, table, "SELECT a % 1, b % 1, c % 1, d % 1, e % 1, f % 1, g % 1, h % 1 FROM %s WHERE a = 1 AND b = 2"),
-                   row(0, 0, 0, 0, c_float(0.5).value, 0.5, 0, Decimal("0.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % 1, b % 1, c % 1, d % 1, e % 1, f % 1, g % 1, h % 1 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(0, 0, 0, 0, c_float(0.5).value, 0.5, 0, Decimal("0.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % 2, b % 2, c % 2, d % 2, e % 2, f % 2, g % 2, h % 2 FROM %s WHERE a = 1 AND b = 2"),
-                   row(1, 0, 1, 0, c_float(1.5).value, 0.5, 1, Decimal("0.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % 2, b % 2, c % 2, d % 2, e % 2, f % 2, g % 2, h % 2 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(1, 0, 1, 0, c_float(1.5).value, 0.5, 1, Decimal("0.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % 3, b % 3, c % 3, d % 3, e % 3, f % 3, g % 3, h % 3 FROM %s WHERE a = 1 AND b = 2"),
-                   row(1, 2, 0, 1, c_float(2.5).value, 0.5, 1, Decimal("2.5")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % 3, b % 3, c % 3, d % 3, e % 3, f % 3, g % 3, h % 3 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(1, 2, 0, 1, c_float(2.5).value, 0.5, 1, Decimal("2.5")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % " + str(bigInt) + ","
-                            + " b % " + str(bigInt) + ","
-                            + " c % " + str(bigInt) + ","
-                            + " d % " + str(bigInt) + ","
-                            + " e % " + str(bigInt) + ","
-                            + " f % " + str(bigInt) + ","
-                            + " g % " + str(bigInt) + ","
-                            + " h % " + str(bigInt) + " FROM %s WHERE a = 1 AND b = 2"),
-                               row(1 % bigInt,
-                                   2 % bigInt,
-                                   3 % bigInt,
-                                   4 % bigInt,
-                                   5.5 % bigInt,
-                                   6.5 % bigInt,
-                                   7 % bigInt,
-                                   Decimal(8.5 % bigInt)))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % "
+                + str(bigInt)
+                + ","
+                + " b % "
+                + str(bigInt)
+                + ","
+                + " c % "
+                + str(bigInt)
+                + ","
+                + " d % "
+                + str(bigInt)
+                + ","
+                + " e % "
+                + str(bigInt)
+                + ","
+                + " f % "
+                + str(bigInt)
+                + ","
+                + " g % "
+                + str(bigInt)
+                + ","
+                + " h % "
+                + str(bigInt)
+                + " FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(
+                1 % bigInt,
+                2 % bigInt,
+                3 % bigInt,
+                4 % bigInt,
+                5.5 % bigInt,
+                6.5 % bigInt,
+                7 % bigInt,
+                Decimal(8.5 % bigInt),
+            ),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % 5.5, b % 5.5, c % 5.5, d % 5.5, e % 5.5, f % 5.5, g % 5.5, h % 5.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(1.0, 2.0, 3.0, 4.0, 0.0, 1.0, Decimal("1.5"), Decimal("3.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % 5.5, b % 5.5, c % 5.5, d % 5.5, e % 5.5, f % 5.5, g % 5.5, h % 5.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(1.0, 2.0, 3.0, 4.0, 0.0, 1.0, Decimal("1.5"), Decimal("3.0")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a % 6.5, b % 6.5, c % 6.5, d % 6.5, e % 6.5, f % 6.5, g % 6.5, h % 6.5 FROM %s WHERE a = 1 AND b = 2"),
-                   row(1.0, 2.0, 3.0, 4.0, 5.5, 0.0, Decimal("0.5"), Decimal("2.0")))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a % 6.5, b % 6.5, c % 6.5, d % 6.5, e % 6.5, f % 6.5, g % 6.5, h % 6.5 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(1.0, 2.0, 3.0, 4.0, 5.5, 0.0, Decimal("0.5"), Decimal("2.0")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a, b, 1 + 1, 2 - 1, 2 * 2, 2 / 1 , 2 % 1, (int) -1 FROM %s WHERE a = 1 AND b = 2"),
-                   row(1, 2, 2, 1, 4, 2, 0, -1))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, 1 + 1, 2 - 1, 2 * 2, 2 / 1 , 2 % 1, (int) -1 FROM %s WHERE a = 1 AND b = 2",
+            ),
+            row(1, 2, 2, 1, 4, 2, 0, -1),
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testDivisionWithDecimals(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(numerator decimal, denominator decimal, PRIMARY KEY ((numerator, denominator)))") as table:
-        execute(cql, table, "INSERT INTO %s (numerator, denominator) VALUES (8.5, 200000000000000000000000000000000000)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(numerator decimal, denominator decimal, PRIMARY KEY ((numerator, denominator)))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (numerator, denominator) VALUES (8.5, 200000000000000000000000000000000000)",
+        )
         execute(cql, table, "INSERT INTO %s (numerator, denominator) VALUES (10000, 3)")
 
-        assertRows(execute(cql, table, "SELECT numerator / denominator from %s"),
-                   row(Decimal("0.0000000000000000000000000000000000425")),
-                   row(Decimal("3333.33333333333333333333333333333333")))
+        assertRows(
+            execute(cql, table, "SELECT numerator / denominator from %s"),
+            row(Decimal("0.0000000000000000000000000000000000425")),
+            row(Decimal("3333.33333333333333333333333333333333")),
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testWithCounters(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b counter)") as table:
         execute(cql, table, "UPDATE %s SET b = b + 1 WHERE a = 1")
         execute(cql, table, "UPDATE %s SET b = b + 1 WHERE a = 1")
         assertRows(execute(cql, table, "SELECT b FROM %s WHERE a = 1"), row(2))
 
-        assertRows(execute(cql, table, "SELECT b + (tinyint) 1,"
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT b + (tinyint) 1,"
                 + " b + (smallint) 1,"
                 + " b + 1,"
                 + " b + (bigint) 1,"
@@ -508,10 +1395,16 @@ def testWithCounters(cql, test_keyspace):
                 + " b + 1.5,"
                 + " b + (varint) 1,"
                 + " b + (decimal) 1.5,"
-                + " b + b FROM %s WHERE a = 1"),
-                   row(3, 3, 3, 3, 3.5, 3.5, 3, Decimal("3.5"), 4))
+                + " b + b FROM %s WHERE a = 1",
+            ),
+            row(3, 3, 3, 3, 3.5, 3.5, 3, Decimal("3.5"), 4),
+        )
 
-        assertRows(execute(cql, table, "SELECT b - (tinyint) 1,"
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT b - (tinyint) 1,"
                 + " b - (smallint) 1,"
                 + " b - 1,"
                 + " b - (bigint) 1,"
@@ -519,10 +1412,16 @@ def testWithCounters(cql, test_keyspace):
                 + " b - 1.5,"
                 + " b - (varint) 1,"
                 + " b - (decimal) 1.5,"
-                + " b - b FROM %s WHERE a = 1"),
-                   row(1, 1, 1, 1, 0.5, 0.5, 1, Decimal("0.5"), 0))
+                + " b - b FROM %s WHERE a = 1",
+            ),
+            row(1, 1, 1, 1, 0.5, 0.5, 1, Decimal("0.5"), 0),
+        )
 
-        assertRows(execute(cql, table, "SELECT b * (tinyint) 1,"
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT b * (tinyint) 1,"
                 + " b * (smallint) 1,"
                 + " b * 1,"
                 + " b * (bigint) 1,"
@@ -530,10 +1429,16 @@ def testWithCounters(cql, test_keyspace):
                 + " b * 1.5,"
                 + " b * (varint) 1,"
                 + " b * (decimal) 1.5,"
-                + " b * b FROM %s WHERE a = 1"),
-                   row(2, 2, 2, 2, 3.0, 3.0, 2, Decimal("3.00"), 4))
+                + " b * b FROM %s WHERE a = 1",
+            ),
+            row(2, 2, 2, 2, 3.0, 3.0, 2, Decimal("3.00"), 4),
+        )
 
-        assertRows(execute(cql, table, "SELECT b / (tinyint) 1,"
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT b / (tinyint) 1,"
                 + " b / (smallint) 1,"
                 + " b / 1,"
                 + " b / (bigint) 1,"
@@ -541,10 +1446,16 @@ def testWithCounters(cql, test_keyspace):
                 + " b / 0.5,"
                 + " b / (varint) 1,"
                 + " b / (decimal) 0.5,"
-                + " b / b FROM %s WHERE a = 1"),
-                   row(2, 2, 2, 2, 4.0, 4.0, 2, Decimal("4"), 1))
+                + " b / b FROM %s WHERE a = 1",
+            ),
+            row(2, 2, 2, 2, 4.0, 4.0, 2, Decimal("4"), 1),
+        )
 
-        assertRows(execute(cql, table, "SELECT b % (tinyint) 1,"
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT b % (tinyint) 1,"
                 + " b % (smallint) 1,"
                 + " b % 1,"
                 + " b % (bigint) 1,"
@@ -552,14 +1463,19 @@ def testWithCounters(cql, test_keyspace):
                 + " b % 0.5,"
                 + " b % (varint) 1,"
                 + " b % (decimal) 0.5,"
-                + " b % b FROM %s WHERE a = 1"),
-                   row(0, 0, 0, 0, 0.0, 0.0, 0, Decimal("0.0"), 0))
+                + " b % b FROM %s WHERE a = 1",
+            ),
+            row(0, 0, 0, 0, 0.0, 0.0, 0, Decimal("0.0"), 0),
+        )
 
         assertRows(execute(cql, table, "SELECT -b FROM %s WHERE a = 1"), row(-2))
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testPrecedenceAndParentheses(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (2, 5, 25, 4)")
 
         with original_column_names(cql) as cql:
@@ -604,7 +1520,9 @@ def testPrecedenceAndParentheses(cql, test_keyspace):
             assertRows(rs, row(0))
 
             # test with aliases
-            rs = execute(cql, table, "SELECT (int)((c - a) % d / (a + d)) as result FROM %s")
+            rs = execute(
+                cql, table, "SELECT (int)((c - a) % d / (a + d)) as result FROM %s"
+            )
             assertColumnNames(rs, "result")
             assertRows(rs, row(0))
 
@@ -612,166 +1530,449 @@ def testPrecedenceAndParentheses(cql, test_keyspace):
             assertColumnNames(rs, "divisions")
             assertRows(rs, row(2))
 
-            assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = (int) ? / 2 - 5", 2, 20),
-                   row(2, 5, 25, 4))
+            assertRows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = ? AND b = (int) ? / 2 - 5",
+                    2,
+                    20,
+                ),
+                row(2, 5, 25, 4),
+            )
 
-            assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = (int) ? / (2 + 2)", 2, 20),
-                   row(2, 5, 25, 4))
+            assertRows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = ? AND b = (int) ? / (2 + 2)",
+                    2,
+                    20,
+                ),
+                row(2, 5, 25, 4),
+            )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testWithDivisionByZero(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY (a, b))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (0, 2, 3, 4, 5.5, 6.5, 7, 8.5)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY (a, b))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (0, 2, 3, 4, 5.5, 6.5, 7, 8.5)",
+        )
 
         OperationExecutionException = FunctionFailure
-        assertInvalidThrowMessage(cql, table, "the operation 'tinyint / tinyint' failed: / by zero",
-                                  OperationExecutionException,
-                                  "SELECT a / a FROM %s WHERE a = 0 AND b = 2")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'tinyint / tinyint' failed: / by zero",
+            OperationExecutionException,
+            "SELECT a / a FROM %s WHERE a = 0 AND b = 2",
+        )
 
-        assertInvalidThrowMessage(cql, table, "the operation 'smallint / tinyint' failed: / by zero",
-                                  OperationExecutionException,
-                                  "SELECT b / a FROM %s WHERE a = 0 AND b = 2")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'smallint / tinyint' failed: / by zero",
+            OperationExecutionException,
+            "SELECT b / a FROM %s WHERE a = 0 AND b = 2",
+        )
 
-        assertInvalidThrowMessage(cql, table, "the operation 'int / tinyint' failed: / by zero",
-                                  OperationExecutionException,
-                                  "SELECT c / a FROM %s WHERE a = 0 AND b = 2")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'int / tinyint' failed: / by zero",
+            OperationExecutionException,
+            "SELECT c / a FROM %s WHERE a = 0 AND b = 2",
+        )
 
-        assertInvalidThrowMessage(cql, table, "the operation 'bigint / tinyint' failed: / by zero",
-                                  OperationExecutionException,
-                                  "SELECT d / a FROM %s WHERE a = 0 AND b = 2")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'bigint / tinyint' failed: / by zero",
+            OperationExecutionException,
+            "SELECT d / a FROM %s WHERE a = 0 AND b = 2",
+        )
 
-        assertInvalidThrowMessage(cql, table, "the operation 'smallint / smallint' failed: / by zero",
-                                  OperationExecutionException,
-                                  "SELECT a FROM %s WHERE a = 0 AND b = 10/0")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'smallint / smallint' failed: / by zero",
+            OperationExecutionException,
+            "SELECT a FROM %s WHERE a = 0 AND b = 10/0",
+        )
 
-        assertRows(execute(cql, table, "SELECT e / a FROM %s WHERE a = 0 AND b = 2"), row(float('inf')))
-        assertRows(execute(cql, table, "SELECT f / a FROM %s WHERE a = 0 AND b = 2"), row(float('inf')))
+        assertRows(
+            execute(cql, table, "SELECT e / a FROM %s WHERE a = 0 AND b = 2"),
+            row(float("inf")),
+        )
+        assertRows(
+            execute(cql, table, "SELECT f / a FROM %s WHERE a = 0 AND b = 2"),
+            row(float("inf")),
+        )
 
-        assertInvalidThrowMessage(cql, table, "the operation 'varint / tinyint' failed: BigInteger divide by zero",
-                                  OperationExecutionException,
-                                  "SELECT g / a FROM %s WHERE a = 0 AND b = 2")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'varint / tinyint' failed: BigInteger divide by zero",
+            OperationExecutionException,
+            "SELECT g / a FROM %s WHERE a = 0 AND b = 2",
+        )
 
-        assertInvalidThrowMessage(cql, table, "the operation 'decimal / tinyint' failed: BigInteger divide by zero",
-                                  OperationExecutionException,
-                                  "SELECT h / a FROM %s WHERE a = 0 AND b = 2")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'decimal / tinyint' failed: BigInteger divide by zero",
+            OperationExecutionException,
+            "SELECT h / a FROM %s WHERE a = 0 AND b = 2",
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testWithNanAndInfinity(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b double, c decimal)") as table:
-        assertInvalidMessage(cql, table, "Ambiguous '+' operation with args ? and 1: use type hint to disambiguate, example '(int) ?'",
-                             "INSERT INTO %s (a, b, c) VALUES (? + 1, ?, ?)", 0, float('nan'), Decimal("1"))
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b double, c decimal)"
+    ) as table:
+        assertInvalidMessage(
+            cql,
+            table,
+            "Ambiguous '+' operation with args ? and 1: use type hint to disambiguate, example '(int) ?'",
+            "INSERT INTO %s (a, b, c) VALUES (? + 1, ?, ?)",
+            0,
+            float("nan"),
+            Decimal("1"),
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ((int) ? + 1, -?, ?)", 0, float('nan'), Decimal("1"))
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES ((int) ? + 1, -?, ?)",
+            0,
+            float("nan"),
+            Decimal("1"),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"), row(1, result_cleanup(float('nan')), Decimal("1")))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, result_cleanup(float("nan")), Decimal("1")),
+        )
 
-        assertRows(execute(cql, table, "SELECT a + NAN, b + 1 FROM %s"), row(result_cleanup(float('nan')), result_cleanup(float('nan'))))
+        assertRows(
+            execute(cql, table, "SELECT a + NAN, b + 1 FROM %s"),
+            row(result_cleanup(float("nan")), result_cleanup(float("nan"))),
+        )
         OperationExecutionException = FunctionFailure
-        assertInvalidThrowMessage(cql, table, "the operation 'decimal + double' failed: A NaN cannot be converted into a decimal",
-                                  OperationExecutionException,
-                                  "SELECT c + NAN FROM %s")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'decimal + double' failed: A NaN cannot be converted into a decimal",
+            OperationExecutionException,
+            "SELECT c + NAN FROM %s",
+        )
 
-        assertRows(execute(cql, table, "SELECT a + (float) NAN, b + 1 FROM %s"), row(result_cleanup(float('nan')), result_cleanup(float('nan'))))
-        assertInvalidThrowMessage(cql, table, "the operation 'decimal + float' failed: A NaN cannot be converted into a decimal",
-                                  OperationExecutionException,
-                                  "SELECT c + (float) NAN FROM %s")
+        assertRows(
+            execute(cql, table, "SELECT a + (float) NAN, b + 1 FROM %s"),
+            row(result_cleanup(float("nan")), result_cleanup(float("nan"))),
+        )
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'decimal + float' failed: A NaN cannot be converted into a decimal",
+            OperationExecutionException,
+            "SELECT c + (float) NAN FROM %s",
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, float('inf'), Decimal("1"))
-        assertRows(execute(cql, table, "SELECT * FROM %s"), row(1, float('inf'), Decimal("1")))
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+            1,
+            float("inf"),
+            Decimal("1"),
+        )
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"), row(1, float("inf"), Decimal("1"))
+        )
 
-        assertRows(execute(cql, table, "SELECT a + INFINITY, b + 1 FROM %s"), row(float('inf'), float('inf')))
-        assertInvalidThrowMessage(cql, table, "the operation 'decimal + double' failed: An infinite number cannot be converted into a decimal",
-                                  OperationExecutionException,
-                                  "SELECT c + INFINITY FROM %s")
+        assertRows(
+            execute(cql, table, "SELECT a + INFINITY, b + 1 FROM %s"),
+            row(float("inf"), float("inf")),
+        )
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'decimal + double' failed: An infinite number cannot be converted into a decimal",
+            OperationExecutionException,
+            "SELECT c + INFINITY FROM %s",
+        )
 
-        assertRows(execute(cql, table, "SELECT a + (float) INFINITY, b + 1 FROM %s"), row(float('inf'), float('inf')))
-        assertInvalidThrowMessage(cql, table, "the operation 'decimal + float' failed: An infinite number cannot be converted into a decimal",
-                                  OperationExecutionException,
-                                  "SELECT c + (float) INFINITY FROM %s")
+        assertRows(
+            execute(cql, table, "SELECT a + (float) INFINITY, b + 1 FROM %s"),
+            row(float("inf"), float("inf")),
+        )
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'decimal + float' failed: An infinite number cannot be converted into a decimal",
+            OperationExecutionException,
+            "SELECT c + (float) INFINITY FROM %s",
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, float('-inf'), Decimal("1"))
-        assertRows(execute(cql, table, "SELECT * FROM %s"), row(1, float('-inf'), Decimal("1")))
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+            1,
+            float("-inf"),
+            Decimal("1"),
+        )
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"), row(1, float("-inf"), Decimal("1"))
+        )
 
-        assertRows(execute(cql, table, "SELECT a + -INFINITY, b + 1 FROM %s"), row(float('-inf'), float('-inf')))
-        assertInvalidThrowMessage(cql, table, "the operation 'decimal + double' failed: An infinite number cannot be converted into a decimal",
-                                  OperationExecutionException,
-                                  "SELECT c + -INFINITY FROM %s")
+        assertRows(
+            execute(cql, table, "SELECT a + -INFINITY, b + 1 FROM %s"),
+            row(float("-inf"), float("-inf")),
+        )
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'decimal + double' failed: An infinite number cannot be converted into a decimal",
+            OperationExecutionException,
+            "SELECT c + -INFINITY FROM %s",
+        )
 
-        assertRows(execute(cql, table, "SELECT a + (float) -INFINITY, b + 1 FROM %s"), row(float('-inf'), float('-inf')))
-        assertInvalidThrowMessage(cql, table, "the operation 'decimal + float' failed: An infinite number cannot be converted into a decimal",
-                                  OperationExecutionException,
-                                  "SELECT c + (float) -INFINITY FROM %s")
+        assertRows(
+            execute(cql, table, "SELECT a + (float) -INFINITY, b + 1 FROM %s"),
+            row(float("-inf"), float("-inf")),
+        )
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'decimal + float' failed: An infinite number cannot be converted into a decimal",
+            OperationExecutionException,
+            "SELECT c + (float) -INFINITY FROM %s",
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testInvalidTypes(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b boolean, c text)") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, True, "test")
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b boolean, c text)"
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, True, "test"
+        )
 
-        assertInvalidMessage(cql, table, "the '+' operation is not supported between a and b", "SELECT a + b FROM %s")
-        assertInvalidMessage(cql, table, "the '+' operation is not supported between b and c", "SELECT b + c FROM %s")
-        assertInvalidMessage(cql, table, "the '+' operation is not supported between b and 1", "SELECT b + 1 FROM %s")
-        assertInvalidMessage(cql, table, "the '+' operation is not supported between 1 and b", "SELECT 1 + b FROM %s")
-        assertInvalidMessage(cql, table, "the '+' operation is not supported between b and NaN", "SELECT b + NaN FROM %s")
-        assertInvalidMessage(cql, table, "the '/' operation is not supported between a and b", "SELECT a / b FROM %s")
-        assertInvalidMessage(cql, table, "the '/' operation is not supported between b and c", "SELECT b / c FROM %s")
-        assertInvalidMessage(cql, table, "the '/' operation is not supported between b and 1", "SELECT b / 1 FROM %s")
-        assertInvalidMessage(cql, table, "the '/' operation is not supported between NaN and b", "SELECT NaN / b FROM %s")
-        assertInvalidMessage(cql, table, "the '/' operation is not supported between -Infinity and b", "SELECT -Infinity / b FROM %s")
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '+' operation is not supported between a and b",
+            "SELECT a + b FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '+' operation is not supported between b and c",
+            "SELECT b + c FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '+' operation is not supported between b and 1",
+            "SELECT b + 1 FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '+' operation is not supported between 1 and b",
+            "SELECT 1 + b FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '+' operation is not supported between b and NaN",
+            "SELECT b + NaN FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '/' operation is not supported between a and b",
+            "SELECT a / b FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '/' operation is not supported between b and c",
+            "SELECT b / c FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '/' operation is not supported between b and 1",
+            "SELECT b / 1 FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '/' operation is not supported between NaN and b",
+            "SELECT NaN / b FROM %s",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '/' operation is not supported between -Infinity and b",
+            "SELECT -Infinity / b FROM %s",
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testOverflow(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b tinyint, c smallint)") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b tinyint, c smallint)"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 1, 1)
-        assertRows(execute(cql, table, "SELECT a + (int) ?, b + (tinyint) ?, c + (smallint) ? FROM %s", 1, 1, 1),
-                   row(2, 2, 2))
-        assertRows(execute(cql, table, "SELECT a + (int) ?, b + (tinyint) ?, c + (smallint) ? FROM %s", 2147483647, 127, 32767),
-                   row(-2147483648, -128, -32768))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + (int) ?, b + (tinyint) ?, c + (smallint) ? FROM %s",
+                1,
+                1,
+                1,
+            ),
+            row(2, 2, 2),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT a + (int) ?, b + (tinyint) ?, c + (smallint) ? FROM %s",
+                2147483647,
+                127,
+                32767,
+            ),
+            row(-2147483648, -128, -32768),
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testOperationsWithDuration(cql, test_keyspace):
     # Test with timestamp type.
-    with create_table(cql, test_keyspace, "(pk int, time timestamp, v int, primary key (pk, time))") as table:
-        execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:10:00 UTC', 1)")
-        execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:12:00 UTC', 2)")
-        execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:14:00 UTC', 3)")
-        execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:15:00 UTC', 4)")
-        execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:21:00 UTC', 5)")
-        execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:22:00 UTC', 6)")
+    with create_table(
+        cql, test_keyspace, "(pk int, time timestamp, v int, primary key (pk, time))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:10:00 UTC', 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:12:00 UTC', 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:14:00 UTC', 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:15:00 UTC', 4)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:21:00 UTC', 5)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27 16:22:00 UTC', 6)",
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND time > ? - 5m", datetime(2016,9,27,16,20,0)),
-                   row(1, datetime(2016,9,27,16,21,0), 5),
-                   row(1, datetime(2016,9,27,16,22,0), 6))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = 1 AND time > ? - 5m",
+                datetime(2016, 9, 27, 16, 20, 0),
+            ),
+            row(1, datetime(2016, 9, 27, 16, 21, 0), 5),
+            row(1, datetime(2016, 9, 27, 16, 22, 0), 6),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND time >= ? - 10m", datetime(2016,9,27,16,25,0)),
-                   row(1, datetime(2016,9,27,16,15,0), 4),
-                   row(1, datetime(2016,9,27,16,21,0), 5),
-                   row(1, datetime(2016,9,27,16,22,0), 6))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = 1 AND time >= ? - 10m",
+                datetime(2016, 9, 27, 16, 25, 0),
+            ),
+            row(1, datetime(2016, 9, 27, 16, 15, 0), 4),
+            row(1, datetime(2016, 9, 27, 16, 21, 0), 5),
+            row(1, datetime(2016, 9, 27, 16, 22, 0), 6),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND time >= ? + 5m", datetime(2016,9,27,16,15,0)),
-                   row(1, datetime(2016,9,27,16,21,0), 5),
-                   row(1, datetime(2016,9,27,16,22,0), 6))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = 1 AND time >= ? + 5m",
+                datetime(2016, 9, 27, 16, 15, 0),
+            ),
+            row(1, datetime(2016, 9, 27, 16, 21, 0), 5),
+            row(1, datetime(2016, 9, 27, 16, 22, 0), 6),
+        )
 
-        assertRows(execute(cql, table, "SELECT time - 10m FROM %s WHERE pk = 1"),
-                   row(datetime(2016,9,27,16,0,0)),
-                   row(datetime(2016,9,27,16,2,0)),
-                   row(datetime(2016,9,27,16,4,0)),
-                   row(datetime(2016,9,27,16,5,0)),
-                   row(datetime(2016,9,27,16,11,0)),
-                   row(datetime(2016,9,27,16,12,0)))
+        assertRows(
+            execute(cql, table, "SELECT time - 10m FROM %s WHERE pk = 1"),
+            row(datetime(2016, 9, 27, 16, 0, 0)),
+            row(datetime(2016, 9, 27, 16, 2, 0)),
+            row(datetime(2016, 9, 27, 16, 4, 0)),
+            row(datetime(2016, 9, 27, 16, 5, 0)),
+            row(datetime(2016, 9, 27, 16, 11, 0)),
+            row(datetime(2016, 9, 27, 16, 12, 0)),
+        )
 
-        assertInvalidMessage(cql, table, "the '%' operation is not supported between time and 10m",
-                             "SELECT time % 10m FROM %s WHERE pk = 1")
-        assertInvalidMessage(cql, table, "the '*' operation is not supported between time and 10m",
-                             "SELECT time * 10m FROM %s WHERE pk = 1")
-        assertInvalidMessage(cql, table, "the '/' operation is not supported between time and 10m",
-                             "SELECT time / 10m FROM %s WHERE pk = 1")
-        assertInvalidThrowMessage(cql, table, "the operation 'timestamp - duration' failed: The duration must have a millisecond precision. Was: 10us",
-                             FunctionFailure,
-                             "SELECT * FROM %s WHERE pk = 1 AND time > ? - 10us", datetime(2016,9,27,16,15,0))
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '%' operation is not supported between time and 10m",
+            "SELECT time % 10m FROM %s WHERE pk = 1",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '*' operation is not supported between time and 10m",
+            "SELECT time * 10m FROM %s WHERE pk = 1",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '/' operation is not supported between time and 10m",
+            "SELECT time / 10m FROM %s WHERE pk = 1",
+        )
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'timestamp - duration' failed: The duration must have a millisecond precision. Was: 10us",
+            FunctionFailure,
+            "SELECT * FROM %s WHERE pk = 1 AND time > ? - 10us",
+            datetime(2016, 9, 27, 16, 15, 0),
+        )
 
     # Test with date type.
-    with create_table(cql, test_keyspace, "(pk int, time date, v int, primary key (pk, time))") as table:
-
+    with create_table(
+        cql, test_keyspace, "(pk int, time date, v int, primary key (pk, time))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-27', 1)")
         execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-28', 2)")
         execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-09-29', 3)")
@@ -779,44 +1980,90 @@ def testOperationsWithDuration(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-10-01', 5)")
         execute(cql, table, "INSERT INTO %s (pk, time, v) VALUES (1, '2016-10-04', 6)")
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND time > ? - 5d", Date("2016-10-04")),
-                   row(1, Date("2016-09-30"), 4),
-                   row(1, Date("2016-10-01"), 5),
-                   row(1, Date("2016-10-04"), 6))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = 1 AND time > ? - 5d",
+                Date("2016-10-04"),
+            ),
+            row(1, Date("2016-09-30"), 4),
+            row(1, Date("2016-10-01"), 5),
+            row(1, Date("2016-10-04"), 6),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND time > ? - 6d", Date("2016-10-04")),
-                   row(1, Date("2016-09-29"), 3),
-                   row(1, Date("2016-09-30"), 4),
-                   row(1, Date("2016-10-01"), 5),
-                   row(1, Date("2016-10-04"), 6))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = 1 AND time > ? - 6d",
+                Date("2016-10-04"),
+            ),
+            row(1, Date("2016-09-29"), 3),
+            row(1, Date("2016-09-30"), 4),
+            row(1, Date("2016-10-01"), 5),
+            row(1, Date("2016-10-04"), 6),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND time >= ? + 1d",  Date("2016-10-01")),
-                   row(1, Date("2016-10-04"), 6))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = 1 AND time >= ? + 1d",
+                Date("2016-10-01"),
+            ),
+            row(1, Date("2016-10-04"), 6),
+        )
 
-        assertRows(execute(cql, table, "SELECT time - 2d FROM %s WHERE pk = 1"),
-                   row(Date("2016-09-25")),
-                   row(Date("2016-09-26")),
-                   row(Date("2016-09-27")),
-                   row(Date("2016-09-28")),
-                   row(Date("2016-09-29")),
-                   row(Date("2016-10-02")))
+        assertRows(
+            execute(cql, table, "SELECT time - 2d FROM %s WHERE pk = 1"),
+            row(Date("2016-09-25")),
+            row(Date("2016-09-26")),
+            row(Date("2016-09-27")),
+            row(Date("2016-09-28")),
+            row(Date("2016-09-29")),
+            row(Date("2016-10-02")),
+        )
 
-        assertInvalidMessage(cql, table, "the '%' operation is not supported between time and 10m",
-                             "SELECT time % 10m FROM %s WHERE pk = 1")
-        assertInvalidMessage(cql, table, "the '*' operation is not supported between time and 10m",
-                             "SELECT time * 10m FROM %s WHERE pk = 1")
-        assertInvalidMessage(cql, table, "the '/' operation is not supported between time and 10m",
-                             "SELECT time / 10m FROM %s WHERE pk = 1")
-        assertInvalidThrowMessage(cql, table, "the operation 'date - duration' failed: The duration must have a day precision. Was: 10m",
-                             FunctionFailure,
-                             "SELECT * FROM %s WHERE pk = 1 AND time > ? - 10m", Date("2016-10-04"))
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '%' operation is not supported between time and 10m",
+            "SELECT time % 10m FROM %s WHERE pk = 1",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '*' operation is not supported between time and 10m",
+            "SELECT time * 10m FROM %s WHERE pk = 1",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "the '/' operation is not supported between time and 10m",
+            "SELECT time / 10m FROM %s WHERE pk = 1",
+        )
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'date - duration' failed: The duration must have a day precision. Was: 10m",
+            FunctionFailure,
+            "SELECT * FROM %s WHERE pk = 1 AND time > ? - 10m",
+            Date("2016-10-04"),
+        )
 
-@pytest.mark.xfail(reason="#2693")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testFunctionException(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int, c1 int, c2 int, v text, primary key (pk, c1, c2))") as table:
+    with create_table(
+        cql, test_keyspace, "(pk int, c1 int, c2 int, v text, primary key (pk, c1, c2))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (1, 0, 2, 'test')")
 
-        assertInvalidThrowMessage(cql, table,
-                                  "the operation 'int / int' failed: / by zero",
-                                  FunctionFailure,
-                                  "SELECT c2 / c1 FROM %s WHERE pk = 1")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "the operation 'int / int' failed: / by zero",
+            FunctionFailure,
+            "SELECT c2 / c1 FROM %s WHERE pk = 1",
+        )

--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -19,626 +19,1899 @@ from datetime import datetime, timezone
 from socket import getaddrinfo
 import json
 
+
 def testSelectJsonWithPagingWithFrozenTuple(cql, test_keyspace):
     uuid = UUID("2dd2cd62-6af3-4cf6-96fc-91b9ab62eedc")
     partitionKey = (uuid, 2)
-    with create_table(cql, test_keyspace, "(k1 FROZEN<TUPLE<uuid, int>>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k1 FROZEN<TUPLE<uuid, int>>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))",
+    ) as table:
         # prepare data
         for i in range(1, 5):
-            execute(cql, table, "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)", partitionKey, (uuid, i), i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)",
+                partitionKey,
+                (uuid, i),
+                i,
+            )
 
         for pageSize in range(1, 6):
             # SELECT JSON
-            assert_rows(execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
-                ["{\"k1\": [\"" + str(uuid) + "\", 2], \"c1\": [\"" + str(uuid) + "\", 1], \"value\": 1}"],
-                ["{\"k1\": [\"" + str(uuid) + "\", 2], \"c1\": [\"" + str(uuid) + "\", 2], \"value\": 2}"],
-                ["{\"k1\": [\"" + str(uuid) + "\", 2], \"c1\": [\"" + str(uuid) + "\", 3], \"value\": 3}"],
-                ["{\"k1\": [\"" + str(uuid) + "\", 2], \"c1\": [\"" + str(uuid) + "\", 4], \"value\": 4}"])
+            assert_rows(
+                execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
+                [
+                    '{"k1": ["'
+                    + str(uuid)
+                    + '", 2], "c1": ["'
+                    + str(uuid)
+                    + '", 1], "value": 1}'
+                ],
+                [
+                    '{"k1": ["'
+                    + str(uuid)
+                    + '", 2], "c1": ["'
+                    + str(uuid)
+                    + '", 2], "value": 2}'
+                ],
+                [
+                    '{"k1": ["'
+                    + str(uuid)
+                    + '", 2], "c1": ["'
+                    + str(uuid)
+                    + '", 3], "value": 3}'
+                ],
+                [
+                    '{"k1": ["'
+                    + str(uuid)
+                    + '", 2], "c1": ["'
+                    + str(uuid)
+                    + '", 4], "value": 4}'
+                ],
+            )
 
             # SELECT toJson(column)
-            assert_rows(execute_with_paging(cql, table, "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s", pageSize),
-                ["[\"" + str(uuid) + "\", 2]", "[\"" + str(uuid) + "\", 1]", "1"],
-                ["[\"" + str(uuid) + "\", 2]", "[\"" + str(uuid) + "\", 2]", "2"],
-                ["[\"" + str(uuid) + "\", 2]", "[\"" + str(uuid) + "\", 3]", "3"],
-                ["[\"" + str(uuid) + "\", 2]", "[\"" + str(uuid) + "\", 4]", "4"])
+            assert_rows(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s",
+                    pageSize,
+                ),
+                ['["' + str(uuid) + '", 2]', '["' + str(uuid) + '", 1]', "1"],
+                ['["' + str(uuid) + '", 2]', '["' + str(uuid) + '", 2]', "2"],
+                ['["' + str(uuid) + '", 2]', '["' + str(uuid) + '", 3]', "3"],
+                ['["' + str(uuid) + '", 2]', '["' + str(uuid) + '", 4]', "4"],
+            )
+
 
 def testSelectJsonWithPagingWithFrozenMap(cql, test_keyspace):
     uuid = UUID("2dd2cd62-6af3-4cf6-96fc-91b9ab62eedc")
     partitionKey = {1: (uuid, 1), 2: (uuid, 2)}
-    with create_table(cql, test_keyspace, "(k1 FROZEN<map<int, tuple<uuid, int>>>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k1 FROZEN<map<int, tuple<uuid, int>>>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))",
+    ) as table:
         # prepare data
         for i in range(1, 5):
-            execute(cql, table, "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)", partitionKey, (uuid, i), i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)",
+                partitionKey,
+                (uuid, i),
+                i,
+            )
 
         for pageSize in range(1, 6):
             # SELECT JSON
-            assert_rows(execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
-                          ["{\"k1\": {\"1\": [\"" + str(uuid) + "\", 1], \"2\": [\"" + str(uuid) + "\", 2]}, \"c1\": [\"" + str(uuid) + "\", 1], \"value\": 1}"],
-                          ["{\"k1\": {\"1\": [\"" + str(uuid) + "\", 1], \"2\": [\"" + str(uuid) + "\", 2]}, \"c1\": [\"" + str(uuid) + "\", 2], \"value\": 2}"],
-                          ["{\"k1\": {\"1\": [\"" + str(uuid) + "\", 1], \"2\": [\"" + str(uuid) + "\", 2]}, \"c1\": [\"" + str(uuid) + "\", 3], \"value\": 3}"],
-                          ["{\"k1\": {\"1\": [\"" + str(uuid) + "\", 1], \"2\": [\"" + str(uuid) + "\", 2]}, \"c1\": [\"" + str(uuid) + "\", 4], \"value\": 4}"])
+            assert_rows(
+                execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
+                [
+                    '{"k1": {"1": ["'
+                    + str(uuid)
+                    + '", 1], "2": ["'
+                    + str(uuid)
+                    + '", 2]}, "c1": ["'
+                    + str(uuid)
+                    + '", 1], "value": 1}'
+                ],
+                [
+                    '{"k1": {"1": ["'
+                    + str(uuid)
+                    + '", 1], "2": ["'
+                    + str(uuid)
+                    + '", 2]}, "c1": ["'
+                    + str(uuid)
+                    + '", 2], "value": 2}'
+                ],
+                [
+                    '{"k1": {"1": ["'
+                    + str(uuid)
+                    + '", 1], "2": ["'
+                    + str(uuid)
+                    + '", 2]}, "c1": ["'
+                    + str(uuid)
+                    + '", 3], "value": 3}'
+                ],
+                [
+                    '{"k1": {"1": ["'
+                    + str(uuid)
+                    + '", 1], "2": ["'
+                    + str(uuid)
+                    + '", 2]}, "c1": ["'
+                    + str(uuid)
+                    + '", 4], "value": 4}'
+                ],
+            )
 
             # SELECT toJson(column)
-            assert_rows(execute_with_paging(cql, table, "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s", pageSize),
-                          ["{\"1\": [\"" + str(uuid) + "\", 1], \"2\": [\"" + str(uuid) + "\", 2]}", "[\"" + str(uuid) + "\", 1]", "1"],
-                          ["{\"1\": [\"" + str(uuid) + "\", 1], \"2\": [\"" + str(uuid) + "\", 2]}", "[\"" + str(uuid) + "\", 2]", "2"],
-                          ["{\"1\": [\"" + str(uuid) + "\", 1], \"2\": [\"" + str(uuid) + "\", 2]}", "[\"" + str(uuid) + "\", 3]", "3"],
-                          ["{\"1\": [\"" + str(uuid) + "\", 1], \"2\": [\"" + str(uuid) + "\", 2]}", "[\"" + str(uuid) + "\", 4]", "4"])
+            assert_rows(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s",
+                    pageSize,
+                ),
+                [
+                    '{"1": ["' + str(uuid) + '", 1], "2": ["' + str(uuid) + '", 2]}',
+                    '["' + str(uuid) + '", 1]',
+                    "1",
+                ],
+                [
+                    '{"1": ["' + str(uuid) + '", 1], "2": ["' + str(uuid) + '", 2]}',
+                    '["' + str(uuid) + '", 2]',
+                    "2",
+                ],
+                [
+                    '{"1": ["' + str(uuid) + '", 1], "2": ["' + str(uuid) + '", 2]}',
+                    '["' + str(uuid) + '", 3]',
+                    "3",
+                ],
+                [
+                    '{"1": ["' + str(uuid) + '", 1], "2": ["' + str(uuid) + '", 2]}',
+                    '["' + str(uuid) + '", 4]',
+                    "4",
+                ],
+            )
+
 
 def testSelectJsonWithPagingWithFrozenSet(cql, test_keyspace):
     uuid = UUID("2dd2cd62-6af3-4cf6-96fc-91b9ab62eedc")
     partitionKey = {((1, 2), 1), ((2, 3), 2)}
-    with create_table(cql, test_keyspace, "(k1 frozen<set<tuple<list<int>, int>>>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k1 frozen<set<tuple<list<int>, int>>>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))",
+    ) as table:
         # prepare data
         for i in range(1, 5):
-            execute(cql, table, "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)", partitionKey, (uuid, i), i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)",
+                partitionKey,
+                (uuid, i),
+                i,
+            )
 
         for pageSize in range(1, 6):
             # SELECT JSON
-            assert_rows(execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
-                          ["{\"k1\": [[[1, 2], 1], [[2, 3], 2]], \"c1\": [\"" + str(uuid) + "\", 1], \"value\": 1}"],
-                          ["{\"k1\": [[[1, 2], 1], [[2, 3], 2]], \"c1\": [\"" + str(uuid) + "\", 2], \"value\": 2}"],
-                          ["{\"k1\": [[[1, 2], 1], [[2, 3], 2]], \"c1\": [\"" + str(uuid) + "\", 3], \"value\": 3}"],
-                          ["{\"k1\": [[[1, 2], 1], [[2, 3], 2]], \"c1\": [\"" + str(uuid) + "\", 4], \"value\": 4}"])
+            assert_rows(
+                execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
+                [
+                    '{"k1": [[[1, 2], 1], [[2, 3], 2]], "c1": ["'
+                    + str(uuid)
+                    + '", 1], "value": 1}'
+                ],
+                [
+                    '{"k1": [[[1, 2], 1], [[2, 3], 2]], "c1": ["'
+                    + str(uuid)
+                    + '", 2], "value": 2}'
+                ],
+                [
+                    '{"k1": [[[1, 2], 1], [[2, 3], 2]], "c1": ["'
+                    + str(uuid)
+                    + '", 3], "value": 3}'
+                ],
+                [
+                    '{"k1": [[[1, 2], 1], [[2, 3], 2]], "c1": ["'
+                    + str(uuid)
+                    + '", 4], "value": 4}'
+                ],
+            )
 
             # SELECT toJson(column)
-            assert_rows(execute_with_paging(cql, table, "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s", pageSize),
-                          ["[[[1, 2], 1], [[2, 3], 2]]", "[\"" + str(uuid) + "\", 1]", "1"],
-                          ["[[[1, 2], 1], [[2, 3], 2]]", "[\"" + str(uuid) + "\", 2]", "2"],
-                          ["[[[1, 2], 1], [[2, 3], 2]]", "[\"" + str(uuid) + "\", 3]", "3"],
-                          ["[[[1, 2], 1], [[2, 3], 2]]", "[\"" + str(uuid) + "\", 4]", "4"])
+            assert_rows(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s",
+                    pageSize,
+                ),
+                ["[[[1, 2], 1], [[2, 3], 2]]", '["' + str(uuid) + '", 1]', "1"],
+                ["[[[1, 2], 1], [[2, 3], 2]]", '["' + str(uuid) + '", 2]', "2"],
+                ["[[[1, 2], 1], [[2, 3], 2]]", '["' + str(uuid) + '", 3]', "3"],
+                ["[[[1, 2], 1], [[2, 3], 2]]", '["' + str(uuid) + '", 4]', "4"],
+            )
+
 
 def testSelectJsonWithPagingWithFrozenList(cql, test_keyspace):
     uuid = UUID("2dd2cd62-6af3-4cf6-96fc-91b9ab62eedc")
     partitionKey = [(uuid, 2), (uuid, 3)]
-    with create_table(cql, test_keyspace, "(k1 frozen<list<tuple<uuid, int>>>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k1 frozen<list<tuple<uuid, int>>>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))",
+    ) as table:
         # prepare data
         for i in range(1, 5):
-            execute(cql, table, "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)", partitionKey, (uuid, i), i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)",
+                partitionKey,
+                (uuid, i),
+                i,
+            )
 
         for pageSize in range(1, 6):
             # SELECT JSON
-            assert_rows(execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
-                      ["{\"k1\": [[\"" + str(uuid) + "\", 2], [\"" + str(uuid) + "\", 3]], \"c1\": [\"" + str(uuid) + "\", 1], \"value\": 1}"],
-                      ["{\"k1\": [[\"" + str(uuid) + "\", 2], [\"" + str(uuid) + "\", 3]], \"c1\": [\"" + str(uuid) + "\", 2], \"value\": 2}"],
-                      ["{\"k1\": [[\"" + str(uuid) + "\", 2], [\"" + str(uuid) + "\", 3]], \"c1\": [\"" + str(uuid) + "\", 3], \"value\": 3}"],
-                      ["{\"k1\": [[\"" + str(uuid) + "\", 2], [\"" + str(uuid) + "\", 3]], \"c1\": [\"" + str(uuid) + "\", 4], \"value\": 4}"])
+            assert_rows(
+                execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
+                [
+                    '{"k1": [["'
+                    + str(uuid)
+                    + '", 2], ["'
+                    + str(uuid)
+                    + '", 3]], "c1": ["'
+                    + str(uuid)
+                    + '", 1], "value": 1}'
+                ],
+                [
+                    '{"k1": [["'
+                    + str(uuid)
+                    + '", 2], ["'
+                    + str(uuid)
+                    + '", 3]], "c1": ["'
+                    + str(uuid)
+                    + '", 2], "value": 2}'
+                ],
+                [
+                    '{"k1": [["'
+                    + str(uuid)
+                    + '", 2], ["'
+                    + str(uuid)
+                    + '", 3]], "c1": ["'
+                    + str(uuid)
+                    + '", 3], "value": 3}'
+                ],
+                [
+                    '{"k1": [["'
+                    + str(uuid)
+                    + '", 2], ["'
+                    + str(uuid)
+                    + '", 3]], "c1": ["'
+                    + str(uuid)
+                    + '", 4], "value": 4}'
+                ],
+            )
 
             # SELECT toJson(column)
-            assert_rows(execute_with_paging(cql, table, "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s", pageSize),
-                      ["[[\"" + str(uuid) + "\", 2], [\"" + str(uuid) + "\", 3]]", "[\"" + str(uuid) + "\", 1]", "1"],
-                      ["[[\"" + str(uuid) + "\", 2], [\"" + str(uuid) + "\", 3]]", "[\"" + str(uuid) + "\", 2]", "2"],
-                      ["[[\"" + str(uuid) + "\", 2], [\"" + str(uuid) + "\", 3]]", "[\"" + str(uuid) + "\", 3]", "3"],
-                      ["[[\"" + str(uuid) + "\", 2], [\"" + str(uuid) + "\", 3]]", "[\"" + str(uuid) + "\", 4]", "4"])
+            assert_rows(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s",
+                    pageSize,
+                ),
+                [
+                    '[["' + str(uuid) + '", 2], ["' + str(uuid) + '", 3]]',
+                    '["' + str(uuid) + '", 1]',
+                    "1",
+                ],
+                [
+                    '[["' + str(uuid) + '", 2], ["' + str(uuid) + '", 3]]',
+                    '["' + str(uuid) + '", 2]',
+                    "2",
+                ],
+                [
+                    '[["' + str(uuid) + '", 2], ["' + str(uuid) + '", 3]]',
+                    '["' + str(uuid) + '", 3]',
+                    "3",
+                ],
+                [
+                    '[["' + str(uuid) + '", 2], ["' + str(uuid) + '", 3]]',
+                    '["' + str(uuid) + '", 4]',
+                    "4",
+                ],
+            )
+
 
 def testSelectJsonWithPagingWithFrozenUDT(cql, test_keyspace):
     uuid = UUID("2dd2cd62-6af3-4cf6-96fc-91b9ab62eedc")
-    abc_tuple = collections.namedtuple('abc_tuple', ['a', 'b', 'c'])
+    abc_tuple = collections.namedtuple("abc_tuple", ["a", "b", "c"])
     partitionKey = abc_tuple(1, 2, ["1", "2"])
     with create_type(cql, test_keyspace, "(a int, b int, c list<text>)") as type_name:
-        with create_table(cql, test_keyspace, f"(k1 frozen<{type_name}>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))") as table:
+        with create_table(
+            cql,
+            test_keyspace,
+            f"(k1 frozen<{type_name}>, c1 frozen<tuple<uuid, int>>, value int, PRIMARY KEY (k1, c1))",
+        ) as table:
             # prepare data
             for i in range(1, 5):
-                execute(cql, table, "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)", partitionKey, (uuid, i), i)
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (k1, c1, value) VALUES (?, ?, ?)",
+                    partitionKey,
+                    (uuid, i),
+                    i,
+                )
 
             for pageSize in range(1, 6):
                 # SELECT JSON
-                assert_rows(execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
-                          ["{\"k1\": {\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}, \"c1\": [\"" + str(uuid) + "\", 1], \"value\": 1}"],
-                          ["{\"k1\": {\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}, \"c1\": [\"" + str(uuid) + "\", 2], \"value\": 2}"],
-                          ["{\"k1\": {\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}, \"c1\": [\"" + str(uuid) + "\", 3], \"value\": 3}"],
-                          ["{\"k1\": {\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}, \"c1\": [\"" + str(uuid) + "\", 4], \"value\": 4}"])
+                assert_rows(
+                    execute_with_paging(cql, table, "SELECT JSON * FROM %s", pageSize),
+                    [
+                        '{"k1": {"a": 1, "b": 2, "c": ["1", "2"]}, "c1": ["'
+                        + str(uuid)
+                        + '", 1], "value": 1}'
+                    ],
+                    [
+                        '{"k1": {"a": 1, "b": 2, "c": ["1", "2"]}, "c1": ["'
+                        + str(uuid)
+                        + '", 2], "value": 2}'
+                    ],
+                    [
+                        '{"k1": {"a": 1, "b": 2, "c": ["1", "2"]}, "c1": ["'
+                        + str(uuid)
+                        + '", 3], "value": 3}'
+                    ],
+                    [
+                        '{"k1": {"a": 1, "b": 2, "c": ["1", "2"]}, "c1": ["'
+                        + str(uuid)
+                        + '", 4], "value": 4}'
+                    ],
+                )
 
                 # SELECT toJson(column)
-                assert_rows(execute_with_paging(cql, table, "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s", pageSize),
-                          ["{\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}", "[\"" + str(uuid) + "\", 1]", "1"],
-                          ["{\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}", "[\"" + str(uuid) + "\", 2]", "2"],
-                          ["{\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}", "[\"" + str(uuid) + "\", 3]", "3"],
-                          ["{\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}", "[\"" + str(uuid) + "\", 4]", "4"])
+                assert_rows(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT toJson(k1), toJson(c1), toJson(value) FROM %s",
+                        pageSize,
+                    ),
+                    [
+                        '{"a": 1, "b": 2, "c": ["1", "2"]}',
+                        '["' + str(uuid) + '", 1]',
+                        "1",
+                    ],
+                    [
+                        '{"a": 1, "b": 2, "c": ["1", "2"]}',
+                        '["' + str(uuid) + '", 2]',
+                        "2",
+                    ],
+                    [
+                        '{"a": 1, "b": 2, "c": ["1", "2"]}',
+                        '["' + str(uuid) + '", 3]',
+                        "3",
+                    ],
+                    [
+                        '{"a": 1, "b": 2, "c": ["1", "2"]}',
+                        '["' + str(uuid) + '", 4]',
+                        "4",
+                    ],
+                )
+
 
 # Reproduces issue #7911, #7912, #7914, #7915, #7944, #7954
-@pytest.mark.xfail(reason="issues #7914, #7915, #7944, #7954")
+@pytest.mark.xfail(
+    reason='fromJson() integer overflow should cause an error, not silent wrap-around #7914, fromJson() should accept "true" and "false" also as strings #7915, fromJson() should not accept the empty string "" as a number #7944, fromJson() fails to set null tuple elements #7954'
+)
 def testFromJsonFct(cql, test_keyspace):
-    abc_tuple = collections.namedtuple('abc_tuple', ['a', 'b', 'c'])
+    abc_tuple = collections.namedtuple("abc_tuple", ["a", "b", "c"])
     with create_type(cql, test_keyspace, "(a int, b uuid, c set<text>)") as type_name:
-        with create_table(cql, test_keyspace, "(" +
-                "k int PRIMARY KEY, " +
-                "asciival ascii, " +
-                "bigintval bigint, " +
-                "blobval blob, " +
-                "booleanval boolean, " +
-                "dateval date, " +
-                "decimalval decimal, " +
-                "doubleval double, " +
-                "floatval float, " +
-                "inetval inet, " +
-                "intval int, " +
-                "smallintval smallint, " +
-                "textval text, " +
-                "timeval time, " +
-                "timestampval timestamp, " +
-                "timeuuidval timeuuid, " +
-                "tinyintval tinyint, " +
-                "uuidval uuid," +
-                "varcharval varchar, " +
-                "varintval varint, " +
-                "listval list<int>, " +
-                "frozenlistval frozen<list<int>>, " +
-                "setval set<uuid>, " +
-                "frozensetval frozen<set<uuid>>, " +
-                "mapval map<ascii, int>," +
-                "frozenmapval frozen<map<ascii, int>>," +
-                "tupleval frozen<tuple<int, ascii, uuid>>," +
-                "udtval frozen<" + type_name + ">," +
-                "durationval duration)") as table:
+        with create_table(
+            cql,
+            test_keyspace,
+            "("
+            + "k int PRIMARY KEY, "
+            + "asciival ascii, "
+            + "bigintval bigint, "
+            + "blobval blob, "
+            + "booleanval boolean, "
+            + "dateval date, "
+            + "decimalval decimal, "
+            + "doubleval double, "
+            + "floatval float, "
+            + "inetval inet, "
+            + "intval int, "
+            + "smallintval smallint, "
+            + "textval text, "
+            + "timeval time, "
+            + "timestampval timestamp, "
+            + "timeuuidval timeuuid, "
+            + "tinyintval tinyint, "
+            + "uuidval uuid,"
+            + "varcharval varchar, "
+            + "varintval varint, "
+            + "listval list<int>, "
+            + "frozenlistval frozen<list<int>>, "
+            + "setval set<uuid>, "
+            + "frozensetval frozen<set<uuid>>, "
+            + "mapval map<ascii, int>,"
+            + "frozenmapval frozen<map<ascii, int>>,"
+            + "tupleval frozen<tuple<int, ascii, uuid>>,"
+            + "udtval frozen<"
+            + type_name
+            + ">,"
+            + "durationval duration)",
+        ) as table:
             # fromJson() can only be used when the receiver type is known
             # Cassandra and Scylla print different error messages - Cassandra
             # says "fromJson() cannot be used in the selection clause", Scylla
             # "fromJson() can only be called if receiver type is known".
-            assert_invalid_message(cql, table, "fromJson()", "SELECT fromJson(asciival) FROM %s", 0, 0)
+            assert_invalid_message(
+                cql, table, "fromJson()", "SELECT fromJson(asciival) FROM %s", 0, 0
+            )
 
             # FIXME: the following tests need *Java* as a UDF language, while
             # Scylla uses Lua, so I didn't translate them.
-            #String func1 = createFunction(KEYSPACE, "int", "CREATE FUNCTION %s (a int) CALLED ON NULL INPUT RETURNS text LANGUAGE java AS $$ return a.toString(); $$")
-            #createFunctionOverload(func1, "int", "CREATE FUNCTION %s (a text) CALLED ON NULL INPUT RETURNS text LANGUAGE java AS $$ return new String(a); $$")
-            #assertInvalidMessage("Ambiguous call to function",
+            # String func1 = createFunction(KEYSPACE, "int", "CREATE FUNCTION %s (a int) CALLED ON NULL INPUT RETURNS text LANGUAGE java AS $$ return a.toString(); $$")
+            # createFunctionOverload(func1, "int", "CREATE FUNCTION %s (a text) CALLED ON NULL INPUT RETURNS text LANGUAGE java AS $$ return new String(a); $$")
+            # assertInvalidMessage("Ambiguous call to function",
             #    "INSERT INTO %s (k, textval) VALUES (?, " + func1 + "(fromJson(?)))", 0, "123")
 
             # fails JSON parsing
             # Reproduces issue #7911:
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))", 0, "\u038E\u0394\u03B4\u03E0")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))",
+                0,
+                "\u038e\u0394\u03b4\u03e0",
+            )
 
             # handle nulls
             # Reproduces issue #7912:
-            execute(cql, table, "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))", 0, None)
-            assert_rows(execute(cql, table, "SELECT k, asciival FROM %s WHERE k = ?", 0), [0, None])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))",
+                0,
+                None,
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, asciival FROM %s WHERE k = ?", 0),
+                [0, None],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, frozenmapval) VALUES (?, fromJson(?))", 0, None)
-            assert_rows(execute(cql, table, "SELECT k, frozenmapval FROM %s WHERE k = ?", 0), [0, None])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozenmapval) VALUES (?, fromJson(?))",
+                0,
+                None,
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, frozenmapval FROM %s WHERE k = ?", 0),
+                [0, None],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))", 0, None)
-            assert_rows(execute(cql, table, "SELECT k, udtval FROM %s WHERE k = ?", 0), [0, None])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))",
+                0,
+                None,
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, udtval FROM %s WHERE k = ?", 0),
+                [0, None],
+            )
 
             # ================ ascii ================
-            execute(cql, table, "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))", 0, "\"ascii text\"")
-            assert_rows(execute(cql, table, "SELECT k, asciival FROM %s WHERE k = ?", 0), [0, "ascii text"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))",
+                0,
+                '"ascii text"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, asciival FROM %s WHERE k = ?", 0),
+                [0, "ascii text"],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))", 0, "\"ascii \\\" text\"")
-            assert_rows(execute(cql, table, "SELECT k, asciival FROM %s WHERE k = ?", 0), [0, "ascii \" text"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))",
+                0,
+                '"ascii \\" text"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, asciival FROM %s WHERE k = ?", 0),
+                [0, 'ascii " text'],
+            )
 
             # reproduces issue #7911:
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))", 0, "\"\\u1fff\\u2013\\u33B4\\u2014\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))",
+                0,
+                '"\\u1fff\\u2013\\u33B4\\u2014"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, asciival) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
             # test that we can use fromJson() in other valid places in queries
-            assert_rows(execute(cql, table, "SELECT asciival FROM %s WHERE k = fromJson(?)", "0"), ["ascii \" text"])
-            execute(cql, table, "UPDATE %s SET asciival = fromJson(?) WHERE k = fromJson(?)", "\"ascii \\\" text\"", "0")
+            assert_rows(
+                execute(
+                    cql, table, "SELECT asciival FROM %s WHERE k = fromJson(?)", "0"
+                ),
+                ['ascii " text'],
+            )
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET asciival = fromJson(?) WHERE k = fromJson(?)",
+                '"ascii \\" text"',
+                "0",
+            )
             execute(cql, table, "DELETE FROM %s WHERE k = fromJson(?)", "0")
 
             # ================ bigint ================
-            execute(cql, table, "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))", 0, "123123123123")
-            assert_rows(execute(cql, table, "SELECT k, bigintval FROM %s WHERE k = ?", 0), [0, 123123123123])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))",
+                0,
+                "123123123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, bigintval FROM %s WHERE k = ?", 0),
+                [0, 123123123123],
+            )
 
             # strings are also accepted
-            execute(cql, table, "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))", 0, "\"123123123123\"")
-            assert_rows(execute(cql, table, "SELECT k, bigintval FROM %s WHERE k = ?", 0), [0, 123123123123])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))",
+                0,
+                '"123123123123"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, bigintval FROM %s WHERE k = ?", 0),
+                [0, 123123123123],
+            )
 
             # overflow (Long.MAX_VALUE + 1)
             # Reproduces #7914
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))", 0, "9223372036854775808")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))",
+                0,
+                "9223372036854775808",
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))", 0, "123.456")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))", 0, "\"abc\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))", 0, "[\"abc\"]")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))",
+                0,
+                "123.456",
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))",
+                0,
+                '"abc"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, bigintval) VALUES (?, fromJson(?))",
+                0,
+                '["abc"]',
+            )
 
             # ================ blob ================
-            execute(cql, table, "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))", 0, "\"0x00000001\"")
-            assert_rows(execute(cql, table, "SELECT k, blobval FROM %s WHERE k = ?", 0), [0, bytearray([0,0,0,1])])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))",
+                0,
+                '"0x00000001"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, blobval FROM %s WHERE k = ?", 0),
+                [0, bytearray([0, 0, 0, 1])],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))", 0, "\"123\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))", 0, "\"0x123\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))",
+                0,
+                '"123"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))",
+                0,
+                '"0x123"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, blobval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
             # ================ boolean ================
-            execute(cql, table, "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))", 0, "true")
-            assert_rows(execute(cql, table, "SELECT k, booleanval FROM %s WHERE k = ?", 0), [0, True])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))",
+                0,
+                "true",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, booleanval FROM %s WHERE k = ?", 0),
+                [0, True],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))", 0, "false")
-            assert_rows(execute(cql, table, "SELECT k, booleanval FROM %s WHERE k = ?", 0), [0, False])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))",
+                0,
+                "false",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, booleanval FROM %s WHERE k = ?", 0),
+                [0, False],
+            )
 
             # strings are also accepted
             # Reproduces issue #7915
-            execute(cql, table, "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))", 0, "\"false\"")
-            assert_rows(execute(cql, table, "SELECT k, booleanval FROM %s WHERE k = ?", 0), [0, False])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))",
+                0,
+                '"false"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, booleanval FROM %s WHERE k = ?", 0),
+                [0, False],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))", 0, "\"abc\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))",
+                0,
+                '"abc"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, booleanval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
             # ================ date ================
-            execute(cql, table, "INSERT INTO %s (k, dateval) VALUES (?, fromJson(?))", 0, "\"1987-03-23\"")
-            assert_rows(execute(cql, table, "SELECT k, dateval FROM %s WHERE k = ?", 0), [0, Date("1987-03-23")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, dateval) VALUES (?, fromJson(?))",
+                0,
+                '"1987-03-23"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, dateval FROM %s WHERE k = ?", 0),
+                [0, Date("1987-03-23")],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, dateval) VALUES (?, fromJson(?))", 0, "123")
-            assert_invalid_throw_message(cql, table, "Unable to coerce 'xyz' to a formatted date", FunctionFailure,
-                "INSERT INTO %s (k, dateval) VALUES (?, fromJson(?))", 0, "\"xyz\"")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, dateval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
+            assert_invalid_throw_message(
+                cql,
+                table,
+                "Unable to coerce 'xyz' to a formatted date",
+                FunctionFailure,
+                "INSERT INTO %s (k, dateval) VALUES (?, fromJson(?))",
+                0,
+                '"xyz"',
+            )
 
             # ================ decimal ================
-            execute(cql, table, "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))", 0, "123123.123123")
-            assert_rows(execute(cql, table, "SELECT k, decimalval FROM %s WHERE k = ?", 0), [0, Decimal("123123.123123")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))",
+                0,
+                "123123.123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, decimalval FROM %s WHERE k = ?", 0),
+                [0, Decimal("123123.123123")],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))", 0, "123123")
-            assert_rows(execute(cql, table, "SELECT k, decimalval FROM %s WHERE k = ?", 0), [0, Decimal("123123")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))",
+                0,
+                "123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, decimalval FROM %s WHERE k = ?", 0),
+                [0, Decimal("123123")],
+            )
 
             # accept strings for numbers that cannot be represented as doubles
-            execute(cql, table, "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))", 0, "\"123123.123123\"")
-            assert_rows(execute(cql, table, "SELECT k, decimalval FROM %s WHERE k = ?", 0), [0, Decimal("123123.123123")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))",
+                0,
+                '"123123.123123"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, decimalval FROM %s WHERE k = ?", 0),
+                [0, Decimal("123123.123123")],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))", 0, "\"-1.23E-12\"")
-            assert_rows(execute(cql, table, "SELECT k, decimalval FROM %s WHERE k = ?", 0), [0, Decimal("-1.23E-12")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))",
+                0,
+                '"-1.23E-12"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, decimalval FROM %s WHERE k = ?", 0),
+                [0, Decimal("-1.23E-12")],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))", 0, "true")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, decimalval) VALUES (?, fromJson(?))",
+                0,
+                "true",
+            )
 
             # ================ double ================
-            execute(cql, table, "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))", 0, "123123.123123")
-            assert_rows(execute(cql, table, "SELECT k, doubleval FROM %s WHERE k = ?", 0), [0, 123123.123123])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))",
+                0,
+                "123123.123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, doubleval FROM %s WHERE k = ?", 0),
+                [0, 123123.123123],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))", 0, "123123")
-            assert_rows(execute(cql, table, "SELECT k, doubleval FROM %s WHERE k = ?", 0), [0, 123123.0])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))",
+                0,
+                "123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, doubleval FROM %s WHERE k = ?", 0),
+                [0, 123123.0],
+            )
 
             # strings are also accepted
-            execute(cql, table, "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))", 0, "\"123123\"")
-            assert_rows(execute(cql, table, "SELECT k, doubleval FROM %s WHERE k = ?", 0), [0, 123123.0])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))",
+                0,
+                '"123123"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, doubleval FROM %s WHERE k = ?", 0),
+                [0, 123123.0],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))", 0, "true")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, doubleval) VALUES (?, fromJson(?))",
+                0,
+                "true",
+            )
 
             # ================ float ================
-            execute(cql, table, "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))", 0, "123123.123123")
-            assert_rows(execute(cql, table, "SELECT k, floatval FROM %s WHERE k = ?", 0), [0, to_float(123123.123123)])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))",
+                0,
+                "123123.123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, floatval FROM %s WHERE k = ?", 0),
+                [0, to_float(123123.123123)],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))", 0, "123123")
-            assert_rows(execute(cql, table, "SELECT k, floatval FROM %s WHERE k = ?", 0), [0, to_float(123123.0)])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))",
+                0,
+                "123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, floatval FROM %s WHERE k = ?", 0),
+                [0, to_float(123123.0)],
+            )
 
             # strings are also accepted
-            execute(cql, table, "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))", 0, "\"123123.0\"")
-            assert_rows(execute(cql, table, "SELECT k, floatval FROM %s WHERE k = ?", 0), [0, to_float(123123.0)])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))",
+                0,
+                '"123123.0"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, floatval FROM %s WHERE k = ?", 0),
+                [0, to_float(123123.0)],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))", 0, "true")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, floatval) VALUES (?, fromJson(?))",
+                0,
+                "true",
+            )
 
             # ================ inet ================
-            execute(cql, table, "INSERT INTO %s (k, inetval) VALUES (?, fromJson(?))", 0, "\"127.0.0.1\"")
-            assert_rows(execute(cql, table, "SELECT k, inetval FROM %s WHERE k = ?", 0), [0, "127.0.0.1"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, inetval) VALUES (?, fromJson(?))",
+                0,
+                '"127.0.0.1"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, inetval FROM %s WHERE k = ?", 0),
+                [0, "127.0.0.1"],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, inetval) VALUES (?, fromJson(?))", 0, "\"::1\"")
-            assert_rows(execute(cql, table, "SELECT k, inetval FROM %s WHERE k = ?", 0), [0, "::1"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, inetval) VALUES (?, fromJson(?))",
+                0,
+                '"::1"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, inetval FROM %s WHERE k = ?", 0),
+                [0, "::1"],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, inetval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, inetval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, inetval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, inetval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
             # ================ int ================
-            execute(cql, table, "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))", 0, "123123")
-            assert_rows(execute(cql, table, "SELECT k, intval FROM %s WHERE k = ?", 0), [0, 123123])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))",
+                0,
+                "123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, intval FROM %s WHERE k = ?", 0),
+                [0, 123123],
+            )
 
             # strings are also accepted
-            execute(cql, table, "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))", 0, "\"123123\"")
-            assert_rows(execute(cql, table, "SELECT k, intval FROM %s WHERE k = ?", 0), [0, 123123])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))",
+                0,
+                '"123123"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, intval FROM %s WHERE k = ?", 0),
+                [0, 123123],
+            )
 
             # int overflow (2 ^ 32, or Integer.MAX_INT + 1)
             # Reproduces #7914
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))", 0, "2147483648")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))",
+                0,
+                "2147483648",
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                    "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))", 0, "123.456")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                    "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                    "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))", 0, "true")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))",
+                0,
+                "123.456",
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, intval) VALUES (?, fromJson(?))",
+                0,
+                "true",
+            )
 
             # ================ smallint ================
-            execute(cql, table, "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))", 0, "32767")
-            assert_rows(execute(cql, table, "SELECT k, smallintval FROM %s WHERE k = ?", 0), [0, 32767])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))",
+                0,
+                "32767",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, smallintval FROM %s WHERE k = ?", 0),
+                [0, 32767],
+            )
 
             # strings are also accepted
-            execute(cql, table, "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))", 0, "\"32767\"")
-            assert_rows(execute(cql, table, "SELECT k, smallintval FROM %s WHERE k = ?", 0), [0, 32767])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))",
+                0,
+                '"32767"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, smallintval FROM %s WHERE k = ?", 0),
+                [0, 32767],
+            )
 
             # smallint overflow (Short.MAX_VALUE + 1)
             # Reproduces #7914
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))", 0, "32768")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))",
+                0,
+                "32768",
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))", 0, "123.456")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))", 0, "true")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))",
+                0,
+                "123.456",
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, smallintval) VALUES (?, fromJson(?))",
+                0,
+                "true",
+            )
 
             # ================ tinyint ================
-            execute(cql, table, "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))", 0, "127")
-            assert_rows(execute(cql, table, "SELECT k, tinyintval FROM %s WHERE k = ?", 0), [0, 127])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))",
+                0,
+                "127",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, tinyintval FROM %s WHERE k = ?", 0),
+                [0, 127],
+            )
 
             # strings are also accepted
-            execute(cql, table, "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))", 0, "\"127\"")
-            assert_rows(execute(cql, table, "SELECT k, tinyintval FROM %s WHERE k = ?", 0), [0, 127])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))",
+                0,
+                '"127"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, tinyintval FROM %s WHERE k = ?", 0),
+                [0, 127],
+            )
 
             # tinyint overflow (Byte.MAX_VALUE + 1)
             # Reproduces #7914
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))", 0, "128")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))",
+                0,
+                "128",
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))", 0, "123.456")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))", 0, "true")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))",
+                0,
+                "123.456",
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, tinyintval) VALUES (?, fromJson(?))",
+                0,
+                "true",
+            )
 
             # ================ text (varchar) ================
-            execute(cql, table, "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))", 0, "\"\"")
-            assert_rows(execute(cql, table, "SELECT k, textval FROM %s WHERE k = ?", 0), [0, ""])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))",
+                0,
+                '""',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, textval FROM %s WHERE k = ?", 0), [0, ""]
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))", 0, "\"abcd\"")
-            assert_rows(execute(cql, table, "SELECT k, textval FROM %s WHERE k = ?", 0), [0, "abcd"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))",
+                0,
+                '"abcd"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, textval FROM %s WHERE k = ?", 0),
+                [0, "abcd"],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))", 0, "\"some \\\" text\"")
-            assert_rows(execute(cql, table, "SELECT k, textval FROM %s WHERE k = ?", 0), [0, "some \" text"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))",
+                0,
+                '"some \\" text"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, textval FROM %s WHERE k = ?", 0),
+                [0, 'some " text'],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))", 0, "\"\\u2013\"")
-            assert_rows(execute(cql, table, "SELECT k, textval FROM %s WHERE k = ?", 0), [0, "\u2013"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))",
+                0,
+                '"\\u2013"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, textval FROM %s WHERE k = ?", 0),
+                [0, "\u2013"],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, textval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
             # ================ time ================
-            execute(cql, table, "INSERT INTO %s (k, timeval) VALUES (?, fromJson(?))", 0, "\"07:35:07.000111222\"")
-            assert_rows(execute(cql, table, "SELECT k, timeval FROM %s WHERE k = ?", 0), [0, Time("07:35:07.000111222")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, timeval) VALUES (?, fromJson(?))",
+                0,
+                '"07:35:07.000111222"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, timeval FROM %s WHERE k = ?", 0),
+                [0, Time("07:35:07.000111222")],
+            )
 
             # Reproduces #7911
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, timeval) VALUES (?, fromJson(?))", 0, "123456")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, timeval) VALUES (?, fromJson(?))", 0, "\"xyz\"")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, timeval) VALUES (?, fromJson(?))",
+                0,
+                "123456",
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, timeval) VALUES (?, fromJson(?))",
+                0,
+                '"xyz"',
+            )
 
             # ================ timestamp ================
-            execute(cql, table, "INSERT INTO %s (k, timestampval) VALUES (?, fromJson(?))", 0, "123123123123")
-            assert_rows(execute(cql, table, "SELECT k, timestampval FROM %s WHERE k = ?", 0), [0, datetime.fromtimestamp(123123123123/1e3, timezone.utc)])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, timestampval) VALUES (?, fromJson(?))",
+                0,
+                "123123123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, timestampval FROM %s WHERE k = ?", 0),
+                [0, datetime.fromtimestamp(123123123123 / 1e3, timezone.utc)],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, timestampval) VALUES (?, fromJson(?))", 0, "\"2014-01-01\"")
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, timestampval) VALUES (?, fromJson(?))",
+                0,
+                '"2014-01-01"',
+            )
             # The following comparison is a big mess in Python because of
             # timezone issues. We need the datetime() object to have a UTC
             # timezone, but not to indicate that it does otherwise the
             # result will not compare equal. The following weird conversion
             # appears to do the right thing...
-            assert_rows(execute(cql, table, "SELECT k, timestampval FROM %s WHERE k = ?", 0), [0, datetime.fromtimestamp(datetime(2014, 1, 1, 0, 0, 0).timestamp(), timezone.utc)])
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, timestampval) VALUES (?, fromJson(?))", 0, "123.456")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, timestampval) VALUES (?, fromJson(?))", 0, "\"abcd\"")
+            assert_rows(
+                execute(cql, table, "SELECT k, timestampval FROM %s WHERE k = ?", 0),
+                [
+                    0,
+                    datetime.fromtimestamp(
+                        datetime(2014, 1, 1, 0, 0, 0).timestamp(), timezone.utc
+                    ),
+                ],
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, timestampval) VALUES (?, fromJson(?))",
+                0,
+                "123.456",
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, timestampval) VALUES (?, fromJson(?))",
+                0,
+                '"abcd"',
+            )
 
             # ================ timeuuid ================
-            execute(cql, table, "INSERT INTO %s (k, timeuuidval) VALUES (?, fromJson(?))", 0, "\"6bddc89a-5644-11e4-97fc-56847afe9799\"")
-            assert_rows(execute(cql, table, "SELECT k, timeuuidval FROM %s WHERE k = ?", 0), [0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, timeuuidval) VALUES (?, fromJson(?))",
+                0,
+                '"6bddc89a-5644-11e4-97fc-56847afe9799"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, timeuuidval FROM %s WHERE k = ?", 0),
+                [0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799")],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, timeuuidval) VALUES (?, fromJson(?))", 0, "\"6BDDC89A-5644-11E4-97FC-56847AFE9799\"")
-            assert_rows(execute(cql, table, "SELECT k, timeuuidval FROM %s WHERE k = ?", 0), [0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, timeuuidval) VALUES (?, fromJson(?))",
+                0,
+                '"6BDDC89A-5644-11E4-97FC-56847AFE9799"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, timeuuidval FROM %s WHERE k = ?", 0),
+                [0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799")],
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, timeuuidval) VALUES (?, fromJson(?))", 0, "\"00000000-0000-0000-0000-000000000000\"")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, timeuuidval) VALUES (?, fromJson(?))",
+                0,
+                '"00000000-0000-0000-0000-000000000000"',
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, timeuuidval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, timeuuidval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
-             # ================ uuidval ================
-            execute(cql, table, "INSERT INTO %s (k, uuidval) VALUES (?, fromJson(?))", 0, "\"6bddc89a-5644-11e4-97fc-56847afe9799\"")
-            assert_rows(execute(cql, table, "SELECT k, uuidval FROM %s WHERE k = ?", 0), [0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799")])
+            # ================ uuidval ================
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, uuidval) VALUES (?, fromJson(?))",
+                0,
+                '"6bddc89a-5644-11e4-97fc-56847afe9799"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, uuidval FROM %s WHERE k = ?", 0),
+                [0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799")],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, uuidval) VALUES (?, fromJson(?))", 0, "\"6BDDC89A-5644-11E4-97FC-56847AFE9799\"")
-            assert_rows(execute(cql, table, "SELECT k, uuidval FROM %s WHERE k = ?", 0), [0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799")])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, uuidval) VALUES (?, fromJson(?))",
+                0,
+                '"6BDDC89A-5644-11E4-97FC-56847AFE9799"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, uuidval FROM %s WHERE k = ?", 0),
+                [0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799")],
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, uuidval) VALUES (?, fromJson(?))", 0, "\"00000000-0000-0000-zzzz-000000000000\"")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, uuidval) VALUES (?, fromJson(?))",
+                0,
+                '"00000000-0000-0000-zzzz-000000000000"',
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, uuidval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, uuidval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
             # ================ varint ================
-            execute(cql, table, "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))", 0, "123123123123")
-            assert_rows(execute(cql, table, "SELECT k, varintval FROM %s WHERE k = ?", 0), [0, 123123123123])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))",
+                0,
+                "123123123123",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, varintval FROM %s WHERE k = ?", 0),
+                [0, 123123123123],
+            )
 
             # accept strings for numbers that cannot be represented as longs
-            execute(cql, table, "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))", 0, "\"1234567890123456789012345678901234567890\"")
-            assert_rows(execute(cql, table, "SELECT k, varintval FROM %s WHERE k = ?", 0), [0, 1234567890123456789012345678901234567890])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))",
+                0,
+                '"1234567890123456789012345678901234567890"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, varintval FROM %s WHERE k = ?", 0),
+                [0, 1234567890123456789012345678901234567890],
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))", 0, "123123.123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))",
+                0,
+                "123123.123",
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))", 0, "\"xyzz\"")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))",
+                0,
+                '"xyzz"',
+            )
 
             # reproduces #7944
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))", 0, "\"\"")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))",
+                0,
+                '""',
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))", 0, "true")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, varintval) VALUES (?, fromJson(?))",
+                0,
+                "true",
+            )
 
             # ================ lists ================
-            execute(cql, table, "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))", 0, "[1, 2, 3]")
-            assert_rows(execute(cql, table, "SELECT k, listval FROM %s WHERE k = ?", 0), [0, [1, 2, 3]])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))",
+                0,
+                "[1, 2, 3]",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, listval FROM %s WHERE k = ?", 0),
+                [0, [1, 2, 3]],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))", 0, "[]")
-            assert_rows(execute(cql, table, "SELECT k, listval FROM %s WHERE k = ?", 0), [0, None])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))",
+                0,
+                "[]",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, listval FROM %s WHERE k = ?", 0),
+                [0, None],
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))", 0, "[\"abc\"]")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))",
+                0,
+                '["abc"]',
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))", 0, "[null]")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, listval) VALUES (?, fromJson(?))",
+                0,
+                "[null]",
+            )
 
             # frozen
-            execute(cql, table, "INSERT INTO %s (k, frozenlistval) VALUES (?, fromJson(?))", 0, "[1, 2, 3]")
-            assert_rows(execute(cql, table, "SELECT k, frozenlistval FROM %s WHERE k = ?", 0), [0, [1, 2, 3]])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozenlistval) VALUES (?, fromJson(?))",
+                0,
+                "[1, 2, 3]",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, frozenlistval FROM %s WHERE k = ?", 0),
+                [0, [1, 2, 3]],
+            )
 
             # ================ sets ================
-            execute(cql, table, "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))",
-                0, "[\"6bddc89a-5644-11e4-97fc-56847afe9798\", \"6bddc89a-5644-11e4-97fc-56847afe9799\"]")
-            assert_rows(execute(cql, table, "SELECT k, setval FROM %s WHERE k = ?", 0),
-                [0, {UUID("6bddc89a-5644-11e4-97fc-56847afe9798"), (UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))",
+                0,
+                '["6bddc89a-5644-11e4-97fc-56847afe9798", "6bddc89a-5644-11e4-97fc-56847afe9799"]',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, setval FROM %s WHERE k = ?", 0),
+                [
+                    0,
+                    {
+                        UUID("6bddc89a-5644-11e4-97fc-56847afe9798"),
+                        (UUID("6bddc89a-5644-11e4-97fc-56847afe9799")),
+                    },
+                ],
+            )
 
             # duplicates are okay, just like in CQL
-            execute(cql, table, "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))",
-                0, "[\"6bddc89a-5644-11e4-97fc-56847afe9798\", \"6bddc89a-5644-11e4-97fc-56847afe9798\", \"6bddc89a-5644-11e4-97fc-56847afe9799\"]")
-            assert_rows(execute(cql, table, "SELECT k, setval FROM %s WHERE k = ?", 0),
-                [0, {UUID("6bddc89a-5644-11e4-97fc-56847afe9798"), (UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))",
+                0,
+                '["6bddc89a-5644-11e4-97fc-56847afe9798", "6bddc89a-5644-11e4-97fc-56847afe9798", "6bddc89a-5644-11e4-97fc-56847afe9799"]',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, setval FROM %s WHERE k = ?", 0),
+                [
+                    0,
+                    {
+                        UUID("6bddc89a-5644-11e4-97fc-56847afe9798"),
+                        (UUID("6bddc89a-5644-11e4-97fc-56847afe9799")),
+                    },
+                ],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))", 0, "[]")
-            assert_rows(execute(cql, table, "SELECT k, setval FROM %s WHERE k = ?", 0), [0, None])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))",
+                0,
+                "[]",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, setval FROM %s WHERE k = ?", 0),
+                [0, None],
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))", 0, "[\"abc\"]")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))",
+                0,
+                '["abc"]',
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))", 0, "[null]")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, setval) VALUES (?, fromJson(?))",
+                0,
+                "[null]",
+            )
 
             # frozen
-            execute(cql, table, "INSERT INTO %s (k, frozensetval) VALUES (?, fromJson(?))",
-                0, "[\"6bddc89a-5644-11e4-97fc-56847afe9798\", \"6bddc89a-5644-11e4-97fc-56847afe9799\"]")
-            assert_rows(execute(cql, table, "SELECT k, frozensetval FROM %s WHERE k = ?", 0),
-                [0, {UUID("6bddc89a-5644-11e4-97fc-56847afe9798"), (UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozensetval) VALUES (?, fromJson(?))",
+                0,
+                '["6bddc89a-5644-11e4-97fc-56847afe9798", "6bddc89a-5644-11e4-97fc-56847afe9799"]',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, frozensetval FROM %s WHERE k = ?", 0),
+                [
+                    0,
+                    {
+                        UUID("6bddc89a-5644-11e4-97fc-56847afe9798"),
+                        (UUID("6bddc89a-5644-11e4-97fc-56847afe9799")),
+                    },
+                ],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, frozensetval) VALUES (?, fromJson(?))",
-                0, "[\"6bddc89a-5644-11e4-97fc-56847afe9799\", \"6bddc89a-5644-11e4-97fc-56847afe9798\"]")
-            assert_rows(execute(cql, table, "SELECT k, frozensetval FROM %s WHERE k = ?", 0),
-                [0, {UUID("6bddc89a-5644-11e4-97fc-56847afe9798"), (UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozensetval) VALUES (?, fromJson(?))",
+                0,
+                '["6bddc89a-5644-11e4-97fc-56847afe9799", "6bddc89a-5644-11e4-97fc-56847afe9798"]',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, frozensetval FROM %s WHERE k = ?", 0),
+                [
+                    0,
+                    {
+                        UUID("6bddc89a-5644-11e4-97fc-56847afe9798"),
+                        (UUID("6bddc89a-5644-11e4-97fc-56847afe9799")),
+                    },
+                ],
+            )
 
             # ================ maps ================
             # Reproduces #7949:
-            execute(cql, table, "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))", 0, "{\"a\": 1, \"b\": 2}")
-            assert_rows(execute(cql, table, "SELECT k, mapval FROM %s WHERE k = ?", 0), [0, {"a": 1, "b": 2}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))",
+                0,
+                '{"a": 1, "b": 2}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, mapval FROM %s WHERE k = ?", 0),
+                [0, {"a": 1, "b": 2}],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))", 0, "{}")
-            assert_rows(execute(cql, table, "SELECT k, mapval FROM %s WHERE k = ?", 0), [0, None])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))",
+                0,
+                "{}",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, mapval FROM %s WHERE k = ?", 0),
+                [0, None],
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))", 0, "123")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))",
+                0,
+                "123",
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))", 0, "{\"\\u1fff\\u2013\\u33B4\\u2014\": 1}")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))",
+                0,
+                '{"\\u1fff\\u2013\\u33B4\\u2014": 1}',
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))", 0, "{\"a\": null}")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, mapval) VALUES (?, fromJson(?))",
+                0,
+                '{"a": null}',
+            )
 
             # frozen
             # Reproduces #7949:
-            execute(cql, table, "INSERT INTO %s (k, frozenmapval) VALUES (?, fromJson(?))", 0, "{\"a\": 1, \"b\": 2}")
-            assert_rows(execute(cql, table, "SELECT k, frozenmapval FROM %s WHERE k = ?", 0), [0, {"a": 1, "b": 2}])
-            execute(cql, table, "INSERT INTO %s (k, frozenmapval) VALUES (?, fromJson(?))", 0, "{\"b\": 2, \"a\": 1}")
-            assert_rows(execute(cql, table, "SELECT k, frozenmapval FROM %s WHERE k = ?", 0), [0, {"a": 1, "b": 2}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozenmapval) VALUES (?, fromJson(?))",
+                0,
+                '{"a": 1, "b": 2}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, frozenmapval FROM %s WHERE k = ?", 0),
+                [0, {"a": 1, "b": 2}],
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozenmapval) VALUES (?, fromJson(?))",
+                0,
+                '{"b": 2, "a": 1}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, frozenmapval FROM %s WHERE k = ?", 0),
+                [0, {"a": 1, "b": 2}],
+            )
 
             # ================ tuples ================
-            execute(cql, table, "INSERT INTO %s (k, tupleval) VALUES (?, fromJson(?))", 0, "[1, \"foobar\", \"6bddc89a-5644-11e4-97fc-56847afe9799\"]")
-            assert_rows(execute(cql, table, "SELECT k, tupleval FROM %s WHERE k = ?", 0),
-                [0, (1, "foobar", UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, tupleval) VALUES (?, fromJson(?))",
+                0,
+                '[1, "foobar", "6bddc89a-5644-11e4-97fc-56847afe9799"]',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, tupleval FROM %s WHERE k = ?", 0),
+                [0, (1, "foobar", UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))],
+            )
 
             # Reproduces #7954:
-            execute(cql, table, "INSERT INTO %s (k, tupleval) VALUES (?, fromJson(?))", 0, "[1, null, \"6bddc89a-5644-11e4-97fc-56847afe9799\"]")
-            assert_rows(execute(cql, table, "SELECT k, tupleval FROM %s WHERE k = ?", 0),
-                [0, (1, None, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))])
-
-            assert_invalid_throw(cql, table, FunctionFailure,
+            execute(
+                cql,
+                table,
                 "INSERT INTO %s (k, tupleval) VALUES (?, fromJson(?))",
-                0, "[1, \"foobar\", \"6bddc89a-5644-11e4-97fc-56847afe9799\", 1, 2, 3]")
+                0,
+                '[1, null, "6bddc89a-5644-11e4-97fc-56847afe9799"]',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, tupleval FROM %s WHERE k = ?", 0),
+                [0, (1, None, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))],
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
                 "INSERT INTO %s (k, tupleval) VALUES (?, fromJson(?))",
-                0, "[1, \"foobar\"]")
+                0,
+                '[1, "foobar", "6bddc89a-5644-11e4-97fc-56847afe9799", 1, 2, 3]',
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
                 "INSERT INTO %s (k, tupleval) VALUES (?, fromJson(?))",
-                0, "[\"not an int\", \"foobar\", \"6bddc89a-5644-11e4-97fc-56847afe9799\"]")
+                0,
+                '[1, "foobar"]',
+            )
+
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, tupleval) VALUES (?, fromJson(?))",
+                0,
+                '["not an int", "foobar", "6bddc89a-5644-11e4-97fc-56847afe9799"]',
+            )
 
             # ================ UDTs ================
-            execute(cql, table, "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))", 0, "{\"a\": 1, \"b\": \"6bddc89a-5644-11e4-97fc-56847afe9799\", \"c\": [\"foo\", \"bar\"]}")
-            assert_rows(execute(cql, table, "SELECT k, udtval.a, udtval.b, udtval.c FROM %s WHERE k = ?", 0),
-                [0, 1, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), {"bar", "foo"}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))",
+                0,
+                '{"a": 1, "b": "6bddc89a-5644-11e4-97fc-56847afe9799", "c": ["foo", "bar"]}',
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, udtval.a, udtval.b, udtval.c FROM %s WHERE k = ?",
+                    0,
+                ),
+                [0, 1, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), {"bar", "foo"}],
+            )
 
             # ================ duration ================
-            execute(cql, table, "INSERT INTO %s (k, durationval) VALUES (?, fromJson(?))", 0, "\"53us\"")
-            assert_rows(execute(cql, table, "SELECT k, durationval FROM %s WHERE k = ?", 0), [0, Duration(0, 0, 53000)])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, durationval) VALUES (?, fromJson(?))",
+                0,
+                '"53us"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, durationval FROM %s WHERE k = ?", 0),
+                [0, Duration(0, 0, 53000)],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, durationval) VALUES (?, fromJson(?))", 0, "\"P2W\"")
-            assert_rows(execute(cql, table,"SELECT k, durationval FROM %s WHERE k = ?", 0), [0, Duration(0, 14, 0)])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, durationval) VALUES (?, fromJson(?))",
+                0,
+                '"P2W"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, durationval FROM %s WHERE k = ?", 0),
+                [0, Duration(0, 14, 0)],
+            )
 
             # Unlike all the other cases of unsuccessful fromJson() parsing which return FunctionFailure,
             # in this specific case Cassandra returns InvalidQuery. I don't know why, and I don't think
             # Scylla needs to reproduce this idiosyncrasy. So let's allow both.
-            assert_invalid_throw(cql, table, (FunctionFailure, InvalidRequest),
-                "INSERT INTO %s (k, durationval) VALUES (?, fromJson(?))", 0, "\"xyz\"")
+            assert_invalid_throw(
+                cql,
+                table,
+                (FunctionFailure, InvalidRequest),
+                "INSERT INTO %s (k, durationval) VALUES (?, fromJson(?))",
+                0,
+                '"xyz"',
+            )
 
             # order of fields shouldn't matter
-            execute(cql, table, "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))", 0, "{\"b\": \"6bddc89a-5644-11e4-97fc-56847afe9799\", \"a\": 1, \"c\": [\"foo\", \"bar\"]}")
-            assert_rows(execute(cql, table, "SELECT k, udtval.a, udtval.b, udtval.c FROM %s WHERE k = ?", 0),
-                [0, 1, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), {"bar", "foo"}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))",
+                0,
+                '{"b": "6bddc89a-5644-11e4-97fc-56847afe9799", "a": 1, "c": ["foo", "bar"]}',
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, udtval.a, udtval.b, udtval.c FROM %s WHERE k = ?",
+                    0,
+                ),
+                [0, 1, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), {"bar", "foo"}],
+            )
 
             # test nulls
-            execute(cql, table, "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))", 0, "{\"a\": null, \"b\": \"6bddc89a-5644-11e4-97fc-56847afe9799\", \"c\": [\"foo\", \"bar\"]}")
-            assert_rows(execute(cql, table, "SELECT k, udtval.a, udtval.b, udtval.c FROM %s WHERE k = ?", 0),
-                [0, None, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), {"bar", "foo"}])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))",
+                0,
+                '{"a": null, "b": "6bddc89a-5644-11e4-97fc-56847afe9799", "c": ["foo", "bar"]}',
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, udtval.a, udtval.b, udtval.c FROM %s WHERE k = ?",
+                    0,
+                ),
+                [0, None, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), {"bar", "foo"}],
+            )
 
             # test missing fields
-            execute(cql, table, "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))", 0, "{\"a\": 1, \"b\": \"6bddc89a-5644-11e4-97fc-56847afe9799\"}")
-            assert_rows(execute(cql, table, "SELECT k, udtval.a, udtval.b, udtval.c FROM %s WHERE k = ?", 0),
-                [0, 1, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), None])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))",
+                0,
+                '{"a": 1, "b": "6bddc89a-5644-11e4-97fc-56847afe9799"}',
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, udtval.a, udtval.b, udtval.c FROM %s WHERE k = ?",
+                    0,
+                ),
+                [0, 1, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), None],
+            )
 
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))", 0, "{\"xxx\": 1}")
-            assert_invalid_throw(cql, table, FunctionFailure,
-                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))", 0, "{\"a\": \"foobar\"}")
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))",
+                0,
+                '{"xxx": 1}',
+            )
+            assert_invalid_throw(
+                cql,
+                table,
+                FunctionFailure,
+                "INSERT INTO %s (k, udtval) VALUES (?, fromJson(?))",
+                0,
+                '{"a": "foobar"}',
+            )
+
 
 # The following test will check the output of Cassandra's and Scylla's toJson()
 # function, which converts various types to JSON. However, obviously there is
@@ -652,16 +1925,19 @@ def testFromJsonFct(cql, test_keyspace):
 class EquivalentJson:
     def __init__(self, s):
         self.obj = json.loads(s)
+
     def __eq__(self, other):
         if isinstance(other, EquivalentJson):
             return self.obj == other.obj
         elif isinstance(other, str):
             return self.obj == json.loads(other)
         return NotImplemented
+
     # Implementing __repr__ is useful because when a comparison fails, pytest
     # helpfully prints what it tried to compare, and uses __repr__ for that.
     def __repr__(self):
         return f'EquivalentJson("{self.obj}")'
+
 
 # Similarly, EquivalentIp compares two JSON strings which are supposed to
 # contain an IP address. For example, "::1" and "0:0:0:0:0:0:0:1" are
@@ -669,6 +1945,7 @@ class EquivalentJson:
 class EquivalentIp:
     def __init__(self, s):
         self.obj = json.loads(s)
+
     def __eq__(self, other):
         if isinstance(other, EquivalentIp):
             otherobj = other.obj
@@ -679,278 +1956,692 @@ class EquivalentIp:
         if self.obj == otherobj:
             return True
         return getaddrinfo(self.obj, 0) == getaddrinfo(otherobj, 0)
+
     def __repr__(self):
         return f'EquivalentIp("{self.obj}")'
 
+
 # Reproduces issue #7972, #7988, #7997, #8001
-@pytest.mark.xfail(reason="issues #7997, #8001")
+@pytest.mark.xfail(
+    reason='toJson() is missing a timezone on timestamp #7997, Documented unit "µs" not supported for assigning a "duration" type #8001'
+)
 def testToJsonFct(cql, test_keyspace):
-    abc_tuple = collections.namedtuple('abc_tuple', ['a', 'b', 'c'])
+    abc_tuple = collections.namedtuple("abc_tuple", ["a", "b", "c"])
     with create_type(cql, test_keyspace, "(a int, b uuid, c set<text>)") as type_name:
-        with create_table(cql, test_keyspace, "(" +
-                "k int PRIMARY KEY, " +
-                "asciival ascii, " +
-                "bigintval bigint, " +
-                "blobval blob, " +
-                "booleanval boolean, " +
-                "dateval date, " +
-                "decimalval decimal, " +
-                "doubleval double, " +
-                "floatval float, " +
-                "inetval inet, " +
-                "intval int, " +
-                "smallintval smallint, " +
-                "textval text, " +
-                "timeval time, " +
-                "timestampval timestamp, " +
-                "timeuuidval timeuuid, " +
-                "tinyintval tinyint, " +
-                "uuidval uuid," +
-                "varcharval varchar, " +
-                "varintval varint, " +
-                "listval list<int>, " +
-                "frozenlistval frozen<list<int>>, " +
-                "setval set<uuid>, " +
-                "frozensetval frozen<set<uuid>>, " +
-                "mapval map<ascii, int>," +
-                "frozenmapval frozen<map<ascii, int>>," +
-                "tupleval frozen<tuple<int, ascii, uuid>>," +
-                "udtval frozen<" + type_name + ">," +
-                "durationval duration)") as table:
+        with create_table(
+            cql,
+            test_keyspace,
+            "("
+            + "k int PRIMARY KEY, "
+            + "asciival ascii, "
+            + "bigintval bigint, "
+            + "blobval blob, "
+            + "booleanval boolean, "
+            + "dateval date, "
+            + "decimalval decimal, "
+            + "doubleval double, "
+            + "floatval float, "
+            + "inetval inet, "
+            + "intval int, "
+            + "smallintval smallint, "
+            + "textval text, "
+            + "timeval time, "
+            + "timestampval timestamp, "
+            + "timeuuidval timeuuid, "
+            + "tinyintval tinyint, "
+            + "uuidval uuid,"
+            + "varcharval varchar, "
+            + "varintval varint, "
+            + "listval list<int>, "
+            + "frozenlistval frozen<list<int>>, "
+            + "setval set<uuid>, "
+            + "frozensetval frozen<set<uuid>>, "
+            + "mapval map<ascii, int>,"
+            + "frozenmapval frozen<map<ascii, int>>,"
+            + "tupleval frozen<tuple<int, ascii, uuid>>,"
+            + "udtval frozen<"
+            + type_name
+            + ">,"
+            + "durationval duration)",
+        ) as table:
             # toJson() can only be used in selections
             # The error message is slightly different in Cassandra and in
             # Scylla. It is "toJson() may only be used within the selection
             # clause" in Cassandra, "toJson() is only valid in SELECT clause"
             # in Scylla.
-            assert_invalid_message(cql, table, "clause",
-                "INSERT INTO %s (k, asciival) VALUES (?, toJson(?))", 0, 0)
-            assert_invalid_message(cql, table, "clause",
-                "UPDATE %s SET asciival = toJson(?) WHERE k = ?", 0, 0)
-            assert_invalid_message(cql, table, "clause",
-                "DELETE FROM %s WHERE k = fromJson(toJson(?))", 0)
+            assert_invalid_message(
+                cql,
+                table,
+                "clause",
+                "INSERT INTO %s (k, asciival) VALUES (?, toJson(?))",
+                0,
+                0,
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                "clause",
+                "UPDATE %s SET asciival = toJson(?) WHERE k = ?",
+                0,
+                0,
+            )
+            assert_invalid_message(
+                cql, table, "clause", "DELETE FROM %s WHERE k = fromJson(toJson(?))", 0
+            )
 
             # ================ ascii ================
-            execute(cql, table, "INSERT INTO %s (k, asciival) VALUES (?, ?)", 0, "ascii text")
-            assert_rows(execute(cql, table, "SELECT k, toJson(asciival) FROM %s WHERE k = ?", 0), [0, "\"ascii text\""])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, asciival) VALUES (?, ?)",
+                0,
+                "ascii text",
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(asciival) FROM %s WHERE k = ?", 0
+                ),
+                [0, '"ascii text"'],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, asciival) VALUES (?, ?)", 0, "")
-            assert_rows(execute(cql, table, "SELECT k, toJson(asciival) FROM %s WHERE k = ?", 0), [0, "\"\""])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(asciival) FROM %s WHERE k = ?", 0
+                ),
+                [0, '""'],
+            )
 
             # ================ bigint ================
-            execute(cql, table, "INSERT INTO %s (k, bigintval) VALUES (?, ?)", 0, 123123123123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(bigintval) FROM %s WHERE k = ?", 0), [0, "123123123123"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, bigintval) VALUES (?, ?)",
+                0,
+                123123123123,
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(bigintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "123123123123"],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, bigintval) VALUES (?, ?)", 0, 0)
-            assert_rows(execute(cql, table, "SELECT k, toJson(bigintval) FROM %s WHERE k = ?", 0), [0, "0"])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(bigintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "0"],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, bigintval) VALUES (?, ?)", 0, -123123123123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(bigintval) FROM %s WHERE k = ?", 0), [0, "-123123123123"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, bigintval) VALUES (?, ?)",
+                0,
+                -123123123123,
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(bigintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "-123123123123"],
+            )
 
             # ================ blob ================
-            execute(cql, table, "INSERT INTO %s (k, blobval) VALUES (?, ?)", 0, bytearray([0,0,0,1]))
-            assert_rows(execute(cql, table, "SELECT k, toJson(blobval) FROM %s WHERE k = ?", 0), [0, "\"0x00000001\""])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, blobval) VALUES (?, ?)",
+                0,
+                bytearray([0, 0, 0, 1]),
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(blobval) FROM %s WHERE k = ?", 0),
+                [0, '"0x00000001"'],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, blobval) VALUES (?, ?)", 0, bytearray())
-            assert_rows(execute(cql, table, "SELECT k, toJson(blobval) FROM %s WHERE k = ?", 0), [0, "\"0x\""])
+            execute(
+                cql, table, "INSERT INTO %s (k, blobval) VALUES (?, ?)", 0, bytearray()
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(blobval) FROM %s WHERE k = ?", 0),
+                [0, '"0x"'],
+            )
 
             # ================ boolean ================
             execute(cql, table, "INSERT INTO %s (k, booleanval) VALUES (?, ?)", 0, True)
-            assert_rows(execute(cql, table, "SELECT k, toJson(booleanval) FROM %s WHERE k = ?", 0), [0, "true"])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(booleanval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "true"],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, booleanval) VALUES (?, ?)", 0, False)
-            assert_rows(execute(cql, table, "SELECT k, toJson(booleanval) FROM %s WHERE k = ?", 0), [0, "false"])
+            execute(
+                cql, table, "INSERT INTO %s (k, booleanval) VALUES (?, ?)", 0, False
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(booleanval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "false"],
+            )
 
             # ================ date ================
-            execute(cql, table, "INSERT INTO %s (k, dateval) VALUES (?, ?)", 0, Date("1987-03-23"))
-            assert_rows(execute(cql, table, "SELECT k, toJson(dateval) FROM %s WHERE k = ?", 0), [0, "\"1987-03-23\""])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, dateval) VALUES (?, ?)",
+                0,
+                Date("1987-03-23"),
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(dateval) FROM %s WHERE k = ?", 0),
+                [0, '"1987-03-23"'],
+            )
 
             # ================ decimal ================
-            execute(cql, table, "INSERT INTO %s (k, decimalval) VALUES (?, ?)", 0, Decimal("123123.123123"))
-            assert_rows(execute(cql, table, "SELECT k, toJson(decimalval) FROM %s WHERE k = ?", 0), [0, "123123.123123"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, decimalval) VALUES (?, ?)",
+                0,
+                Decimal("123123.123123"),
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(decimalval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "123123.123123"],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, decimalval) VALUES (?, ?)", 0, Decimal("-1.23E-12"))
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, decimalval) VALUES (?, ?)",
+                0,
+                Decimal("-1.23E-12"),
+            )
             # Scylla may print floating-point numbers with different choice
             # of capitalization, exponent, etc, so we use EquivalentJson.
             # Note that some representations may be equivalent, but
             # objectively bad - see issue #80002.
-            assert_rows(execute(cql, table, "SELECT k, toJson(decimalval) FROM %s WHERE k = ?", 0), [0, EquivalentJson("-1.23E-12")])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(decimalval) FROM %s WHERE k = ?", 0
+                ),
+                [0, EquivalentJson("-1.23E-12")],
+            )
 
             # ================ double ================
             # Reproduces #7972:
-            execute(cql, table, "INSERT INTO %s (k, doubleval) VALUES (?, ?)", 0, 123123.123123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(doubleval) FROM %s WHERE k = ?", 0), [0, "123123.123123"])
-            execute(cql, table, "INSERT INTO %s (k, doubleval) VALUES (?, ?)", 0, 123123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(doubleval) FROM %s WHERE k = ?", 0), [0, "123123.0"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, doubleval) VALUES (?, ?)",
+                0,
+                123123.123123,
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(doubleval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "123123.123123"],
+            )
+            execute(
+                cql, table, "INSERT INTO %s (k, doubleval) VALUES (?, ?)", 0, 123123
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(doubleval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "123123.0"],
+            )
 
             # ================ float ================
-            execute(cql, table, "INSERT INTO %s (k, floatval) VALUES (?, ?)", 0, 123.123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(floatval) FROM %s WHERE k = ?", 0), [0, "123.123"])
+            execute(
+                cql, table, "INSERT INTO %s (k, floatval) VALUES (?, ?)", 0, 123.123
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(floatval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "123.123"],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, floatval) VALUES (?, ?)", 0, 123123)
             # Cassandra prints "123123.0", Scylla prints "123123". Since JSON
             # does not have a distinction between integers and floating point,
             # this difference is fine.
-            assert_rows(execute(cql, table, "SELECT k, toJson(floatval) FROM %s WHERE k = ?", 0), [0, EquivalentJson("123123.0")])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(floatval) FROM %s WHERE k = ?", 0
+                ),
+                [0, EquivalentJson("123123.0")],
+            )
 
             # ================ inet ================
-            execute(cql, table, "INSERT INTO %s (k, inetval) VALUES (?, ?)", 0, "127.0.0.1")
-            assert_rows(execute(cql, table, "SELECT k, toJson(inetval) FROM %s WHERE k = ?", 0), [0, "\"127.0.0.1\""])
+            execute(
+                cql, table, "INSERT INTO %s (k, inetval) VALUES (?, ?)", 0, "127.0.0.1"
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(inetval) FROM %s WHERE k = ?", 0),
+                [0, '"127.0.0.1"'],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, inetval) VALUES (?, ?)", 0, "::1")
             # Cassandra prints ::1 as "0:0:0:0:0:0:0:1", Scylla as "::1", both
             # are fine... We need to compare them using IP address equivalence
             # test...
-            assert_rows(execute(cql, table, "SELECT k, toJson(inetval) FROM %s WHERE k = ?", 0), [0, EquivalentIp("\"0:0:0:0:0:0:0:1\"")])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(inetval) FROM %s WHERE k = ?", 0),
+                [0, EquivalentIp('"0:0:0:0:0:0:0:1"')],
+            )
 
             # ================ int ================
             execute(cql, table, "INSERT INTO %s (k, intval) VALUES (?, ?)", 0, 123123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(intval) FROM %s WHERE k = ?", 0), [0, "123123"])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(intval) FROM %s WHERE k = ?", 0),
+                [0, "123123"],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, intval) VALUES (?, ?)", 0, 0)
-            assert_rows(execute(cql, table, "SELECT k, toJson(intval) FROM %s WHERE k = ?", 0), [0, "0"])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(intval) FROM %s WHERE k = ?", 0),
+                [0, "0"],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, intval) VALUES (?, ?)", 0, -123123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(intval) FROM %s WHERE k = ?", 0), [0, "-123123"])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(intval) FROM %s WHERE k = ?", 0),
+                [0, "-123123"],
+            )
 
             # ================ smallint ================
-            execute(cql, table, "INSERT INTO %s (k, smallintval) VALUES (?, ?)", 0, 32767)
-            assert_rows(execute(cql, table, "SELECT k, toJson(smallintval) FROM %s WHERE k = ?", 0), [0, "32767"])
+            execute(
+                cql, table, "INSERT INTO %s (k, smallintval) VALUES (?, ?)", 0, 32767
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(smallintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "32767"],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, smallintval) VALUES (?, ?)", 0, 0)
-            assert_rows(execute(cql, table, "SELECT k, toJson(smallintval) FROM %s WHERE k = ?", 0), [0, "0"])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(smallintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "0"],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, smallintval) VALUES (?, ?)", 0, -32768)
-            assert_rows(execute(cql, table, "SELECT k, toJson(smallintval) FROM %s WHERE k = ?", 0), [0, "-32768"])
+            execute(
+                cql, table, "INSERT INTO %s (k, smallintval) VALUES (?, ?)", 0, -32768
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(smallintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "-32768"],
+            )
 
             # ================ tinyint ================
             execute(cql, table, "INSERT INTO %s (k, tinyintval) VALUES (?, ?)", 0, 127)
-            assert_rows(execute(cql, table, "SELECT k, toJson(tinyintval) FROM %s WHERE k = ?", 0), [0, "127"])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(tinyintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "127"],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, tinyintval) VALUES (?, ?)", 0, 0)
-            assert_rows(execute(cql, table, "SELECT k, toJson(tinyintval) FROM %s WHERE k = ?", 0), [0, "0"])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(tinyintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "0"],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, tinyintval) VALUES (?, ?)", 0, -128)
-            assert_rows(execute(cql, table, "SELECT k, toJson(tinyintval) FROM %s WHERE k = ?", 0), [0, "-128"])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(tinyintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "-128"],
+            )
 
             # ================ text (varchar) ================
             execute(cql, table, "INSERT INTO %s (k, textval) VALUES (?, ?)", 0, "")
-            assert_rows(execute(cql, table, "SELECT k, toJson(textval) FROM %s WHERE k = ?", 0), [0, "\"\""])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(textval) FROM %s WHERE k = ?", 0),
+                [0, '""'],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, textval) VALUES (?, ?)", 0, "abcd")
-            assert_rows(execute(cql, table, "SELECT k, toJson(textval) FROM %s WHERE k = ?", 0), [0, "\"abcd\""])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(textval) FROM %s WHERE k = ?", 0),
+                [0, '"abcd"'],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, textval) VALUES (?, ?)", 0, "\u8422")
-            assert_rows(execute(cql, table, "SELECT k, toJson(textval) FROM %s WHERE k = ?", 0), [0, "\"\u8422\""])
+            execute(
+                cql, table, "INSERT INTO %s (k, textval) VALUES (?, ?)", 0, "\u8422"
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(textval) FROM %s WHERE k = ?", 0),
+                [0, '"\u8422"'],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, textval) VALUES (?, ?)", 0, "\u0000")
-            assert_rows(execute(cql, table, "SELECT k, toJson(textval) FROM %s WHERE k = ?", 0), [0, "\"\\u0000\""])
+            execute(
+                cql, table, "INSERT INTO %s (k, textval) VALUES (?, ?)", 0, "\u0000"
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(textval) FROM %s WHERE k = ?", 0),
+                [0, '"\\u0000"'],
+            )
 
             # ================ time ================
             # Reproduces #7988:
             execute(cql, table, "INSERT INTO %s (k, timeval) VALUES (?, ?)", 0, 123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(timeval) FROM %s WHERE k = ?", 0), [0, "\"00:00:00.000000123\""])
-            execute(cql, table, "INSERT INTO %s (k, timeval) VALUES (?, fromJson(?))", 0, "\"07:35:07.000111222\"")
-            assert_rows(execute(cql, table, "SELECT k, toJson(timeval) FROM %s WHERE k = ?", 0), [0, "\"07:35:07.000111222\""])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(timeval) FROM %s WHERE k = ?", 0),
+                [0, '"00:00:00.000000123"'],
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, timeval) VALUES (?, fromJson(?))",
+                0,
+                '"07:35:07.000111222"',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(timeval) FROM %s WHERE k = ?", 0),
+                [0, '"07:35:07.000111222"'],
+            )
 
             # ================ timestamp ================
             # Reproduces #7997:
-            execute(cql, table, "INSERT INTO %s (k, timestampval) VALUES (?, ?)", 0, datetime(2014, 1, 1, 0, 0, 0))
-            assert_rows(execute(cql, table, "SELECT k, toJson(timestampval) FROM %s WHERE k = ?", 0), [0, "\"2014-01-01 00:00:00.000Z\""])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, timestampval) VALUES (?, ?)",
+                0,
+                datetime(2014, 1, 1, 0, 0, 0),
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(timestampval) FROM %s WHERE k = ?", 0
+                ),
+                [0, '"2014-01-01 00:00:00.000Z"'],
+            )
 
             # ================ timeuuid ================
-            execute(cql, table, "INSERT INTO %s (k, timeuuidval) VALUES (?, ?)", 0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))
-            assert_rows(execute(cql, table, "SELECT k, toJson(timeuuidval) FROM %s WHERE k = ?", 0), [0, "\"6bddc89a-5644-11e4-97fc-56847afe9799\""])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, timeuuidval) VALUES (?, ?)",
+                0,
+                UUID("6bddc89a-5644-11e4-97fc-56847afe9799"),
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(timeuuidval) FROM %s WHERE k = ?", 0
+                ),
+                [0, '"6bddc89a-5644-11e4-97fc-56847afe9799"'],
+            )
 
             # ================ uuidval ================
-            execute(cql, table, "INSERT INTO %s (k, uuidval) VALUES (?, ?)", 0, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))
-            assert_rows(execute(cql, table, "SELECT k, toJson(uuidval) FROM %s WHERE k = ?", 0), [0, "\"6bddc89a-5644-11e4-97fc-56847afe9799\""])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, uuidval) VALUES (?, ?)",
+                0,
+                UUID("6bddc89a-5644-11e4-97fc-56847afe9799"),
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(uuidval) FROM %s WHERE k = ?", 0),
+                [0, '"6bddc89a-5644-11e4-97fc-56847afe9799"'],
+            )
 
             # ================ varint ================
-            execute(cql, table, "INSERT INTO %s (k, varintval) VALUES (?, ?)", 0, 123123123123123123123)
-            assert_rows(execute(cql, table, "SELECT k, toJson(varintval) FROM %s WHERE k = ?", 0), [0, "123123123123123123123"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, varintval) VALUES (?, ?)",
+                0,
+                123123123123123123123,
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(varintval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "123123123123123123123"],
+            )
 
             # ================ lists ================
-            execute(cql, table, "INSERT INTO %s (k, listval) VALUES (?, ?)", 0, [1, 2, 3])
-            assert_rows(execute(cql, table, "SELECT k, toJson(listval) FROM %s WHERE k = ?", 0), [0, "[1, 2, 3]"])
+            execute(
+                cql, table, "INSERT INTO %s (k, listval) VALUES (?, ?)", 0, [1, 2, 3]
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(listval) FROM %s WHERE k = ?", 0),
+                [0, "[1, 2, 3]"],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, listval) VALUES (?, ?)", 0, [])
-            assert_rows(execute(cql, table, "SELECT k, toJson(listval) FROM %s WHERE k = ?", 0), [0, "null"])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(listval) FROM %s WHERE k = ?", 0),
+                [0, "null"],
+            )
 
             # frozen
-            execute(cql, table, "INSERT INTO %s (k, frozenlistval) VALUES (?, ?)", 0, [1, 2, 3])
-            assert_rows(execute(cql, table, "SELECT k, toJson(frozenlistval) FROM %s WHERE k = ?", 0), [0, "[1, 2, 3]"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozenlistval) VALUES (?, ?)",
+                0,
+                [1, 2, 3],
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(frozenlistval) FROM %s WHERE k = ?", 0
+                ),
+                [0, "[1, 2, 3]"],
+            )
 
             # ================ sets ================
-            execute(cql, table, "INSERT INTO %s (k, setval) VALUES (?, ?)",
-                0, {UUID("6bddc89a-5644-11e4-97fc-56847afe9798"), UUID("6bddc89a-5644-11e4-97fc-56847afe9799")})
-            assert_rows(execute(cql, table, "SELECT k, toJson(setval) FROM %s WHERE k = ?", 0),
-                [0, "[\"6bddc89a-5644-11e4-97fc-56847afe9798\", \"6bddc89a-5644-11e4-97fc-56847afe9799\"]"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, setval) VALUES (?, ?)",
+                0,
+                {
+                    UUID("6bddc89a-5644-11e4-97fc-56847afe9798"),
+                    UUID("6bddc89a-5644-11e4-97fc-56847afe9799"),
+                },
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(setval) FROM %s WHERE k = ?", 0),
+                [
+                    0,
+                    '["6bddc89a-5644-11e4-97fc-56847afe9798", "6bddc89a-5644-11e4-97fc-56847afe9799"]',
+                ],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, setval) VALUES (?, ?)", 0, {})
-            assert_rows(execute(cql, table, "SELECT k, toJson(setval) FROM %s WHERE k = ?", 0), [0, "null"])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(setval) FROM %s WHERE k = ?", 0),
+                [0, "null"],
+            )
 
             # frozen
-            execute(cql, table, "INSERT INTO %s (k, frozensetval) VALUES (?, ?)",
-                0, {UUID("6bddc89a-5644-11e4-97fc-56847afe9798"), UUID("6bddc89a-5644-11e4-97fc-56847afe9799")})
-            assert_rows(execute(cql, table, "SELECT k, toJson(frozensetval) FROM %s WHERE k = ?", 0),
-                [0, "[\"6bddc89a-5644-11e4-97fc-56847afe9798\", \"6bddc89a-5644-11e4-97fc-56847afe9799\"]"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozensetval) VALUES (?, ?)",
+                0,
+                {
+                    UUID("6bddc89a-5644-11e4-97fc-56847afe9798"),
+                    UUID("6bddc89a-5644-11e4-97fc-56847afe9799"),
+                },
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(frozensetval) FROM %s WHERE k = ?", 0
+                ),
+                [
+                    0,
+                    '["6bddc89a-5644-11e4-97fc-56847afe9798", "6bddc89a-5644-11e4-97fc-56847afe9799"]',
+                ],
+            )
 
             # ================ maps ================
-            execute(cql, table, "INSERT INTO %s (k, mapval) VALUES (?, ?)", 0, {"a": 1, "b": 2})
-            assert_rows(execute(cql, table, "SELECT k, toJson(mapval) FROM %s WHERE k = ?", 0), [0, "{\"a\": 1, \"b\": 2}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, mapval) VALUES (?, ?)",
+                0,
+                {"a": 1, "b": 2},
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(mapval) FROM %s WHERE k = ?", 0),
+                [0, '{"a": 1, "b": 2}'],
+            )
 
             execute(cql, table, "INSERT INTO %s (k, mapval) VALUES (?, ?)", 0, {})
-            assert_rows(execute(cql, table, "SELECT k, toJson(mapval) FROM %s WHERE k = ?", 0), [0, "null"])
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(mapval) FROM %s WHERE k = ?", 0),
+                [0, "null"],
+            )
 
             # frozen
-            execute(cql, table, "INSERT INTO %s (k, frozenmapval) VALUES (?, ?)", 0, {"a": 1, "b": 2})
-            assert_rows(execute(cql, table, "SELECT k, toJson(frozenmapval) FROM %s WHERE k = ?", 0), [0, "{\"a\": 1, \"b\": 2}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, frozenmapval) VALUES (?, ?)",
+                0,
+                {"a": 1, "b": 2},
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(frozenmapval) FROM %s WHERE k = ?", 0
+                ),
+                [0, '{"a": 1, "b": 2}'],
+            )
 
             # ================ tuples ================
-            execute(cql, table, "INSERT INTO %s (k, tupleval) VALUES (?, ?)", 0, (1, "foobar", UUID("6bddc89a-5644-11e4-97fc-56847afe9799")))
-            assert_rows(execute(cql, table, "SELECT k, toJson(tupleval) FROM %s WHERE k = ?", 0),
-                [0, "[1, \"foobar\", \"6bddc89a-5644-11e4-97fc-56847afe9799\"]"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, tupleval) VALUES (?, ?)",
+                0,
+                (1, "foobar", UUID("6bddc89a-5644-11e4-97fc-56847afe9799")),
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(tupleval) FROM %s WHERE k = ?", 0
+                ),
+                [0, '[1, "foobar", "6bddc89a-5644-11e4-97fc-56847afe9799"]'],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, tupleval) VALUES (?, ?)", 0, (1, "foobar", None))
-            assert_rows(execute(cql, table, "SELECT k, toJson(tupleval) FROM %s WHERE k = ?", 0),
-                [0, "[1, \"foobar\", null]"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, tupleval) VALUES (?, ?)",
+                0,
+                (1, "foobar", None),
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(tupleval) FROM %s WHERE k = ?", 0
+                ),
+                [0, '[1, "foobar", null]'],
+            )
 
             # ================ UDTs ================
-            execute(cql, table, "INSERT INTO %s (k, udtval) VALUES (?, {a: ?, b: ?, c: ?})", 0, 1, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"), {"foo", "bar"})
-            assert_rows(execute(cql, table, "SELECT k, toJson(udtval) FROM %s WHERE k = ?", 0),
-                [0, "{\"a\": 1, \"b\": \"6bddc89a-5644-11e4-97fc-56847afe9799\", \"c\": [\"bar\", \"foo\"]}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, udtval) VALUES (?, {a: ?, b: ?, c: ?})",
+                0,
+                1,
+                UUID("6bddc89a-5644-11e4-97fc-56847afe9799"),
+                {"foo", "bar"},
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(udtval) FROM %s WHERE k = ?", 0),
+                [
+                    0,
+                    '{"a": 1, "b": "6bddc89a-5644-11e4-97fc-56847afe9799", "c": ["bar", "foo"]}',
+                ],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, udtval) VALUES (?, {a: ?, b: ?})", 0, 1, UUID("6bddc89a-5644-11e4-97fc-56847afe9799"))
-            assert_rows(execute(cql, table, "SELECT k, toJson(udtval) FROM %s WHERE k = ?", 0),
-                [0, "{\"a\": 1, \"b\": \"6bddc89a-5644-11e4-97fc-56847afe9799\", \"c\": null}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, udtval) VALUES (?, {a: ?, b: ?})",
+                0,
+                1,
+                UUID("6bddc89a-5644-11e4-97fc-56847afe9799"),
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, toJson(udtval) FROM %s WHERE k = ?", 0),
+                [0, '{"a": 1, "b": "6bddc89a-5644-11e4-97fc-56847afe9799", "c": null}'],
+            )
 
             # ================ duration ================
             # Reproduces #8001:
             execute(cql, table, "INSERT INTO %s (k, durationval) VALUES (?, 12µs)", 0)
-            assert_rows(execute(cql, table, "SELECT k, toJson(durationval) FROM %s WHERE k = ?", 0), [0, "\"12us\""])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(durationval) FROM %s WHERE k = ?", 0
+                ),
+                [0, '"12us"'],
+            )
 
-            execute(cql, table, "INSERT INTO %s (k, durationval) VALUES (?, P1Y1M2DT10H5M)", 0)
-            assert_rows(execute(cql, table, "SELECT k, toJson(durationval) FROM %s WHERE k = ?", 0), [0, "\"1y1mo2d10h5m\""])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, durationval) VALUES (?, P1Y1M2DT10H5M)",
+                0,
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, toJson(durationval) FROM %s WHERE k = ?", 0
+                ),
+                [0, '"1y1mo2d10h5m"'],
+            )
+
 
 # Reproduces issue #8077
 def testJsonWithGroupBy(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))"
+    ) as table:
         # tests SELECT JSON statements
         execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (0, 0, 0)")
         execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (0, 1, 1)")
         execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (1, 0, 1)")
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON * FROM %s GROUP BY k"),
-                   ["{\"k\": 0, \"c\": 0, \"v\": 0}"],
-                   ["{\"k\": 1, \"c\": 0, \"v\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON * FROM %s GROUP BY k"),
+            ['{"k": 0, "c": 0, "v": 0}'],
+            ['{"k": 1, "c": 0, "v": 1}'],
+        )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON k, c, v FROM %s GROUP BY k"),
-                   ["{\"k\": 0, \"c\": 0, \"v\": 0}"],
-                   ["{\"k\": 1, \"c\": 0, \"v\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON k, c, v FROM %s GROUP BY k"),
+            ['{"k": 0, "c": 0, "v": 0}'],
+            ['{"k": 1, "c": 0, "v": 1}'],
+        )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON count(*) FROM %s GROUP BY k"),
-                ["{\"count\": 2}"],
-                ["{\"count\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON count(*) FROM %s GROUP BY k"),
+            ['{"count": 2}'],
+            ['{"count": 1}'],
+        )
+
 
 # Reproduces issues #8077, #8078
 def testSelectJsonSyntax(cql, test_keyspace):
@@ -959,291 +2650,582 @@ def testSelectJsonSyntax(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (k, v) VALUES (0, 0)")
         execute(cql, table, "INSERT INTO %s (k, v) VALUES (1, 1)")
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON * FROM %s"),
-                ["{\"k\": 0, \"v\": 0}"],
-                ["{\"k\": 1, \"v\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON * FROM %s"),
+            ['{"k": 0, "v": 0}'],
+            ['{"k": 1, "v": 1}'],
+        )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON k, v FROM %s"),
-                ["{\"k\": 0, \"v\": 0}"],
-                ["{\"k\": 1, \"v\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON k, v FROM %s"),
+            ['{"k": 0, "v": 0}'],
+            ['{"k": 1, "v": 1}'],
+        )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON v, k FROM %s"),
-                ["{\"v\": 0, \"k\": 0}"],
-                ["{\"v\": 1, \"k\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON v, k FROM %s"),
+            ['{"v": 0, "k": 0}'],
+            ['{"v": 1, "k": 1}'],
+        )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON v as foo, k as bar FROM %s"),
-                ["{\"foo\": 0, \"bar\": 0}"],
-                ["{\"foo\": 1, \"bar\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON v as foo, k as bar FROM %s"),
+            ['{"foo": 0, "bar": 0}'],
+            ['{"foo": 1, "bar": 1}'],
+        )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON ttl(v), k FROM %s"),
-                ["{\"ttl(v)\": null, \"k\": 0}"],
-                ["{\"ttl(v)\": null, \"k\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON ttl(v), k FROM %s"),
+            ['{"ttl(v)": null, "k": 0}'],
+            ['{"ttl(v)": null, "k": 1}'],
+        )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON ttl(v) as foo, k FROM %s"),
-                ["{\"foo\": null, \"k\": 0}"],
-                ["{\"foo\": null, \"k\": 1}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON ttl(v) as foo, k FROM %s"),
+            ['{"foo": null, "k": 0}'],
+            ['{"foo": null, "k": 1}'],
+        )
 
         # Reproduces #8077:
-        assert_rows(execute(cql, table, "SELECT JSON count(*) FROM %s"),
-                ["{\"count\": 2}"])
+        assert_rows(
+            execute(cql, table, "SELECT JSON count(*) FROM %s"), ['{"count": 2}']
+        )
 
-        assert_rows(execute(cql, table, "SELECT JSON count(*) as foo FROM %s"),
-                ["{\"foo\": 2}"])
+        assert_rows(
+            execute(cql, table, "SELECT JSON count(*) as foo FROM %s"), ['{"foo": 2}']
+        )
 
         # Reproduces #8077:
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON toJson(blobAsInt(intAsBlob(v))) FROM %s"),
-                ["{\"system.tojson(system.blobasint(system.intasblob(v)))\": \"0\"}"],
-                ["{\"system.tojson(system.blobasint(system.intasblob(v)))\": \"1\"}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON toJson(blobAsInt(intAsBlob(v))) FROM %s"),
+            ['{"system.tojson(system.blobasint(system.intasblob(v)))": "0"}'],
+            ['{"system.tojson(system.blobasint(system.intasblob(v)))": "1"}'],
+        )
+
 
 # Reproduces issues #8085
-@pytest.mark.xfail(reason="issues #8085")
+@pytest.mark.xfail(
+    reason="INSERT JSON with bad arguments should yield InvalidRequest error, not internal error #8085"
+)
 def testInsertJsonSyntax(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"v\": 0}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "v": 0}')
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, 0])
 
         # without specifying column names
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"v\": 0}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "v": 0}')
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, 0])
 
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"v\": null}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "v": null}')
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, None])
 
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"v\": 1, \"k\": 0}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"v": 1, "k": 0}')
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, 1])
 
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0}')
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, None])
 
-        assert_invalid_message(cql, table, "JSON values map contains unrecognized column",
-                "INSERT INTO %s JSON ?",
-                "{\"k\": 0, \"v\": 0, \"zzz\": 0}")
+        assert_invalid_message(
+            cql,
+            table,
+            "JSON values map contains unrecognized column",
+            "INSERT INTO %s JSON ?",
+            '{"k": 0, "v": 0, "zzz": 0}',
+        )
 
         # Reproduces issue #8085: it's not very important which specific
         # error message the following requests generate, but it's important
         # that it's an InvalidRequest error, not some internal server error.
-        assert_invalid_message(cql, table, "Got null for INSERT JSON values", "INSERT INTO %s JSON ?", None)
-        assert_invalid_message(cql, table, "Got null for INSERT JSON values", "INSERT INTO %s JSON ?", "null")
-        assert_invalid_message(cql, table, "Could not decode JSON string as a map", "INSERT INTO %s JSON ?", "\"notamap\"")
-        assert_invalid_message(cql, table, "Could not decode JSON string as a map", "INSERT INTO %s JSON ?", "12.34")
-        assert_invalid_message(cql, table, "Unable to make int from",
-                "INSERT INTO %s JSON ?",
-                "{\"k\": 0, \"v\": \"notanint\"}")
+        assert_invalid_message(
+            cql, table, "Got null for INSERT JSON values", "INSERT INTO %s JSON ?", None
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Got null for INSERT JSON values",
+            "INSERT INTO %s JSON ?",
+            "null",
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Could not decode JSON string as a map",
+            "INSERT INTO %s JSON ?",
+            '"notamap"',
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Could not decode JSON string as a map",
+            "INSERT INTO %s JSON ?",
+            "12.34",
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Unable to make int from",
+            "INSERT INTO %s JSON ?",
+            '{"k": 0, "v": "notanint"}',
+        )
+
 
 def testInsertJsonSyntaxDefaultUnset(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int primary key, v1 int, v2 int)") as table:
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"v1\": 0, \"v2\": 0}")
+    with create_table(
+        cql, test_keyspace, "(k int primary key, v1 int, v2 int)"
+    ) as table:
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "v1": 0, "v2": 0}')
 
         # leave v1 unset
-        execute(cql, table, "INSERT INTO %s JSON ? DEFAULT UNSET", "{\"k\": 0, \"v2\": 2}")
+        execute(cql, table, "INSERT INTO %s JSON ? DEFAULT UNSET", '{"k": 0, "v2": 2}')
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, 0, 2])
 
         # explicit specification DEFAULT NULL
-        execute(cql, table, "INSERT INTO %s JSON ? DEFAULT NULL", "{\"k\": 0, \"v2\": 2}")
+        execute(cql, table, "INSERT INTO %s JSON ? DEFAULT NULL", '{"k": 0, "v2": 2}')
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, None, 2])
 
         # implicitly setting v2 to null
-        execute(cql, table, "INSERT INTO %s JSON ? DEFAULT NULL", "{\"k\": 0}")
+        execute(cql, table, "INSERT INTO %s JSON ? DEFAULT NULL", '{"k": 0}')
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, None, None])
 
         # mix setting null explicitly with default unset:
         # set values for all fields
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 1, \"v1\": 1, \"v2\": 1}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 1, "v1": 1, "v2": 1}')
         # explicitly set v1 to null while leaving v2 unset which retains its value
-        execute(cql, table, "INSERT INTO %s JSON ? DEFAULT UNSET", "{\"k\": 1, \"v1\": null}")
+        execute(
+            cql, table, "INSERT INTO %s JSON ? DEFAULT UNSET", '{"k": 1, "v1": null}'
+        )
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k=1"), [1, None, 1])
 
         # test string literal instead of bind marker
-        execute(cql, table, "INSERT INTO %s JSON '{\"k\": 2, \"v1\": 2, \"v2\": 2}'")
+        execute(cql, table, 'INSERT INTO %s JSON \'{"k": 2, "v1": 2, "v2": 2}\'')
         # explicitly set v1 to null while leaving v2 unset which retains its value
-        execute(cql, table, "INSERT INTO %s JSON '{\"k\": 2, \"v1\": null}' DEFAULT UNSET")
+        execute(
+            cql, table, 'INSERT INTO %s JSON \'{"k": 2, "v1": null}\' DEFAULT UNSET'
+        )
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k=2"), [2, None, 2])
         execute(cql, table, "INSERT INTO %s JSON '{\"k\": 2}' DEFAULT NULL")
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k=2"), [2, None, None])
 
+
 # Reproduces issues #8078, #8086
-@pytest.mark.xfail(reason="issues #8086")
+@pytest.mark.xfail(
+    reason="INSERT JSON cannot handle user-defined types with case-sensitive component names #8086"
+)
 def testCaseSensitivity(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int primary key, \"Foo\" int)") as table:
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"\\\"Foo\\\"\": 0}")
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"K\": 0, \"\\\"Foo\\\"\": 0}")
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"\\\"k\\\"\": 0, \"\\\"Foo\\\"\": 0}")
+    with create_table(cql, test_keyspace, '(k int primary key, "Foo" int)') as table:
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "\\"Foo\\"": 0}')
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"K": 0, "\\"Foo\\"": 0}')
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"\\"k\\"": 0, "\\"Foo\\"": 0}')
 
         # results should preserve and quote case-sensitive identifiers
-        assert_rows(execute(cql, table, "SELECT JSON * FROM %s"), ["{\"k\": 0, \"\\\"Foo\\\"\": 0}"])
+        assert_rows(
+            execute(cql, table, "SELECT JSON * FROM %s"), ['{"k": 0, "\\"Foo\\"": 0}']
+        )
         # reproduces #7078 (the "AS" in SELECT JSON):
-        assert_rows(execute(cql, table, "SELECT JSON k, \"Foo\" as foo FROM %s"), ["{\"k\": 0, \"foo\": 0}"])
-        assert_rows(execute(cql, table, "SELECT JSON k, \"Foo\" as \"Bar\" FROM %s"), ["{\"k\": 0, \"\\\"Bar\\\"\": 0}"])
+        assert_rows(
+            execute(cql, table, 'SELECT JSON k, "Foo" as foo FROM %s'),
+            ['{"k": 0, "foo": 0}'],
+        )
+        assert_rows(
+            execute(cql, table, 'SELECT JSON k, "Foo" as "Bar" FROM %s'),
+            ['{"k": 0, "\\"Bar\\"": 0}'],
+        )
 
-        assert_invalid(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"foo\": 0}")
-        assert_invalid(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"\\\"foo\\\"\": 0}")
+        assert_invalid(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "foo": 0}')
+        assert_invalid(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "\\"foo\\"": 0}')
 
         # user-defined types also need to handle case-sensitivity
-        with create_type(cql, test_keyspace, "(a int, \"Foo\" int)") as type_name:
-            with create_table(cql, test_keyspace, f"(k int primary key, v frozen<{type_name}>)") as t2:
-                #Reproduces #8086:
-                execute(cql, t2, "INSERT INTO %s JSON ?", "{\"k\": 0, \"v\": {\"a\": 0, \"\\\"Foo\\\"\": 0}}")
-                assert_rows(execute(cql, t2, "SELECT JSON k, v FROM %s"), ["{\"k\": 0, \"v\": {\"a\": 0, \"\\\"Foo\\\"\": 0}}"])
-                execute(cql, t2, "INSERT INTO %s JSON ?", "{\"k\": 0, \"v\": {\"A\": 0, \"\\\"Foo\\\"\": 0}}")
-                assert_rows(execute(cql, t2, "SELECT JSON k, v FROM %s"), ["{\"k\": 0, \"v\": {\"a\": 0, \"\\\"Foo\\\"\": 0}}"])
+        with create_type(cql, test_keyspace, '(a int, "Foo" int)') as type_name:
+            with create_table(
+                cql, test_keyspace, f"(k int primary key, v frozen<{type_name}>)"
+            ) as t2:
+                # Reproduces #8086:
+                execute(
+                    cql,
+                    t2,
+                    "INSERT INTO %s JSON ?",
+                    '{"k": 0, "v": {"a": 0, "\\"Foo\\"": 0}}',
+                )
+                assert_rows(
+                    execute(cql, t2, "SELECT JSON k, v FROM %s"),
+                    ['{"k": 0, "v": {"a": 0, "\\"Foo\\"": 0}}'],
+                )
+                execute(
+                    cql,
+                    t2,
+                    "INSERT INTO %s JSON ?",
+                    '{"k": 0, "v": {"A": 0, "\\"Foo\\"": 0}}',
+                )
+                assert_rows(
+                    execute(cql, t2, "SELECT JSON k, v FROM %s"),
+                    ['{"k": 0, "v": {"a": 0, "\\"Foo\\"": 0}}'],
+                )
+
 
 def testInsertJsonSyntaxWithCollections(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, " +
-                "m map<text, boolean>, " +
-                "mf frozen<map<text, boolean>>, " +
-                "s set<int>, " +
-                "sf frozen<set<int>>, " +
-                "l list<int>, " +
-                "lf frozen<list<int>>)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int PRIMARY KEY, "
+        + "m map<text, boolean>, "
+        + "mf frozen<map<text, boolean>>, "
+        + "s set<int>, "
+        + "sf frozen<set<int>>, "
+        + "l list<int>, "
+        + "lf frozen<list<int>>)",
+    ) as table:
         # map
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"m\": {\"a\": true, \"b\": false}}")
-        assert_rows(execute(cql, table, "SELECT k, m FROM %s"), [0, {"a": True, "b": False}])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s JSON ?",
+            '{"k": 0, "m": {"a": true, "b": false}}',
+        )
+        assert_rows(
+            execute(cql, table, "SELECT k, m FROM %s"), [0, {"a": True, "b": False}]
+        )
 
         # frozen map
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"mf\": {\"a\": true, \"b\": false}}")
-        assert_rows(execute(cql, table, "SELECT k, mf FROM %s"), [0, {"a": True, "b": False}])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s JSON ?",
+            '{"k": 0, "mf": {"a": true, "b": false}}',
+        )
+        assert_rows(
+            execute(cql, table, "SELECT k, mf FROM %s"), [0, {"a": True, "b": False}]
+        )
 
         # set
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"s\": [3, 1, 2]}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "s": [3, 1, 2]}')
         assert_rows(execute(cql, table, "SELECT k, s FROM %s"), [0, {1, 2, 3}])
 
         # frozen set
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"sf\": [3, 1, 2]}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "sf": [3, 1, 2]}')
         assert_rows(execute(cql, table, "SELECT k, sf FROM %s"), [0, {1, 2, 3}])
 
         # list
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"l\": [1, 2, 3]}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "l": [1, 2, 3]}')
         assert_rows(execute(cql, table, "SELECT k, l FROM %s"), [0, [1, 2, 3]])
 
         # frozen list
-        execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"lf\": [1, 2, 3]}")
+        execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "lf": [1, 2, 3]}')
         assert_rows(execute(cql, table, "SELECT k, lf FROM %s"), [0, [1, 2, 3]])
 
+
 # Reproduces issue #8087
-@pytest.mark.xfail(reason="issue #8087")
+@pytest.mark.xfail(
+    reason="SELECT JSON incorrectly quotes strings inside map keys #8087"
+)
 def testInsertJsonSyntaxWithNonNativeMapKeys(cql, test_keyspace):
     # JSON doesn't allow non-string keys, so we accept string representations of any type as map keys and
     # return maps with string keys when necessary.
     with create_type(cql, test_keyspace, "(a int)") as type_name:
-        with create_table(cql, test_keyspace, "(" +
-                "k int PRIMARY KEY, " +
-                "intmap map<int, boolean>, " +
-                "bigintmap map<bigint, boolean>, " +
-                "varintmap map<varint, boolean>, " +
-                "smallintmap map<smallint, boolean>, " +
-                "tinyintmap map<tinyint, boolean>, " +
-                "booleanmap map<boolean, boolean>, " +
-                "floatmap map<float, boolean>, " +
-                "doublemap map<double, boolean>, " +
-                "decimalmap map<decimal, boolean>, " +
-                "tuplemap map<frozen<tuple<int, text>>, boolean>, " +
-                "udtmap map<frozen<" + type_name + ">, boolean>, " +
-                "setmap map<frozen<set<int>>, boolean>, " +
-                "listmap map<frozen<list<int>>, boolean>, " +
-                "textsetmap map<frozen<set<text>>, boolean>, " +
-                "nestedsetmap map<frozen<map<set<text>, text>>, boolean>, " +
-                "frozensetmap frozen<map<set<int>, boolean>>)") as table:
+        with create_table(
+            cql,
+            test_keyspace,
+            "("
+            + "k int PRIMARY KEY, "
+            + "intmap map<int, boolean>, "
+            + "bigintmap map<bigint, boolean>, "
+            + "varintmap map<varint, boolean>, "
+            + "smallintmap map<smallint, boolean>, "
+            + "tinyintmap map<tinyint, boolean>, "
+            + "booleanmap map<boolean, boolean>, "
+            + "floatmap map<float, boolean>, "
+            + "doublemap map<double, boolean>, "
+            + "decimalmap map<decimal, boolean>, "
+            + "tuplemap map<frozen<tuple<int, text>>, boolean>, "
+            + "udtmap map<frozen<"
+            + type_name
+            + ">, boolean>, "
+            + "setmap map<frozen<set<int>>, boolean>, "
+            + "listmap map<frozen<list<int>>, boolean>, "
+            + "textsetmap map<frozen<set<text>>, boolean>, "
+            + "nestedsetmap map<frozen<map<set<text>, text>>, boolean>, "
+            + "frozensetmap frozen<map<set<int>, boolean>>)",
+        ) as table:
             # int keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"intmap\": {\"0\": true, \"1\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, intmap FROM %s"), ["{\"k\": 0, \"intmap\": {\"0\": true, \"1\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "intmap": {"0": true, "1": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, intmap FROM %s"),
+                ['{"k": 0, "intmap": {"0": true, "1": false}}'],
+            )
 
             # bigint keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"bigintmap\": {\"0\": true, \"1\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, bigintmap FROM %s"), ["{\"k\": 0, \"bigintmap\": {\"0\": true, \"1\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "bigintmap": {"0": true, "1": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, bigintmap FROM %s"),
+                ['{"k": 0, "bigintmap": {"0": true, "1": false}}'],
+            )
 
             # varint keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"varintmap\": {\"0\": true, \"1\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, varintmap FROM %s"), ["{\"k\": 0, \"varintmap\": {\"0\": true, \"1\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "varintmap": {"0": true, "1": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, varintmap FROM %s"),
+                ['{"k": 0, "varintmap": {"0": true, "1": false}}'],
+            )
 
             # smallint keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"smallintmap\": {\"0\": true, \"1\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, smallintmap FROM %s"), ["{\"k\": 0, \"smallintmap\": {\"0\": true, \"1\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "smallintmap": {"0": true, "1": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, smallintmap FROM %s"),
+                ['{"k": 0, "smallintmap": {"0": true, "1": false}}'],
+            )
 
             # tinyint keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"tinyintmap\": {\"0\": true, \"1\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, tinyintmap FROM %s"), ["{\"k\": 0, \"tinyintmap\": {\"0\": true, \"1\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "tinyintmap": {"0": true, "1": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, tinyintmap FROM %s"),
+                ['{"k": 0, "tinyintmap": {"0": true, "1": false}}'],
+            )
 
             # boolean keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"booleanmap\": {\"true\": true, \"false\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, booleanmap FROM %s"), ["{\"k\": 0, \"booleanmap\": {\"false\": false, \"true\": true}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "booleanmap": {"true": true, "false": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, booleanmap FROM %s"),
+                ['{"k": 0, "booleanmap": {"false": false, "true": true}}'],
+            )
 
             # float keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"floatmap\": {\"1.23\": true, \"4.56\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, floatmap FROM %s"), ["{\"k\": 0, \"floatmap\": {\"1.23\": true, \"4.56\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "floatmap": {"1.23": true, "4.56": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, floatmap FROM %s"),
+                ['{"k": 0, "floatmap": {"1.23": true, "4.56": false}}'],
+            )
 
             # double keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"doublemap\": {\"1.23\": true, \"4.56\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, doublemap FROM %s"), ["{\"k\": 0, \"doublemap\": {\"1.23\": true, \"4.56\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "doublemap": {"1.23": true, "4.56": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, doublemap FROM %s"),
+                ['{"k": 0, "doublemap": {"1.23": true, "4.56": false}}'],
+            )
 
             # decimal keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"decimalmap\": {\"1.23\": true, \"4.56\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, decimalmap FROM %s"), ["{\"k\": 0, \"decimalmap\": {\"1.23\": true, \"4.56\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "decimalmap": {"1.23": true, "4.56": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, decimalmap FROM %s"),
+                ['{"k": 0, "decimalmap": {"1.23": true, "4.56": false}}'],
+            )
 
             # tuple<int, text> keys
             # Reproduces issue #8087:
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"tuplemap\": {\"[0, \\\"a\\\"]\": true, \"[1, \\\"b\\\"]\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, tuplemap FROM %s"), ["{\"k\": 0, \"tuplemap\": {\"[0, \\\"a\\\"]\": true, \"[1, \\\"b\\\"]\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "tuplemap": {"[0, \\"a\\"]": true, "[1, \\"b\\"]": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, tuplemap FROM %s"),
+                ['{"k": 0, "tuplemap": {"[0, \\"a\\"]": true, "[1, \\"b\\"]": false}}'],
+            )
 
             # UDT keys
             # Reproduces issue #8087:
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"udtmap\": {\"{\\\"a\\\": 0}\": true, \"{\\\"a\\\": 1}\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, udtmap FROM %s"), ["{\"k\": 0, \"udtmap\": {\"{\\\"a\\\": 0}\": true, \"{\\\"a\\\": 1}\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "udtmap": {"{\\"a\\": 0}": true, "{\\"a\\": 1}": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, udtmap FROM %s"),
+                ['{"k": 0, "udtmap": {"{\\"a\\": 0}": true, "{\\"a\\": 1}": false}}'],
+            )
 
             # set<int> keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"setmap\": {\"[0, 1, 2]\": true, \"[3, 4, 5]\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, setmap FROM %s"), ["{\"k\": 0, \"setmap\": {\"[0, 1, 2]\": true, \"[3, 4, 5]\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "setmap": {"[0, 1, 2]": true, "[3, 4, 5]": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, setmap FROM %s"),
+                ['{"k": 0, "setmap": {"[0, 1, 2]": true, "[3, 4, 5]": false}}'],
+            )
 
             # list<int> keys
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"listmap\": {\"[0, 1, 2]\": true, \"[3, 4, 5]\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, listmap FROM %s"), ["{\"k\": 0, \"listmap\": {\"[0, 1, 2]\": true, \"[3, 4, 5]\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "listmap": {"[0, 1, 2]": true, "[3, 4, 5]": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, listmap FROM %s"),
+                ['{"k": 0, "listmap": {"[0, 1, 2]": true, "[3, 4, 5]": false}}'],
+            )
 
             # set<text> keys
             # Reproduces issue #8087:
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"textsetmap\": {\"[\\\"0\\\", \\\"1\\\"]\": true, \"[\\\"3\\\", \\\"4\\\"]\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, textsetmap FROM %s"), ["{\"k\": 0, \"textsetmap\": {\"[\\\"0\\\", \\\"1\\\"]\": true, \"[\\\"3\\\", \\\"4\\\"]\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "textsetmap": {"[\\"0\\", \\"1\\"]": true, "[\\"3\\", \\"4\\"]": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, textsetmap FROM %s"),
+                [
+                    '{"k": 0, "textsetmap": {"[\\"0\\", \\"1\\"]": true, "[\\"3\\", \\"4\\"]": false}}'
+                ],
+            )
 
             # map<set<text>, text> keys
             # Reproduces issue #8087:
-            innerKey1 = "[\"0\", \"1\"]"
-            fullKey1 = "{"+json.dumps(innerKey1)+": \"a\"}"
+            innerKey1 = '["0", "1"]'
+            fullKey1 = "{" + json.dumps(innerKey1) + ': "a"}'
             stringKey1 = json.dumps(fullKey1)
-            innerKey2 = "[\"3\", \"4\"]"
-            fullKey2 = "{"+json.dumps(innerKey2)+": \"b\"}"
+            innerKey2 = '["3", "4"]'
+            fullKey2 = "{" + json.dumps(innerKey2) + ': "b"}'
             stringKey2 = json.dumps(fullKey2)
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"nestedsetmap\": {" + stringKey1 + ": true, " + stringKey2 + ": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, nestedsetmap FROM %s"), ["{\"k\": 0, \"nestedsetmap\": {" + stringKey1 + ": true, " + stringKey2 + ": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "nestedsetmap": {'
+                + stringKey1
+                + ": true, "
+                + stringKey2
+                + ": false}}",
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, nestedsetmap FROM %s"),
+                [
+                    '{"k": 0, "nestedsetmap": {'
+                    + stringKey1
+                    + ": true, "
+                    + stringKey2
+                    + ": false}}"
+                ],
+            )
 
             # set<int> keys in a frozen map
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"frozensetmap\": {\"[0, 1, 2]\": true, \"[3, 4, 5]\": false}}")
-            assert_rows(execute(cql, table, "SELECT JSON k, frozensetmap FROM %s"), ["{\"k\": 0, \"frozensetmap\": {\"[0, 1, 2]\": true, \"[3, 4, 5]\": false}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "frozensetmap": {"[0, 1, 2]": true, "[3, 4, 5]": false}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON k, frozensetmap FROM %s"),
+                ['{"k": 0, "frozensetmap": {"[0, 1, 2]": true, "[3, 4, 5]": false}}'],
+            )
+
 
 def testInsertJsonSyntaxWithTuplesAndUDTs(cql, test_keyspace):
-    with create_type(cql, test_keyspace, "(a int, b frozen<set<int>>, c tuple<int, int>)") as type_name:
-        with create_table(cql, test_keyspace, "(" +
-                "k int PRIMARY KEY, " +
-                "a frozen<" + type_name + ">, " +
-                "b tuple<int, boolean>)") as table:
+    with create_type(
+        cql, test_keyspace, "(a int, b frozen<set<int>>, c tuple<int, int>)"
+    ) as type_name:
+        with create_table(
+            cql,
+            test_keyspace,
+            "("
+            + "k int PRIMARY KEY, "
+            + "a frozen<"
+            + type_name
+            + ">, "
+            + "b tuple<int, boolean>)",
+        ) as table:
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "a": {"a": 0, "b": [1, 2, 3], "c": [0, 1]}, "b": [0, true]}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT k, a.a, a.b, a.c, b FROM %s"),
+                [0, 0, {1, 2, 3}, (0, 1), (0, True)],
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "a": {"a": 0, "b": [1, 2, 3], "c": null}, "b": null}',
+            )
 
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"a\": {\"a\": 0, \"b\": [1, 2, 3], \"c\": [0, 1]}, \"b\": [0, true]}")
-            assert_rows(execute(cql, table, "SELECT k, a.a, a.b, a.c, b FROM %s"), [0, 0, {1, 2, 3}, (0, 1), (0, True)])
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"a\": {\"a\": 0, \"b\": [1, 2, 3], \"c\": null}, \"b\": null}")
 
 # done for CASSANDRA-11146
-@pytest.mark.xfail(reason="issue #8092")
+@pytest.mark.xfail(
+    reason="SELECT JSON missing null component after adding field to UDT definition #8092"
+)
 def testAlterUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as type_name:
-        with create_table(cql, test_keyspace, "(" +
-                "k int PRIMARY KEY, " +
-                "a frozen<" + type_name + ">)") as table:
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"a\": {\"a\": 0}}")
-            assert_rows(execute(cql, table, "SELECT JSON * FROM %s"), ["{\"k\": 0, \"a\": {\"a\": 0}}"])
+        with create_table(
+            cql,
+            test_keyspace,
+            "(" + "k int PRIMARY KEY, " + "a frozen<" + type_name + ">)",
+        ) as table:
+            execute(cql, table, "INSERT INTO %s JSON ?", '{"k": 0, "a": {"a": 0}}')
+            assert_rows(
+                execute(cql, table, "SELECT JSON * FROM %s"),
+                ['{"k": 0, "a": {"a": 0}}'],
+            )
 
             execute(cql, table, "ALTER TYPE " + type_name + " ADD b boolean")
             # This assert, and only this one (not the following one) fails in #8092
-            assert_rows(execute(cql, table, "SELECT JSON * FROM %s"), ["{\"k\": 0, \"a\": {\"a\": 0, \"b\": null}}"])
+            assert_rows(
+                execute(cql, table, "SELECT JSON * FROM %s"),
+                ['{"k": 0, "a": {"a": 0, "b": null}}'],
+            )
 
-            execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"a\": {\"a\": 0, \"b\": true}}")
-            assert_rows(execute(cql, table, "SELECT JSON * FROM %s"), ["{\"k\": 0, \"a\": {\"a\": 0, \"b\": true}}"])
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s JSON ?",
+                '{"k": 0, "a": {"a": 0, "b": true}}',
+            )
+            assert_rows(
+                execute(cql, table, "SELECT JSON * FROM %s"),
+                ['{"k": 0, "a": {"a": 0, "b": true}}'],
+            )
 
 
 # I did not translate testJsonThreadSafety() to Python. This test checks a
@@ -1251,20 +3233,32 @@ def testAlterUDT(cql, test_keyspace):
 # requires threading in the client, which I don't want to do for functional
 # tests.
 
+
 def testEmptyStringJsonSerialization(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id INT, name TEXT, PRIMARY KEY(id))") as table:
+    with create_table(
+        cql, test_keyspace, "(id INT, name TEXT, PRIMARY KEY(id))"
+    ) as table:
         execute(cql, table, "insert into %s(id, name) VALUES (0, 'Foo');")
         execute(cql, table, "insert into %s(id, name) VALUES (2, '');")
         execute(cql, table, "insert into %s(id, name) VALUES (3, null);")
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT JSON * FROM %s"),
-                   ["{\"id\": 0, \"name\": \"Foo\"}"],
-                   ["{\"id\": 2, \"name\": \"\"}"],
-                   ["{\"id\": 3, \"name\": null}"])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT JSON * FROM %s"),
+            ['{"id": 0, "name": "Foo"}'],
+            ['{"id": 2, "name": ""}'],
+            ['{"id": 3, "name": null}'],
+        )
+
 
 # CASSANDRA-14286
 # Reproduces #8100
-@pytest.mark.xfail(reason="issue #28467")
+# We have to *skip* this test instead of *xfail*, because our buggy
+# implementation not only fails to produce the right results, it reads
+# already-freed memory to do so, which crashes the debug build with the
+# sanitizer enabled.
+@pytest.mark.skip(
+    reason="SELECT JSON with IN and ORDER BY does not obey the ORDER BY #8100"
+)
 def testJsonOrdering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a INT, b INT, PRIMARY KEY(a, b))") as table:
         execute(cql, table, "INSERT INTO %s(a, b) VALUES (20, 30);")
@@ -1274,72 +3268,178 @@ def testJsonOrdering(cql, test_keyspace):
         # partition key; you must either remove the ORDER BY or the IN and
         # sort client side, or disable paging for this query."
         # So we have to disable paging in this test.
-        assert_rows(execute_without_paging(cql, table, "SELECT JSON a, b FROM %s WHERE a IN (20, 100) ORDER BY b"),
-                   ["{\"a\": 20, \"b\": 30}"],
-                   ["{\"a\": 100, \"b\": 200}"])
+        assert_rows(
+            execute_without_paging(
+                cql, table, "SELECT JSON a, b FROM %s WHERE a IN (20, 100) ORDER BY b"
+            ),
+            ['{"a": 20, "b": 30}'],
+            ['{"a": 100, "b": 200}'],
+        )
 
-        assert_rows(execute_without_paging(cql, table, "SELECT JSON a, b FROM %s WHERE a IN (20, 100) ORDER BY b DESC"),
-                   ["{\"a\": 100, \"b\": 200}"],
-                   ["{\"a\": 20, \"b\": 30}"])
+        assert_rows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT JSON a, b FROM %s WHERE a IN (20, 100) ORDER BY b DESC",
+            ),
+            ['{"a": 100, "b": 200}'],
+            ['{"a": 20, "b": 30}'],
+        )
 
-        assert_rows(execute_without_paging(cql, table, "SELECT JSON a FROM %s WHERE a IN (20, 100) ORDER BY b DESC"),
-                   ["{\"a\": 100}"],
-                   ["{\"a\": 20}"])
+        assert_rows(
+            execute_without_paging(
+                cql, table, "SELECT JSON a FROM %s WHERE a IN (20, 100) ORDER BY b DESC"
+            ),
+            ['{"a": 100}'],
+            ['{"a": 20}'],
+        )
 
         # Check ordering with alias
-        assert_rows(execute_without_paging(cql, table, "SELECT JSON a, b as c FROM %s WHERE a IN (20, 100) ORDER BY b"),
-                   ["{\"a\": 20, \"c\": 30}"],
-                   ["{\"a\": 100, \"c\": 200}"])
+        assert_rows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT JSON a, b as c FROM %s WHERE a IN (20, 100) ORDER BY b",
+            ),
+            ['{"a": 20, "c": 30}'],
+            ['{"a": 100, "c": 200}'],
+        )
 
-        assert_rows(execute_without_paging(cql, table, "SELECT JSON a, b as c FROM %s WHERE a IN (20, 100) ORDER BY b DESC"),
-                   ["{\"a\": 100, \"c\": 200}"],
-                   ["{\"a\": 20, \"c\": 30}"])
+        assert_rows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT JSON a, b as c FROM %s WHERE a IN (20, 100) ORDER BY b DESC",
+            ),
+            ['{"a": 100, "c": 200}'],
+            ['{"a": 20, "c": 30}'],
+        )
 
         # Check ordering with CAST
-        assert_rows(execute_without_paging(cql, table, "SELECT JSON a, CAST(b AS FLOAT) FROM %s WHERE a IN (20, 100) ORDER BY b"),
-                   ["{\"a\": 20, \"cast(b as float)\": 30.0}"],
-                   ["{\"a\": 100, \"cast(b as float)\": 200.0}"])
+        assert_rows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT JSON a, CAST(b AS FLOAT) FROM %s WHERE a IN (20, 100) ORDER BY b",
+            ),
+            ['{"a": 20, "cast(b as float)": 30.0}'],
+            ['{"a": 100, "cast(b as float)": 200.0}'],
+        )
 
-        assert_rows(execute_without_paging(cql, table, "SELECT JSON a, CAST(b AS FLOAT) FROM %s WHERE a IN (20, 100) ORDER BY b DESC"),
-                   ["{\"a\": 100, \"cast(b as float)\": 200.0}"],
-                   ["{\"a\": 20, \"cast(b as float)\": 30.0}"])
+        assert_rows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT JSON a, CAST(b AS FLOAT) FROM %s WHERE a IN (20, 100) ORDER BY b DESC",
+            ),
+            ['{"a": 100, "cast(b as float)": 200.0}'],
+            ['{"a": 20, "cast(b as float)": 30.0}'],
+        )
+
 
 def testInsertAndSelectJsonSyntaxWithEmptyAndNullValues(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id INT, name TEXT, name_asc ASCII, bytes BLOB, PRIMARY KEY(id))") as table:
-         # Test with empty values
-         execute(cql, table, "INSERT INTO %s JSON ?", "{\"id\": 0, \"bytes\": \"0x\", \"name\": \"\", \"name_asc\": \"\"}")
-         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE id=0"), [0, b"", "", ""])
-         assert_rows(execute(cql, table, "SELECT JSON * FROM %s WHERE id = 0"),
-                    ["{\"id\": 0, \"bytes\": \"0x\", \"name\": \"\", \"name_asc\": \"\"}"])
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id INT, name TEXT, name_asc ASCII, bytes BLOB, PRIMARY KEY(id))",
+    ) as table:
+        # Test with empty values
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s JSON ?",
+            '{"id": 0, "bytes": "0x", "name": "", "name_asc": ""}',
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE id=0"), [0, b"", "", ""]
+        )
+        assert_rows(
+            execute(cql, table, "SELECT JSON * FROM %s WHERE id = 0"),
+            ['{"id": 0, "bytes": "0x", "name": "", "name_asc": ""}'],
+        )
 
-         execute(cql, table, "INSERT INTO %s(id, name, name_asc, bytes) VALUES (1, ?, ?, ?);", "", "", b"")
-         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE id=1"), [1, b"", "", ""])
-         assert_rows(execute(cql, table, "SELECT JSON * FROM %s WHERE id = 1"),
-                    ["{\"id\": 1, \"bytes\": \"0x\", \"name\": \"\", \"name_asc\": \"\"}"])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(id, name, name_asc, bytes) VALUES (1, ?, ?, ?);",
+            "",
+            "",
+            b"",
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE id=1"), [1, b"", "", ""]
+        )
+        assert_rows(
+            execute(cql, table, "SELECT JSON * FROM %s WHERE id = 1"),
+            ['{"id": 1, "bytes": "0x", "name": "", "name_asc": ""}'],
+        )
 
-         # Test with null values
-         execute(cql, table, "INSERT INTO %s JSON ?", "{\"id\": 2, \"bytes\": null, \"name\": null, \"name_asc\": null}")
-         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE id=2"), [2, None, None, None])
-         assert_rows(execute(cql, table, "SELECT JSON * FROM %s WHERE id = 2"),
-                    ["{\"id\": 2, \"bytes\": null, \"name\": null, \"name_asc\": null}"])
+        # Test with null values
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s JSON ?",
+            '{"id": 2, "bytes": null, "name": null, "name_asc": null}',
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE id=2"), [2, None, None, None]
+        )
+        assert_rows(
+            execute(cql, table, "SELECT JSON * FROM %s WHERE id = 2"),
+            ['{"id": 2, "bytes": null, "name": null, "name_asc": null}'],
+        )
 
-         execute(cql, table, "INSERT INTO %s(id, name, name_asc, bytes) VALUES (3, ?, ?, ?);", None, None, None)
-         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE id=3"), [3, None, None, None])
-         assert_rows(execute(cql, table, "SELECT JSON * FROM %s WHERE id = 3"),
-                 ["{\"id\": 3, \"bytes\": null, \"name\": null, \"name_asc\": null}"])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(id, name, name_asc, bytes) VALUES (3, ?, ?, ?);",
+            None,
+            None,
+            None,
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE id=3"), [3, None, None, None]
+        )
+        assert_rows(
+            execute(cql, table, "SELECT JSON * FROM %s WHERE id = 3"),
+            ['{"id": 3, "bytes": null, "name": null, "name_asc": null}'],
+        )
+
 
 def testJsonWithNaNAndInfinity(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int PRIMARY KEY, f1 float, f2 float, f3 float, d1 double, d2 double, d3 double)") as table:
-        execute(cql, table, "INSERT INTO %s (pk, f1, f2, f3, d1, d2, d3) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                1, float('nan'), float('inf'), float('-inf'), float('nan'), float('inf'), float('-inf'))
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk int PRIMARY KEY, f1 float, f2 float, f3 float, d1 double, d2 double, d3 double)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, f1, f2, f3, d1, d2, d3) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            1,
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+        )
 
         # JSON does not support NaN, Infinity and -Infinity values. Most of the parser convert them into null.
-        assert_rows(execute(cql, table, "SELECT JSON * FROM %s"), ["{\"pk\": 1, \"d1\": null, \"d2\": null, \"d3\": null, \"f1\": null, \"f2\": null, \"f3\": null}"])
+        assert_rows(
+            execute(cql, table, "SELECT JSON * FROM %s"),
+            [
+                '{"pk": 1, "d1": null, "d2": null, "d3": null, "f1": null, "f2": null, "f3": null}'
+            ],
+        )
+
 
 def testDurationJsonRoundtrip(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int PRIMARY KEY, d duration)") as table:
         execute(cql, table, "INSERT INTO %s (pk, d) VALUES (1, 6h40m)")
         json = execute(cql, table, "SELECT JSON * FROM %s WHERE pk = 1").one()[0]
         execute(cql, table, "DELETE FROM %s WHERE pk = 1")
-        execute(cql, table, "INSERT INTO %s JSON '"+json+"'")
-        assert execute(cql, table, "SELECT JSON * FROM %s WHERE pk = 1").one()[0] == json
+        execute(cql, table, "INSERT INTO %s JSON '" + json + "'")
+        assert (
+            execute(cql, table, "SELECT JSON * FROM %s WHERE pk = 1").one()[0] == json
+        )

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
@@ -451,7 +451,7 @@ TOO_BIG = 1024 * 65
 # make sure we check conditional and unconditional statements,
 # both singly and in batches (CASSANDRA-10536)
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 @pytest.mark.parametrize("test_keyspace",
                          ["tablets", "vnodes"],
                          indirect=True)
@@ -510,7 +510,7 @@ def testIndexOnPartitionKeyInsertValueOver64k(cql, test_keyspace):
         #}
 
 # Reproduces issue #8708:
-@pytest.mark.xfail(reason="issue #8708")
+@pytest.mark.xfail(reason="Secondary index is missing partitions with only a static row #8708")
 def testIndexOnPartitionKeyWithStaticColumnAndNoRows(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk1 int, pk2 int, c int, s int static, v int, PRIMARY KEY((pk1, pk2), c))") as table:
         execute(cql, table, "CREATE INDEX ON %s (pk2)")
@@ -565,7 +565,7 @@ def testIndexOnClusteringColumnInsertValueOver64k(cql, test_keyspace):
         #}
 
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 @pytest.mark.parametrize("test_keyspace",
                          ["tablets", "vnodes"],
                          indirect=True)
@@ -587,7 +587,7 @@ def testIndexOnFullCollectionEntryInsertCollectionValueOver64k(cql, test_keyspac
                    "INSERT INTO %s (a, b) VALUES (0, ?) IF NOT EXISTS;\n" +
                    "APPLY BATCH", map)
 
-@pytest.mark.xfail(reason="issue #2203")
+@pytest.mark.xfail(reason="Secondary index CREATE INDEX syntax is missing the \"values\" option #2203")
 def testPrepareStatementsWithLIKEClauses(cql, test_keyspace):
     SASI = 'org.apache.cassandra.index.sasi.SASIIndex'
     with create_table(cql, test_keyspace, "(a int, c1 text, c2 text, v1 text, v2 text, v3 int, PRIMARY KEY (a, c1, c2))") as table:
@@ -696,7 +696,7 @@ def testIndexesOnNonStaticColumnsWhereSchemaIncludesStaticColumns(cql, test_keys
 # Reproduces Scylla issues #4244 (mixing single-column and multi-columns
 # restriction) and #8711 (Finding or filtering with an empty string with
 # a secondary index seems to be broken).
-@pytest.mark.xfail(reason="issues #4244, #8711")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244, Finding or filtering with an empty string with a secondary index seems to be broken #8711")
 def testWithEmptyRestrictionValueAndSecondaryIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))") as table:
         execute(cql, table, "CREATE INDEX ON %s(c)")
@@ -1026,7 +1026,7 @@ def testIndexOnNonFrozenCollectionOfFrozenUDT(cql, test_keyspace):
             assert_invalid_message(cql, table, "ALLOW FILTERING",
                              "SELECT * FROM %s WHERE v CONTAINS ?", udt1)
 
-@pytest.mark.xfail(reason="#8745")
+@pytest.mark.xfail(reason="Secondary index CREATE INDEX syntax is missing the \"values\" option #8745")
 def testIndexOnNonFrozenUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as t:
         with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, v {t})") as table:

--- a/test/cqlpy/cassandra_tests/validation/entities/type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/type_test.py
@@ -10,31 +10,99 @@
 
 from ...porting import *
 
+
 def testNonExistingOnes(cql, test_keyspace):
     # The Scylla and Cassandra error messages are slightly different, but both
     # include the type's full name and the word "exist":
-    assert_invalid_message_re(cql, test_keyspace, f"{test_keyspace}.type_does_not_exist.* exist", "DROP TYPE " + test_keyspace + ".type_does_not_exist")
-    assert_invalid_message(cql, test_keyspace, "keyspace_does_not_exist", "DROP TYPE keyspace_does_not_exist.type_does_not_exist")
-    execute(cql, test_keyspace, "DROP TYPE IF EXISTS " + test_keyspace + ".type_does_not_exist")
+    assert_invalid_message_re(
+        cql,
+        test_keyspace,
+        f"{test_keyspace}.type_does_not_exist.* exist",
+        "DROP TYPE " + test_keyspace + ".type_does_not_exist",
+    )
+    assert_invalid_message(
+        cql,
+        test_keyspace,
+        "keyspace_does_not_exist",
+        "DROP TYPE keyspace_does_not_exist.type_does_not_exist",
+    )
+    execute(
+        cql,
+        test_keyspace,
+        "DROP TYPE IF EXISTS " + test_keyspace + ".type_does_not_exist",
+    )
     # Reproduces issue #9082 - if the keyspace doesn't exist, an error was
     # reported instead of just doing nothing:
-    execute(cql, test_keyspace, "DROP TYPE IF EXISTS keyspace_does_not_exist.type_does_not_exist")
+    execute(
+        cql,
+        test_keyspace,
+        "DROP TYPE IF EXISTS keyspace_does_not_exist.type_does_not_exist",
+    )
 
-@pytest.mark.skip(reason="Issue #9300")
+
+@pytest.mark.skip(reason="testNowToUUIDCompatibility is flaky #9300")
 def testNowToUUIDCompatibility(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b uuid, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b uuid, PRIMARY KEY (a, b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")
-        assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=0 AND b < now()"))) == 1
+        assert (
+            len(list(execute(cql, table, "SELECT * FROM %s WHERE a=0 AND b < now()")))
+            == 1
+        )
+
 
 def testDateCompatibility(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b timestamp, c bigint, d varint, PRIMARY KEY (a, b, c, d))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (0, toUnixTimestamp(now()), toTimestamp(now()), toTimestamp(now()))")
-        assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=0 AND b <= toUnixTimestamp(now())"))) == 1
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, unixTimestampOf(now()), dateOf(now()), dateOf(now()))")
-        assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b <= toUnixTimestamp(now())"))) == 1
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b timestamp, c bigint, d varint, PRIMARY KEY (a, b, c, d))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (0, toUnixTimestamp(now()), toTimestamp(now()), toTimestamp(now()))",
+        )
+        assert (
+            len(
+                list(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE a=0 AND b <= toUnixTimestamp(now())",
+                    )
+                )
+            )
+            == 1
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (1, unixTimestampOf(now()), dateOf(now()), dateOf(now()))",
+        )
+        assert (
+            len(
+                list(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE a=1 AND b <= toUnixTimestamp(now())",
+                    )
+                )
+            )
+            == 1
+        )
 
-@pytest.mark.skip(reason="Issue #9300")
+
+@pytest.mark.skip(reason="testNowToUUIDCompatibility is flaky #9300")
 def testReversedTypeCompatibility(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b timeuuid, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b timeuuid, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")
-        assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=0 AND b < now()"))) == 1
+        assert (
+            len(list(execute(cql, table, "SELECT * FROM %s WHERE a=0 AND b < now()")))
+            == 1
+        )

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -16,26 +16,41 @@ from cassandra.util import Date
 from ....util import new_function, unique_name, new_secondary_index
 import os
 
+
 def is_scylla(cql, test_keyspace):
     try:
-        with new_function(cql, test_keyspace, "() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 1;'"):
+        with new_function(
+            cql,
+            test_keyspace,
+            "() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 1;'",
+        ):
             pass
         return True
     except:
         return False
 
+
 def read_function_from_file(file_name, wasm_name=None, udf_name=None):
-    wat_path = os.path.realpath(os.path.join(__file__, f'../../../../../../build/wasm/{file_name}.wat'))
+    wat_path = os.path.realpath(
+        os.path.join(__file__, f"../../../../../../build/wasm/{file_name}.wat")
+    )
     wasm_name = wasm_name or file_name
     udf_name = udf_name or wasm_name
     try:
-      with open(wat_path, "r") as f:
-          return f.read().replace("'", "''").replace(f'export "{wasm_name}"', f'export "{udf_name}"')
+        with open(wat_path, "r") as f:
+            return (
+                f.read()
+                .replace("'", "''")
+                .replace(f'export "{wasm_name}"', f'export "{udf_name}"')
+            )
     except:
         print(f"Can't open {wat_path}.\nPlease build Wasm examples.")
         exit(1)
 
-@pytest.mark.skip(reason="Issue #22799")
+
+@pytest.mark.skip(
+    reason="CI regression in test - uf_types_test test_complex_null_values #22799"
+)
 def test_complex_null_values(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(txt text, i int)") as type:
         schema = f"(key int primary key, lst list<double>, st set<text>, mp map<int, boolean>, tup frozen<tuple<double, text, int, boolean>>, udt frozen<{type}>)"
@@ -43,38 +58,80 @@ def test_complex_null_values(cql, test_keyspace):
             use_wasm = is_scylla(cql, test_keyspace)
             lang = "wasm" if use_wasm else "java"
             flist_name = unique_name()
-            flist_wasm_src = read_function_from_file("test_complex_null_values", "return_input_flist", flist_name) if use_wasm else 'return input;'
+            flist_wasm_src = (
+                read_function_from_file(
+                    "test_complex_null_values", "return_input_flist", flist_name
+                )
+                if use_wasm
+                else "return input;"
+            )
             flist_src = f"(input list<double>) CALLED ON NULL INPUT RETURNS list<double> LANGUAGE {lang} AS '{flist_wasm_src}'"
             fset_name = unique_name()
-            fset_wasm_src = read_function_from_file("test_complex_null_values", "return_input_fset", fset_name) if use_wasm else 'return input;'
+            fset_wasm_src = (
+                read_function_from_file(
+                    "test_complex_null_values", "return_input_fset", fset_name
+                )
+                if use_wasm
+                else "return input;"
+            )
             fset_src = f"(input set<text>) CALLED ON NULL INPUT RETURNS set<text> LANGUAGE {lang} AS '{fset_wasm_src}'"
             fmap_name = unique_name()
-            fmap_wasm_src = read_function_from_file("test_complex_null_values", "return_input_fmap", fmap_name) if use_wasm else 'return input;'
+            fmap_wasm_src = (
+                read_function_from_file(
+                    "test_complex_null_values", "return_input_fmap", fmap_name
+                )
+                if use_wasm
+                else "return input;"
+            )
             fmap_src = f"(input map<int, boolean>) CALLED ON NULL INPUT RETURNS map<int, boolean> LANGUAGE {lang} AS '{fmap_wasm_src}'"
             ftup_name = unique_name()
-            ftup_wasm_src = read_function_from_file("test_complex_null_values", "return_input_ftup", ftup_name) if use_wasm else 'return input;'
+            ftup_wasm_src = (
+                read_function_from_file(
+                    "test_complex_null_values", "return_input_ftup", ftup_name
+                )
+                if use_wasm
+                else "return input;"
+            )
             ftup_src = f"(input tuple<double, text, int, boolean>) CALLED ON NULL INPUT RETURNS tuple<double, text, int, boolean> LANGUAGE {lang} AS '{ftup_wasm_src}'"
             fudt_name = unique_name()
-            fudt_wasm_src = read_function_from_file("test_complex_null_values", "return_input_fudt", fudt_name) if use_wasm else 'return input;'
+            fudt_wasm_src = (
+                read_function_from_file(
+                    "test_complex_null_values", "return_input_fudt", fudt_name
+                )
+                if use_wasm
+                else "return input;"
+            )
             fudt_src = f"(input {type}) CALLED ON NULL INPUT RETURNS {type} LANGUAGE {lang} AS '{fudt_wasm_src}'"
 
-            cql.execute(f"INSERT INTO {table} (key, lst, st, mp, tup, udt) VALUES (1, [1.0, 2.0, 3.0], {{'one', 'three', 'two'}}, {{1:true, 2:false, 3:true}}, (1.0, 'one', 42, false), {{txt:'one', i:1}})")
-            cql.execute(f"INSERT INTO {table} (key, lst, st, mp, tup, udt) VALUES (2, null, null, null, null, null)")
-            with new_function(cql, test_keyspace, flist_src, flist_name), new_function(cql, test_keyspace, fset_src, fset_name), \
-            new_function(cql, test_keyspace, fmap_src, fmap_name), new_function(cql, test_keyspace, ftup_src, ftup_name), \
-            new_function(cql, test_keyspace, fudt_src, fudt_name):
+            cql.execute(
+                f"INSERT INTO {table} (key, lst, st, mp, tup, udt) VALUES (1, [1.0, 2.0, 3.0], {{'one', 'three', 'two'}}, {{1:true, 2:false, 3:true}}, (1.0, 'one', 42, false), {{txt:'one', i:1}})"
+            )
+            cql.execute(
+                f"INSERT INTO {table} (key, lst, st, mp, tup, udt) VALUES (2, null, null, null, null, null)"
+            )
+            with (
+                new_function(cql, test_keyspace, flist_src, flist_name),
+                new_function(cql, test_keyspace, fset_src, fset_name),
+                new_function(cql, test_keyspace, fmap_src, fmap_name),
+                new_function(cql, test_keyspace, ftup_src, ftup_name),
+                new_function(cql, test_keyspace, fudt_src, fudt_name),
+            ):
                 cql.execute(f"SELECT {flist_name}(lst) FROM {table} WHERE key = 1")
                 cql.execute(f"SELECT {fset_name}(st) FROM {table} WHERE key = 1")
                 cql.execute(f"SELECT {fmap_name}(mp) FROM {table} WHERE key = 1")
                 cql.execute(f"SELECT {ftup_name}(tup) FROM {table} WHERE key = 1")
                 cql.execute(f"SELECT {fudt_name}(udt) FROM {table} WHERE key = 1")
-                row = cql.execute(f"SELECT {flist_name}(lst) as l, {fset_name}(st) as s, {fmap_name}(mp) as m, {ftup_name}(tup) as t, {fudt_name}(udt) as u FROM {table} WHERE key = 1").one()
+                row = cql.execute(
+                    f"SELECT {flist_name}(lst) as l, {fset_name}(st) as s, {fmap_name}(mp) as m, {ftup_name}(tup) as t, {fudt_name}(udt) as u FROM {table} WHERE key = 1"
+                ).one()
                 assert row.l
                 assert row.s
                 assert row.m
                 assert row.t
                 assert row.u
-                row = cql.execute(f"SELECT {flist_name}(lst) as l, {fset_name}(st) as s, {fmap_name}(mp) as m, {ftup_name}(tup) as t, {fudt_name}(udt) as u FROM {table} WHERE key = 2").one()
+                row = cql.execute(
+                    f"SELECT {flist_name}(lst) as l, {fset_name}(st) as s, {fmap_name}(mp) as m, {ftup_name}(tup) as t, {fudt_name}(udt) as u FROM {table} WHERE key = 2"
+                ).one()
                 assert not row.l
                 assert not row.s
                 assert not row.m
@@ -83,12 +140,14 @@ def test_complex_null_values(cql, test_keyspace):
                 # Cassandra tests query execution both using internal commands and using the API for all protocol versions.
                 # We only test the API here, but if we add more ABI versions we should test them as well.
 
+
 class TypesTestDef:
     def __init__(self, udf_type, table_type, column_name, reference_value):
         self.udf_type = udf_type
         self.table_type = table_type
         self.column_name = column_name
         self.reference_value = reference_value
+
 
 def test_types_with_and_without_nulls(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(txt text, i int)") as type:
@@ -97,7 +156,9 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
         micros = now.microsecond // 1000 * 1000
         type_defs = [
             # udf type, table type, column, reference value
-            TypesTestDef("timestamp", "timestamp", "ts", now.replace(microsecond=micros)),
+            TypesTestDef(
+                "timestamp", "timestamp", "ts", now.replace(microsecond=micros)
+            ),
             TypesTestDef("date", "date", "dt", Date(12345)),
             TypesTestDef("time", "time", "tim", 12345),
             TypesTestDef("uuid", "uuid", "uu", uuid.uuid4()),
@@ -112,13 +173,15 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
             TypesTestDef("ascii", "ascii", "a", "tqbfjutld"),
             TypesTestDef("text", "text", "txt", "k\u00f6lsche jung"),
             # TypesTestDef(type, f"frozen<{type}>", "u", null),
-            TypesTestDef("tuple<int, text>", "frozen<tuple<int, text>>", "tup", (1, "foo")),
+            TypesTestDef(
+                "tuple<int, text>", "frozen<tuple<int, text>>", "tup", (1, "foo")
+            ),
         ]
 
         schema = "(key int PRIMARY KEY"
         values = [1]
         for type_def in type_defs:
-            schema += ", " + type_def.column_name + ' ' + type_def.table_type
+            schema += ", " + type_def.column_name + " " + type_def.table_type
             values.append(type_def.reference_value)
         schema += ")"
 
@@ -142,70 +205,204 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
                 use_wasm = is_scylla(cql, test_keyspace)
                 lang = "wasm" if use_wasm else "java"
                 fun_name = unique_name()
-                fun_wasm_src = read_function_from_file("test_types_with_and_without_nulls", f"check_arg_and_return_{type_def.column_name}", fun_name) if use_wasm else 'return input;'
+                fun_wasm_src = (
+                    read_function_from_file(
+                        "test_types_with_and_without_nulls",
+                        f"check_arg_and_return_{type_def.column_name}",
+                        fun_name,
+                    )
+                    if use_wasm
+                    else "return input;"
+                )
                 fun_src = f"(input {type_def.udf_type}) CALLED ON NULL INPUT RETURNS {type_def.udf_type} LANGUAGE {lang} AS '{fun_wasm_src}'"
                 with new_function(cql, test_keyspace, fun_src, fun_name):
                     # Cassandra returns timeuuids returned from UDFs as bytes (even though UUIDs are UUIDs), so if we're running Cassandra we should also compare the result to bytes.
-                    ref_val = type_def.reference_value if use_wasm or type_def.udf_type != "timeuuid" else type_def.reference_value.bytes
-                    assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1"), row(ref_val))
+                    ref_val = (
+                        type_def.reference_value
+                        if use_wasm or type_def.udf_type != "timeuuid"
+                        else type_def.reference_value.bytes
+                    )
+                    assertRows(
+                        execute(
+                            cql,
+                            table,
+                            f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1",
+                        ),
+                        row(ref_val),
+                    )
 
                 fun_name = unique_name()
-                fun_wasm_src = read_function_from_file("test_types_with_and_without_nulls", f"called_on_null_{type_def.column_name}", fun_name) if use_wasm else 'return \"called\";'
+                fun_wasm_src = (
+                    read_function_from_file(
+                        "test_types_with_and_without_nulls",
+                        f"called_on_null_{type_def.column_name}",
+                        fun_name,
+                    )
+                    if use_wasm
+                    else 'return "called";'
+                )
                 fun_src = f"(input {type_def.udf_type}) CALLED ON NULL INPUT RETURNS text LANGUAGE {lang} AS '{fun_wasm_src}'"
                 with new_function(cql, test_keyspace, fun_src, fun_name):
-                    assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1"), row("called"))
-                    assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 2"), row("called"))
+                    assertRows(
+                        execute(
+                            cql,
+                            table,
+                            f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1",
+                        ),
+                        row("called"),
+                    )
+                    assertRows(
+                        execute(
+                            cql,
+                            table,
+                            f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 2",
+                        ),
+                        row("called"),
+                    )
 
                 fun_name = unique_name()
-                fun_wasm_src = read_function_from_file("test_types_with_and_without_nulls", f"returns_null_on_null_{type_def.column_name}", fun_name) if use_wasm else 'return \"called\";'
+                fun_wasm_src = (
+                    read_function_from_file(
+                        "test_types_with_and_without_nulls",
+                        f"returns_null_on_null_{type_def.column_name}",
+                        fun_name,
+                    )
+                    if use_wasm
+                    else 'return "called";'
+                )
                 fun_src = f"(input {type_def.udf_type}) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE {lang} AS '{fun_wasm_src}'"
                 with new_function(cql, test_keyspace, fun_src, fun_name):
-                    assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1"), row("called"))
-                    assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 2"), row(None))
+                    assertRows(
+                        execute(
+                            cql,
+                            table,
+                            f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1",
+                        ),
+                        row("called"),
+                    )
+                    assertRows(
+                        execute(
+                            cql,
+                            table,
+                            f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 2",
+                        ),
+                        row(None),
+                    )
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+
+@pytest.mark.skip(
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746"
+)
+@pytest.mark.xfail(
+    reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855"
+)
+@pytest.mark.xfail(
+    reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860"
+)
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_set_type(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<set<int>>)") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b frozen<set<int>>)"
+    ) as table:
         with new_secondary_index(cql, table, "FULL(b)"):
             use_wasm = is_scylla(cql, test_keyspace)
             lang = "wasm" if use_wasm else "java"
             execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 0, set())
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 1, set([1, 2, 3]))
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 2, set([4, 5, 6]))
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 3, set([7, 8, 9]))
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 1, set([1, 2, 3])
+            )
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 2, set([4, 5, 6])
+            )
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 3, set([7, 8, 9])
+            )
 
             fun_name = unique_name()
-            sum_set_src = read_function_from_file("test_functions_with_frozen_types", "sum_set", fun_name) if use_wasm else 'int sum = 0; for (int value : values) {sum += value;} return sum;'
+            sum_set_src = (
+                read_function_from_file(
+                    "test_functions_with_frozen_types", "sum_set", fun_name
+                )
+                if use_wasm
+                else "int sum = 0; for (int value : values) {sum += value;} return sum;"
+            )
             frozen_arg_src = f"(values frozen<set<int>>) CALLED ON NULL INPUT RETURNS int LANGUAGE {lang} AS '{sum_set_src}'"
-            assertInvalidMessage(cql, "", "cannot be frozen", f"CREATE FUNCTION {test_keyspace}.{fun_name} {frozen_arg_src}")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"CREATE FUNCTION {test_keyspace}.{fun_name} {frozen_arg_src}",
+            )
 
             ret_name = unique_name()
-            return_set_src = read_function_from_file("test_functions_with_frozen_types", "return_set", ret_name) if use_wasm else 'return values;'
+            return_set_src = (
+                read_function_from_file(
+                    "test_functions_with_frozen_types", "return_set", ret_name
+                )
+                if use_wasm
+                else "return values;"
+            )
             frozen_ret_src = f"(values set<int>) CALLED ON NULL INPUT RETURNS frozen<set<int>> LANGUAGE {lang} AS '{return_set_src}'"
-            assertInvalidMessage(cql, "", "cannot be frozen", f"CREATE FUNCTION {test_keyspace}.{ret_name} {frozen_ret_src}")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"CREATE FUNCTION {test_keyspace}.{ret_name} {frozen_ret_src}",
+            )
 
             fun_src = f"(values set<int>) CALLED ON NULL INPUT RETURNS int LANGUAGE {lang} AS '{sum_set_src}'"
             with new_function(cql, test_keyspace, fun_src, fun_name):
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"), row(0, 0))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"), row(1, 6))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"), row(2, 15))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"), row(3, 24))
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"),
+                    row(0, 0),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"),
+                    row(1, 6),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"),
+                    row(2, 15),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"),
+                    row(3, 24),
+                )
 
             fun_src = f"(values set<int>) CALLED ON NULL INPUT RETURNS set<int> LANGUAGE {lang} AS '{return_set_src}'"
             with new_function(cql, test_keyspace, fun_src, ret_name):
-                assertRows(execute(cql, table, f"SELECT a FROM %s WHERE b = {ret_name}(?)", set([1, 2, 3])), row(1))
+                assertRows(
+                    execute(
+                        cql,
+                        table,
+                        f"SELECT a FROM %s WHERE b = {ret_name}(?)",
+                        set([1, 2, 3]),
+                    ),
+                    row(1),
+                )
 
-            assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<set<int>>)")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<set<int>>)",
+            )
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+
+@pytest.mark.skip(
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746"
+)
+@pytest.mark.xfail(
+    reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855"
+)
+@pytest.mark.xfail(
+    reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860"
+)
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_list_type(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<list<int>>)") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b frozen<list<int>>)"
+    ) as table:
         with new_secondary_index(cql, table, "FULL(b)"):
             use_wasm = is_scylla(cql, test_keyspace)
             lang = "wasm" if use_wasm else "java"
@@ -215,68 +412,182 @@ def test_function_with_frozen_list_type(cql, test_keyspace):
             execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 3, [7, 8, 9])
 
             fun_name = unique_name()
-            sum_list_src = read_function_from_file("test_functions_with_frozen_types", "sum_list", fun_name) if use_wasm else 'int sum = 0; for (int value : values) {sum += value;} return sum;'
+            sum_list_src = (
+                read_function_from_file(
+                    "test_functions_with_frozen_types", "sum_list", fun_name
+                )
+                if use_wasm
+                else "int sum = 0; for (int value : values) {sum += value;} return sum;"
+            )
             frozen_arg_src = f"(values frozen<list<int>>) CALLED ON NULL INPUT RETURNS int LANGUAGE {lang} AS '{sum_list_src}'"
-            assertInvalidMessage(cql, "", "cannot be frozen", f"CREATE FUNCTION {test_keyspace}.{fun_name} {frozen_arg_src}")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"CREATE FUNCTION {test_keyspace}.{fun_name} {frozen_arg_src}",
+            )
 
             ret_name = unique_name()
-            return_list_src = read_function_from_file("test_functions_with_frozen_types", "return_list", ret_name) if use_wasm else 'return values;'
+            return_list_src = (
+                read_function_from_file(
+                    "test_functions_with_frozen_types", "return_list", ret_name
+                )
+                if use_wasm
+                else "return values;"
+            )
             frozen_ret_src = f"(values list<int>) CALLED ON NULL INPUT RETURNS frozen<list<int>> LANGUAGE {lang} AS '{return_list_src}'"
-            assertInvalidMessage(cql, "", "cannot be frozen", f"CREATE FUNCTION {test_keyspace}.{ret_name} {frozen_ret_src}")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"CREATE FUNCTION {test_keyspace}.{ret_name} {frozen_ret_src}",
+            )
 
             fun_src = f"(values list<int>) CALLED ON NULL INPUT RETURNS int LANGUAGE {lang} AS '{sum_list_src}'"
             with new_function(cql, test_keyspace, fun_src, fun_name):
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"), row(0, 0))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"), row(1, 6))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"), row(2, 15))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"), row(3, 24))
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"),
+                    row(0, 0),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"),
+                    row(1, 6),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"),
+                    row(2, 15),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"),
+                    row(3, 24),
+                )
 
             fun_src = f"(values list<int>) CALLED ON NULL INPUT RETURNS list<int> LANGUAGE {lang} AS '{return_list_src}'"
             with new_function(cql, test_keyspace, fun_src, ret_name):
-                assertRows(execute(cql, table, f"SELECT a FROM %s WHERE b = {ret_name}(?)", [1, 2, 3]), row(1))
+                assertRows(
+                    execute(
+                        cql,
+                        table,
+                        f"SELECT a FROM %s WHERE b = {ret_name}(?)",
+                        [1, 2, 3],
+                    ),
+                    row(1),
+                )
 
-            assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<list<int>>)")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<list<int>>)",
+            )
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+
+@pytest.mark.skip(
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746"
+)
+@pytest.mark.xfail(
+    reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855"
+)
+@pytest.mark.xfail(
+    reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860"
+)
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_map_type(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<map<int, int>>)") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b frozen<map<int, int>>)"
+    ) as table:
         with new_secondary_index(cql, table, "FULL(b)"):
             use_wasm = is_scylla(cql, test_keyspace)
             lang = "wasm" if use_wasm else "java"
             execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 0, {})
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 1, {1: 1, 2: 2, 3: 3})
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 2, {4: 4, 5: 5, 6: 6})
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 3, {7: 7, 8: 8, 9: 9})
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 1, {1: 1, 2: 2, 3: 3}
+            )
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 2, {4: 4, 5: 5, 6: 6}
+            )
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 3, {7: 7, 8: 8, 9: 9}
+            )
 
             fun_name = unique_name()
-            sum_map_src = read_function_from_file("test_functions_with_frozen_types", "sum_map", fun_name) if use_wasm else 'int sum = 0; for (int value : values.values()) {sum += value;} return sum;'
+            sum_map_src = (
+                read_function_from_file(
+                    "test_functions_with_frozen_types", "sum_map", fun_name
+                )
+                if use_wasm
+                else "int sum = 0; for (int value : values.values()) {sum += value;} return sum;"
+            )
             frozen_arg_src = f"(values frozen<map<int, int>>) CALLED ON NULL INPUT RETURNS int LANGUAGE {lang} AS '{sum_map_src}'"
-            assertInvalidMessage(cql, "", "cannot be frozen", f"CREATE FUNCTION {test_keyspace}.{fun_name} {frozen_arg_src}")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"CREATE FUNCTION {test_keyspace}.{fun_name} {frozen_arg_src}",
+            )
 
             ret_name = unique_name()
-            return_map_src = read_function_from_file("test_functions_with_frozen_types", "return_map", ret_name) if use_wasm else 'return values;'
+            return_map_src = (
+                read_function_from_file(
+                    "test_functions_with_frozen_types", "return_map", ret_name
+                )
+                if use_wasm
+                else "return values;"
+            )
             frozen_ret_src = f"(values map<int, int>) CALLED ON NULL INPUT RETURNS frozen<map<int, int>> LANGUAGE {lang} AS '{return_map_src}'"
-            assertInvalidMessage(cql, "", "cannot be frozen", f"CREATE FUNCTION {test_keyspace}.{ret_name} {frozen_ret_src}")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"CREATE FUNCTION {test_keyspace}.{ret_name} {frozen_ret_src}",
+            )
 
             fun_src = f"(values map<int, int>) CALLED ON NULL INPUT RETURNS int LANGUAGE {lang} AS '{sum_map_src}'"
             with new_function(cql, test_keyspace, fun_src, fun_name):
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"), row(0, 0))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"), row(1, 6))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"), row(2, 15))
-                assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"), row(3, 24))
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"),
+                    row(0, 0),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"),
+                    row(1, 6),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"),
+                    row(2, 15),
+                )
+                assertRows(
+                    execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"),
+                    row(3, 24),
+                )
 
             fun_src = f"(values map<int, int>) CALLED ON NULL INPUT RETURNS map<int, int> LANGUAGE {lang} AS '{return_map_src}'"
             with new_function(cql, test_keyspace, fun_src, ret_name):
-                assertRows(execute(cql, table, f"SELECT a FROM %s WHERE b = {ret_name}(?)", {1: 1, 2: 2, 3: 3}), row(1))
+                assertRows(
+                    execute(
+                        cql,
+                        table,
+                        f"SELECT a FROM %s WHERE b = {ret_name}(?)",
+                        {1: 1, 2: 2, 3: 3},
+                    ),
+                    row(1),
+                )
 
-            assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<map<int, int>>)")
+            assertInvalidMessage(
+                cql,
+                "",
+                "cannot be frozen",
+                f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<map<int, int>>)",
+            )
 
-@pytest.mark.skip(reason="Issue #13746")
+
+@pytest.mark.skip(
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746"
+)
 def test_function_with_frozen_tuple_type(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<tuple<int, int>>)") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b frozen<tuple<int, int>>)"
+    ) as table:
         with new_secondary_index(cql, table, "b"):
             use_wasm = is_scylla(cql, test_keyspace)
             lang = "wasm" if use_wasm else "java"
@@ -286,35 +597,102 @@ def test_function_with_frozen_tuple_type(cql, test_keyspace):
             execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", 3, (7, 8))
 
             ret_name = unique_name()
-            return_tuple_src = read_function_from_file("test_functions_with_frozen_types", "return_tuple", ret_name) if use_wasm else 'return values;'
-            cql.execute(f"CREATE FUNCTION {test_keyspace}.{ret_name} (values frozen<tuple<int, int>>) CALLED ON NULL INPUT RETURNS frozen<tuple<int, int>> LANGUAGE {lang} AS '{return_tuple_src}'")
+            return_tuple_src = (
+                read_function_from_file(
+                    "test_functions_with_frozen_types", "return_tuple", ret_name
+                )
+                if use_wasm
+                else "return values;"
+            )
+            cql.execute(
+                f"CREATE FUNCTION {test_keyspace}.{ret_name} (values frozen<tuple<int, int>>) CALLED ON NULL INPUT RETURNS frozen<tuple<int, int>> LANGUAGE {lang} AS '{return_tuple_src}'"
+            )
 
-            assertRowCount(cql.execute(f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{ret_name}'"), 1)
-            cql.execute(f"DROP FUNCTION {test_keyspace}.{ret_name} (frozen<tuple<int, int>>)")
-            assertRowCount(cql.execute(f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{ret_name}'"), 0)
+            assertRowCount(
+                cql.execute(
+                    f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{ret_name}'"
+                ),
+                1,
+            )
+            cql.execute(
+                f"DROP FUNCTION {test_keyspace}.{ret_name} (frozen<tuple<int, int>>)"
+            )
+            assertRowCount(
+                cql.execute(
+                    f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{ret_name}'"
+                ),
+                0,
+            )
 
             fun_name = unique_name()
-            tostring_tuple_src = read_function_from_file("test_functions_with_frozen_types", "tostring_tuple", fun_name) if use_wasm else 'return values.toString();'
-            cql.execute(f"CREATE FUNCTION {test_keyspace}.{fun_name}(values frozen<tuple<int, int>>) CALLED ON NULL INPUT RETURNS text LANGUAGE {lang} AS '{tostring_tuple_src}'")
+            tostring_tuple_src = (
+                read_function_from_file(
+                    "test_functions_with_frozen_types", "tostring_tuple", fun_name
+                )
+                if use_wasm
+                else "return values.toString();"
+            )
+            cql.execute(
+                f"CREATE FUNCTION {test_keyspace}.{fun_name}(values frozen<tuple<int, int>>) CALLED ON NULL INPUT RETURNS text LANGUAGE {lang} AS '{tostring_tuple_src}'"
+            )
 
             # In the future, we may want to decide on a string representation of UDTs in Wasm UDFs that's
             # independent of the language used to implement them, for now we use the Rust debug representation.
-            assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"), row(0, "Some((None, None))" if use_wasm else "(NULL,NULL)"))
-            assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"), row(1, "Some((Some(1), Some(2)))" if use_wasm else "(1,2)"))
-            assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"), row(2, "Some((Some(4), Some(5)))" if use_wasm else "(4,5)"))
-            assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"), row(3, "Some((Some(7), Some(8)))" if use_wasm else "(7,8)"))
+            assertRows(
+                execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"),
+                row(0, "Some((None, None))" if use_wasm else "(NULL,NULL)"),
+            )
+            assertRows(
+                execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"),
+                row(1, "Some((Some(1), Some(2)))" if use_wasm else "(1,2)"),
+            )
+            assertRows(
+                execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"),
+                row(2, "Some((Some(4), Some(5)))" if use_wasm else "(4,5)"),
+            )
+            assertRows(
+                execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"),
+                row(3, "Some((Some(7), Some(8)))" if use_wasm else "(7,8)"),
+            )
 
-            with new_function(cql, test_keyspace, f"(values tuple<int, int>) CALLED ON NULL INPUT RETURNS tuple<int, int> LANGUAGE {lang} AS '{return_tuple_src}'", ret_name):
-                assertRows(execute(cql, table, f"SELECT a FROM %s WHERE b = {ret_name}(?)", (1, 2)), row(1))
+            with new_function(
+                cql,
+                test_keyspace,
+                f"(values tuple<int, int>) CALLED ON NULL INPUT RETURNS tuple<int, int> LANGUAGE {lang} AS '{return_tuple_src}'",
+                ret_name,
+            ):
+                assertRows(
+                    execute(
+                        cql, table, f"SELECT a FROM %s WHERE b = {ret_name}(?)", (1, 2)
+                    ),
+                    row(1),
+                )
 
-            assertRowCount(cql.execute(f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{fun_name}'"), 1)
-            cql.execute(f"DROP FUNCTION {test_keyspace}.{fun_name} (frozen<tuple<int, int>>)")
-            assertRowCount(cql.execute(f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{fun_name}'"), 0)
+            assertRowCount(
+                cql.execute(
+                    f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{fun_name}'"
+                ),
+                1,
+            )
+            cql.execute(
+                f"DROP FUNCTION {test_keyspace}.{fun_name} (frozen<tuple<int, int>>)"
+            )
+            assertRowCount(
+                cql.execute(
+                    f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{fun_name}'"
+                ),
+                0,
+            )
 
-@pytest.mark.skip(reason="Issue #13746")
+
+@pytest.mark.skip(
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746"
+)
 def test_function_with_frozen_udt_type(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(f int)") as type:
-        with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b frozen<{type}>)") as table:
+        with create_table(
+            cql, test_keyspace, f"(a int PRIMARY KEY, b frozen<{type}>)"
+        ) as table:
             with new_secondary_index(cql, table, "b"):
                 use_wasm = is_scylla(cql, test_keyspace)
                 lang = "wasm" if use_wasm else "java"
@@ -324,26 +702,80 @@ def test_function_with_frozen_udt_type(cql, test_keyspace):
                 execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, {f : ?})", 3, 7)
 
                 fun_name = unique_name()
-                tostring_udt_src = read_function_from_file("test_functions_with_frozen_types", "tostring_udt", fun_name) if use_wasm else 'return values.toString();'
+                tostring_udt_src = (
+                    read_function_from_file(
+                        "test_functions_with_frozen_types", "tostring_udt", fun_name
+                    )
+                    if use_wasm
+                    else "return values.toString();"
+                )
                 frozen_arg_src = f"(values frozen<{type}>) CALLED ON NULL INPUT RETURNS text LANGUAGE {lang} AS '{tostring_udt_src}'"
-                assertInvalidMessage(cql, "", "not be frozen", f"CREATE FUNCTION {test_keyspace}.{fun_name} {frozen_arg_src}")
+                assertInvalidMessage(
+                    cql,
+                    "",
+                    "not be frozen",
+                    f"CREATE FUNCTION {test_keyspace}.{fun_name} {frozen_arg_src}",
+                )
 
                 ret_name = unique_name()
-                return_udt_src = read_function_from_file("test_functions_with_frozen_types", "return_udt", ret_name) if use_wasm else 'return values;'
+                return_udt_src = (
+                    read_function_from_file(
+                        "test_functions_with_frozen_types", "return_udt", ret_name
+                    )
+                    if use_wasm
+                    else "return values;"
+                )
                 frozen_ret_src = f"(values {type}) CALLED ON NULL INPUT RETURNS frozen<{type}> LANGUAGE {lang} AS '{return_udt_src}'"
-                assertInvalidMessage(cql, "", "not be frozen", f"CREATE FUNCTION {test_keyspace}.{ret_name} {frozen_ret_src}")
+                assertInvalidMessage(
+                    cql,
+                    "",
+                    "not be frozen",
+                    f"CREATE FUNCTION {test_keyspace}.{ret_name} {frozen_ret_src}",
+                )
 
                 tostring_src = f"(values {type}) CALLED ON NULL INPUT RETURNS text LANGUAGE {lang} AS '{tostring_udt_src}'"
                 with new_function(cql, test_keyspace, tostring_src, fun_name):
-
                     # In the future, we may want to decide on a string representation of UDTs in Wasm UDFs that's
                     # independent of the language used to implement them, for now we use the Rust debug representation.
-                    assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"), row(0, "Some(Udt { f: Some(0) })" if use_wasm else "{f:0}"))
-                    assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"), row(1, "Some(Udt { f: Some(1) })" if use_wasm else "{f:1}"))
-                    assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"), row(2, "Some(Udt { f: Some(4) })" if use_wasm else "{f:4}"))
-                    assertRows(execute(cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"), row(3, "Some(Udt { f: Some(7) })" if use_wasm else "{f:7}"))
+                    assertRows(
+                        execute(
+                            cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 0"
+                        ),
+                        row(0, "Some(Udt { f: Some(0) })" if use_wasm else "{f:0}"),
+                    )
+                    assertRows(
+                        execute(
+                            cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 1"
+                        ),
+                        row(1, "Some(Udt { f: Some(1) })" if use_wasm else "{f:1}"),
+                    )
+                    assertRows(
+                        execute(
+                            cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 2"
+                        ),
+                        row(2, "Some(Udt { f: Some(4) })" if use_wasm else "{f:4}"),
+                    )
+                    assertRows(
+                        execute(
+                            cql, table, f"SELECT a, {fun_name}(b) FROM %s WHERE a = 3"
+                        ),
+                        row(3, "Some(Udt { f: Some(7) })" if use_wasm else "{f:7}"),
+                    )
 
                     nonfrozen_ret_src = f"(values {type}) CALLED ON NULL INPUT RETURNS {type} LANGUAGE {lang} AS '{return_udt_src}'"
                     with new_function(cql, test_keyspace, nonfrozen_ret_src, ret_name):
-                        assertRows(execute(cql, table, f"SELECT a FROM %s WHERE b = {ret_name}({{f : ?}})", 1), row(1))
-                    assertInvalidMessage(cql, "", "not be frozen", f"DROP FUNCTION {test_keyspace}.{fun_name} (frozen<{type}>)")
+                        assertRows(
+                            execute(
+                                cql,
+                                table,
+                                f"SELECT a FROM %s WHERE b = {ret_name}({{f : ?}})",
+                                1,
+                            ),
+                            row(1),
+                        )
+                    assertInvalidMessage(
+                        cql,
+                        "",
+                        "not be frozen",
+                        f"DROP FUNCTION {test_keyspace}.{fun_name} (frozen<{type}>)",
+                    )

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -25,6 +25,7 @@
 from ...porting import *
 from cassandra.protocol import ConfigurationException
 
+
 def testDropColumnAsPreparedStatement(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(key int PRIMARY KEY, value int)") as table:
         prepared = cql.prepare(f"ALTER TABLE {table} DROP value")
@@ -34,215 +35,523 @@ def testDropColumnAsPreparedStatement(cql, test_keyspace):
         cql.execute(f"ALTER TABLE {table} ADD value int")
         assert_rows(cql.execute(f"SELECT * FROM {table}"), [1, None])
 
+
 def testAddList(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id text PRIMARY KEY, content text)") as table:
+    with create_table(
+        cql, test_keyspace, "(id text PRIMARY KEY, content text)"
+    ) as table:
         execute(cql, table, "ALTER TABLE %s ADD myCollection list<text>")
-        execute(cql, table, "INSERT INTO %s (id, content, myCollection) VALUES ('test', 'first test', ['first element'])")
-        assert_rows(execute(cql, table, "SELECT * FROM %s"), ["test", "first test", ["first element"]])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, content, myCollection) VALUES ('test', 'first test', ['first element'])",
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            ["test", "first test", ["first element"]],
+        )
+
 
 def testDropList(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id text PRIMARY KEY, content text, myCollection list<text>)") as table:
-        execute(cql, table, "INSERT INTO %s (id, content , myCollection) VALUES ('test', 'first test', ['first element']);")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id text PRIMARY KEY, content text, myCollection list<text>)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, content , myCollection) VALUES ('test', 'first test', ['first element']);",
+        )
         execute(cql, table, "ALTER TABLE %s DROP myCollection")
         assert_rows(execute(cql, table, "SELECT * FROM %s;"), ["test", "first test"])
+
 
 def testAddMap(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id text PRIMARY KEY, content text)") as table:
+    with create_table(
+        cql, test_keyspace, "(id text PRIMARY KEY, content text)"
+    ) as table:
         execute(cql, table, "ALTER TABLE %s ADD myCollection map<text, text>;")
-        execute(cql, table, "INSERT INTO %s (id, content , myCollection) VALUES ('test', 'first test', { '1' : 'first element'});")
-        assert_rows(execute(cql, table, "SELECT * FROM %s;"), ["test", "first test", {"1": "first element"}])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, content , myCollection) VALUES ('test', 'first test', { '1' : 'first element'});",
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s;"),
+            ["test", "first test", {"1": "first element"}],
+        )
+
 
 def testDropMap(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id text PRIMARY KEY, content text, myCollection map<text, text>)") as table:
-        execute(cql, table, "INSERT INTO %s (id, content , myCollection) VALUES ('test', 'first test', { '1' : 'first element'})")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id text PRIMARY KEY, content text, myCollection map<text, text>)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, content , myCollection) VALUES ('test', 'first test', { '1' : 'first element'})",
+        )
         execute(cql, table, "ALTER TABLE %s DROP myCollection")
         assert_rows(execute(cql, table, "SELECT * FROM %s;"), ["test", "first test"])
 
+
 def testDropListAndAddListWithSameName(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id text PRIMARY KEY, content text, myCollection list<text>)") as table:
-        execute(cql, table, "INSERT INTO %s (id, content, myCollection) VALUES ('test', 'first test', ['first element'])")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id text PRIMARY KEY, content text, myCollection list<text>)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, content, myCollection) VALUES ('test', 'first test', ['first element'])",
+        )
         execute(cql, table, "ALTER TABLE %s DROP myCollection")
         execute(cql, table, "ALTER TABLE %s ADD myCollection list<text>")
-        assert_rows(execute(cql, table, "SELECT * FROM %s;"), ["test", "first test", None])
-        execute(cql, table, "UPDATE %s set myCollection = ['second element'] WHERE id = 'test'")
-        assert_rows(execute(cql, table, "SELECT * FROM %s;"), ["test", "first test", ["second element"]])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s;"), ["test", "first test", None]
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s set myCollection = ['second element'] WHERE id = 'test'",
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s;"),
+            ["test", "first test", ["second element"]],
+        )
+
 
 def testDropListAndAddMapWithSameName(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id text PRIMARY KEY, content text, myCollection list<text>)") as table:
-        execute(cql, table, "INSERT INTO %s (id, content, myCollection) VALUES ('test', 'first test', ['first element'])")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id text PRIMARY KEY, content text, myCollection list<text>)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, content, myCollection) VALUES ('test', 'first test', ['first element'])",
+        )
         execute(cql, table, "ALTER TABLE %s DROP myCollection")
         assert_invalid(cql, table, "ALTER TABLE %s ADD myCollection map<int, int>")
 
+
 # Reproduces #9929
 def testDropWithTimestamp(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id int, c1 int, v1 int, todrop int,  PRIMARY KEY (id, c1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id int, c1 int, v1 int, todrop int,  PRIMARY KEY (id, c1))",
+    ) as table:
         for i in range(5):
-            execute(cql, table, "INSERT INTO %s (id, c1, v1, todrop) VALUES (?, ?, ?, ?) USING TIMESTAMP ?", 1, i, i, i, 10000 * i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (id, c1, v1, todrop) VALUES (?, ?, ?, ?) USING TIMESTAMP ?",
+                1,
+                i,
+                i,
+                i,
+                10000 * i,
+            )
 
         # flush is necessary since otherwise the values of `todrop` will get discarded during
         # alter statement
         flush(cql, table)
         execute(cql, table, "ALTER TABLE %s DROP todrop USING TIMESTAMP 20000")
         execute(cql, table, "ALTER TABLE %s ADD todrop int")
-        execute(cql, table, "INSERT INTO %s (id, c1, v1, todrop) VALUES (?, ?, ?, ?) USING TIMESTAMP ?", 1, 100, 100, 100, 30000)
-        assert_rows(execute(cql, table, "SELECT id, c1, v1, todrop FROM %s"),
-               [1, 0, 0, None],
-               [1, 1, 1, None],
-               [1, 2, 2, None],
-               [1, 3, 3, 3],
-               [1, 4, 4, 4],
-               [1, 100, 100, 100])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, c1, v1, todrop) VALUES (?, ?, ?, ?) USING TIMESTAMP ?",
+            1,
+            100,
+            100,
+            100,
+            30000,
+        )
+        assert_rows(
+            execute(cql, table, "SELECT id, c1, v1, todrop FROM %s"),
+            [1, 0, 0, None],
+            [1, 1, 1, None],
+            [1, 2, 2, None],
+            [1, 3, 3, 3],
+            [1, 4, 4, 4],
+            [1, 100, 100, 100],
+        )
 
-@pytest.mark.xfail(reason="Issue #9930")
+
+@pytest.mark.xfail(
+    reason="Forbid re-adding static columns as regular and vice versa #9930"
+)
 def testDropAddWithDifferentKind(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int static,  PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int static,  PRIMARY KEY (a, b))"
+    ) as table:
         execute(cql, table, "ALTER TABLE %s DROP c")
         execute(cql, table, "ALTER TABLE %s DROP d")
 
-        assert_invalid_message(cql, table, "Cannot re-add previously dropped column 'c' of kind STATIC, incompatible with previous kind REGULAR",
-                         "ALTER TABLE %s ADD c int static")
+        assert_invalid_message(
+            cql,
+            table,
+            "Cannot re-add previously dropped column 'c' of kind STATIC, incompatible with previous kind REGULAR",
+            "ALTER TABLE %s ADD c int static",
+        )
 
-        assert_invalid_message(cql, table, "Cannot re-add previously dropped column 'd' of kind REGULAR, incompatible with previous kind STATIC",
-                         "ALTER TABLE %s ADD d int")
+        assert_invalid_message(
+            cql,
+            table,
+            "Cannot re-add previously dropped column 'd' of kind REGULAR, incompatible with previous kind STATIC",
+            "ALTER TABLE %s ADD d int",
+        )
+
 
 # Reproduces #9929
 def testDropStaticWithTimestamp(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id int, c1 int, v1 int, todrop int static,  PRIMARY KEY (id, c1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id int, c1 int, v1 int, todrop int static,  PRIMARY KEY (id, c1))",
+    ) as table:
         for i in range(5):
-            execute(cql, table, "INSERT INTO %s (id, c1, v1, todrop) VALUES (?, ?, ?, ?) USING TIMESTAMP ?", 1, i, i, i, 10000 * i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (id, c1, v1, todrop) VALUES (?, ?, ?, ?) USING TIMESTAMP ?",
+                1,
+                i,
+                i,
+                i,
+                10000 * i,
+            )
 
         # flush is necessary since otherwise the values of `todrop` will get discarded during
         # alter statement
         flush(cql, table)
         execute(cql, table, "ALTER TABLE %s DROP todrop USING TIMESTAMP 20000")
         execute(cql, table, "ALTER TABLE %s ADD todrop int static")
-        execute(cql, table, "INSERT INTO %s (id, c1, v1, todrop) VALUES (?, ?, ?, ?) USING TIMESTAMP ?", 1, 100, 100, 100, 30000)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, c1, v1, todrop) VALUES (?, ?, ?, ?) USING TIMESTAMP ?",
+            1,
+            100,
+            100,
+            100,
+            30000,
+        )
         # static column value with largest timestamp will be available again
-        assert_rows(execute(cql, table, "SELECT id, c1, v1, todrop FROM %s"),
-               [1, 0, 0, 4],
-               [1, 1, 1, 4],
-               [1, 2, 2, 4],
-               [1, 3, 3, 4],
-               [1, 4, 4, 4],
-               [1, 100, 100, 4])
+        assert_rows(
+            execute(cql, table, "SELECT id, c1, v1, todrop FROM %s"),
+            [1, 0, 0, 4],
+            [1, 1, 1, 4],
+            [1, 2, 2, 4],
+            [1, 3, 3, 4],
+            [1, 4, 4, 4],
+            [1, 100, 100, 4],
+        )
+
 
 # Reproduces #9929
 def testDropMultipleWithTimestamp(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id int, c1 int, v1 int, todrop1 int, todrop2 int,  PRIMARY KEY (id, c1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id int, c1 int, v1 int, todrop1 int, todrop2 int,  PRIMARY KEY (id, c1))",
+    ) as table:
         for i in range(5):
-            execute(cql, table, "INSERT INTO %s (id, c1, v1, todrop1, todrop2) VALUES (?, ?, ?, ?, ?) USING TIMESTAMP ?", 1, i, i, i, i, 10000 * i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (id, c1, v1, todrop1, todrop2) VALUES (?, ?, ?, ?, ?) USING TIMESTAMP ?",
+                1,
+                i,
+                i,
+                i,
+                i,
+                10000 * i,
+            )
         # flush is necessary since otherwise the values of `todrop1` and `todrop2` will get discarded during
         # alter statement
         flush(cql, table)
-        execute(cql, table, "ALTER TABLE %s DROP (todrop1, todrop2) USING TIMESTAMP 20000;")
+        execute(
+            cql, table, "ALTER TABLE %s DROP (todrop1, todrop2) USING TIMESTAMP 20000;"
+        )
         execute(cql, table, "ALTER TABLE %s ADD todrop1 int;")
         execute(cql, table, "ALTER TABLE %s ADD todrop2 int;")
 
-        execute(cql, table, "INSERT INTO %s (id, c1, v1, todrop1, todrop2) VALUES (?, ?, ?, ?, ?) USING TIMESTAMP ?", 1, 100, 100, 100, 100, 40000)
-        assert_rows(execute(cql, table, "SELECT id, c1, v1, todrop1, todrop2 FROM %s"),
-               [1, 0, 0, None, None],
-               [1, 1, 1, None, None],
-               [1, 2, 2, None, None],
-               [1, 3, 3, 3, 3],
-               [1, 4, 4, 4, 4],
-               [1, 100, 100, 100, 100])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (id, c1, v1, todrop1, todrop2) VALUES (?, ?, ?, ?, ?) USING TIMESTAMP ?",
+            1,
+            100,
+            100,
+            100,
+            100,
+            40000,
+        )
+        assert_rows(
+            execute(cql, table, "SELECT id, c1, v1, todrop1, todrop2 FROM %s"),
+            [1, 0, 0, None, None],
+            [1, 1, 1, None, None],
+            [1, 2, 2, None, None],
+            [1, 3, 3, 3, 3],
+            [1, 4, 4, 4, 4],
+            [1, 100, 100, 100, 100],
+        )
+
 
 def testChangeStrategyWithUnquotedAgrument(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id text PRIMARY KEY)") as table:
-        assert_invalid_syntax(cql, table,
-            "ALTER TABLE %s WITH caching = {'keys' : 'all', 'rows_per_partition' : ALL};")
+        assert_invalid_syntax(
+            cql,
+            table,
+            "ALTER TABLE %s WITH caching = {'keys' : 'all', 'rows_per_partition' : ALL};",
+        )
+
 
 # tests CASSANDRA-7976
 def testAlterIndexInterval(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id uuid, album text, atrist text, data blob, PRIMARY KEY (id))") as table:
-        execute(cql, table, "ALTER TABLE %s WITH min_index_interval=256 AND max_index_interval=512")
-        [ks, cf] = table.split('.')
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id uuid, album text, atrist text, data blob, PRIMARY KEY (id))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "ALTER TABLE %s WITH min_index_interval=256 AND max_index_interval=512",
+        )
+        [ks, cf] = table.split(".")
         options = cql.cluster.metadata.keyspaces[ks].tables[cf].options
-        assert options['min_index_interval'] == 256
-        assert options['max_index_interval'] == 512
+        assert options["min_index_interval"] == 256
+        assert options["max_index_interval"] == 512
 
         execute(cql, table, "ALTER TABLE %s WITH caching = {}")
         options = cql.cluster.metadata.keyspaces[ks].tables[cf].options
-        assert options['min_index_interval'] == 256
-        assert options['max_index_interval'] == 512
+        assert options["min_index_interval"] == 256
+        assert options["max_index_interval"] == 512
+
 
 # Migrated from cql_tests.py:TestCQL.create_alter_options_test()
 # Reproduces #9935
-@pytest.mark.xfail(reason="Issue #9935")
+@pytest.mark.xfail(
+    reason="Scylla stores un-expanded compaction class name in system tables #9935"
+)
 def testCreateAlterKeyspaces(cql, test_keyspace, this_dc):
     # ScyllaDB allows default parameters on CREATE KEYSPACE, so these checks
     # are no longer valid:
-    #assert_invalid_throw(cql, test_keyspace, SyntaxException, "CREATE KEYSPACE ks1")
-    #assert_invalid_throw(cql, test_keyspace, ConfigurationException, "CREATE KEYSPACE ks1 WITH replication= { 'replication_factor' : 1 }")
+    # assert_invalid_throw(cql, test_keyspace, SyntaxException, "CREATE KEYSPACE ks1")
+    # assert_invalid_throw(cql, test_keyspace, ConfigurationException, "CREATE KEYSPACE ks1 WITH replication= { 'replication_factor' : 1 }")
 
-    with create_keyspace(cql, "replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }") as ks1:
-        with create_keyspace(cql, "replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 1 } AND durable_writes=false") as ks2:
-            assert_rows_ignoring_order_and_extra(execute(cql, ks1, "SELECT keyspace_name, durable_writes FROM system_schema.keyspaces"),
-               [ks1, True],
-               [ks2, False])
+    with create_keyspace(
+        cql, "replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }"
+    ) as ks1:
+        with create_keyspace(
+            cql,
+            "replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 1 } AND durable_writes=false",
+        ) as ks2:
+            assert_rows_ignoring_order_and_extra(
+                execute(
+                    cql,
+                    ks1,
+                    "SELECT keyspace_name, durable_writes FROM system_schema.keyspaces",
+                ),
+                [ks1, True],
+                [ks2, False],
+            )
 
-            execute(cql, ks1, "ALTER KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 } AND durable_writes=False")
+            execute(
+                cql,
+                ks1,
+                "ALTER KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', '"
+                + this_dc
+                + "' : 1 } AND durable_writes=False",
+            )
             execute(cql, ks2, "ALTER KEYSPACE %s WITH durable_writes=true")
 
-            assert_rows_ignoring_order_and_extra(execute(cql, ks1, "SELECT keyspace_name, durable_writes, replication FROM system_schema.keyspaces"),
-               [ks1, False, {"class": "org.apache.cassandra.locator.NetworkTopologyStrategy", this_dc: "1"}],
-               [ks2, True, {"class": "org.apache.cassandra.locator.SimpleStrategy", "replication_factor": "1"}])
+            assert_rows_ignoring_order_and_extra(
+                execute(
+                    cql,
+                    ks1,
+                    "SELECT keyspace_name, durable_writes, replication FROM system_schema.keyspaces",
+                ),
+                [
+                    ks1,
+                    False,
+                    {
+                        "class": "org.apache.cassandra.locator.NetworkTopologyStrategy",
+                        this_dc: "1",
+                    },
+                ],
+                [
+                    ks2,
+                    True,
+                    {
+                        "class": "org.apache.cassandra.locator.SimpleStrategy",
+                        "replication_factor": "1",
+                    },
+                ],
+            )
 
-            assert_invalid_throw(cql, ks1, ConfigurationException, "CREATE TABLE %s.cf1 (a int PRIMARY KEY, b int) WITH compaction = { 'min_threshold' : 4 }")
+            assert_invalid_throw(
+                cql,
+                ks1,
+                ConfigurationException,
+                "CREATE TABLE %s.cf1 (a int PRIMARY KEY, b int) WITH compaction = { 'min_threshold' : 4 }",
+            )
 
-            with create_table(cql, ks1, "(a int PRIMARY KEY, b int) WITH compaction = { 'class' : 'SizeTieredCompactionStrategy', 'min_threshold' : 7 }") as table:
-                [ks, cf] = table.split('.')
+            with create_table(
+                cql,
+                ks1,
+                "(a int PRIMARY KEY, b int) WITH compaction = { 'class' : 'SizeTieredCompactionStrategy', 'min_threshold' : 7 }",
+            ) as table:
+                [ks, cf] = table.split(".")
                 # There's a minor difference here between Scylla and Cassandra-
                 # Cassandra expands the name SizeTieredCompactionStrategy to
                 # org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,
                 # and stores that in system_schema.tables. Scylla doesn't -
                 # it stores the original short name given in the table creation
                 # command. See issue #9935.
-                assert_rows(execute(cql, ks, "SELECT table_name, compaction FROM system_schema.tables WHERE keyspace_name='%s'"),
-                   [cf, {"class": "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy",
-                              "min_threshold": "7",
-                              "max_threshold": "32"}])
+                assert_rows(
+                    execute(
+                        cql,
+                        ks,
+                        "SELECT table_name, compaction FROM system_schema.tables WHERE keyspace_name='%s'",
+                    ),
+                    [
+                        cf,
+                        {
+                            "class": "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy",
+                            "min_threshold": "7",
+                            "max_threshold": "32",
+                        },
+                    ],
+                )
+
 
 # NOTE: The two tests, testCreateAlterNetworkTopologyWithDefaults() and
 # testCreateSimpleAlterNTSDefaults() were not translated to this test
 # framework because it doesn't create more than one DC - which these
 # two tests try to test.
 
+
 # Test {@link ConfigurationException} thrown on alter keyspace to no DC
 # option in replication configuration.
 # Reproduces CASSANDRA-12681 and Scylla #10036
-def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace, this_dc, has_tablets):
+def testAlterKeyspaceWithNoOptionThrowsConfigurationException(
+    cql, test_keyspace, this_dc, has_tablets
+):
     if has_tablets:
         extra_opts = " AND TABLETS = {'enabled': false}"
     else:
         extra_opts = ""
     # Create keyspaces
-    with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3 }" + extra_opts) as abc:
-        with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }" + extra_opts) as xyz:
+    with create_keyspace(
+        cql,
+        "replication={ 'class' : 'NetworkTopologyStrategy', '"
+        + this_dc
+        + "' : 3 }"
+        + extra_opts,
+    ) as abc:
+        with create_keyspace(
+            cql,
+            "replication={ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }"
+            + extra_opts,
+        ) as xyz:
             # Try to alter the created keyspace without any option
-            assert_invalid_throw(cql, xyz, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'SimpleStrategy' }")
-            assert_invalid_throw(cql, abc, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy' }")
+            assert_invalid_throw(
+                cql,
+                xyz,
+                ConfigurationException,
+                "ALTER KEYSPACE %s WITH replication={ 'class' : 'SimpleStrategy' }",
+            )
+            assert_invalid_throw(
+                cql,
+                abc,
+                ConfigurationException,
+                "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy' }",
+            )
             # Make sure that the alter works as expected
-            execute(cql, abc, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }")
-            execute(cql, xyz, "ALTER KEYSPACE %s WITH replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }")
+            execute(
+                cql,
+                abc,
+                "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '"
+                + this_dc
+                + "' : 2 }",
+            )
+            execute(
+                cql,
+                xyz,
+                "ALTER KEYSPACE %s WITH replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 2 }",
+            )
+
 
 # Test {@link ConfigurationException} thrown when altering a keyspace to
 # invalid DC option in replication configuration.
-def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keyspace, this_dc):
+def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(
+    cql, test_keyspace, this_dc
+):
     # Create a keyspace with expected DC name.
-    with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as ks:
-        pattern = re.compile("Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy|Unrecognized datacenter name 'INVALID_DC'")
+    with create_keyspace(
+        cql,
+        "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }",
+    ) as ks:
+        pattern = re.compile(
+            "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy|Unrecognized datacenter name 'INVALID_DC'"
+        )
         # try modifying the keyspace
-        execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
+        execute(
+            cql,
+            ks,
+            "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '"
+            + this_dc
+            + "' : 1 }",
+        )
         # Mix valid and invalid, should throw an exception
-        assert_invalid_throw_message_re(cql, ks, pattern, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 , 'INVALID_DC': 1}")
+        assert_invalid_throw_message_re(
+            cql,
+            ks,
+            pattern,
+            ConfigurationException,
+            "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '"
+            + this_dc
+            + "' : 1 , 'INVALID_DC': 1}",
+        )
 
-def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(cql, test_keyspace, this_dc):
+
+def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(
+    cql, test_keyspace, this_dc
+):
     # Create a keyspace
-    with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as ks:
+    with create_keyspace(
+        cql,
+        "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }",
+    ) as ks:
         # try modifying the keyspace
-        assert_invalid_throw(cql, ks, SyntaxException, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2, '" + this_dc + "' : 1 }")
-        execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1}")
+        assert_invalid_throw(
+            cql,
+            ks,
+            SyntaxException,
+            "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '"
+            + this_dc
+            + "' : 2, '"
+            + this_dc
+            + "' : 1 }",
+        )
+        execute(
+            cql,
+            ks,
+            "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '"
+            + this_dc
+            + "' : 1}",
+        )
+
 
 # Test for bug of CASSANDRA-5232,
 # migrated from cql_tests.py:TestCQL.alter_bug_test()
@@ -250,11 +559,10 @@ def testAlterStatementWithAdd(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int PRIMARY KEY, t text)") as table:
         execute(cql, table, "UPDATE %s SET t = '111' WHERE id = 1")
         execute(cql, table, "ALTER TABLE %s ADD l list<text>")
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-               [1, None, "111"])
+        assert_rows(execute(cql, table, "SELECT * FROM %s"), [1, None, "111"])
         execute(cql, table, "ALTER TABLE %s ADD m map<int, text>")
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-               [1, None, None, "111"])
+        assert_rows(execute(cql, table, "SELECT * FROM %s"), [1, None, None, "111"])
+
 
 # Test for CASSANDRA-7744,
 # migrated from cql_tests.py:TestCQL.downgrade_to_compact_bug_test()
@@ -265,59 +573,221 @@ def testDowngradeToCompact(cql, test_keyspace):
         execute(cql, table, "alter table %s drop v")
         execute(cql, table, "alter table %s add v1 int")
 
+
 # tests CASSANDRA-9565
 def testDoubleWith(cql, test_keyspace):
-    stmts = [ "ALTER KEYSPACE WITH WITH DURABLE_WRITES = true",
-              f"ALTER KEYSPACE {test_keyspace} WITH WITH DURABLE_WRITES = true" ]
+    stmts = [
+        "ALTER KEYSPACE WITH WITH DURABLE_WRITES = true",
+        f"ALTER KEYSPACE {test_keyspace} WITH WITH DURABLE_WRITES = true",
+    ]
     for stmt in stmts:
         assert_invalid_throw(cql, test_keyspace, SyntaxException, stmt)
 
-@pytest.mark.xfail(reason="Issue #8948")
+
+@pytest.mark.xfail(
+    reason='Cassandra 3.11.10 uses "class" instead of "sstable_compression" for compression settings by default #8948'
+)
 def testAlterTableWithCompression(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b int, c int, primary key (a, b))") as table:
-        [ks, cf] = table.split('.')
+    with create_table(
+        cql, test_keyspace, "(a text, b int, c int, primary key (a, b))"
+    ) as table:
+        [ks, cf] = table.split(".")
         # This first assert already reproduces #8948
-        assert_rows(execute(cql, table, "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;", ks, cf),
-               [{"chunk_length_in_kb": "16", "class": "org.apache.cassandra.io.compress.LZ4Compressor"}])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;",
+                ks,
+                cf,
+            ),
+            [
+                {
+                    "chunk_length_in_kb": "16",
+                    "class": "org.apache.cassandra.io.compress.LZ4Compressor",
+                }
+            ],
+        )
 
-        execute(cql, table, "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };")
-        assert_rows(execute(cql, table, "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;", ks, cf),
-               [{"chunk_length_in_kb": "32", "class": "org.apache.cassandra.io.compress.SnappyCompressor"}])
+        execute(
+            cql,
+            table,
+            "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;",
+                ks,
+                cf,
+            ),
+            [
+                {
+                    "chunk_length_in_kb": "32",
+                    "class": "org.apache.cassandra.io.compress.SnappyCompressor",
+                }
+            ],
+        )
 
-        execute(cql, table, "ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'chunk_length_in_kb' : 64 };")
-        assert_rows(execute(cql, table, "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;", ks, cf),
-               [{"chunk_length_in_kb": "64", "class": "org.apache.cassandra.io.compress.LZ4Compressor"}])
+        execute(
+            cql,
+            table,
+            "ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'chunk_length_in_kb' : 64 };",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;",
+                ks,
+                cf,
+            ),
+            [
+                {
+                    "chunk_length_in_kb": "64",
+                    "class": "org.apache.cassandra.io.compress.LZ4Compressor",
+                }
+            ],
+        )
 
-        execute(cql, table, "ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 2 };")
-        assert_rows(execute(cql, table, "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;", ks, cf),
-               [{"chunk_length_in_kb": "16", "class": "org.apache.cassandra.io.compress.LZ4Compressor", "min_compress_ratio": "2.0"}])
+        execute(
+            cql,
+            table,
+            "ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 2 };",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;",
+                ks,
+                cf,
+            ),
+            [
+                {
+                    "chunk_length_in_kb": "16",
+                    "class": "org.apache.cassandra.io.compress.LZ4Compressor",
+                    "min_compress_ratio": "2.0",
+                }
+            ],
+        )
 
-        execute(cql, table, "ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 1 };")
-        assert_rows(execute(cql, table, "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;", ks, cf),
-               [{"chunk_length_in_kb": "16", "class": "org.apache.cassandra.io.compress.LZ4Compressor", "min_compress_ratio": "1.0"}])
+        execute(
+            cql,
+            table,
+            "ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 1 };",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;",
+                ks,
+                cf,
+            ),
+            [
+                {
+                    "chunk_length_in_kb": "16",
+                    "class": "org.apache.cassandra.io.compress.LZ4Compressor",
+                    "min_compress_ratio": "1.0",
+                }
+            ],
+        )
 
-        execute(cql, table, "ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 0 };")
-        assert_rows(execute(cql, table, "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;", ks, cf),
-               [{"chunk_length_in_kb": "16", "class": "org.apache.cassandra.io.compress.LZ4Compressor"}])
+        execute(
+            cql,
+            table,
+            "ALTER TABLE %s WITH compression = { 'class' : 'LZ4Compressor', 'min_compress_ratio' : 0 };",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;",
+                ks,
+                cf,
+            ),
+            [
+                {
+                    "chunk_length_in_kb": "16",
+                    "class": "org.apache.cassandra.io.compress.LZ4Compressor",
+                }
+            ],
+        )
 
-        execute(cql, table, "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };")
+        execute(
+            cql,
+            table,
+            "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_in_kb' : 32 };",
+        )
         execute(cql, table, "ALTER TABLE %s WITH compression = { 'enabled' : 'false'};")
-        assert_rows(execute(cql, table, "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;", ks, cf),
-               [{"enabled": "false"}])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT compression FROM system_schema.tables WHERE keyspace_name = ? and table_name = ?;",
+                ks,
+                cf,
+            ),
+            [{"enabled": "false"}],
+        )
 
-        assert_invalid_throw_message(cql, table, "Missing sub-option 'class' for the 'compression' option.", ConfigurationException, "ALTER TABLE %s WITH  compression = {'chunk_length_in_kb' : 32};")
+        assert_invalid_throw_message(
+            cql,
+            table,
+            "Missing sub-option 'class' for the 'compression' option.",
+            ConfigurationException,
+            "ALTER TABLE %s WITH  compression = {'chunk_length_in_kb' : 32};",
+        )
 
-        assert_invalid_throw_message(cql, table, "The 'class' option must not be empty. To disable compression use 'enabled' : false", ConfigurationException, "ALTER TABLE %s WITH  compression = { 'class' : ''};");
+        assert_invalid_throw_message(
+            cql,
+            table,
+            "The 'class' option must not be empty. To disable compression use 'enabled' : false",
+            ConfigurationException,
+            "ALTER TABLE %s WITH  compression = { 'class' : ''};",
+        )
+        assert_invalid_throw_message(
+            cql,
+            table,
+            "If the 'enabled' option is set to false no other options must be specified",
+            ConfigurationException,
+            "ALTER TABLE %s WITH compression = { 'enabled' : 'false', 'class' : 'SnappyCompressor'};",
+        )
 
-        assert_invalid_throw_message(cql, table, "If the 'enabled' option is set to false no other options must be specified", ConfigurationException, "ALTER TABLE %s WITH compression = { 'enabled' : 'false', 'class' : 'SnappyCompressor'};")
+        assert_invalid_throw_message(
+            cql,
+            table,
+            "The 'sstable_compression' option must not be used if the compression algorithm is already specified by the 'class' option",
+            ConfigurationException,
+            "ALTER TABLE %s WITH compression = { 'sstable_compression' : 'SnappyCompressor', 'class' : 'SnappyCompressor'};",
+        )
 
-        assert_invalid_throw_message(cql, table, "The 'sstable_compression' option must not be used if the compression algorithm is already specified by the 'class' option", ConfigurationException, "ALTER TABLE %s WITH compression = { 'sstable_compression' : 'SnappyCompressor', 'class' : 'SnappyCompressor'};")
+        assert_invalid_throw_message(
+            cql,
+            table,
+            "The 'chunk_length_kb' option must not be used if the chunk length is already specified by the 'chunk_length_in_kb' option",
+            ConfigurationException,
+            "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_kb' : 32 , 'chunk_length_in_kb' : 32 };",
+        )
 
-        assert_invalid_throw_message(cql, table, "The 'chunk_length_kb' option must not be used if the chunk length is already specified by the 'chunk_length_in_kb' option", ConfigurationException, "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'chunk_length_kb' : 32 , 'chunk_length_in_kb' : 32 };")
+        assert_invalid_throw_message(
+            cql,
+            table,
+            "Invalid negative min_compress_ratio",
+            ConfigurationException,
+            "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'min_compress_ratio' : -1 };",
+        )
 
-        assert_invalid_throw_message(cql, table, "Invalid negative min_compress_ratio", ConfigurationException, "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'min_compress_ratio' : -1 };")
+        assert_invalid_throw_message(
+            cql,
+            table,
+            "min_compress_ratio can either be 0 or greater than or equal to 1",
+            ConfigurationException,
+            "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'min_compress_ratio' : 0.5 };",
+        )
 
-        assert_invalid_throw_message(cql, table, "min_compress_ratio can either be 0 or greater than or equal to 1", ConfigurationException, "ALTER TABLE %s WITH compression = { 'class' : 'SnappyCompressor', 'min_compress_ratio' : 0.5 };")
 
 # Test for CASSANDRA-13337. Checks that dropping a column when a sstable contains only data for that column
 # works properly.
@@ -331,11 +801,14 @@ def testAlterDropEmptySSTable(cql, test_keyspace):
         compact(cql, table)
         assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, 1])
 
+
 # Similarly to testAlterDropEmptySSTable, checks we don't return empty rows from queries (testAlterDropEmptySSTable
 # tests the compaction case).
 def testAlterOnlyColumnBehaviorWithFlush(cql, test_keyspace):
     for flushAfterInsert in [True, False]:
-        with create_table(cql, test_keyspace, "(k int PRIMARY KEY, x int, y int)") as table:
+        with create_table(
+            cql, test_keyspace, "(k int PRIMARY KEY, x int, y int)"
+        ) as table:
             execute(cql, table, "UPDATE %s SET x = 1 WHERE k = 0")
             assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, 1, None])
             if flushAfterInsert:
@@ -343,19 +816,30 @@ def testAlterOnlyColumnBehaviorWithFlush(cql, test_keyspace):
             execute(cql, table, "ALTER TABLE %s DROP x")
             assert_empty(execute(cql, table, "SELECT * FROM %s"))
 
+
 # This test was modified from the original Cassandra test. Cassandra lists
 # in the error message all the tables which need the UDT, but Scylla doesn't
 # so we need a more direct test that doesn't rely on the error message.
 # Reproduces CASSANDRA-15933
 def testAlterTypeUsedInPartitionKey(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(v1 int)") as type1:
-        with create_type(cql, test_keyspace, f"(v1 frozen<{type1}>, v2 frozen<{type1}>)") as type2:
+        with create_type(
+            cql, test_keyspace, f"(v1 frozen<{type1}>, v2 frozen<{type1}>)"
+        ) as type2:
             # frozen UDT used directly in a partition key
-            with create_table(cql, test_keyspace, f"(pk frozen<{type1}>, val int, PRIMARY KEY(pk))") as table1:
+            with create_table(
+                cql, test_keyspace, f"(pk frozen<{type1}>, val int, PRIMARY KEY(pk))"
+            ) as table1:
                 assert_invalid_message(cql, type1, table1, "ALTER TYPE %s ADD v2 int;")
             # frozen UDT used in a frozen UDT used in a partition key
-            with create_table(cql, test_keyspace, f"(pk frozen<{type2}>, val int, PRIMARY KEY(pk))") as table2:
+            with create_table(
+                cql, test_keyspace, f"(pk frozen<{type2}>, val int, PRIMARY KEY(pk))"
+            ) as table2:
                 assert_invalid_message(cql, type1, table2, "ALTER TYPE %s ADD v2 int;")
             # frozen UDT used in a frozen collection used in a partition key
-            with create_table(cql, test_keyspace, f"(pk frozen<list<frozen<{type1}>>>, val int, PRIMARY KEY(pk))") as table3:
+            with create_table(
+                cql,
+                test_keyspace,
+                f"(pk frozen<list<frozen<{type1}>>>, val int, PRIMARY KEY(pk))",
+            ) as table3:
                 assert_invalid_message(cql, type1, table3, "ALTER TYPE %s ADD v2 int;")

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -13,9 +13,11 @@ from uuid import UUID
 
 compactOption = " WITH COMPACT STORAGE"
 
+
 @pytest.fixture(scope="function", autouse=True)
 def all_tests_in_this_file_use_compact_storage(compact_storage):
-     pass
+    pass
+
 
 # ALTER ... DROP COMPACT STORAGE was recently dropped (unless a special
 # flag is used) by Cassandra, and it was never implemented in Scylla, so
@@ -23,155 +25,355 @@ def all_tests_in_this_file_use_compact_storage(compact_storage):
 # See issue #3882
 @pytest.mark.skip
 def testSparseCompactTableIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(key ascii PRIMARY KEY, val ascii) WITH COMPACT STORAGE") as table:
-
+    with create_table(
+        cql, test_keyspace, "(key ascii PRIMARY KEY, val ascii) WITH COMPACT STORAGE"
+    ) as table:
         # Indexes are allowed only on the sparse compact tables
         execute(cql, table, "CREATE INDEX ON %s(val)")
         for i in range(10):
-            execute(cql, table, "INSERT INTO %s (key, val) VALUES (?, ?)", str(i), str(i * 10))
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (key, val) VALUES (?, ?)",
+                str(i),
+                str(i * 10),
+            )
 
         execute(cql, table, "ALTER TABLE %s DROP COMPACT STORAGE")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE val = '50'"),
-                   ["5", None, "50", None])
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE key = '5'"),
-                   ["5", None, "50", None])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE val = '50'"),
+            ["5", None, "50", None],
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE key = '5'"),
+            ["5", None, "50", None],
+        )
+
 
 def testBefore(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(key TEXT, column TEXT, value BLOB, PRIMARY KEY (key, column)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(key TEXT, column TEXT, value BLOB, PRIMARY KEY (key, column)) WITH COMPACT STORAGE",
+    ) as table:
         largeBytes = bytearray(100000)
-        execute(cql, table, "INSERT INTO %s (key, column, value) VALUES (?, ?, ?)", "test", "a", largeBytes)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (key, column, value) VALUES (?, ?, ?)",
+            "test",
+            "a",
+            largeBytes,
+        )
         smallBytes = bytearray(10)
-        execute(cql, table, "INSERT INTO %s (key, column, value) VALUES (?, ?, ?)", "test", "c", smallBytes)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (key, column, value) VALUES (?, ?, ?)",
+            "test",
+            "c",
+            smallBytes,
+        )
 
         flush(cql, table)
 
-        assert_rows(execute(cql, table, "SELECT column FROM %s WHERE key = ? AND column IN (?, ?, ?)", "test", "c", "a", "b"),
-                   ["a"],
-                   ["c"])
-
-def testStaticCompactTables(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k text PRIMARY KEY, v1 int, v2 text) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "first", 1, "value1")
-        execute(cql, table, "INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "second", 2, "value2")
-        execute(cql, table, "INSERT INTO %s (k, v1, v2) values (?, ?, ?)", "third", 3, "value3")
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ?", "first"),
-                   ["first", 1, "value1"]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT column FROM %s WHERE key = ? AND column IN (?, ?, ?)",
+                "test",
+                "c",
+                "a",
+                "b",
+            ),
+            ["a"],
+            ["c"],
         )
 
-        assert_rows(execute(cql, table, "SELECT v2 FROM %s WHERE k = ?", "second"),
-                   ["value2"]
+
+def testStaticCompactTables(cql, test_keyspace):
+    with create_table(
+        cql, test_keyspace, "(k text PRIMARY KEY, v1 int, v2 text) WITH COMPACT STORAGE"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v1, v2) values (?, ?, ?)",
+            "first",
+            1,
+            "value1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v1, v2) values (?, ?, ?)",
+            "second",
+            2,
+            "value2",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v1, v2) values (?, ?, ?)",
+            "third",
+            3,
+            "value3",
+        )
+
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k = ?", "first"),
+            ["first", 1, "value1"],
+        )
+
+        assert_rows(
+            execute(cql, table, "SELECT v2 FROM %s WHERE k = ?", "second"), ["value2"]
         )
 
         # Murmur3 order
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   ["third", 3, "value3"],
-                   ["second", 2, "value2"],
-                   ["first", 1, "value1"]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            ["third", 3, "value3"],
+            ["second", 2, "value2"],
+            ["first", 1, "value1"],
         )
 
+
 def testCompactStorageUpdateWithNull(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, value int, PRIMARY KEY (partitionKey, clustering_1)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 1, 1)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, value int, PRIMARY KEY (partitionKey, clustering_1)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 1, 1)",
+        )
 
         flush(cql, table)
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?", None, 0, 0)
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))", 0, 0, 1),
-                   [0, 1, 1]
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            None,
+            0,
+            0,
         )
+
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
+                0,
+                0,
+                1,
+            ),
+            [0, 1, 1],
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.collection_compact_test()
 def testCompactCollections(cql, test_keyspace):
     tableName = test_keyspace + "." + unique_name()
-    assert_invalid(cql, test_keyspace, f"CREATE TABLE {tableName} (user ascii PRIMARY KEY, mails list < text >) WITH COMPACT STORAGE;")
+    assert_invalid(
+        cql,
+        test_keyspace,
+        f"CREATE TABLE {tableName} (user ascii PRIMARY KEY, mails list < text >) WITH COMPACT STORAGE;",
+    )
+
 
 # Check for a table with counters,
 # migrated from cql_tests.py:TestCQL.counters_test()
 @pytest.mark.xfail(reason="Cassandra 3.10's += syntax not yet supported. Issue #7735")
 def testCounters(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(userid int, url text, total counter, PRIMARY KEY (userid, url)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [1])
+    with create_table(
+        cql,
+        test_keyspace,
+        "(userid int, url text, total counter, PRIMARY KEY (userid, url)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [1],
+        )
 
-        execute(cql, table, "UPDATE %s SET total = total - 4 WHERE userid = 1 AND url = 'http://foo.com'")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [-3])
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET total = total - 4 WHERE userid = 1 AND url = 'http://foo.com'",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [-3],
+        )
 
-        execute(cql, table, "UPDATE %s SET total = total+1 WHERE userid = 1 AND url = 'http://foo.com'")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [-2])
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET total = total+1 WHERE userid = 1 AND url = 'http://foo.com'",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [-2],
+        )
 
-        execute(cql, table, "UPDATE %s SET total = total -2 WHERE userid = 1 AND url = 'http://foo.com'")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [-4])
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET total = total -2 WHERE userid = 1 AND url = 'http://foo.com'",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [-4],
+        )
 
         # Reproduces #7735:
-        execute(cql, table, "UPDATE %s SET total += 6 WHERE userid = 1 AND url = 'http://foo.com'")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [2])
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET total += 6 WHERE userid = 1 AND url = 'http://foo.com'",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [2],
+        )
 
-        execute(cql, table, "UPDATE %s SET total -= 1 WHERE userid = 1 AND url = 'http://foo.com'")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [1])
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET total -= 1 WHERE userid = 1 AND url = 'http://foo.com'",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [1],
+        )
 
-        execute(cql, table, "UPDATE %s SET total += -2 WHERE userid = 1 AND url = 'http://foo.com'")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [-1])
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET total += -2 WHERE userid = 1 AND url = 'http://foo.com'",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [-1],
+        )
 
-        execute(cql, table, "UPDATE %s SET total -= -2 WHERE userid = 1 AND url = 'http://foo.com'")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [1])
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET total -= -2 WHERE userid = 1 AND url = 'http://foo.com'",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [1],
+        )
+
 
 def testCounterFiltering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, a COUNTER) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(k int PRIMARY KEY, a COUNTER) WITH COMPACT STORAGE"
+    ) as table:
         for i in range(10):
             execute(cql, table, "UPDATE %s SET a = a + ? WHERE k = ?", i, i)
 
         execute(cql, table, "UPDATE %s SET a = a + ? WHERE k = ?", 6, 10)
 
         # GT
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a > ? ALLOW FILTERING", 5),
-                                [6, 6],
-                                [7, 7],
-                                [8, 8],
-                                [9, 9],
-                                [10, 6])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a > ? ALLOW FILTERING", 5),
+            [6, 6],
+            [7, 7],
+            [8, 8],
+            [9, 9],
+            [10, 6],
+        )
 
         # GTE
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a >= ? ALLOW FILTERING", 6),
-                                [6, 6],
-                                [7, 7],
-                                [8, 8],
-                                [9, 9],
-                                [10, 6])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a >= ? ALLOW FILTERING", 6),
+            [6, 6],
+            [7, 7],
+            [8, 8],
+            [9, 9],
+            [10, 6],
+        )
 
         # LT
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a < ? ALLOW FILTERING", 3),
-                                [0, 0],
-                                [1, 1],
-                                [2, 2])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a < ? ALLOW FILTERING", 3),
+            [0, 0],
+            [1, 1],
+            [2, 2],
+        )
 
         # LTE
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a <= ? ALLOW FILTERING", 3),
-                                [0, 0],
-                                [1, 1],
-                                [2, 2],
-                                [3, 3])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a <= ? ALLOW FILTERING", 3),
+            [0, 0],
+            [1, 1],
+            [2, 2],
+            [3, 3],
+        )
 
         # EQ
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a = ? ALLOW FILTERING", 6),
-                                [6, 6],
-                                [10, 6])
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? ALLOW FILTERING", 6),
+            [6, 6],
+            [10, 6],
+        )
+
 
 # Test for the bug of CASSANDRA-11726.
 def testCounterAndColumnSelection(cql, test_keyspace):
     for compactStorageClause in ["", " WITH COMPACT STORAGE"]:
-        with create_table(cql, test_keyspace, "(k int PRIMARY KEY, c counter) " + compactStorageClause) as table:
+        with create_table(
+            cql, test_keyspace, "(k int PRIMARY KEY, c counter) " + compactStorageClause
+        ) as table:
             # Flush 2 updates in different sstable so that the following select does a merge, which is what triggers
             # the problem from CASSANDRA-11726
             execute(cql, table, "UPDATE %s SET c = c + ? WHERE k = ?", 1, 0)
@@ -182,89 +384,151 @@ def testCounterAndColumnSelection(cql, test_keyspace):
             # it's value, which broke at merge (post-CASSANDRA-11726 are special cases to never skip values).
             assert_rows(execute(cql, table, "SELECT k FROM %s"), [0])
 
+
 # Check that a counter batch works as intended
 def testCounterBatch(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(userid int, url text, total counter, PRIMARY KEY (userid, url)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(userid int, url text, total counter, PRIMARY KEY (userid, url)) WITH COMPACT STORAGE",
+    ) as table:
         # Ensure we handle updates to the same CQL row in the same partition properly
-        execute(cql, table, "BEGIN UNLOGGED BATCH " +
-                "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'; " +
-                "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'; " +
-                "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'; " +
-                "APPLY BATCH; ")
-        assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [3])
+        execute(
+            cql,
+            table,
+            "BEGIN UNLOGGED BATCH "
+            + "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'; "
+            + "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'; "
+            + "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://foo.com'; "
+            + "APPLY BATCH; ",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [3],
+        )
 
         # Ensure we handle different CQL rows in the same partition properly
-        execute(cql, table, "BEGIN UNLOGGED BATCH " +
-                "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://bar.com'; " +
-                "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://baz.com'; " +
-                "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://bad.com'; " +
-                "APPLY BATCH; ")
-        assert_rows(execute(cql, table, "SELECT url, total FROM %s WHERE userid = 1"),
-                   ["http://bad.com", 1],
-                   ["http://bar.com", 1],
-                   ["http://baz.com", 1],
-                   ["http://foo.com", 3]) # from previous batch
+        execute(
+            cql,
+            table,
+            "BEGIN UNLOGGED BATCH "
+            + "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://bar.com'; "
+            + "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://baz.com'; "
+            + "UPDATE %s SET total = total + 1 WHERE userid = 1 AND url = 'http://bad.com'; "
+            + "APPLY BATCH; ",
+        )
+        assert_rows(
+            execute(cql, table, "SELECT url, total FROM %s WHERE userid = 1"),
+            ["http://bad.com", 1],
+            ["http://bar.com", 1],
+            ["http://baz.com", 1],
+            ["http://foo.com", 3],
+        )  # from previous batch
 
-    with create_table(cql, test_keyspace, "(userid int, url text, first counter, second counter, third counter, PRIMARY KEY (userid, url))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(userid int, url text, first counter, second counter, third counter, PRIMARY KEY (userid, url))",
+    ) as table:
         # Different counters in the same CQL Row
-        execute(cql, table, "BEGIN UNLOGGED BATCH " +
-                "UPDATE %s SET first = first + 1 WHERE userid = 1 AND url = 'http://foo.com'; " +
-                "UPDATE %s SET first = first + 1 WHERE userid = 1 AND url = 'http://foo.com'; " +
-                "UPDATE %s SET second = second + 1 WHERE userid = 1 AND url = 'http://foo.com'; " +
-                "APPLY BATCH; ")
-        assert_rows(execute(cql, table, "SELECT first, second, third FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
-                   [2, 1, None])
+        execute(
+            cql,
+            table,
+            "BEGIN UNLOGGED BATCH "
+            + "UPDATE %s SET first = first + 1 WHERE userid = 1 AND url = 'http://foo.com'; "
+            + "UPDATE %s SET first = first + 1 WHERE userid = 1 AND url = 'http://foo.com'; "
+            + "UPDATE %s SET second = second + 1 WHERE userid = 1 AND url = 'http://foo.com'; "
+            + "APPLY BATCH; ",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT first, second, third FROM %s WHERE userid = 1 AND url = 'http://foo.com'",
+            ),
+            [2, 1, None],
+        )
 
         # Different counters in different CQL Rows
-        execute(cql, table, "BEGIN UNLOGGED BATCH " +
-                "UPDATE %s SET first = first + 1 WHERE userid = 1 AND url = 'http://bad.com'; " +
-                "UPDATE %s SET first = first + 1, second = second + 1 WHERE userid = 1 AND url = 'http://bar.com'; " +
-                "UPDATE %s SET first = first - 1, second = second - 1 WHERE userid = 1 AND url = 'http://bar.com'; " +
-                "UPDATE %s SET second = second + 1 WHERE userid = 1 AND url = 'http://baz.com'; " +
-                "APPLY BATCH; ")
-        assert_rows(execute(cql, table, "SELECT url, first, second, third FROM %s WHERE userid = 1"),
-                   ["http://bad.com", 1, None, None],
-                   ["http://bar.com", 0, 0, None],
-                   ["http://baz.com", None, 1, None],
-                   ["http://foo.com", 2, 1, None]) # from previous batch
+        execute(
+            cql,
+            table,
+            "BEGIN UNLOGGED BATCH "
+            + "UPDATE %s SET first = first + 1 WHERE userid = 1 AND url = 'http://bad.com'; "
+            + "UPDATE %s SET first = first + 1, second = second + 1 WHERE userid = 1 AND url = 'http://bar.com'; "
+            + "UPDATE %s SET first = first - 1, second = second - 1 WHERE userid = 1 AND url = 'http://bar.com'; "
+            + "UPDATE %s SET second = second + 1 WHERE userid = 1 AND url = 'http://baz.com'; "
+            + "APPLY BATCH; ",
+        )
+        assert_rows(
+            execute(
+                cql, table, "SELECT url, first, second, third FROM %s WHERE userid = 1"
+            ),
+            ["http://bad.com", 1, None, None],
+            ["http://bar.com", 0, 0, None],
+            ["http://baz.com", None, 1, None],
+            ["http://foo.com", 2, 1, None],
+        )  # from previous batch
 
         # Different counters in different partitions
-        execute(cql, table, "BEGIN UNLOGGED BATCH " +
-                "UPDATE %s SET first = first + 1 WHERE userid = 2 AND url = 'http://bad.com'; " +
-                "UPDATE %s SET first = first + 1, second = second + 1 WHERE userid = 3 AND url = 'http://bar.com'; " +
-                "UPDATE %s SET first = first - 1, second = second - 1 WHERE userid = 4 AND url = 'http://bar.com'; " +
-                "UPDATE %s SET second = second + 1 WHERE userid = 5 AND url = 'http://baz.com'; " +
-                "APPLY BATCH; ")
-        assert_rows_ignoring_order(execute(cql, table, "SELECT userid, url, first, second, third FROM %s WHERE userid IN (2, 3, 4, 5)"),
-                                [2, "http://bad.com", 1, None, None],
-                                [3, "http://bar.com", 1, 1, None],
-                                [4, "http://bar.com", -1, -1, None],
-                                [5, "http://baz.com", None, 1, None])
+        execute(
+            cql,
+            table,
+            "BEGIN UNLOGGED BATCH "
+            + "UPDATE %s SET first = first + 1 WHERE userid = 2 AND url = 'http://bad.com'; "
+            + "UPDATE %s SET first = first + 1, second = second + 1 WHERE userid = 3 AND url = 'http://bar.com'; "
+            + "UPDATE %s SET first = first - 1, second = second - 1 WHERE userid = 4 AND url = 'http://bar.com'; "
+            + "UPDATE %s SET second = second + 1 WHERE userid = 5 AND url = 'http://baz.com'; "
+            + "APPLY BATCH; ",
+        )
+        assert_rows_ignoring_order(
+            execute(
+                cql,
+                table,
+                "SELECT userid, url, first, second, third FROM %s WHERE userid IN (2, 3, 4, 5)",
+            ),
+            [2, "http://bad.com", 1, None, None],
+            [3, "http://bar.com", 1, 1, None],
+            [4, "http://bar.com", -1, -1, None],
+            [5, "http://baz.com", None, 1, None],
+        )
+
 
 # from FrozenCollectionsTest
 def testClusteringKeyUsageSet(cql, test_keyspace):
-    runClusteringKeyUsage(cql, test_keyspace, "set<int>", set(),
-                               {1, 2, 3},
-                               {4, 5, 6},
-                               {7, 8, 9})
+    runClusteringKeyUsage(
+        cql, test_keyspace, "set<int>", set(), {1, 2, 3}, {4, 5, 6}, {7, 8, 9}
+    )
+
 
 def testClusteringKeyUsageList(cql, test_keyspace):
-    runClusteringKeyUsage(cql, test_keyspace, "list<int>",
-                               [],
-                               [1, 2, 3],
-                               [4, 5, 6],
-                               [7, 8, 9])
+    runClusteringKeyUsage(
+        cql, test_keyspace, "list<int>", [], [1, 2, 3], [4, 5, 6], [7, 8, 9]
+    )
+
 
 def testClusteringKeyUsageMap(cql, test_keyspace):
-    runClusteringKeyUsage(cql, test_keyspace, "map<int, int>",
-                               {},
-                               {1: 10, 2: 20, 3: 30},
-                               {4: 40, 5: 50, 6: 60},
-                               {7: 70, 8: 80, 9: 90})
+    runClusteringKeyUsage(
+        cql,
+        test_keyspace,
+        "map<int, int>",
+        {},
+        {1: 10, 2: 20, 3: 30},
+        {4: 40, 5: 50, 6: 60},
+        {7: 70, 8: 80, 9: 90},
+    )
+
 
 def runClusteringKeyUsage(cql, test_keyspace, typ, v1, v2, v3, v4):
-    with create_table(cql, test_keyspace, f"(a int, b frozen<{typ}>, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int, b frozen<{typ}>, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, v1, 1)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, v2, 1)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, v3, 0)
@@ -274,454 +538,868 @@ def runClusteringKeyUsage(cql, test_keyspace, typ, v1, v2, v3, v4):
         execute(cql, table, "UPDATE %s SET c=? WHERE a=? AND b=?", 0, 0, v1)
         execute(cql, table, "UPDATE %s SET c=? WHERE a=? AND b=?", 0, 0, v2)
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   [0, v1, 0],
-                   [0, v2, 0],
-                   [0, v3, 0],
-                   [0, v4, 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            [0, v1, 0],
+            [0, v2, 0],
+            [0, v3, 0],
+            [0, v4, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT b FROM %s"),
-                   [v1],
-                   [v2],
-                   [v3],
-                   [v4]
+        assert_rows(execute(cql, table, "SELECT b FROM %s"), [v1], [v2], [v3], [v4])
+
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s LIMIT 2"), [0, v1, 0], [0, v2, 0]
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s LIMIT 2"),
-                   [0, v1, 0],
-                   [0, v2, 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, v3), [0, v3, 0]
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, v3),
-                   [0, v3, 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, v1), [0, v1, 0]
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, v1),
-                   [0, v1, 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b IN ?", 0, [v3, v1]),
+            [0, v1, 0],
+            [0, v3, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b IN ?", 0, [v3, v1]),
-                   [0, v1, 0],
-                   [0, v3, 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b > ?", 0, v3),
+            [0, v4, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b > ?", 0, v3),
-                   [0, v4, 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b >= ?", 0, v3),
+            [0, v3, 0],
+            [0, v4, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b >= ?", 0, v3),
-                   [0, v3, 0],
-                   [0, v4, 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b < ?", 0, v3),
+            [0, v1, 0],
+            [0, v2, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b < ?", 0, v3),
-                   [0, v1, 0],
-                   [0, v2, 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b <= ?", 0, v3),
+            [0, v1, 0],
+            [0, v2, 0],
+            [0, v3, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b <= ?", 0, v3),
-                   [0, v1, 0],
-                   [0, v2, 0],
-                   [0, v3, 0]
-        )
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b > ? AND b <= ?", 0, v2, v3),
-                   [0, v3, 0]
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a=? AND b > ? AND b <= ?", 0, v2, v3
+            ),
+            [0, v3, 0],
         )
 
         execute(cql, table, "DELETE FROM %s WHERE a=? AND b=?", 0, v1)
         execute(cql, table, "DELETE FROM %s WHERE a=? AND b=?", 0, v3)
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   [0, v2, 0],
-                   [0, v4, 0]
-        )
+        assert_rows(execute(cql, table, "SELECT * FROM %s"), [0, v2, 0], [0, v4, 0])
+
 
 def testNestedClusteringKeyUsage(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(a int, b frozen<map<set<int>, list<int>>>, c frozen<set<int>>, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {}, set(), 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {frozenset(): [1, 2, 3]}, set(), 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0)
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   [0, {}, set(), 0],
-                   [0, {frozenset(): [1, 2, 3]}, set(), 0],
-                   [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
-                   [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
-                   [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0]
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int, b frozen<map<set<int>, list<int>>>, c frozen<set<int>>, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {},
+            set(),
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {frozenset(): [1, 2, 3]},
+            set(),
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {frozenset({1, 2, 3}): [1, 2, 3]},
+            {1, 2, 3},
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {frozenset({4, 5, 6}): [1, 2, 3]},
+            {1, 2, 3},
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {frozenset({7, 8, 9}): [1, 2, 3]},
+            {1, 2, 3},
+            0,
         )
 
-        assert_rows(execute(cql, table, "SELECT b FROM %s"),
-                   [{}],
-                   [{frozenset(): [1, 2, 3]}],
-                   [{frozenset({1, 2, 3}): [1, 2, 3]}],
-                   [{frozenset({4, 5, 6}): [1, 2, 3]}],
-                   [{frozenset({7, 8, 9}): [1, 2, 3]}]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            [0, {}, set(), 0],
+            [0, {frozenset(): [1, 2, 3]}, set(), 0],
+            [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
+            [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
+            [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s"),
-                   [set()],
-                   [set()],
-                   [{1, 2, 3}],
-                   [{1, 2, 3}],
-                   [{1, 2, 3}]
+        assert_rows(
+            execute(cql, table, "SELECT b FROM %s"),
+            [{}],
+            [{frozenset(): [1, 2, 3]}],
+            [{frozenset({1, 2, 3}): [1, 2, 3]}],
+            [{frozenset({4, 5, 6}): [1, 2, 3]}],
+            [{frozenset({7, 8, 9}): [1, 2, 3]}],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s LIMIT 3"),
-                   [0, {}, set(), 0],
-                   [0, {frozenset(): [1, 2, 3]}, set(), 0],
-                   [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_rows(
+            execute(cql, table, "SELECT c FROM %s"),
+            [set()],
+            [set()],
+            [{1, 2, 3}],
+            [{1, 2, 3}],
+            [{1, 2, 3}],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=0 ORDER BY b DESC LIMIT 4"),
-                   [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0],
-                   [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
-                   [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
-                   [0, {frozenset(): [1, 2, 3]}, set(), 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s LIMIT 3"),
+            [0, {}, set(), 0],
+            [0, {frozenset(): [1, 2, 3]}, set(), 0],
+            [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, {}),
-                   [0, {}, set(), 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=0 ORDER BY b DESC LIMIT 4"),
+            [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0],
+            [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
+            [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
+            [0, {frozenset(): [1, 2, 3]}, set(), 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, {frozenset(): [1, 2, 3]}),
-                   [0, {frozenset(): [1, 2, 3]}, set(), 0]
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, {}),
+            [0, {}, set(), 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, {frozenset({1, 2, 3}): [1, 2, 3]}),
-                   [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=?",
+                0,
+                {frozenset(): [1, 2, 3]},
+            ),
+            [0, {frozenset(): [1, 2, 3]}, set(), 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset(): [1, 2, 3]}, set()),
-                   [0, {frozenset(): [1, 2, 3]}, set(), 0]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=?",
+                0,
+                {frozenset({1, 2, 3}): [1, 2, 3]},
+            ),
+            [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND (b, c) IN ?", 0, [({frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}), ({}, set())]),
-                   [0, {}, set(), 0],
-                   [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=? AND c=?",
+                0,
+                {frozenset(): [1, 2, 3]},
+                set(),
+            ),
+            [0, {frozenset(): [1, 2, 3]}, set(), 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b > ?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND (b, c) IN ?",
+                0,
+                [({frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}), ({}, set())],
+            ),
+            [0, {}, set(), 0],
+            [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b >= ?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
-                   [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b > ?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b < ?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   [0, {}, set(), 0],
-                   [0, {frozenset(): [1, 2, 3]}, set(), 0],
-                   [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b >= ?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
+            [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b <= ?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   [0, {}, set(), 0],
-                   [0, {frozenset(): [1, 2, 3]}, set(), 0],
-                   [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
-                   [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b < ?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            [0, {}, set(), 0],
+            [0, {frozenset(): [1, 2, 3]}, set(), 0],
+            [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b > ? AND b <= ?", 0, {frozenset({1, 2, 3}): [1, 2, 3]}, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b <= ?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            [0, {}, set(), 0],
+            [0, {frozenset(): [1, 2, 3]}, set(), 0],
+            [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
+            [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
+        )
+
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b > ? AND b <= ?",
+                0,
+                {frozenset({1, 2, 3}): [1, 2, 3]},
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            [0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0],
         )
 
         execute(cql, table, "DELETE FROM %s WHERE a=? AND b=? AND c=?", 0, {}, set())
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {}, set()))
-
-        execute(cql, table, "DELETE FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset(): [1, 2, 3]}, set())
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset(): [1, 2, 3]}, set()))
-
-        execute(cql, table, "DELETE FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3})
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}))
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
-                   [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0]
+        assert_empty(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {}, set()
+            )
         )
+
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a=? AND b=? AND c=?",
+            0,
+            {frozenset(): [1, 2, 3]},
+            set(),
+        )
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=? AND c=?",
+                0,
+                {frozenset(): [1, 2, 3]},
+                set(),
+            )
+        )
+
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a=? AND b=? AND c=?",
+            0,
+            {frozenset({4, 5, 6}): [1, 2, 3]},
+            {1, 2, 3},
+        )
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=? AND c=?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+                {1, 2, 3},
+            )
+        )
+
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            [0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0],
+            [0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0],
+        )
+
 
 def testNestedClusteringKeyUsageWithReverseOrder(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(a int, b frozen<map<set<int>, list<int>>>, c frozen<set<int>>, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b DESC)") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {}, set(), 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {frozenset(): [1, 2, 3]}, set(), 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0)
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset(): [1, 2, 3]}, set(), 0),
-                   row(0, {}, set(), 0)
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int, b frozen<map<set<int>, list<int>>>, c frozen<set<int>>, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b DESC)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {},
+            set(),
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {frozenset(): [1, 2, 3]},
+            set(),
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {frozenset({1, 2, 3}): [1, 2, 3]},
+            {1, 2, 3},
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {frozenset({4, 5, 6}): [1, 2, 3]},
+            {1, 2, 3},
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            {frozenset({7, 8, 9}): [1, 2, 3]},
+            {1, 2, 3},
+            0,
         )
 
-        assert_rows(execute(cql, table, "SELECT b FROM %s"),
-                   row({frozenset({7, 8, 9}): [1, 2, 3]}),
-                   row({frozenset({4, 5, 6}): [1, 2, 3]}),
-                   row({frozenset({1, 2, 3}): [1, 2, 3]}),
-                   row({frozenset(): [1, 2, 3]}),
-                   row({})
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset(): [1, 2, 3]}, set(), 0),
+            row(0, {}, set(), 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s"),
-                   row({1, 2, 3}),
-                   row({1, 2, 3}),
-                   row({1, 2, 3}),
-                   row(set()),
-                   row(set())
+        assert_rows(
+            execute(cql, table, "SELECT b FROM %s"),
+            row({frozenset({7, 8, 9}): [1, 2, 3]}),
+            row({frozenset({4, 5, 6}): [1, 2, 3]}),
+            row({frozenset({1, 2, 3}): [1, 2, 3]}),
+            row({frozenset(): [1, 2, 3]}),
+            row({}),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s LIMIT 3"),
-                   row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0)
+        assert_rows(
+            execute(cql, table, "SELECT c FROM %s"),
+            row({1, 2, 3}),
+            row({1, 2, 3}),
+            row({1, 2, 3}),
+            row(set()),
+            row(set()),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=0 ORDER BY b DESC LIMIT 4"),
-                   row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset(): [1, 2, 3]}, set(), 0)
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s LIMIT 3"),
+            row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, {}),
-                   row(0, {}, set(), 0)
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=0 ORDER BY b DESC LIMIT 4"),
+            row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset(): [1, 2, 3]}, set(), 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, {frozenset(): [1, 2, 3]}),
-                   row(0, {frozenset(): [1, 2, 3]}, set(), 0)
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, {}),
+            row(0, {}, set(), 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=?", 0, {frozenset({1, 2, 3}): [1, 2, 3]}),
-                   row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0)
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=?",
+                0,
+                {frozenset(): [1, 2, 3]},
+            ),
+            row(0, {frozenset(): [1, 2, 3]}, set(), 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset(): [1, 2, 3]}, set()),
-                   row(0, {frozenset(): [1, 2, 3]}, set(), 0)
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=?",
+                0,
+                {frozenset({1, 2, 3}): [1, 2, 3]},
+            ),
+            row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND (b, c) IN ?", 0, [({frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}),
-                                                                                 ({}, set())]),
-                   row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {}, set(), 0)
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=? AND c=?",
+                0,
+                {frozenset(): [1, 2, 3]},
+                set(),
+            ),
+            row(0, {frozenset(): [1, 2, 3]}, set(), 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b > ?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0)
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND (b, c) IN ?",
+                0,
+                [({frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}), ({}, set())],
+            ),
+            row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {}, set(), 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b >= ?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0)
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b > ?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b < ?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset(): [1, 2, 3]}, set(), 0),
-                   row(0, {}, set(), 0)
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b >= ?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b <= ?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset(): [1, 2, 3]}, set(), 0),
-                   row(0, {}, set(), 0)
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b < ?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset(): [1, 2, 3]}, set(), 0),
+            row(0, {}, set(), 0),
         )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b > ? AND b <= ?", 0, {frozenset({1, 2, 3}): [1, 2, 3]}, {frozenset({4, 5, 6}): [1, 2, 3]}),
-                   row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0)
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b <= ?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset(): [1, 2, 3]}, set(), 0),
+            row(0, {}, set(), 0),
+        )
+
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b > ? AND b <= ?",
+                0,
+                {frozenset({1, 2, 3}): [1, 2, 3]},
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+            ),
+            row(0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}, 0),
         )
 
         execute(cql, table, "DELETE FROM %s WHERE a=? AND b=? AND c=?", 0, {}, set())
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {}, set()))
-
-        execute(cql, table, "DELETE FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset(): [1, 2, 3]}, set())
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset(): [1, 2, 3]}, set()))
-
-        execute(cql, table, "DELETE FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3})
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}))
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
-                   row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0)
+        assertEmpty(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 0, {}, set()
+            )
         )
 
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a=? AND b=? AND c=?",
+            0,
+            {frozenset(): [1, 2, 3]},
+            set(),
+        )
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=? AND c=?",
+                0,
+                {frozenset(): [1, 2, 3]},
+                set(),
+            )
+        )
+
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a=? AND b=? AND c=?",
+            0,
+            {frozenset({4, 5, 6}): [1, 2, 3]},
+            {1, 2, 3},
+        )
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND b=? AND c=?",
+                0,
+                {frozenset({4, 5, 6}): [1, 2, 3]},
+                {1, 2, 3},
+            )
+        )
+
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(0, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}, 0),
+            row(0, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}, 0),
+        )
+
+
 def testNormalColumnUsage(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b frozen<map<set<int>, list<int>>>, c frozen<set<int>>)" + compactOption ) as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int PRIMARY KEY, b frozen<map<set<int>, list<int>>>, c frozen<set<int>>)"
+        + compactOption,
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, {}, set())
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, {frozenset(): [99999, 999999, 99999]}, set())
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 2, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3})
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 3, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3})
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 4, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3})
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+            1,
+            {frozenset(): [99999, 999999, 99999]},
+            set(),
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+            2,
+            {frozenset({1, 2, 3}): [1, 2, 3]},
+            {1, 2, 3},
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+            3,
+            {frozenset({4, 5, 6}): [1, 2, 3]},
+            {1, 2, 3},
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+            4,
+            {frozenset({7, 8, 9}): [1, 2, 3]},
+            {1, 2, 3},
+        )
 
         # overwrite with update
         execute(cql, table, "UPDATE %s SET b=? WHERE a=?", {frozenset(): [1, 2, 3]}, 1)
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s"),
-                                [0, {}, set()],
-                                [1, {frozenset(): [1, 2, 3]}, set()],
-                                [2, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}],
-                                [3, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}],
-                                [4, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s"),
+            [0, {}, set()],
+            [1, {frozenset(): [1, 2, 3]}, set()],
+            [2, {frozenset({1, 2, 3}): [1, 2, 3]}, {1, 2, 3}],
+            [3, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}],
+            [4, {frozenset({7, 8, 9}): [1, 2, 3]}, {1, 2, 3}],
         )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT b FROM %s"),
-                                [{}],
-                                [{frozenset(): [1, 2, 3]}],
-                                [{frozenset({1, 2, 3}): [1, 2, 3]}],
-                                [{frozenset({4, 5, 6}): [1, 2, 3]}],
-                                [{frozenset({7, 8, 9}): [1, 2, 3]}]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT b FROM %s"),
+            [{}],
+            [{frozenset(): [1, 2, 3]}],
+            [{frozenset({1, 2, 3}): [1, 2, 3]}],
+            [{frozenset({4, 5, 6}): [1, 2, 3]}],
+            [{frozenset({7, 8, 9}): [1, 2, 3]}],
         )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT c FROM %s"),
-                                [set()],
-                                [set()],
-                                [{1, 2, 3}],
-                                [{1, 2, 3}],
-                                [{1, 2, 3}]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT c FROM %s"),
+            [set()],
+            [set()],
+            [{1, 2, 3}],
+            [{1, 2, 3}],
+            [{1, 2, 3}],
         )
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a=?", 3),
-                                [3, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a=?", 3),
+            [3, {frozenset({4, 5, 6}): [1, 2, 3]}, {1, 2, 3}],
         )
 
         execute(cql, table, "UPDATE %s SET b=? WHERE a=?", null, 1)
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a=?", 1),
-                                [1, None, set()]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a=?", 1), [1, None, set()]
         )
 
         execute(cql, table, "UPDATE %s SET b=? WHERE a=?", {}, 1)
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a=?", 1),
-                                [1, {}, set()]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a=?", 1), [1, {}, set()]
         )
 
         execute(cql, table, "UPDATE %s SET c=? WHERE a=?", None, 2)
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a=?", 2),
-                                [2, {frozenset({1, 2, 3}): [1, 2, 3]}, None]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a=?", 2),
+            [2, {frozenset({1, 2, 3}): [1, 2, 3]}, None],
         )
 
         execute(cql, table, "UPDATE %s SET c=? WHERE a=?", set(), 2)
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a=?", 2),
-                                [2, {frozenset({1, 2, 3}): [1, 2, 3]}, set()]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a=?", 2),
+            [2, {frozenset({1, 2, 3}): [1, 2, 3]}, set()],
         )
 
         execute(cql, table, "DELETE b FROM %s WHERE a=?", 3)
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a=?", 3),
-                                [3, None, {1, 2, 3}]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a=?", 3), [3, None, {1, 2, 3}]
         )
 
         execute(cql, table, "DELETE c FROM %s WHERE a=?", 4)
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a=?", 4),
-                                [4, {frozenset({7, 8, 9}): [1, 2, 3]}, None]
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE a=?", 4),
+            [4, {frozenset({7, 8, 9}): [1, 2, 3]}, None],
         )
+
 
 TOO_BIG = 1024 * 65
 
+
 # from SecondaryIndexTest
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627"
+)
 def testCompactTableWithValueOver64k(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int,  b blob, PRIMARY KEY (a)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(a int,  b blob, PRIMARY KEY (a)) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(b)")
-        too_big = bytearray([1])*TOO_BIG
+        too_big = bytearray([1]) * TOO_BIG
         failInsert(cql, table, "INSERT INTO %s (a, b) VALUES (0, ?)", too_big)
-        failInsert(cql, table, "INSERT INTO %s (a, b) VALUES (0, ?) IF NOT EXISTS", too_big)
-        failInsert(cql, table, "BEGIN BATCH\n" +
-                   "INSERT INTO %s (a, b) VALUES (0, ?);\n" +
-                   "APPLY BATCH",
-                   too_big)
-        failInsert(cql, table, "BEGIN BATCH\n" +
-                   "INSERT INTO %s (a, b) VALUES (0, ?) IF NOT EXISTS;\n" +
-                   "APPLY BATCH",
-                   too_big)
+        failInsert(
+            cql, table, "INSERT INTO %s (a, b) VALUES (0, ?) IF NOT EXISTS", too_big
+        )
+        failInsert(
+            cql,
+            table,
+            "BEGIN BATCH\n" + "INSERT INTO %s (a, b) VALUES (0, ?);\n" + "APPLY BATCH",
+            too_big,
+        )
+        failInsert(
+            cql,
+            table,
+            "BEGIN BATCH\n"
+            + "INSERT INTO %s (a, b) VALUES (0, ?) IF NOT EXISTS;\n"
+            + "APPLY BATCH",
+            too_big,
+        )
+
 
 def failInsert(cql, table, insertCQL, *args):
     with pytest.raises(InvalidRequest):
         execute(cql, table, insertCQL, *args)
 
+
 # Migrated from cql_tests.py:TestCQL.invalid_clustering_indexing_test()
 def testIndexesOnClusteringInvalid(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int,  b int, c int, d int, PRIMARY KEY ((a, b))) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int,  b int, c int, d int, PRIMARY KEY ((a, b))) WITH COMPACT STORAGE",
+    ) as table:
         assert_invalid(cql, table, "CREATE INDEX ON %s (a)")
         assert_invalid(cql, table, "CREATE INDEX ON %s (b)")
-    with create_table(cql, test_keyspace, "(a int,  b int, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int,  b int, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         assert_invalid(cql, table, "CREATE INDEX ON %s (a)")
         assert_invalid(cql, table, "CREATE INDEX ON %s (b)")
         assert_invalid(cql, table, "CREATE INDEX ON %s (c)")
 
-def testEmptyRestrictionValueWithSecondaryIndexAndCompactTables(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c)) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "COMPACT STORAGE",
-                             "CREATE INDEX on %s(c)")
 
-    with create_table(cql, test_keyspace, "(pk blob PRIMARY KEY, v blob) WITH COMPACT STORAGE") as table:
+def testEmptyRestrictionValueWithSecondaryIndexAndCompactTables(cql, test_keyspace):
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c)) WITH COMPACT STORAGE",
+    ) as table:
+        assertInvalidMessage(cql, table, "COMPACT STORAGE", "CREATE INDEX on %s(c)")
+
+    with create_table(
+        cql, test_keyspace, "(pk blob PRIMARY KEY, v blob) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "CREATE INDEX on %s(v)")
         execute(cql, table, "INSERT INTO %s (pk, v) VALUES (?, ?)", b"foo123", b"1")
 
         # Test restrictions on non-primary key value
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('');"))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('');",
+            )
+        )
 
-        execute(cql, table, "INSERT INTO %s (pk, v) VALUES (?, ?)", b"foo124", bytearray([]))
+        execute(
+            cql, table, "INSERT INTO %s (pk, v) VALUES (?, ?)", b"foo124", bytearray([])
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE v = textAsBlob('');"),
-                   row(b"foo124", bytearray([])))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE v = textAsBlob('');"),
+            row(b"foo124", bytearray([])),
+        )
+
 
 def testIndicesOnCompactTable(cql, test_keyspace):
-    assertInvalidMessage(cql, test_keyspace, "COMPACT STORAGE with composite PRIMARY KEY allows no more than one column not part of the PRIMARY KEY",
-                             "CREATE TABLE " + test_keyspace + "." + unique_name() + " (pk int, c int, v1 int, v2 int, PRIMARY KEY(pk, c)) WITH COMPACT STORAGE")
-    with create_table(cql, test_keyspace, "(pk blob, c int, v int, PRIMARY KEY (pk, c)) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "COMPACT STORAGE",
-                             "CREATE INDEX ON %s(v)")
+    assertInvalidMessage(
+        cql,
+        test_keyspace,
+        "COMPACT STORAGE with composite PRIMARY KEY allows no more than one column not part of the PRIMARY KEY",
+        "CREATE TABLE "
+        + test_keyspace
+        + "."
+        + unique_name()
+        + " (pk int, c int, v1 int, v2 int, PRIMARY KEY(pk, c)) WITH COMPACT STORAGE",
+    )
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk blob, c int, v int, PRIMARY KEY (pk, c)) WITH COMPACT STORAGE",
+    ) as table:
+        assertInvalidMessage(cql, table, "COMPACT STORAGE", "CREATE INDEX ON %s(v)")
 
-    with create_table(cql, test_keyspace, "(pk int PRIMARY KEY, v int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(pk int PRIMARY KEY, v int) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(v)")
 
         execute(cql, table, "INSERT INTO %s (pk, v) VALUES (?, ?)", 1, 1)
         execute(cql, table, "INSERT INTO %s (pk, v) VALUES (?, ?)", 2, 1)
         execute(cql, table, "INSERT INTO %s (pk, v) VALUES (?, ?)", 3, 3)
 
-        assert_rows(execute(cql, table, "SELECT pk, v FROM %s WHERE v = 1"),
-                   row(1, 1),
-                   row(2, 1))
+        assert_rows(
+            execute(cql, table, "SELECT pk, v FROM %s WHERE v = 1"),
+            row(1, 1),
+            row(2, 1),
+        )
 
-        assert_rows(execute(cql, table, "SELECT pk, v FROM %s WHERE v = 3"),
-                   row(3, 3))
+        assert_rows(execute(cql, table, "SELECT pk, v FROM %s WHERE v = 3"), row(3, 3))
 
         assertEmpty(execute(cql, table, "SELECT pk, v FROM %s WHERE v = 5"))
 
-    with create_table(cql, test_keyspace, "(pk int PRIMARY KEY, v1 int, v2 int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(pk int PRIMARY KEY, v1 int, v2 int) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(v1)")
 
         execute(cql, table, "INSERT INTO %s (pk, v1, v2) VALUES (?, ?, ?)", 1, 1, 1)
         execute(cql, table, "INSERT INTO %s (pk, v1, v2) VALUES (?, ?, ?)", 2, 1, 2)
         execute(cql, table, "INSERT INTO %s (pk, v1, v2) VALUES (?, ?, ?)", 3, 3, 3)
 
-        assert_rows(execute(cql, table, "SELECT pk, v2 FROM %s WHERE v1 = 1"),
-                   row(1, 1),
-                   row(2, 2))
+        assert_rows(
+            execute(cql, table, "SELECT pk, v2 FROM %s WHERE v1 = 1"),
+            row(1, 1),
+            row(2, 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT pk, v2 FROM %s WHERE v1 = 3"),
-                   row(3, 3))
+        assert_rows(
+            execute(cql, table, "SELECT pk, v2 FROM %s WHERE v1 = 3"), row(3, 3)
+        )
 
         assertEmpty(execute(cql, table, "SELECT pk, v2 FROM %s WHERE v1 = 5"))
 
+
 # OverflowTest
+
 
 # Test regression from CASSANDRA-5189,
 # migrated from cql_tests.py:TestCQL.compact_metadata_test()
 def testCompactMetadata(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id int primary key, i int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(id int primary key, i int) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (id, i) VALUES (1, 2)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 2))
+        assert_rows(execute(cql, table, "SELECT * FROM %s"), row(1, 2))
+
 
 def testEmpty(cql, test_keyspace):
     # Same test, but for compact
-    with create_table(cql, test_keyspace, "(k1 int, k2 int, v int, PRIMARY KEY (k1, k2)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k1 int, k2 int, v int, PRIMARY KEY (k1, k2)) WITH COMPACT STORAGE",
+    ) as table:
         # Inserts a few rows to make sure we don 't actually query something
         rows = fill(cql, table)
 
@@ -736,184 +1414,394 @@ def testEmpty(cql, test_keyspace):
         execute(cql, table, "UPDATE %s SET v = 3 WHERE k1 IN () AND k2 = 2")
         assertArrayEquals(rows, getRows(execute(cql, table, "SELECT * FROM %s")))
 
+
 def fill(cql, table):
     for i in range(2):
         for j in range(2):
-            execute(cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", i, j, i + j)
+            execute(
+                cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", i, j, i + j
+            )
     return list(execute(cql, table, "SELECT * FROM %s"))
+
 
 # AggregationTest
 def testFunctionsWithCompactStorage(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c double, primary key (a,b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c double, primary key (a,b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 1, 11.5)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, 9.5)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, 9.0)")
 
-        assert_rows(execute(cql, table, "SELECT max(b), min(b), sum(b), avg(b) , max(c), sum(c), avg(c) FROM %s"),
-                   row(3, 1, 6, 2, 11.5, 30.0, 10.0))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT max(b), min(b), sum(b), avg(b) , max(c), sum(c), avg(c) FROM %s",
+            ),
+            row(3, 1, 6, 2, 11.5, 30.0, 10.0),
+        )
 
         assert_rows(execute(cql, table, "SELECT COUNT(*) FROM %s"), row(3))
         assert_rows(execute(cql, table, "SELECT COUNT(1) FROM %s"), row(3))
-        assert_rows(execute(cql, table, "SELECT COUNT(*) FROM %s WHERE a = 1 AND b > 1"), row(2))
-        assert_rows(execute(cql, table, "SELECT COUNT(1) FROM %s WHERE a = 1 AND b > 1"), row(2))
-        assert_rows(execute(cql, table, "SELECT max(b), min(b), sum(b), avg(b) , max(c), sum(c), avg(c) FROM %s WHERE a = 1 AND b > 1"),
-                   row(3, 2, 5, 2, 9.5, 18.5, 9.25))
+        assert_rows(
+            execute(cql, table, "SELECT COUNT(*) FROM %s WHERE a = 1 AND b > 1"), row(2)
+        )
+        assert_rows(
+            execute(cql, table, "SELECT COUNT(1) FROM %s WHERE a = 1 AND b > 1"), row(2)
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT max(b), min(b), sum(b), avg(b) , max(c), sum(c), avg(c) FROM %s WHERE a = 1 AND b > 1",
+            ),
+            row(3, 2, 5, 2, 9.5, 18.5, 9.25),
+        )
+
 
 # BatchTest
-@pytest.mark.xfail(reason="issue #12471")
+@pytest.mark.xfail(reason="Range deletions on COMPACT STORAGE is not supported #12471")
 def testBatchRangeDelete(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, primary key (partitionKey, clustering)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering int, value int, primary key (partitionKey, clustering)) WITH COMPACT STORAGE",
+    ) as table:
         value = 0
         for partitionKey in range(4):
             for clustering1 in range(5):
-                execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (?, ?, ?)",
-                    partitionKey, clustering1, value)
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (partitionKey, clustering, value) VALUES (?, ?, ?)",
+                    partitionKey,
+                    clustering1,
+                    value,
+                )
                 value += 1
-        execute(cql, table, "BEGIN BATCH " +
-                "DELETE FROM %s WHERE partitionKey = 1;" +
-                "DELETE FROM %s WHERE partitionKey = 0 AND  clustering >= 4;" +
-                "DELETE FROM %s WHERE partitionKey = 0 AND clustering <= 0;" +
-                "DELETE FROM %s WHERE partitionKey = 2 AND clustering >= 0 AND clustering <= 3;" +
-                "DELETE FROM %s WHERE partitionKey = 2 AND clustering <= 3 AND clustering >= 4;" +
-                "DELETE FROM %s WHERE partitionKey = 3 AND (clustering) >= (3) AND (clustering) <= (6);" +
-                "APPLY BATCH;")
+        execute(
+            cql,
+            table,
+            "BEGIN BATCH "
+            + "DELETE FROM %s WHERE partitionKey = 1;"
+            + "DELETE FROM %s WHERE partitionKey = 0 AND  clustering >= 4;"
+            + "DELETE FROM %s WHERE partitionKey = 0 AND clustering <= 0;"
+            + "DELETE FROM %s WHERE partitionKey = 2 AND clustering >= 0 AND clustering <= 3;"
+            + "DELETE FROM %s WHERE partitionKey = 2 AND clustering <= 3 AND clustering >= 4;"
+            + "DELETE FROM %s WHERE partitionKey = 3 AND (clustering) >= (3) AND (clustering) <= (6);"
+            + "APPLY BATCH;",
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, 1, 1),
-                   row(0, 2, 2),
-                   row(0, 3, 3),
-                   row(2, 4, 14),
-                   row(3, 0, 15),
-                   row(3, 1, 16),
-                   row(3, 2, 17))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(0, 1, 1),
+            row(0, 2, 2),
+            row(0, 3, 3),
+            row(2, 4, 14),
+            row(3, 0, 15),
+            row(3, 1, 16),
+            row(3, 2, 17),
+        )
+
 
 # CreateTest
 # Creation and basic operations on a static table with compact storage,
 # migrated from cql_tests.py:TestCQL.noncomposite_static_cf_test()
 def testDenseStaticTable(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(userid uuid PRIMARY KEY, firstname text, lastname text, age int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(userid uuid PRIMARY KEY, firstname text, lastname text, age int) WITH COMPACT STORAGE",
+    ) as table:
         id1 = UUID("550e8400-e29b-41d4-a716-446655440000")
         id2 = UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
-        execute(cql, table, "INSERT INTO %s (userid, firstname, lastname, age) VALUES (?, ?, ?, ?)", id1, "Frodo", "Baggins", 32)
-        execute(cql, table, "UPDATE %s SET firstname = ?, lastname = ?, age = ? WHERE userid = ?", "Samwise", "Gamgee", 33, id2)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, firstname, lastname, age) VALUES (?, ?, ?, ?)",
+            id1,
+            "Frodo",
+            "Baggins",
+            32,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET firstname = ?, lastname = ?, age = ? WHERE userid = ?",
+            "Samwise",
+            "Gamgee",
+            33,
+            id2,
+        )
 
-        assert_rows(execute(cql, table, "SELECT firstname, lastname FROM %s WHERE userid = ?", id1),
-                   row("Frodo", "Baggins"))
+        assert_rows(
+            execute(
+                cql, table, "SELECT firstname, lastname FROM %s WHERE userid = ?", id1
+            ),
+            row("Frodo", "Baggins"),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE userid = ?", id1),
-                   row(id1, 32, "Frodo", "Baggins"))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE userid = ?", id1),
+            row(id1, 32, "Frodo", "Baggins"),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(id2, 33, "Samwise", "Gamgee"),
-                   row(id1, 32, "Frodo", "Baggins")
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(id2, 33, "Samwise", "Gamgee"),
+            row(id1, 32, "Frodo", "Baggins"),
         )
 
         batch = "BEGIN BATCH INSERT INTO %s (userid, age) VALUES (?, ?) UPDATE %s SET age = ? WHERE userid = ? DELETE firstname, lastname FROM %s WHERE userid = ? DELETE firstname, lastname FROM %s WHERE userid = ? APPLY BATCH"
 
         execute(cql, table, batch, id1, 36, 37, id2, id1, id2)
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(id2, 37, None, None),
-                   row(id1, 36, None, None))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(id2, 37, None, None),
+            row(id1, 36, None, None),
+        )
+
 
 # Creation and basic operations on a non-composite table with compact storage,
 # migrated from cql_tests.py:TestCQL.dynamic_cf_test()
 def testDenseNonCompositeTable(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(userid uuid, url text, time bigint, PRIMARY KEY (userid, url)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(userid uuid, url text, time bigint, PRIMARY KEY (userid, url)) WITH COMPACT STORAGE",
+    ) as table:
         id1 = UUID("550e8400-e29b-41d4-a716-446655440000")
         id2 = UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
         id3 = UUID("810e8500-e29b-41d4-a716-446655440000")
 
-        execute(cql, table, "INSERT INTO %s (userid, url, time) VALUES (?, ?, ?)", id1, "http://foo.bar", 42)
-        execute(cql, table, "INSERT INTO %s (userid, url, time) VALUES (?, ?, ?)", id1, "http://foo-2.bar", 24)
-        execute(cql, table, "INSERT INTO %s (userid, url, time) VALUES (?, ?, ?)", id1, "http://bar.bar", 128)
-        execute(cql, table, "UPDATE %s SET time = 24 WHERE userid = ? and url = 'http://bar.foo'", id2)
-        execute(cql, table, "UPDATE %s SET time = 12 WHERE userid IN (?, ?) and url = 'http://foo-3'", id2, id1)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, url, time) VALUES (?, ?, ?)",
+            id1,
+            "http://foo.bar",
+            42,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, url, time) VALUES (?, ?, ?)",
+            id1,
+            "http://foo-2.bar",
+            24,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, url, time) VALUES (?, ?, ?)",
+            id1,
+            "http://bar.bar",
+            128,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET time = 24 WHERE userid = ? and url = 'http://bar.foo'",
+            id2,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET time = 12 WHERE userid IN (?, ?) and url = 'http://foo-3'",
+            id2,
+            id1,
+        )
 
-        assert_rows(execute(cql, table, "SELECT url, time FROM %s WHERE userid = ?", id1),
-                   row("http://bar.bar", 128),
-                   row("http://foo-2.bar", 24),
-                   row("http://foo-3", 12),
-                   row("http://foo.bar", 42))
+        assert_rows(
+            execute(cql, table, "SELECT url, time FROM %s WHERE userid = ?", id1),
+            row("http://bar.bar", 128),
+            row("http://foo-2.bar", 24),
+            row("http://foo-3", 12),
+            row("http://foo.bar", 42),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE userid = ?", id2),
-                   row(id2, "http://bar.foo", 24),
-                   row(id2, "http://foo-3", 12))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE userid = ?", id2),
+            row(id2, "http://bar.foo", 24),
+            row(id2, "http://foo-3", 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT time FROM %s"),
-                   row(24), # id2
-                   row(12),
-                   row(128), # id1
-                   row(24),
-                   row(12),
-                   row(42)
+        assert_rows(
+            execute(cql, table, "SELECT time FROM %s"),
+            row(24),  # id2
+            row(12),
+            row(128),  # id1
+            row(24),
+            row(12),
+            row(42),
         )
 
         # Check we don't allow empty values for url since this is the full underlying cell name (CASSANDRA-6152)
-        assert_invalid(cql, table, "INSERT INTO %s (userid, url, time) VALUES (?, '', 42)", id3)
+        assert_invalid(
+            cql, table, "INSERT INTO %s (userid, url, time) VALUES (?, '', 42)", id3
+        )
+
 
 # Creation and basic operations on a composite table with compact storage,
 # migrated from cql_tests.py:TestCQL.dense_cf_test()
 def testDenseCompositeTable(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(userid uuid, ip text, port int, time bigint, PRIMARY KEY (userid, ip, port)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(userid uuid, ip text, port int, time bigint, PRIMARY KEY (userid, ip, port)) WITH COMPACT STORAGE",
+    ) as table:
         id1 = UUID("550e8400-e29b-41d4-a716-446655440000")
         id2 = UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
 
-        execute(cql, table, "INSERT INTO %s (userid, ip, port, time) VALUES (?, '192.168.0.1', 80, 42)", id1)
-        execute(cql, table, "INSERT INTO %s (userid, ip, port, time) VALUES (?, '192.168.0.2', 80, 24)", id1)
-        execute(cql, table, "INSERT INTO %s (userid, ip, port, time) VALUES (?, '192.168.0.2', 90, 42)", id1)
-        execute(cql, table, "UPDATE %s SET time = 24 WHERE userid = ? AND ip = '192.168.0.2' AND port = 80", id2)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, ip, port, time) VALUES (?, '192.168.0.1', 80, 42)",
+            id1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, ip, port, time) VALUES (?, '192.168.0.2', 80, 24)",
+            id1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, ip, port, time) VALUES (?, '192.168.0.2', 90, 42)",
+            id1,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET time = 24 WHERE userid = ? AND ip = '192.168.0.2' AND port = 80",
+            id2,
+        )
 
         # we don't have to include all of the clustering columns (see CASSANDRA-7990)
-        execute(cql, table, "INSERT INTO %s (userid, ip, time) VALUES (?, '192.168.0.3', 42)", id2)
-        execute(cql, table, "UPDATE %s SET time = 42 WHERE userid = ? AND ip = '192.168.0.4'", id2)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, ip, time) VALUES (?, '192.168.0.3', 42)",
+            id2,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET time = 42 WHERE userid = ? AND ip = '192.168.0.4'",
+            id2,
+        )
 
-        assert_rows(execute(cql, table, "SELECT ip, port, time FROM %s WHERE userid = ?", id1),
-                   row("192.168.0.1", 80, 42),
-                   row("192.168.0.2", 80, 24),
-                   row("192.168.0.2", 90, 42))
+        assert_rows(
+            execute(cql, table, "SELECT ip, port, time FROM %s WHERE userid = ?", id1),
+            row("192.168.0.1", 80, 42),
+            row("192.168.0.2", 80, 24),
+            row("192.168.0.2", 90, 42),
+        )
 
-        assert_rows(execute(cql, table, "SELECT ip, port, time FROM %s WHERE userid = ? and ip >= '192.168.0.2'", id1),
-                   row("192.168.0.2", 80, 24),
-                   row("192.168.0.2", 90, 42))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT ip, port, time FROM %s WHERE userid = ? and ip >= '192.168.0.2'",
+                id1,
+            ),
+            row("192.168.0.2", 80, 24),
+            row("192.168.0.2", 90, 42),
+        )
 
-        assert_rows(execute(cql, table, "SELECT ip, port, time FROM %s WHERE userid = ? and ip = '192.168.0.2'", id1),
-                   row("192.168.0.2", 80, 24),
-                   row("192.168.0.2", 90, 42))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT ip, port, time FROM %s WHERE userid = ? and ip = '192.168.0.2'",
+                id1,
+            ),
+            row("192.168.0.2", 80, 24),
+            row("192.168.0.2", 90, 42),
+        )
 
-        assertEmpty(execute(cql, table, "SELECT ip, port, time FROM %s WHERE userid = ? and ip > '192.168.0.2'", id1))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT ip, port, time FROM %s WHERE userid = ? and ip > '192.168.0.2'",
+                id1,
+            )
+        )
 
-        assert_rows(execute(cql, table, "SELECT ip, port, time FROM %s WHERE userid = ? AND ip = '192.168.0.3'", id2),
-                   row("192.168.0.3", None, 42))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT ip, port, time FROM %s WHERE userid = ? AND ip = '192.168.0.3'",
+                id2,
+            ),
+            row("192.168.0.3", None, 42),
+        )
 
-        assert_rows(execute(cql, table, "SELECT ip, port, time FROM %s WHERE userid = ? AND ip = '192.168.0.4'", id2),
-                   row("192.168.0.4", None, 42))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT ip, port, time FROM %s WHERE userid = ? AND ip = '192.168.0.4'",
+                id2,
+            ),
+            row("192.168.0.4", None, 42),
+        )
 
-        execute(cql, table, "DELETE time FROM %s WHERE userid = ? AND ip = '192.168.0.2' AND port = 80", id1)
+        execute(
+            cql,
+            table,
+            "DELETE time FROM %s WHERE userid = ? AND ip = '192.168.0.2' AND port = 80",
+            id1,
+        )
 
         assertRowCount(execute(cql, table, "SELECT * FROM %s WHERE userid = ?", id1), 2)
 
         execute(cql, table, "DELETE FROM %s WHERE userid = ?", id1)
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE userid = ?", id1))
 
-        execute(cql, table, "DELETE FROM %s WHERE userid = ? AND ip = '192.168.0.3'", id2)
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE userid = ? AND ip = '192.168.0.3'", id2))
+        execute(
+            cql, table, "DELETE FROM %s WHERE userid = ? AND ip = '192.168.0.3'", id2
+        )
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE userid = ? AND ip = '192.168.0.3'",
+                id2,
+            )
+        )
+
 
 def testCreateIndexOnCompactTableWithClusteringColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "COMPACT STORAGE",
-                             "CREATE INDEX ON %s (a);")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
+        assertInvalidMessage(cql, table, "COMPACT STORAGE", "CREATE INDEX ON %s (a);")
 
-        assertInvalidMessage(cql, table, "COMPACT STORAGE",
-                             "CREATE INDEX ON %s (b);")
+        assertInvalidMessage(cql, table, "COMPACT STORAGE", "CREATE INDEX ON %s (b);")
 
-        assertInvalidMessage(cql, table, "COMPACT STORAGE",
-                             "CREATE INDEX ON %s (c);")
+        assertInvalidMessage(cql, table, "COMPACT STORAGE", "CREATE INDEX ON %s (c);")
+
 
 def testCreateIndexOnCompactTableWithoutClusteringColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "Secondary indexes are not supported on PRIMARY KEY columns in COMPACT STORAGE tables",
-                             "CREATE INDEX ON %s (a);")
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int) WITH COMPACT STORAGE"
+    ) as table:
+        assertInvalidMessage(
+            cql,
+            table,
+            "Secondary indexes are not supported on PRIMARY KEY columns in COMPACT STORAGE tables",
+            "CREATE INDEX ON %s (a);",
+        )
 
         execute(cql, table, "CREATE INDEX ON %s (b);")
 
@@ -923,12 +1811,17 @@ def testCreateIndexOnCompactTableWithoutClusteringColumns(cql, test_keyspace):
 
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b = ?", 4), row(2, 4))
 
+
 # DeleteTest
 
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithNoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionkey int PRIMARY KEY, value int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionkey int PRIMARY KEY, value int) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (partitionKey, value) VALUES (0, 0)")
         execute(cql, table, "INSERT INTO %s (partitionKey, value) VALUES (1, 1)")
         execute(cql, table, "INSERT INTO %s (partitionKey, value) VALUES (2, 2)")
@@ -945,319 +1838,760 @@ def testDeleteWithNoClusteringColumns(cql, test_keyspace, forceFlush):
         execute(cql, table, "DELETE FROM %s WHERE partitionKey IN (?, ?)", 0, 1)
         if forceFlush:
             flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(2, 2),
-                   row(3, 3))
+        assert_rows(execute(cql, table, "SELECT * FROM %s"), row(2, 2), row(3, 3))
 
         # test invalid queries
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses for",
-                             "DELETE FROM %s WHERE token(partitionKey) = token(?)", 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses for",
+            "DELETE FROM %s WHERE token(partitionKey) = token(?)",
+            0,
+        )
 
         # multiple time same primary key element in WHERE clause
         # As explained in #12472, Scylla allows this case that Cassandra
         # forbids, so the check is commented out:
-        #assertInvalidMessage(cql, table, "partitionkey cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "partitionkey cannot be restricted by more than one relation if it includes an Equal",
         #                     "DELETE FROM %s WHERE partitionKey = ? AND partitionKey = ?", 0, 1)
 
         # Undefined column names
-        assertInvalidMessage(cql, table, "unknown",
-                             "DELETE unknown FROM %s WHERE partitionKey = ?", 0)
+        assertInvalidMessage(
+            cql, table, "unknown", "DELETE unknown FROM %s WHERE partitionKey = ?", 0
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "DELETE FROM %s WHERE partitionKey1 = ?", 0)
+        assertInvalidMessage(
+            cql, table, "partitionkey1", "DELETE FROM %s WHERE partitionKey1 = ?", 0
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key",
-                             "DELETE FROM %s WHERE partitionKey > ? ", 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key",
+            "DELETE FROM %s WHERE partitionKey > ? ",
+            0,
+        )
 
-        assertInvalidMessage(cql, table, "Cannot use CONTAINS on non-collection column",
-                             "DELETE FROM %s WHERE partitionKey CONTAINS ?", 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Cannot use CONTAINS on non-collection column",
+            "DELETE FROM %s WHERE partitionKey CONTAINS ?",
+            0,
+        )
 
         # Non primary key in the where clause
         # Reproduces #12474:
-        assertInvalidMessage(cql, table, "where clause",
-                             "DELETE FROM %s WHERE partitionKey = ? AND value = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "where clause",
+            "DELETE FROM %s WHERE partitionKey = ? AND value = ?",
+            0,
+            1,
+        )
 
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithOneClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 2, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 3, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 4, 4)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 5, 5)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (1, 0, 6)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 2, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 3, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 4, 4)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 5, 5)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (1, 0, 6)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        execute(cql, table, "DELETE value FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1)
+        execute(
+            cql,
+            table,
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering = ?",
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
 
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering = ?",
+                0,
+                1,
+            )
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1)
+        execute(
+            cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1
+        )
         if forceFlush:
             flush(cql, table)
-        assertEmpty(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering = ?",
+                0,
+                1,
+            )
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey IN (?, ?) AND clustering = ?", 0, 1, 0)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey IN (?, ?) AND clustering = ?",
+            0,
+            1,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 2, 2),
-                   row(0, 3, 3),
-                   row(0, 4, 4),
-                   row(0, 5, 5))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 2, 2),
+            row(0, 3, 3),
+            row(0, 4, 4),
+            row(0, 5, 5),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering) IN ((?), (?))", 0, 4, 5)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering) IN ((?), (?))",
+            0,
+            4,
+            5,
+        )
         if forceFlush:
             flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 2, 2),
-                   row(0, 3, 3))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 2, 2),
+            row(0, 3, 3),
+        )
 
         # test invalid queries
 
         # missing primary key element
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "DELETE FROM %s WHERE clustering = ?", 1)
+        assertInvalidMessage(
+            cql, table, "partitionkey", "DELETE FROM %s WHERE clustering = ?", 1
+        )
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses for",
-                             "DELETE FROM %s WHERE token(partitionKey) = token(?) AND clustering = ? ", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses for",
+            "DELETE FROM %s WHERE token(partitionKey) = token(?) AND clustering = ? ",
+            0,
+            1,
+        )
 
         # multiple time same primary key element in WHERE clause
         # As explained in #12472, Scylla allows this case that Cassandra
         # forbids, so the check is commented out:
-        #assertInvalidMessage(cql, table, "clustering cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "clustering cannot be restricted by more than one relation if it includes an Equal",
         #                     "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND clustering = ?", 0, 1, 1)
 
         # Undefined column names
-        assertInvalidMessage(cql, table, "value1",
-                             "DELETE value1 FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "DELETE value1 FROM %s WHERE partitionKey = ? AND clustering = ?",
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "DELETE FROM %s WHERE partitionKey1 = ? AND clustering = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey1",
+            "DELETE FROM %s WHERE partitionKey1 = ? AND clustering = ?",
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_3",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_3 = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_3",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_3 = ?",
+            0,
+            1,
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key",
-                             "DELETE FROM %s WHERE partitionKey > ? AND clustering = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key",
+            "DELETE FROM %s WHERE partitionKey > ? AND clustering = ?",
+            0,
+            1,
+        )
 
-        assertInvalidMessageRE(cql, table, "Cannot use CONTAINS on non-collection column|Cannot use DELETE with CONTAINS",
-                             "DELETE FROM %s WHERE partitionKey CONTAINS ? AND clustering = ?", 0, 1)
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "Cannot use CONTAINS on non-collection column|Cannot use DELETE with CONTAINS",
+            "DELETE FROM %s WHERE partitionKey CONTAINS ? AND clustering = ?",
+            0,
+            1,
+        )
 
         # Non primary key in the where clause
-        assertInvalidMessage(cql, table, "value",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND value = ?", 0, 1, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND value = ?",
+            0,
+            1,
+            3,
+        )
 
-@pytest.mark.xfail(reason="issue #4244")
+
+@pytest.mark.xfail(
+    reason="Add support for mixing token, multi- and single-column restrictions #4244"
+)
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2)) WITH COMPACT STORAGE") as table:
-
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 2, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 3, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 1, 4)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 2, 5)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 6)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 2, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 3, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 1, 4)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 2, 5)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 6)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        execute(cql, table, "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        execute(
+            cql,
+            table,
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
 
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                            0, 1, 1))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                1,
+            )
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) = (?, ?)", 0, 1, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) = (?, ?)",
+            0,
+            1,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertEmpty(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                            0, 1, 1))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                1,
+            )
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 0, 0)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            0,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 2, 2),
-                   row(0, 0, 3, 3),
-                   row(0, 1, 2, 5))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 0, 1, 1),
+            row(0, 0, 2, 2),
+            row(0, 0, 3, 3),
+            row(0, 1, 2, 5),
+        )
 
         rows = [row(0, 0, 1, 1), row(0, 1, 2, 5)]
 
-        execute(cql, table, "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)", 0, 0, 2, 3)
+        execute(
+            cql,
+            table,
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)",
+            0,
+            0,
+            2,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1), *rows)
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            *rows,
+        )
 
         rows = [row(0, 0, 1, 1)]
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))", 0, 0, 2, 1, 2)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
+            0,
+            0,
+            2,
+            1,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1), *rows)
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            *rows,
+        )
 
         # Reproduces #4244:
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?)) AND clustering_2 = ?", 0, 0, 2, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?)) AND clustering_2 = ?",
+            0,
+            0,
+            2,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 0, 1, 1))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 0, 1, 1),
+        )
 
         # test invalid queries
 
         # missing primary key element
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "DELETE FROM %s WHERE clustering_1 = ? AND clustering_2 = ?", 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "DELETE FROM %s WHERE clustering_1 = ? AND clustering_2 = ?",
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "PRIMARY KEY column \"clustering_2\" cannot be restricted as preceding column \"clustering_1\" is not restricted",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_2 = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            'PRIMARY KEY column "clustering_2" cannot be restricted as preceding column "clustering_1" is not restricted',
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_2 = ?",
+            0,
+            1,
+        )
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses for",
-                             "DELETE FROM %s WHERE token(partitionKey) = token(?) AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses for",
+            "DELETE FROM %s WHERE token(partitionKey) = token(?) AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
         # multiple time same primary key element in WHERE clause
         # As explained in #12472, Scylla allows this case that Cassandra
         # forbids, so the check is commented out:
-        #assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
         #                     "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND clustering_1 = ?", 0, 1, 1, 1)
 
         # Undefined column names
-        assertInvalidMessage(cql, table, "value1",
-                             "DELETE value1 FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "DELETE value1 FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "DELETE FROM %s WHERE partitionKey1 = ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey1",
+            "DELETE FROM %s WHERE partitionKey1 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_3",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_3 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_3",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_3 = ?",
+            0,
+            1,
+            1,
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key",
-                             "DELETE FROM %s WHERE partitionKey > ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key",
+            "DELETE FROM %s WHERE partitionKey > ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "Cannot use CONTAINS on non-collection column",
-                             "DELETE FROM %s WHERE partitionKey CONTAINS ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Cannot use CONTAINS on non-collection column",
+            "DELETE FROM %s WHERE partitionKey CONTAINS ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
         # Non primary key in the where clause
-        assertInvalidMessage(cql, table, "value",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND value = ?", 0, 1, 1, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND value = ?",
+            0,
+            1,
+            1,
+            3,
+        )
+
 
 # InsertTest
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testInsertWithCompactFormat(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, 0, 0),
-                   row(0, 1, 1))
+        assert_rows(execute(cql, table, "SELECT * FROM %s"), row(0, 0, 0), row(0, 1, 1))
 
         # Invalid Null values for the clustering key or the regular column
-        assertInvalidMessage(cql, table, "clustering",
-                             "INSERT INTO %s (partitionKey, value) VALUES (0, 0)")
-        assertInvalidMessage(cql, table, "Column value is mandatory for this COMPACT STORAGE table",
-                             "INSERT INTO %s (partitionKey, clustering) VALUES (0, 0)")
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering",
+            "INSERT INTO %s (partitionKey, value) VALUES (0, 0)",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Column value is mandatory for this COMPACT STORAGE table",
+            "INSERT INTO %s (partitionKey, clustering) VALUES (0, 0)",
+        )
 
         # Missing primary key columns
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "INSERT INTO %s (clustering, value) VALUES (0, 1)")
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "INSERT INTO %s (clustering, value) VALUES (0, 1)",
+        )
 
         # multiple time the same value
-        assertInvalidMessageRE(cql, table, "duplicates|Multiple",
-                             "INSERT INTO %s (partitionKey, clustering, value, value) VALUES (0, 0, 2, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "duplicates|Multiple",
+            "INSERT INTO %s (partitionKey, clustering, value, value) VALUES (0, 0, 2, 2)",
+        )
 
         # multiple time same primary key element in WHERE clause
-        assertInvalidMessageRE(cql, table, "duplicates|Multiple",
-                             "INSERT INTO %s (partitionKey, clustering, clustering, value) VALUES (0, 0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "duplicates|Multiple",
+            "INSERT INTO %s (partitionKey, clustering, clustering, value) VALUES (0, 0, 0, 2)",
+        )
 
         # Undefined column names
-        assertInvalidMessage(cql, table, "clusteringx",
-                             "INSERT INTO %s (partitionKey, clusteringx, value) VALUES (0, 0, 2)")
+        assertInvalidMessage(
+            cql,
+            table,
+            "clusteringx",
+            "INSERT INTO %s (partitionKey, clusteringx, value) VALUES (0, 0, 2)",
+        )
 
-        assertInvalidMessage(cql, table, "valuex",
-                             "INSERT INTO %s (partitionKey, clustering, valuex) VALUES (0, 0, 2)")
+        assertInvalidMessage(
+            cql,
+            table,
+            "valuex",
+            "INSERT INTO %s (partitionKey, clustering, valuex) VALUES (0, 0, 2)",
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testInsertWithCompactStorageAndTwoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, 0, null, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(0, 0, null, 0),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+        )
 
         # Invalid Null values for the clustering key or the regular column
-        assertInvalidMessage(cql, table, "PRIMARY KEY column \"clustering_2\" cannot be restricted as preceding column \"clustering_1\" is not restricted",
-                             "INSERT INTO %s (partitionKey, clustering_2, value) VALUES (0, 0, 0)")
-        assertInvalidMessage(cql, table, "Column value is mandatory for this COMPACT STORAGE table",
-                             "INSERT INTO %s (partitionKey, clustering_1, clustering_2) VALUES (0, 0, 0)")
+        assertInvalidMessage(
+            cql,
+            table,
+            'PRIMARY KEY column "clustering_2" cannot be restricted as preceding column "clustering_1" is not restricted',
+            "INSERT INTO %s (partitionKey, clustering_2, value) VALUES (0, 0, 0)",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Column value is mandatory for this COMPACT STORAGE table",
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2) VALUES (0, 0, 0)",
+        )
 
         # Missing primary key columns
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "INSERT INTO %s (clustering_1, clustering_2, value) VALUES (0, 0, 1)")
-        assertInvalidMessage(cql, table, "PRIMARY KEY column \"clustering_2\" cannot be restricted as preceding column \"clustering_1\" is not restricted",
-                             "INSERT INTO %s (partitionKey, clustering_2, value) VALUES (0, 0, 2)")
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "INSERT INTO %s (clustering_1, clustering_2, value) VALUES (0, 0, 1)",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            'PRIMARY KEY column "clustering_2" cannot be restricted as preceding column "clustering_1" is not restricted',
+            "INSERT INTO %s (partitionKey, clustering_2, value) VALUES (0, 0, 2)",
+        )
 
         # multiple time the same value
-        assertInvalidMessageRE(cql, table, "duplicates|Multiple",
-                             "INSERT INTO %s (partitionKey, clustering_1, value, clustering_2, value) VALUES (0, 0, 2, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "duplicates|Multiple",
+            "INSERT INTO %s (partitionKey, clustering_1, value, clustering_2, value) VALUES (0, 0, 2, 0, 2)",
+        )
 
         # multiple time same primary key element in WHERE clause
-        assertInvalidMessageRE(cql, table, "duplicates|Multiple",
-                             "INSERT INTO %s (partitionKey, clustering_1, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "duplicates|Multiple",
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 2)",
+        )
 
         # Undefined column names
-        assertInvalidMessage(cql, table, "clustering_1x",
-                             "INSERT INTO %s (partitionKey, clustering_1x, clustering_2, value) VALUES (0, 0, 0, 2)")
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_1x",
+            "INSERT INTO %s (partitionKey, clustering_1x, clustering_2, value) VALUES (0, 0, 0, 2)",
+        )
 
-        assertInvalidMessage(cql, table, "valuex",
-                             "INSERT INTO %s (partitionKey, clustering_1, clustering_2, valuex) VALUES (0, 0, 0, 2)")
+        assertInvalidMessage(
+            cql,
+            table,
+            "valuex",
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, valuex) VALUES (0, 0, 0, 2)",
+        )
+
 
 # InsertUpdateIfConditionTest
 # Test for CAS with compact storage table, and CASSANDRA-6813 in particular,
 # migrated from cql_tests.py:TestCQL.cas_and_compact_test()
-@pytest.mark.parametrize("test_keyspace",
-                         ["tablets", "vnodes"],
-                         indirect=True)
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def testCompactStorage(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(partition text, key text, owner text, PRIMARY KEY (partition, key)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (partition, key, owner) VALUES ('a', 'b', null)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partition text, key text, owner text, PRIMARY KEY (partition, key)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (partition, key, owner) VALUES ('a', 'b', null)"
+        )
         # As explained in docs/kb/lwt-differences.rst, Scylla deliberately
         # differs from Cassandra in that it always returns the tested column's
         # value, even in True (successful) conditional writes.
-        assert_rows2(execute(cql, table, "UPDATE %s SET owner='z' WHERE partition='a' AND key='b' IF owner=null"), [row(True)], [row(True, None)])
+        assert_rows2(
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET owner='z' WHERE partition='a' AND key='b' IF owner=null",
+            ),
+            [row(True)],
+            [row(True, None)],
+        )
 
-        assert_rows(execute(cql, table, "UPDATE %s SET owner='b' WHERE partition='a' AND key='b' IF owner='a'"), row(False, "z"))
-        assert_rows2(execute(cql, table, "UPDATE %s SET owner='b' WHERE partition='a' AND key='b' IF owner='z'"), [row(True)], [row(True, 'z')])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET owner='b' WHERE partition='a' AND key='b' IF owner='a'",
+            ),
+            row(False, "z"),
+        )
+        assert_rows2(
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET owner='b' WHERE partition='a' AND key='b' IF owner='z'",
+            ),
+            [row(True)],
+            [row(True, "z")],
+        )
 
-        assert_rows2(execute(cql, table, "INSERT INTO %s (partition, key, owner) VALUES ('a', 'c', 'x') IF NOT EXISTS"), [row(True)], [row(True,None,None,None)])
+        assert_rows2(
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (partition, key, owner) VALUES ('a', 'c', 'x') IF NOT EXISTS",
+            ),
+            [row(True)],
+            [row(True, None, None, None)],
+        )
+
 
 # SelectGroupByTest
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(
+    reason="Add support for mixing token, multi- and single-column restrictions #4244"
+)
 def testGroupByWithoutPaging(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 3, 6)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 2, 6, 12)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 3, 2, 12, 24)")
@@ -1273,495 +2607,899 @@ def testGroupByWithoutPaging(cql, test_keyspace):
         execute(cql, table, "DELETE FROM %s WHERE a = 3")
 
         # Range queries
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a"),
-                   row(1, 2, 6, 4, 24),
-                   row(2, 2, 6, 2, 12),
-                   row(4, 8, 24, 1, 24))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a"),
+            row(1, 2, 6, 4, 24),
+            row(2, 2, 6, 2, 12),
+            row(4, 8, 24, 1, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a, b"),
-                   row(1, 2, 6, 2, 12),
-                   row(1, 4, 12, 2, 24),
-                   row(2, 2, 6, 1, 6),
-                   row(2, 4, 12, 1, 12),
-                   row(4, 8, 24, 1, 24))
+        assert_rows(
+            execute(
+                cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a, b"
+            ),
+            row(1, 2, 6, 2, 12),
+            row(1, 4, 12, 2, 24),
+            row(2, 2, 6, 1, 6),
+            row(2, 4, 12, 1, 12),
+            row(4, 8, 24, 1, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE b = 2 GROUP BY a, b ALLOW FILTERING"),
-                   row(1, 2, 6, 2, 12),
-                   row(2, 2, 6, 1, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE b = 2 GROUP BY a, b ALLOW FILTERING",
+            ),
+            row(1, 2, 6, 2, 12),
+            row(2, 2, 6, 1, 6),
+        )
 
         # Reproduces #12477:
-        assertEmpty(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE b IN () GROUP BY a, b ALLOW FILTERING"))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE b IN () GROUP BY a, b ALLOW FILTERING",
+            )
+        )
 
         # Range queries without aggregates
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b, c"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6),
-                   row(1, 4, 2, 6),
-                   row(2, 2, 3, 3),
-                   row(2, 4, 3, 6),
-                   row(4, 8, 2, 12))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b, c"),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+            row(1, 4, 2, 6),
+            row(2, 2, 3, 3),
+            row(2, 4, 3, 6),
+            row(4, 8, 2, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b"),
-                   row(1, 2, 1, 3),
-                   row(1, 4, 2, 6),
-                   row(2, 2, 3, 3),
-                   row(2, 4, 3, 6),
-                   row(4, 8, 2, 12))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b"),
+            row(1, 2, 1, 3),
+            row(1, 4, 2, 6),
+            row(2, 2, 3, 3),
+            row(2, 4, 3, 6),
+            row(4, 8, 2, 12),
+        )
 
         # Range queries with wildcard
-        assert_rows(execute(cql, table, "SELECT * FROM %s GROUP BY a, b, c"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12),
-                   row(1, 4, 2, 6, 12),
-                   row(2, 2, 3, 3, 6),
-                   row(2, 4, 3, 6, 12),
-                   row(4, 8, 2, 12, 24))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s GROUP BY a, b, c"),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+            row(1, 4, 2, 6, 12),
+            row(2, 2, 3, 3, 6),
+            row(2, 4, 3, 6, 12),
+            row(4, 8, 2, 12, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s GROUP BY a, b"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 4, 2, 6, 12),
-                   row(2, 2, 3, 3, 6),
-                   row(2, 4, 3, 6, 12),
-                   row(4, 8, 2, 12, 24))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s GROUP BY a, b"),
+            row(1, 2, 1, 3, 6),
+            row(1, 4, 2, 6, 12),
+            row(2, 2, 3, 3, 6),
+            row(2, 4, 3, 6, 12),
+            row(4, 8, 2, 12, 24),
+        )
 
         # Range query with LIMIT
         # Reproduces #5361:
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a, b LIMIT 2"),
-                   row(1, 2, 6, 2, 12),
-                   row(1, 4, 12, 2, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a, b LIMIT 2",
+            ),
+            row(1, 2, 6, 2, 12),
+            row(1, 4, 12, 2, 24),
+        )
 
         # Range queries with PER PARTITION LIMIT
         # Reproduces #5363:
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a, b PER PARTITION LIMIT 1"),
-                   row(1, 2, 6, 2, 12),
-                   row(2, 2, 6, 1, 6),
-                   row(4, 8, 24, 1, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a, b PER PARTITION LIMIT 1",
+            ),
+            row(1, 2, 6, 2, 12),
+            row(2, 2, 6, 1, 6),
+            row(4, 8, 24, 1, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a PER PARTITION LIMIT 2"),
-                   row(1, 2, 6, 4, 24),
-                   row(2, 2, 6, 2, 12),
-                   row(4, 8, 24, 1, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 6, 4, 24),
+            row(2, 2, 6, 2, 12),
+            row(4, 8, 24, 1, 24),
+        )
 
         # Range query with PER PARTITION LIMIT and LIMIT
         # Reproduces #5361, #5363:
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a, b PER PARTITION LIMIT 1 LIMIT 2"),
-                   row(1, 2, 6, 2, 12),
-                   row(2, 2, 6, 1, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a, b PER PARTITION LIMIT 1 LIMIT 2",
+            ),
+            row(1, 2, 6, 2, 12),
+            row(2, 2, 6, 1, 6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a PER PARTITION LIMIT 2"),
-                   row(1, 2, 6, 4, 24),
-                   row(2, 2, 6, 2, 12),
-                   row(4, 8, 24, 1, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s GROUP BY a PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 6, 4, 24),
+            row(2, 2, 6, 2, 12),
+            row(4, 8, 24, 1, 24),
+        )
 
         # Range queries without aggregates and with LIMIT
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b, c LIMIT 3"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6),
-                   row(1, 4, 2, 6))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b, c LIMIT 3"),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+            row(1, 4, 2, 6),
+        )
 
         # Reproduces #5362:
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b LIMIT 3"),
-                   row(1, 2, 1, 3),
-                   row(1, 4, 2, 6),
-                   row(2, 2, 3, 3))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b LIMIT 3"),
+            row(1, 2, 1, 3),
+            row(1, 4, 2, 6),
+            row(2, 2, 3, 3),
+        )
 
         # Range queries with wildcard and with LIMIT
-        assert_rows(execute(cql, table, "SELECT * FROM %s GROUP BY a, b, c LIMIT 3"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12),
-                   row(1, 4, 2, 6, 12))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s GROUP BY a, b, c LIMIT 3"),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+            row(1, 4, 2, 6, 12),
+        )
 
         # Reproduces #5362:
-        assert_rows(execute(cql, table, "SELECT * FROM %s GROUP BY a, b LIMIT 3"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 4, 2, 6, 12),
-                   row(2, 2, 3, 3, 6))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s GROUP BY a, b LIMIT 3"),
+            row(1, 2, 1, 3, 6),
+            row(1, 4, 2, 6, 12),
+            row(2, 2, 3, 3, 6),
+        )
 
         # Range queries without aggregates and with PER PARTITION LIMIT
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b, c PER PARTITION LIMIT 2"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6),
-                   row(2, 2, 3, 3),
-                   row(2, 4, 3, 6),
-                   row(4, 8, 2, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s GROUP BY a, b, c PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+            row(2, 2, 3, 3),
+            row(2, 4, 3, 6),
+            row(4, 8, 2, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b PER PARTITION LIMIT 1"),
-                   row(1, 2, 1, 3),
-                   row(2, 2, 3, 3),
-                   row(4, 8, 2, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s GROUP BY a, b PER PARTITION LIMIT 1",
+            ),
+            row(1, 2, 1, 3),
+            row(2, 2, 3, 3),
+            row(4, 8, 2, 12),
+        )
 
         # Range queries with wildcard and with PER PARTITION LIMIT
-        assert_rows(execute(cql, table, "SELECT * FROM %s GROUP BY a, b, c PER PARTITION LIMIT 2"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12),
-                   row(2, 2, 3, 3, 6),
-                   row(2, 4, 3, 6, 12),
-                   row(4, 8, 2, 12, 24))
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s GROUP BY a, b, c PER PARTITION LIMIT 2"
+            ),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+            row(2, 2, 3, 3, 6),
+            row(2, 4, 3, 6, 12),
+            row(4, 8, 2, 12, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s GROUP BY a, b PER PARTITION LIMIT 1"),
-                   row(1, 2, 1, 3, 6),
-                   row(2, 2, 3, 3, 6),
-                   row(4, 8, 2, 12, 24))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s GROUP BY a, b PER PARTITION LIMIT 1"),
+            row(1, 2, 1, 3, 6),
+            row(2, 2, 3, 3, 6),
+            row(4, 8, 2, 12, 24),
+        )
 
         # Range queries without aggregates, with PER PARTITION LIMIT and LIMIT
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s GROUP BY a, b, c PER PARTITION LIMIT 2 LIMIT 3"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6),
-                   row(2, 2, 3, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s GROUP BY a, b, c PER PARTITION LIMIT 2 LIMIT 3",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+            row(2, 2, 3, 3),
+        )
 
         # Range queries with wildcard, with PER PARTITION LIMIT and LIMIT
-        assert_rows(execute(cql, table, "SELECT * FROM %s GROUP BY a, b, c PER PARTITION LIMIT 2 LIMIT 3"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12),
-                   row(2, 2, 3, 3, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s GROUP BY a, b, c PER PARTITION LIMIT 2 LIMIT 3",
+            ),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+            row(2, 2, 3, 3, 6),
+        )
 
         # Range query with DISTINCT
-        assert_rows(execute(cql, table, "SELECT DISTINCT a, count(a)FROM %s GROUP BY a"),
-                   row(1, 1),
-                   row(2, 1),
-                   row(4, 1))
+        assert_rows(
+            execute(cql, table, "SELECT DISTINCT a, count(a)FROM %s GROUP BY a"),
+            row(1, 1),
+            row(2, 1),
+            row(4, 1),
+        )
 
         # Reproduces #12479:
-        assertInvalidMessage(cql, table, "Grouping on clustering columns is not allowed for SELECT DISTINCT queries",
-                             "SELECT DISTINCT a, count(a)FROM %s GROUP BY a, b")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Grouping on clustering columns is not allowed for SELECT DISTINCT queries",
+            "SELECT DISTINCT a, count(a)FROM %s GROUP BY a, b",
+        )
 
         # Range query with DISTINCT and LIMIT
         # Reproduces #5361:
-        assert_rows(execute(cql, table, "SELECT DISTINCT a, count(a)FROM %s GROUP BY a LIMIT 2"),
-                   row(1, 1),
-                   row(2, 1))
+        assert_rows(
+            execute(
+                cql, table, "SELECT DISTINCT a, count(a)FROM %s GROUP BY a LIMIT 2"
+            ),
+            row(1, 1),
+            row(2, 1),
+        )
 
         # Reproduces #12479:
-        assertInvalidMessage(cql, table, "Grouping on clustering columns is not allowed for SELECT DISTINCT queries",
-                             "SELECT DISTINCT a, count(a)FROM %s GROUP BY a, b LIMIT 2")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Grouping on clustering columns is not allowed for SELECT DISTINCT queries",
+            "SELECT DISTINCT a, count(a)FROM %s GROUP BY a, b LIMIT 2",
+        )
 
         # Range query with ORDER BY
-        assertInvalidMessage(cql, table, "ORDER BY is only supported when the partition key is restricted by an EQ or an IN",
-                             "SELECT a, b, c, count(b), max(e) FROM %s GROUP BY a, b ORDER BY b DESC, c DESC")
+        assertInvalidMessage(
+            cql,
+            table,
+            "ORDER BY is only supported when the partition key is restricted by an EQ or an IN",
+            "SELECT a, b, c, count(b), max(e) FROM %s GROUP BY a, b ORDER BY b DESC, c DESC",
+        )
 
         # Single partition queries
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12),
-                   row(1, 4, 12, 2, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+            row(1, 4, 12, 2, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY b, c"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12),
-                   row(1, 4, 12, 2, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY b, c",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+            row(1, 4, 12, 2, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 AND b = 2 GROUP BY a, b, c"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 AND b = 2 GROUP BY a, b, c",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 AND b = 2 GROUP BY a, c"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 AND b = 2 GROUP BY a, c",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 AND b = 2 GROUP BY c"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 AND b = 2 GROUP BY c",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+        )
 
         # Single partition queries without aggregates
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b"),
-                   row(1, 2, 1, 3),
-                   row(1, 4, 2, 6))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b"),
+            row(1, 2, 1, 3),
+            row(1, 4, 2, 6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b, c"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6),
-                   row(1, 4, 2, 6))
+        assert_rows(
+            execute(
+                cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b, c"
+            ),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+            row(1, 4, 2, 6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY b, c"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6),
-                   row(1, 4, 2, 6))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY b, c"),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+            row(1, 4, 2, 6),
+        )
 
         # Reproduces #4244:
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 and token(a) = token(1) GROUP BY b, c"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6),
-                   row(1, 4, 2, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a = 1 and token(a) = token(1) GROUP BY b, c",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+            row(1, 4, 2, 6),
+        )
 
         # Single partition queries with wildcard
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b, c"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12),
-                   row(1, 4, 2, 6, 12))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b, c"),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+            row(1, 4, 2, 6, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 4, 2, 6, 12))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b"),
+            row(1, 2, 1, 3, 6),
+            row(1, 4, 2, 6, 12),
+        )
 
         # Single partition queries with DISTINCT
-        assert_rows(execute(cql, table, "SELECT DISTINCT a, count(a)FROM %s WHERE a = 1 GROUP BY a"),
-                   row(1, 1))
+        assert_rows(
+            execute(
+                cql, table, "SELECT DISTINCT a, count(a)FROM %s WHERE a = 1 GROUP BY a"
+            ),
+            row(1, 1),
+        )
 
         # Reproduces #12479:
-        assertInvalidMessage(cql, table, "Grouping on clustering columns is not allowed for SELECT DISTINCT queries",
-                             "SELECT DISTINCT a, count(a)FROM %s WHERE a = 1 GROUP BY a, b")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Grouping on clustering columns is not allowed for SELECT DISTINCT queries",
+            "SELECT DISTINCT a, count(a)FROM %s WHERE a = 1 GROUP BY a, b",
+        )
 
         # Single partition queries with LIMIT
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 10"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12),
-                   row(1, 4, 12, 2, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 10",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+            row(1, 4, 12, 2, 24),
+        )
 
         # Reproduces #5361:
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 2"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 2",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 1"),
-                   row(1, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 1",
+            ),
+            row(1, 6),
+        )
 
         # Single partition queries with PER PARTITION LIMIT
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 10"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12),
-                   row(1, 4, 12, 2, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 10",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+            row(1, 4, 12, 2, 24),
+        )
 
         # Reproduces #5363:
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 2"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 1"),
-                   row(1, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 1",
+            ),
+            row(1, 6),
+        )
 
         # Single partition queries without aggregates and with LIMIT
         # Reproduces #5362:
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b LIMIT 2"),
-                   row(1, 2, 1, 3),
-                   row(1, 4, 2, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b LIMIT 2",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 4, 2, 6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b LIMIT 1"),
-                   row(1, 2, 1, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b LIMIT 1",
+            ),
+            row(1, 2, 1, 3),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 2"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 2",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+        )
 
         # Single partition queries with wildcard and with LIMIT
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 2"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12))
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b, c LIMIT 2"
+            ),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b LIMIT 1"),
-                   row(1, 2, 1, 3, 6))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b LIMIT 1"),
+            row(1, 2, 1, 3, 6),
+        )
 
         # Single partition queries without aggregates and with PER PARTITION LIMIT
         # Reproduces #5363:
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b PER PARTITION LIMIT 2"),
-                   row(1, 2, 1, 3),
-                   row(1, 4, 2, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 4, 2, 6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b PER PARTITION LIMIT 1"),
-                   row(1, 2, 1, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b PER PARTITION LIMIT 1",
+            ),
+            row(1, 2, 1, 3),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 2"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+        )
 
         # Single partition queries with wildcard and with PER PARTITION LIMIT
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 2"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = 1 GROUP BY a, b, c PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 GROUP BY a, b PER PARTITION LIMIT 1"),
-                   row(1, 2, 1, 3, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = 1 GROUP BY a, b PER PARTITION LIMIT 1",
+            ),
+            row(1, 2, 1, 3, 6),
+        )
 
         # Single partition queries with ORDER BY
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c ORDER BY b DESC, c DESC"),
-                   row(1, 4, 24, 2, 24),
-                   row(1, 2, 12, 1, 12),
-                   row(1, 2, 6, 1, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c ORDER BY b DESC, c DESC",
+            ),
+            row(1, 4, 24, 2, 24),
+            row(1, 2, 12, 1, 12),
+            row(1, 2, 6, 1, 6),
+        )
 
         # Single partition queries with ORDER BY and PER PARTITION LIMIT
         # Reproduces #5363:
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c ORDER BY b DESC, c DESC PER PARTITION LIMIT 1"),
-                   row(1, 4, 24, 2, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c ORDER BY b DESC, c DESC PER PARTITION LIMIT 1",
+            ),
+            row(1, 4, 24, 2, 24),
+        )
 
         # Single partition queries with ORDER BY and LIMIT
         # Reproduces #5361:
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c ORDER BY b DESC, c DESC LIMIT 2"),
-                   row(1, 4, 24, 2, 24),
-                   row(1, 2, 12, 1, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a = 1 GROUP BY a, b, c ORDER BY b DESC, c DESC LIMIT 2",
+            ),
+            row(1, 4, 24, 2, 24),
+            row(1, 2, 12, 1, 12),
+        )
 
         # Multi-partitions queries
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12),
-                   row(1, 4, 12, 2, 24),
-                   row(2, 2, 6, 1, 6),
-                   row(2, 4, 12, 1, 12),
-                   row(4, 8, 24, 1, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+            row(1, 4, 12, 2, 24),
+            row(2, 2, 6, 1, 6),
+            row(2, 4, 12, 1, 12),
+            row(4, 8, 24, 1, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) AND b = 2 GROUP BY a, b, c"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12),
-                   row(2, 2, 6, 1, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) AND b = 2 GROUP BY a, b, c",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+            row(2, 2, 6, 1, 6),
+        )
 
         # Multi-partitions queries without aggregates
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b"),
-                   row(1, 2, 1, 3),
-                   row(1, 4, 2, 6),
-                   row(2, 2, 3, 3),
-                   row(2, 4, 3, 6),
-                   row(4, 8, 2, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 4, 2, 6),
+            row(2, 2, 3, 3),
+            row(2, 4, 3, 6),
+            row(4, 8, 2, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c"),
-                   row(1, 2, 1, 3),
-                   row(1, 2, 2, 6),
-                   row(1, 4, 2, 6),
-                   row(2, 2, 3, 3),
-                   row(2, 4, 3, 6),
-                   row(4, 8, 2, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c",
+            ),
+            row(1, 2, 1, 3),
+            row(1, 2, 2, 6),
+            row(1, 4, 2, 6),
+            row(2, 2, 3, 3),
+            row(2, 4, 3, 6),
+            row(4, 8, 2, 12),
+        )
 
         # Multi-partitions with wildcard
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12),
-                   row(1, 4, 2, 6, 12),
-                   row(2, 2, 3, 3, 6),
-                   row(2, 4, 3, 6, 12),
-                   row(4, 8, 2, 12, 24))
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c"
+            ),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+            row(1, 4, 2, 6, 12),
+            row(2, 2, 3, 3, 6),
+            row(2, 4, 3, 6, 12),
+            row(4, 8, 2, 12, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 4, 2, 6, 12),
-                   row(2, 2, 3, 3, 6),
-                   row(2, 4, 3, 6, 12),
-                   row(4, 8, 2, 12, 24))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b"),
+            row(1, 2, 1, 3, 6),
+            row(1, 4, 2, 6, 12),
+            row(2, 2, 3, 3, 6),
+            row(2, 4, 3, 6, 12),
+            row(4, 8, 2, 12, 24),
+        )
 
         # Multi-partitions query with DISTINCT
-        assert_rows(execute(cql, table, "SELECT DISTINCT a, count(a)FROM %s WHERE a IN (1, 2, 4) GROUP BY a"),
-                   row(1, 1),
-                   row(2, 1),
-                   row(4, 1))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT DISTINCT a, count(a)FROM %s WHERE a IN (1, 2, 4) GROUP BY a",
+            ),
+            row(1, 1),
+            row(2, 1),
+            row(4, 1),
+        )
 
         # Reproduces #12479:
-        assertInvalidMessage(cql, table, "Grouping on clustering columns is not allowed for SELECT DISTINCT queries",
-                             "SELECT DISTINCT a, count(a)FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Grouping on clustering columns is not allowed for SELECT DISTINCT queries",
+            "SELECT DISTINCT a, count(a)FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b",
+        )
 
         # Multi-partitions query with DISTINCT and LIMIT
         # Reproduces #5361:
-        assert_rows(execute(cql, table, "SELECT DISTINCT a, count(a)FROM %s WHERE a IN (1, 2, 4) GROUP BY a LIMIT 2"),
-                   row(1, 1),
-                   row(2, 1))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT DISTINCT a, count(a)FROM %s WHERE a IN (1, 2, 4) GROUP BY a LIMIT 2",
+            ),
+            row(1, 1),
+            row(2, 1),
+        )
 
         # Multi-partitions queries with PER PARTITION LIMIT
         # Reproduces #5363:
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c PER PARTITION LIMIT 1"),
-                   row(1, 2, 6, 1, 6),
-                   row(2, 2, 6, 1, 6),
-                   row(4, 8, 24, 1, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c PER PARTITION LIMIT 1",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(2, 2, 6, 1, 6),
+            row(4, 8, 24, 1, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, e, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c PER PARTITION LIMIT 2"),
-                   row(1, 2, 6, 1, 6),
-                   row(1, 2, 12, 1, 12),
-                   row(2, 2, 6, 1, 6),
-                   row(2, 4, 12, 1, 12),
-                   row(4, 8, 24, 1, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, e, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 6, 1, 6),
+            row(1, 2, 12, 1, 12),
+            row(2, 2, 6, 1, 6),
+            row(2, 4, 12, 1, 12),
+            row(4, 8, 24, 1, 24),
+        )
 
         # Multi-partitions with wildcard and PER PARTITION LIMIT
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c PER PARTITION LIMIT 2"),
-                   row(1, 2, 1, 3, 6),
-                   row(1, 2, 2, 6, 12),
-                   row(2, 2, 3, 3, 6),
-                   row(2, 4, 3, 6, 12),
-                   row(4, 8, 2, 12, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c PER PARTITION LIMIT 2",
+            ),
+            row(1, 2, 1, 3, 6),
+            row(1, 2, 2, 6, 12),
+            row(2, 2, 3, 3, 6),
+            row(2, 4, 3, 6, 12),
+            row(4, 8, 2, 12, 24),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b PER PARTITION LIMIT 1"),
-                   row(1, 2, 1, 3, 6),
-                   row(2, 2, 3, 3, 6),
-                   row(4, 8, 2, 12, 24))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b PER PARTITION LIMIT 1",
+            ),
+            row(1, 2, 1, 3, 6),
+            row(2, 2, 3, 3, 6),
+            row(4, 8, 2, 12, 24),
+        )
 
         # Multi-partitions queries with ORDER BY
         # (NYH: note that because the partition order isn't known, we can't
         # actually check the result order here, hence I added ignoring_order.
         # this makes this test weaker).
-        assert_rows_ignoring_order(execute_without_paging(cql, table, "SELECT a, b, c, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b ORDER BY b DESC, c DESC"),
-                   row(4, 8, 2, 1, 24),
-                   row(2, 4, 3, 1, 12),
-                   row(1, 4, 2, 2, 24),
-                   row(2, 2, 3, 1, 6),
-                   row(1, 2, 2, 2, 12))
+        assert_rows_ignoring_order(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT a, b, c, count(b), max(e) FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b ORDER BY b DESC, c DESC",
+            ),
+            row(4, 8, 2, 1, 24),
+            row(2, 4, 3, 1, 12),
+            row(1, 4, 2, 2, 24),
+            row(2, 2, 3, 1, 6),
+            row(1, 2, 2, 2, 12),
+        )
 
-        assert_rows_ignoring_order(execute_without_paging(cql, table, "SELECT a, b, c, d FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c ORDER BY b DESC, c DESC"),
-                   row(4, 8, 2, 12),
-                   row(2, 4, 3, 6),
-                   row(1, 4, 2, 12),
-                   row(2, 2, 3, 3),
-                   row(1, 2, 2, 6),
-                   row(1, 2, 1, 3))
+        assert_rows_ignoring_order(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT a, b, c, d FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c ORDER BY b DESC, c DESC",
+            ),
+            row(4, 8, 2, 12),
+            row(2, 4, 3, 6),
+            row(1, 4, 2, 12),
+            row(2, 2, 3, 3),
+            row(1, 2, 2, 6),
+            row(1, 2, 1, 3),
+        )
 
         # Multi-partitions queries with ORDER BY and LIMIT
         # NYH: with LIMIT, even ignoring_order is not enough, the LIMIT
         # may cut it in the wrong place. I unfortunately had to comment
         # out these tests.
-        #assert_rows_ignoring_order(execute_without_paging(cql, table, "SELECT a, b, c, d FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b ORDER BY b DESC, c DESC LIMIT 3"),
+        # assert_rows_ignoring_order(execute_without_paging(cql, table, "SELECT a, b, c, d FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b ORDER BY b DESC, c DESC LIMIT 3"),
         #           row(4, 8, 2, 12),
         #           row(2, 4, 3, 6),
         #           row(1, 4, 2, 12))
 
         # Multi-partitions with wildcard, ORDER BY and LIMIT
-        #assert_rows_ignoring_order(execute_without_paging(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c ORDER BY b DESC, c DESC LIMIT 3"),
+        # assert_rows_ignoring_order(execute_without_paging(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 4) GROUP BY a, b, c ORDER BY b DESC, c DESC LIMIT 3"),
         #           row(4, 8, 2, 12, 24),
         #           row(2, 4, 3, 6, 12),
         #           row(1, 4, 2, 12, 24))
 
         # Invalid queries
-        assertInvalidMessage(cql, table, "Group by",
-                             "SELECT a, b, d, count(b), max(c) FROM %s WHERE a = 1 GROUP BY a, e")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Group by",
+            "SELECT a, b, d, count(b), max(c) FROM %s WHERE a = 1 GROUP BY a, e",
+        )
 
-        assertInvalidMessage(cql, table, "Group by",
-                             "SELECT a, b, d, count(b), max(c) FROM %s WHERE a = 1 GROUP BY c")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Group by",
+            "SELECT a, b, d, count(b), max(c) FROM %s WHERE a = 1 GROUP BY c",
+        )
 
-        assertInvalidMessage(cql, table, "Group by",
-                             "SELECT a, b, d, count(b), max(c) FROM %s WHERE a = 1 GROUP BY a, c, b")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Group by",
+            "SELECT a, b, d, count(b), max(c) FROM %s WHERE a = 1 GROUP BY a, c, b",
+        )
 
-        assertInvalidMessage(cql, table, "Group by",
-                             "SELECT a, b, d, count(b), max(c) FROM %s WHERE a = 1 GROUP BY a, a")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Group by",
+            "SELECT a, b, d, count(b), max(c) FROM %s WHERE a = 1 GROUP BY a, a",
+        )
 
-        assertInvalidMessage(cql, table, "Group by",
-                             "SELECT a, b, c, d FROM %s WHERE token(a) = token(1) GROUP BY b, c")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Group by",
+            "SELECT a, b, c, d FROM %s WHERE token(a) = token(1) GROUP BY b, c",
+        )
 
-        assertInvalidMessage(cql, table, "clustering1",
-                             "SELECT a, b as clustering1, max(c) FROM %s WHERE a = 1 GROUP BY a, clustering1")
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering1",
+            "SELECT a, b as clustering1, max(c) FROM %s WHERE a = 1 GROUP BY a, clustering1",
+        )
 
-        assertInvalidMessage(cql, table, "z",
-                             "SELECT a, b, max(c) FROM %s WHERE a = 1 GROUP BY a, b, z")
+        assertInvalidMessage(
+            cql, table, "z", "SELECT a, b, max(c) FROM %s WHERE a = 1 GROUP BY a, b, z"
+        )
 
     # Test with composite partition key
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY ((a, b), c, d)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY ((a, b), c, d)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 1, 1, 3, 6)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 1, 2, 6, 12)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 1, 3, 12, 24)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 12, 24)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 2, 6, 12)")
 
-        assertInvalidMessage(cql, table, "partition key",
-                             "SELECT a, b, max(d) FROM %s GROUP BY a")
+        assertInvalidMessage(
+            cql, table, "partition key", "SELECT a, b, max(d) FROM %s GROUP BY a"
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, max(d) FROM %s GROUP BY a, b"),
-                   row(1, 2, 12),
-                   row(1, 1, 12))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, max(d) FROM %s GROUP BY a, b"),
+            row(1, 2, 12),
+            row(1, 1, 12),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, max(d) FROM %s WHERE a = 1 AND b = 1 GROUP BY b"),
-                   row(1, 1, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, max(d) FROM %s WHERE a = 1 AND b = 1 GROUP BY b",
+            ),
+            row(1, 1, 12),
+        )
 
     # Test with table without clustering key
-    with create_table(cql, test_keyspace, "(a int primary key, b int, c int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(a int primary key, b int, c int) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, 6)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 6, 12)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 12, 24)")
 
-        assertInvalidMessage(cql, table, "Group by",
-                             "SELECT a, max(c) FROM %s WHERE a = 1 GROUP BY a, a")
+        assertInvalidMessage(
+            cql, table, "Group by", "SELECT a, max(c) FROM %s WHERE a = 1 GROUP BY a, a"
+        )
+
 
 def testGroupByWithoutPagingWithDeletions(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 3, 6)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 6, 12)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 9, 18)")
@@ -1778,372 +3516,1012 @@ def testGroupByWithoutPagingWithDeletions(cql, test_keyspace):
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 2 AND c = 1 AND d = 12")
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 2 AND c = 2 AND d = 9")
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, count(b), max(d) FROM %s GROUP BY a, b, c"),
-                   row(1, 2, 1, 3, 9),
-                   row(1, 2, 2, 3, 12),
-                   row(1, 2, 3, 4, 12))
+        assert_rows(
+            execute(
+                cql, table, "SELECT a, b, c, count(b), max(d) FROM %s GROUP BY a, b, c"
+            ),
+            row(1, 2, 1, 3, 9),
+            row(1, 2, 2, 3, 12),
+            row(1, 2, 3, 4, 12),
+        )
+
 
 def testGroupByWithRangeNamesQueryWithoutPaging(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(1, 5):
             for j in range(1, 5):
                 for k in range(1, 5):
-                    execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", i, j, k, i + j)
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+                        i,
+                        j,
+                        k,
+                        i + j,
+                    )
 
         # Makes sure that we have some tombstones
         execute(cql, table, "DELETE FROM %s WHERE a = 3")
 
         # Range queries
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(2, 1, 3, 2, 3),
-                   row(4, 1, 5, 2, 5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(2, 1, 3, 2, 3),
+            row(4, 1, 5, 2, 5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a, b ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(2, 1, 3, 2, 3),
-                   row(4, 1, 5, 2, 5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a, b ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(2, 1, 3, 2, 3),
+            row(4, 1, 5, 2, 5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b IN (1, 2) and c IN (1, 2) GROUP BY a, b ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(1, 2, 3, 2, 3),
-                   row(2, 1, 3, 2, 3),
-                   row(2, 2, 4, 2, 4),
-                   row(4, 1, 5, 2, 5),
-                   row(4, 2, 6, 2, 6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b IN (1, 2) and c IN (1, 2) GROUP BY a, b ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(1, 2, 3, 2, 3),
+            row(2, 1, 3, 2, 3),
+            row(2, 2, 4, 2, 4),
+            row(4, 1, 5, 2, 5),
+            row(4, 2, 6, 2, 6),
+        )
 
         # Range queries with LIMIT
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a LIMIT 5 ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(2, 1, 3, 2, 3),
-                   row(4, 1, 5, 2, 5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a LIMIT 5 ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(2, 1, 3, 2, 3),
+            row(4, 1, 5, 2, 5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a, b LIMIT 3 ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(2, 1, 3, 2, 3),
-                   row(4, 1, 5, 2, 5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a, b LIMIT 3 ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(2, 1, 3, 2, 3),
+            row(4, 1, 5, 2, 5),
+        )
 
         # Reproduces #5361:
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b IN (1, 2) and c IN (1, 2) GROUP BY a, b LIMIT 3 ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(1, 2, 3, 2, 3),
-                   row(2, 1, 3, 2, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b IN (1, 2) and c IN (1, 2) GROUP BY a, b LIMIT 3 ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(1, 2, 3, 2, 3),
+            row(2, 1, 3, 2, 3),
+        )
 
         # Range queries with PER PARTITION LIMIT
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a, b PER PARTITION LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(2, 1, 3, 2, 3),
-                   row(4, 1, 5, 2, 5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a, b PER PARTITION LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(2, 1, 3, 2, 3),
+            row(4, 1, 5, 2, 5),
+        )
 
         # Reproduces #5363:
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b IN (1, 2) and c IN (1, 2) GROUP BY a, b PER PARTITION LIMIT 1 ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(2, 1, 3, 2, 3),
-                   row(4, 1, 5, 2, 5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b IN (1, 2) and c IN (1, 2) GROUP BY a, b PER PARTITION LIMIT 1 ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(2, 1, 3, 2, 3),
+            row(4, 1, 5, 2, 5),
+        )
 
         # Range queries with PER PARTITION LIMIT and LIMIT
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a, b PER PARTITION LIMIT 2 LIMIT 5 ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(2, 1, 3, 2, 3),
-                   row(4, 1, 5, 2, 5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b = 1 and c IN (1, 2) GROUP BY a, b PER PARTITION LIMIT 2 LIMIT 5 ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(2, 1, 3, 2, 3),
+            row(4, 1, 5, 2, 5),
+        )
 
         # Reproduces #5361, #5363
-        assert_rows(execute(cql, table, "SELECT a, b, d, count(b), max(d) FROM %s WHERE b IN (1, 2) and c IN (1, 2) GROUP BY a, b PER PARTITION LIMIT 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 2, 2, 2),
-                   row(2, 1, 3, 2, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, d, count(b), max(d) FROM %s WHERE b IN (1, 2) and c IN (1, 2) GROUP BY a, b PER PARTITION LIMIT 1 LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 2, 2, 2),
+            row(2, 1, 3, 2, 3),
+        )
+
 
 # SelectSingleColumn
 def testClusteringColumnRelationsWithCompactStorage(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 1, 5, 1)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 2, 6, 2)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 3, 7, 3)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "second", 4, 8, 4)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            1,
+            5,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            2,
+            6,
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            3,
+            7,
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "second",
+            4,
+            8,
+            4,
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a in (?, ?)", "first", "second"),
-                   row("first", 1, 5, 1),
-                   row("first", 2, 6, 2),
-                   row("first", 3, 7, 3),
-                   row("second", 4, 8, 4))
+        assert_rows(
+            execute(
+                cql, table, "select * from %s where a in (?, ?)", "first", "second"
+            ),
+            row("first", 1, 5, 1),
+            row("first", 2, 6, 2),
+            row("first", 3, 7, 3),
+            row("second", 4, 8, 4),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b = ? and c in (?, ?)", "first", 2, 6, 7),
-                   row("first", 2, 6, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b = ? and c in (?, ?)",
+                "first",
+                2,
+                6,
+                7,
+            ),
+            row("first", 2, 6, 2),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in (?, ?) and c in (?, ?)", "first", 2, 3, 6, 7),
-                   row("first", 2, 6, 2),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in (?, ?) and c in (?, ?)",
+                "first",
+                2,
+                3,
+                6,
+                7,
+            ),
+            row("first", 2, 6, 2),
+            row("first", 3, 7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in (?, ?) and c in (?, ?)", "first", 3, 2, 7, 6),
-                   row("first", 2, 6, 2),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in (?, ?) and c in (?, ?)",
+                "first",
+                3,
+                2,
+                7,
+                6,
+            ),
+            row("first", 2, 6, 2),
+            row("first", 3, 7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c in (?, ?) and b in (?, ?)", "first", 7, 6, 3, 2),
-                   row("first", 2, 6, 2),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c in (?, ?) and b in (?, ?)",
+                "first",
+                7,
+                6,
+                3,
+                2,
+            ),
+            row("first", 2, 6, 2),
+            row("first", 3, 7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select c, d from %s where a = ? and c in (?, ?) and b in (?, ?)", "first", 7, 6, 3, 2),
-                   row(6, 2),
-                   row(7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select c, d from %s where a = ? and c in (?, ?) and b in (?, ?)",
+                "first",
+                7,
+                6,
+                3,
+                2,
+            ),
+            row(6, 2),
+            row(7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select c, d from %s where a = ? and c in (?, ?) and b in (?, ?, ?)", "first", 7, 6, 3, 2, 3),
-                   row(6, 2),
-                   row(7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select c, d from %s where a = ? and c in (?, ?) and b in (?, ?, ?)",
+                "first",
+                7,
+                6,
+                3,
+                2,
+                3,
+            ),
+            row(6, 2),
+            row(7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in (?, ?) and c = ?", "first", 3, 2, 7),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in (?, ?) and c = ?",
+                "first",
+                3,
+                2,
+                7,
+            ),
+            row("first", 3, 7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in ? and c in ?",
-                           "first", [3, 2], [7, 6]),
-                   row("first", 2, 6, 2),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in ? and c in ?",
+                "first",
+                [3, 2],
+                [7, 6],
+            ),
+            row("first", 2, 6, 2),
+            row("first", 3, 7, 3),
+        )
 
         # Check commented out because Scylla *does* allow equality check
         # with NULL (and it returns nothing).
-        #assertInvalidMessage(cql, table, "Invalid null value for column b",
+        # assertInvalidMessage(cql, table, "Invalid null value for column b",
         #                     "select * from %s where a = ? and b in ? and c in ?", "first", None, [7, 6])
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c >= ? and b in (?, ?)", "first", 6, 3, 2),
-                   row("first", 2, 6, 2),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c >= ? and b in (?, ?)",
+                "first",
+                6,
+                3,
+                2,
+            ),
+            row("first", 2, 6, 2),
+            row("first", 3, 7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c > ? and b in (?, ?)", "first", 6, 3, 2),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c > ? and b in (?, ?)",
+                "first",
+                6,
+                3,
+                2,
+            ),
+            row("first", 3, 7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c <= ? and b in (?, ?)", "first", 6, 3, 2),
-                   row("first", 2, 6, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c <= ? and b in (?, ?)",
+                "first",
+                6,
+                3,
+                2,
+            ),
+            row("first", 2, 6, 2),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c < ? and b in (?, ?)", "first", 7, 3, 2),
-                   row("first", 2, 6, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c < ? and b in (?, ?)",
+                "first",
+                7,
+                3,
+                2,
+            ),
+            row("first", 2, 6, 2),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c >= ? and c <= ? and b in (?, ?)", "first", 6, 7, 3, 2),
-                   row("first", 2, 6, 2),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c >= ? and c <= ? and b in (?, ?)",
+                "first",
+                6,
+                7,
+                3,
+                2,
+            ),
+            row("first", 2, 6, 2),
+            row("first", 3, 7, 3),
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c > ? and c <= ? and b in (?, ?)", "first", 6, 7, 3, 2),
-                   row("first", 3, 7, 3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c > ? and c <= ? and b in (?, ?)",
+                "first",
+                6,
+                7,
+                3,
+                2,
+            ),
+            row("first", 3, 7, 3),
+        )
 
-        assertEmpty(execute(cql, table, "select * from %s where a = ? and c > ? and c < ? and b in (?, ?)", "first", 6, 7, 3, 2))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c > ? and c < ? and b in (?, ?)",
+                "first",
+                6,
+                7,
+                3,
+                2,
+            )
+        )
 
         # Whereas Cassandra doesn't allow the seemingly-non-useful filter
         # "c = ? AND c > ?", Scylla does allow them, intentionally (see
         # discussion in issue #12472. So we commented out these checks:
-        #assertInvalidMessage(cql, table, "Column \"c\" cannot be restricted by both an equality and an inequality relation",
+        # assertInvalidMessage(cql, table, "Column \"c\" cannot be restricted by both an equality and an inequality relation",
         #                     "select * from %s where a = ? and c > ? and c = ? and b in (?, ?)", "first", 6, 7, 3, 2)
         #
-        #assertInvalidMessage(cql, table, "c cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "c cannot be restricted by more than one relation if it includes an Equal",
         #                     "select * from %s where a = ? and c = ? and c > ?  and b in (?, ?)", "first", 6, 7, 3, 2)
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c in (?, ?) and b in (?, ?) order by b DESC",
-                           "first", 7, 6, 3, 2),
-                   row("first", 3, 7, 3),
-                   row("first", 2, 6, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c in (?, ?) and b in (?, ?) order by b DESC",
+                "first",
+                7,
+                6,
+                3,
+                2,
+            ),
+            row("first", 3, 7, 3),
+            row("first", 2, 6, 2),
+        )
 
-        #assertInvalidMessage(cql, table, "More than one restriction was found for the start bound on b",
+        # assertInvalidMessage(cql, table, "More than one restriction was found for the start bound on b",
         #                     "select * from %s where a = ? and b > ? and b > ?", "first", 6, 3, 2)
         #
-        #assertInvalidMessage(cql, table, "More than one restriction was found for the end bound on b",
+        # assertInvalidMessage(cql, table, "More than one restriction was found for the end bound on b",
         #                     "select * from %s where a = ? and b < ? and b <= ?", "first", 6, 3, 2)
+
 
 # SelectTest
 # Check query with KEY IN clause for wide row tables
 # migrated from cql_tests.py:TestCQL.in_clause_wide_rows_test()
 def testSelectKeyInForWideRows(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, c int, v int, PRIMARY KEY (k, c)) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(10):
             execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (0, ?, ?)", i, i)
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c IN (5, 2, 8)"),
-                   row(2), row(5), row(8))
+        assert_rows(
+            execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c IN (5, 2, 8)"),
+            row(2),
+            row(5),
+            row(8),
+        )
 
-    with create_table(cql, test_keyspace, "(k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2)) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(10):
-            execute(cql, table, "INSERT INTO %s (k, c1, c2, v) VALUES (0, 0, ?, ?)", i, i)
+            execute(
+                cql, table, "INSERT INTO %s (k, c1, c2, v) VALUES (0, 0, ?, ?)", i, i
+            )
 
-        assertEmpty(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c1 IN (5, 2, 8) AND c2 = 3"))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT v FROM %s WHERE k = 0 AND c1 IN (5, 2, 8) AND c2 = 3",
+            )
+        )
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c1 = 0 AND c2 IN (5, 2, 8)"),
-                   row(2), row(5), row(8))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT v FROM %s WHERE k = 0 AND c1 = 0 AND c2 IN (5, 2, 8)",
+            ),
+            row(2),
+            row(5),
+            row(8),
+        )
+
 
 # Check SELECT respects inclusive and exclusive bounds
 # migrated from cql_tests.py:TestCQL.exclusive_slice_test()
 def testSelectBounds(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, c int, v int, PRIMARY KEY (k, c)) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(10):
             execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (0, ?, ?)", i, i)
 
         assertRowCount(execute(cql, table, "SELECT v FROM %s WHERE k = 0"), 10)
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c >= 2 AND c <= 6"),
-                   row(2), row(3), row(4), row(5), row(6))
+        assert_rows(
+            execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c >= 2 AND c <= 6"),
+            row(2),
+            row(3),
+            row(4),
+            row(5),
+            row(6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c > 2 AND c <= 6"),
-                   row(3), row(4), row(5), row(6))
+        assert_rows(
+            execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c > 2 AND c <= 6"),
+            row(3),
+            row(4),
+            row(5),
+            row(6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c >= 2 AND c < 6"),
-                   row(2), row(3), row(4), row(5))
+        assert_rows(
+            execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c >= 2 AND c < 6"),
+            row(2),
+            row(3),
+            row(4),
+            row(5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c > 2 AND c < 6"),
-                   row(3), row(4), row(5))
+        assert_rows(
+            execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c > 2 AND c < 6"),
+            row(3),
+            row(4),
+            row(5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c > 2 AND c <= 6 LIMIT 2"),
-                   row(3), row(4))
+        assert_rows(
+            execute(
+                cql, table, "SELECT v FROM %s WHERE k = 0 AND c > 2 AND c <= 6 LIMIT 2"
+            ),
+            row(3),
+            row(4),
+        )
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k = 0 AND c >= 2 AND c < 6 ORDER BY c DESC LIMIT 2"),
-                   row(5), row(4))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT v FROM %s WHERE k = 0 AND c >= 2 AND c < 6 ORDER BY c DESC LIMIT 2",
+            ),
+            row(5),
+            row(4),
+        )
+
 
 # Test for CASSANDRA-4716 bug and more generally for good behavior of ordering,
 # migrated from cql_tests.py:TestCQL.reversed_compact_test()
 def testReverseCompact(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k text, c int, v int, PRIMARY KEY (k, c)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k text, c int, v int, PRIMARY KEY (k, c)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c DESC)",
+    ) as table:
         for i in range(10):
             execute(cql, table, "INSERT INTO %s (k, c, v) VALUES ('foo', ?, ?)", i, i)
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo'"),
-                   row(5), row(4), row(3))
+        assert_rows(
+            execute(cql, table, "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo'"),
+            row(5),
+            row(4),
+            row(3),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo'"),
-                   row(6), row(5), row(4), row(3), row(2))
+        assert_rows(
+            execute(
+                cql, table, "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo'"
+            ),
+            row(6),
+            row(5),
+            row(4),
+            row(3),
+            row(2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo' ORDER BY c ASC"),
-                   row(3), row(4), row(5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo' ORDER BY c ASC",
+            ),
+            row(3),
+            row(4),
+            row(5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo' ORDER BY c ASC"),
-                   row(2), row(3), row(4), row(5), row(6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo' ORDER BY c ASC",
+            ),
+            row(2),
+            row(3),
+            row(4),
+            row(5),
+            row(6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo' ORDER BY c DESC"),
-                   row(5), row(4), row(3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo' ORDER BY c DESC",
+            ),
+            row(5),
+            row(4),
+            row(3),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo' ORDER BY c DESC"),
-                   row(6), row(5), row(4), row(3), row(2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo' ORDER BY c DESC",
+            ),
+            row(6),
+            row(5),
+            row(4),
+            row(3),
+            row(2),
+        )
 
-    with create_table(cql, test_keyspace, "(k text, c int, v int, PRIMARY KEY (k, c)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k text, c int, v int, PRIMARY KEY (k, c)) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(10):
             execute(cql, table, "INSERT INTO %s(k, c, v) VALUES ('foo', ?, ?)", i, i)
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo'"),
-                   row(3), row(4), row(5))
+        assert_rows(
+            execute(cql, table, "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo'"),
+            row(3),
+            row(4),
+            row(5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo'"),
-                   row(2), row(3), row(4), row(5), row(6))
+        assert_rows(
+            execute(
+                cql, table, "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo'"
+            ),
+            row(2),
+            row(3),
+            row(4),
+            row(5),
+            row(6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo' ORDER BY c ASC"),
-                   row(3), row(4), row(5))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo' ORDER BY c ASC",
+            ),
+            row(3),
+            row(4),
+            row(5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo' ORDER BY c ASC"),
-                   row(2), row(3), row(4), row(5), row(6))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo' ORDER BY c ASC",
+            ),
+            row(2),
+            row(3),
+            row(4),
+            row(5),
+            row(6),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo' ORDER BY c DESC"),
-                   row(5), row(4), row(3))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c FROM %s WHERE c > 2 AND c < 6 AND k = 'foo' ORDER BY c DESC",
+            ),
+            row(5),
+            row(4),
+            row(3),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo' ORDER BY c DESC"),
-                   row(6), row(5), row(4), row(3), row(2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c FROM %s WHERE c >= 2 AND c <= 6 AND k = 'foo' ORDER BY c DESC",
+            ),
+            row(6),
+            row(5),
+            row(4),
+            row(3),
+            row(2),
+        )
+
 
 # Test for the bug from CASSANDRA-4760 and CASSANDRA-4759,
 # migrated from cql_tests.py:TestCQL.reversed_compact_multikey_test()
 def testReversedCompactMultikey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(key text, c1 int, c2 int, value text, PRIMARY KEY (key, c1, c2)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c1 DESC, c2 DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(key text, c1 int, c2 int, value text, PRIMARY KEY (key, c1, c2)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c1 DESC, c2 DESC)",
+    ) as table:
         for i in range(3):
             for j in range(3):
-                execute(cql, table, "INSERT INTO %s (key, c1, c2, value) VALUES ('foo', ?, ?, 'bar')", i, j)
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (key, c1, c2, value) VALUES ('foo', ?, ?, 'bar')",
+                    i,
+                    j,
+                )
 
         # Equalities
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 = 1"),
-                   row(1, 2), row(1, 1), row(1, 0))
+        assert_rows(
+            execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 = 1"),
+            row(1, 2),
+            row(1, 1),
+            row(1, 0),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 = 1 ORDER BY c1 ASC, c2 ASC"),
-                   row(1, 0), row(1, 1), row(1, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 = 1 ORDER BY c1 ASC, c2 ASC",
+            ),
+            row(1, 0),
+            row(1, 1),
+            row(1, 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 = 1 ORDER BY c1 DESC, c2 DESC"),
-                   row(1, 2), row(1, 1), row(1, 0))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 = 1 ORDER BY c1 DESC, c2 DESC",
+            ),
+            row(1, 2),
+            row(1, 1),
+            row(1, 0),
+        )
 
         # GT
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 > 1"),
-                   row(2, 2), row(2, 1), row(2, 0))
+        assert_rows(
+            execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 > 1"),
+            row(2, 2),
+            row(2, 1),
+            row(2, 0),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 > 1 ORDER BY c1 ASC, c2 ASC"),
-                   row(2, 0), row(2, 1), row(2, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 > 1 ORDER BY c1 ASC, c2 ASC",
+            ),
+            row(2, 0),
+            row(2, 1),
+            row(2, 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 > 1 ORDER BY c1 DESC, c2 DESC"),
-                   row(2, 2), row(2, 1), row(2, 0))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 > 1 ORDER BY c1 DESC, c2 DESC",
+            ),
+            row(2, 2),
+            row(2, 1),
+            row(2, 0),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 >= 1"),
-                   row(2, 2), row(2, 1), row(2, 0), row(1, 2), row(1, 1), row(1, 0))
+        assert_rows(
+            execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 >= 1"),
+            row(2, 2),
+            row(2, 1),
+            row(2, 0),
+            row(1, 2),
+            row(1, 1),
+            row(1, 0),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 >= 1 ORDER BY c1 ASC, c2 ASC"),
-                   row(1, 0), row(1, 1), row(1, 2), row(2, 0), row(2, 1), row(2, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 >= 1 ORDER BY c1 ASC, c2 ASC",
+            ),
+            row(1, 0),
+            row(1, 1),
+            row(1, 2),
+            row(2, 0),
+            row(2, 1),
+            row(2, 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 >= 1 ORDER BY c1 ASC"),
-                   row(1, 0), row(1, 1), row(1, 2), row(2, 0), row(2, 1), row(2, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 >= 1 ORDER BY c1 ASC",
+            ),
+            row(1, 0),
+            row(1, 1),
+            row(1, 2),
+            row(2, 0),
+            row(2, 1),
+            row(2, 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 >= 1 ORDER BY c1 DESC, c2 DESC"),
-                   row(2, 2), row(2, 1), row(2, 0), row(1, 2), row(1, 1), row(1, 0))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 >= 1 ORDER BY c1 DESC, c2 DESC",
+            ),
+            row(2, 2),
+            row(2, 1),
+            row(2, 0),
+            row(1, 2),
+            row(1, 1),
+            row(1, 0),
+        )
 
         # LT
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 < 1"),
-                   row(0, 2), row(0, 1), row(0, 0))
+        assert_rows(
+            execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 < 1"),
+            row(0, 2),
+            row(0, 1),
+            row(0, 0),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 < 1 ORDER BY c1 ASC, c2 ASC"),
-                   row(0, 0), row(0, 1), row(0, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 < 1 ORDER BY c1 ASC, c2 ASC",
+            ),
+            row(0, 0),
+            row(0, 1),
+            row(0, 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 < 1 ORDER BY c1 DESC, c2 DESC"),
-                   row(0, 2), row(0, 1), row(0, 0))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 < 1 ORDER BY c1 DESC, c2 DESC",
+            ),
+            row(0, 2),
+            row(0, 1),
+            row(0, 0),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 <= 1"),
-                   row(1, 2), row(1, 1), row(1, 0), row(0, 2), row(0, 1), row(0, 0))
+        assert_rows(
+            execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 <= 1"),
+            row(1, 2),
+            row(1, 1),
+            row(1, 0),
+            row(0, 2),
+            row(0, 1),
+            row(0, 0),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 <= 1 ORDER BY c1 ASC, c2 ASC"),
-                   row(0, 0), row(0, 1), row(0, 2), row(1, 0), row(1, 1), row(1, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 <= 1 ORDER BY c1 ASC, c2 ASC",
+            ),
+            row(0, 0),
+            row(0, 1),
+            row(0, 2),
+            row(1, 0),
+            row(1, 1),
+            row(1, 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 <= 1 ORDER BY c1 ASC"),
-                   row(0, 0), row(0, 1), row(0, 2), row(1, 0), row(1, 1), row(1, 2))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 <= 1 ORDER BY c1 ASC",
+            ),
+            row(0, 0),
+            row(0, 1),
+            row(0, 2),
+            row(1, 0),
+            row(1, 1),
+            row(1, 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 <= 1 ORDER BY c1 DESC, c2 DESC"),
-                   row(1, 2), row(1, 1), row(1, 0), row(0, 2), row(0, 1), row(0, 0))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT c1, c2 FROM %s WHERE key='foo' AND c1 <= 1 ORDER BY c1 DESC, c2 DESC",
+            ),
+            row(1, 2),
+            row(1, 1),
+            row(1, 0),
+            row(0, 2),
+            row(0, 1),
+            row(0, 0),
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.multi_in_compact_non_composite_test()
 def testMultiSelectsNonCompositeCompactStorage(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(key int, c int, v int, PRIMARY KEY (key, c)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(key int, c int, v int, PRIMARY KEY (key, c)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (key, c, v) VALUES (0, 0, 0)")
         execute(cql, table, "INSERT INTO %s (key, c, v) VALUES (0, 1, 1)")
         execute(cql, table, "INSERT INTO %s (key, c, v) VALUES (0, 2, 2)")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE key=0 AND c IN (0, 2)"),
-                   row(0, 0, 0), row(0, 2, 2))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE key=0 AND c IN (0, 2)"),
+            row(0, 0, 0),
+            row(0, 2, 2),
+        )
+
 
 def testSelectDistinct(cql, test_keyspace):
     # Test a 'compact storage' table.
-    with create_table(cql, test_keyspace, "(pk0 int, pk1 int, val int, PRIMARY KEY ((pk0, pk1))) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk0 int, pk1 int, val int, PRIMARY KEY ((pk0, pk1))) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(3):
-            execute(cql, table, "INSERT INTO %s (pk0, pk1, val) VALUES (?, ?, ?)", i, i, i)
+            execute(
+                cql, table, "INSERT INTO %s (pk0, pk1, val) VALUES (?, ?, ?)", i, i, i
+            )
 
-        assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 1"),
-                   row(0, 0))
+        assert_rows(
+            execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 1"), row(0, 0)
+        )
 
-        assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 3"),
-                   row(0, 0),
-                   row(2, 2),
-                   row(1, 1))
+        assert_rows(
+            execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 3"),
+            row(0, 0),
+            row(2, 2),
+            row(1, 1),
+        )
 
     # Test a 'wide row' thrift table.
-    with create_table(cql, test_keyspace, "(pk int, name text, val int, PRIMARY KEY (pk, name)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk int, name text, val int, PRIMARY KEY (pk, name)) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(3):
-            execute(cql, table, "INSERT INTO %s (pk, name, val) VALUES (?, 'name0', 0)", i)
-            execute(cql, table, "INSERT INTO %s (pk, name, val) VALUES (?, 'name1', 1)", i)
+            execute(
+                cql, table, "INSERT INTO %s (pk, name, val) VALUES (?, 'name0', 0)", i
+            )
+            execute(
+                cql, table, "INSERT INTO %s (pk, name, val) VALUES (?, 'name1', 1)", i
+            )
 
-        assert_rows(execute(cql, table, "SELECT DISTINCT pk FROM %s LIMIT 1"),
-                   row(1))
+        assert_rows(execute(cql, table, "SELECT DISTINCT pk FROM %s LIMIT 1"), row(1))
 
-        assert_rows(execute(cql, table, "SELECT DISTINCT pk FROM %s LIMIT 3"),
-                   row(1),
-                   row(0),
-                   row(2))
+        assert_rows(
+            execute(cql, table, "SELECT DISTINCT pk FROM %s LIMIT 3"),
+            row(1),
+            row(0),
+            row(2),
+        )
+
 
 REQUIRES_ALLOW_FILTERING_MESSAGE = "Cannot execute this query as it might involve data filtering and thus may have unpredictable performance. If you want to execute this query despite the performance unpredictability, use ALLOW FILTERING"
 
-@pytest.mark.xfail(reason="issue #12526")
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringOnCompactTablesWithoutIndices(cql, test_keyspace):
     # Test COMPACT table with clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, 4)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, 6)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 4, 4)")
@@ -2157,61 +4535,115 @@ def testFilteringOnCompactTablesWithoutIndices(cql, test_keyspace):
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4 ALLOW FILTERING"),
-                       row(1, 4, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4 ALLOW FILTERING",
+                ),
+                row(1, 4, 4),
+            )
 
-            assertInvalidMessage(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
-                                 "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7)")
+            assertInvalidMessage(
+                cql,
+                table,
+                "IN predicates on non-primary-key columns (c) is not yet supported",
+                "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7)",
+            )
 
-            assertInvalidMessage(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
-                                 "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7) ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "IN predicates on non-primary-key columns (c) is not yet supported",
+                "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7) ALLOW FILTERING",
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > 4")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > 4 ALLOW FILTERING"),
-                       row(1, 3, 6),
-                       row(2, 3, 7))
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE c > 4 ALLOW FILTERING"),
+                row(1, 3, 6),
+                row(2, 3, 7),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b < 3 AND c <= 4")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b < 3 AND c <= 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b < 3 AND c <= 4 ALLOW FILTERING"),
-                       row(1, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b < 3 AND c <= 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= 3 AND c <= 6")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= 3 AND c <= 6",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= 3 AND c <= 6 ALLOW FILTERING"),
-                       row(1, 2, 4),
-                       row(1, 3, 6),
-                       row(1, 4, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= 3 AND c <= 6 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+                row(1, 3, 6),
+                row(1, 4, 4),
+            )
 
         # Checks filtering with null
         # tests commented out because Scylla does support comparison with null
         # (returning nothing)
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c = null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c > null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
+            unset(),
+        )
 
     # Test COMPACT table without clustering columns
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, 4)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, 6)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 2, 4)")
@@ -2224,64 +4656,136 @@ def testFilteringOnCompactTablesWithoutIndices(cql, test_keyspace):
         execute(cql, table, "DELETE FROM %s WHERE a = 5")
 
         for _ in before_and_after_flush(cql, table):
-
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 4 ALLOW FILTERING"),
-                       row(1, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+            )
 
-            assertInvalidMessage(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
-                                 "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7)")
+            assertInvalidMessage(
+                cql,
+                table,
+                "IN predicates on non-primary-key columns (c) is not yet supported",
+                "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7)",
+            )
 
-            assertInvalidMessage(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
-                                 "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7) ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "IN predicates on non-primary-key columns (c) is not yet supported",
+                "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7) ALLOW FILTERING",
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > 4")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > 4 ALLOW FILTERING"),
-                       row(2, 1, 6),
-                       row(4, 1, 7))
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE c > 4 ALLOW FILTERING"),
+                row(2, 1, 6),
+                row(4, 1, 7),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b < 3 AND c <= 4")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b < 3 AND c <= 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b < 3 AND c <= 4 ALLOW FILTERING"),
-                       row(1, 2, 4),
-                       row(3, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b < 3 AND c <= 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+                row(3, 2, 4),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= 3 AND c <= 6")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= 3 AND c <= 6",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= 3 AND c <= 6 ALLOW FILTERING"),
-                       row(1, 2, 4),
-                       row(2, 1, 6),
-                       row(3, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= 3 AND c <= 6 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+                row(2, 1, 6),
+                row(3, 2, 4),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table,REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c = null")
-        assertInvalidMessage(cql, table,"Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c > null")
-        assertInvalidMessage(cql, table,"Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c > null ALLOW FILTERING",
+        )
 
         # // Checks filtering with unset
-        assertInvalidMessage(cql, table,"Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table,"Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
+            unset(),
+        )
 
-@pytest.mark.xfail(reason="issue #12526")
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
     # Test COMPACT table with clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<list<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, [4, 2])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, [6, 2])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 4, [4, 1])")
@@ -2289,72 +4793,168 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = [4, 1]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = [4, 1]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = [4, 1] ALLOW FILTERING"),
-                       row(1, 4, [4, 1]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = [4, 1] ALLOW FILTERING",
+                ),
+                row(1, 4, [4, 1]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > [4, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > [4, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > [4, 2] ALLOW FILTERING"),
-                       row(1, 3, [6, 2]),
-                       row(2, 3, [7, 1]))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c > [4, 2] ALLOW FILTERING"
+                ),
+                row(1, 3, [6, 2]),
+                row(2, 3, [7, 1]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b <= 3 AND c < [6, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b <= 3 AND c < [6, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b <= 3 AND c < [6, 2] ALLOW FILTERING"),
-                       row(1, 2, [4, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b <= 3 AND c < [6, 2] ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= [4, 2] AND c <= [6, 4]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= [4, 2] AND c <= [6, 4]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= [4, 2] AND c <= [6, 4] ALLOW FILTERING"),
-                       row(1, 2, [4, 2]),
-                       row(1, 3, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= [4, 2] AND c <= [6, 4] ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+                row(1, 3, [6, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, [4, 2]),
-                       row(1, 3, [6, 2]))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"
+                ),
+                row(1, 2, [4, 2]),
+                row(1, 3, [6, 2]),
+            )
 
-            assertInvalidMessage(cql, table, "Cannot use CONTAINS KEY on non-map column c",
-                                 "SELECT * FROM %s WHERE c CONTAINS KEY 2 ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Cannot use CONTAINS KEY on non-map column c",
+                "SELECT * FROM %s WHERE c CONTAINS KEY 2 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING"),
-                       row(1, 3, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING",
+                ),
+                row(1, 3, [6, 2]),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
 
     # Test COMPACT table without clustering columns
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c frozen<list<int>>) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c frozen<list<int>>) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, [4, 2])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, [6, 2])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 2, [4, 1])")
@@ -2362,74 +4962,171 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = [4, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = [4, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = [4, 2] ALLOW FILTERING"),
-                       row(1, 2, [4, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = [4, 2] ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > [4, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > [4, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > [4, 2] ALLOW FILTERING"),
-                       row(2, 1, [6, 2]),
-                       row(4, 1, [7, 1]))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c > [4, 2] ALLOW FILTERING"
+                ),
+                row(2, 1, [6, 2]),
+                row(4, 1, [7, 1]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b < 3 AND c <= [4, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b < 3 AND c <= [4, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b < 3 AND c <= [4, 2] ALLOW FILTERING"),
-                       row(1, 2, [4, 2]),
-                       row(3, 2, [4, 1]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b < 3 AND c <= [4, 2] ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+                row(3, 2, [4, 1]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= [4, 3] AND c <= [7]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= [4, 3] AND c <= [7]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= [4, 3] AND c <= [7] ALLOW FILTERING"),
-                       row(2, 1, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= [4, 3] AND c <= [7] ALLOW FILTERING",
+                ),
+                row(2, 1, [6, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, [4, 2]),
-                       row(2, 1, [6, 2]))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"
+                ),
+                row(1, 2, [4, 2]),
+                row(2, 1, [6, 2]),
+            )
 
-            assertInvalidMessage(cql, table, "Cannot use CONTAINS KEY on non-map column c",
-                                 "SELECT * FROM %s WHERE c CONTAINS KEY 2 ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Cannot use CONTAINS KEY on non-map column c",
+                "SELECT * FROM %s WHERE c CONTAINS KEY 2 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING"),
-                       row(2, 1, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING",
+                ),
+                row(2, 1, [6, 2]),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
 
-@pytest.mark.xfail(reason="issue #12526")
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringOnCompactTablesWithoutIndicesAndWithSets(cql, test_keyspace):
     # Test COMPACT table with clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<set<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<set<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, {4, 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, {6, 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 4, {4, 1})")
@@ -2437,73 +5134,168 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithSets(cql, test_keyspace):
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = {4, 1}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = {4, 1}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = {4, 1} ALLOW FILTERING"),
-                       row(1, 4, {4, 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = {4, 1} ALLOW FILTERING",
+                ),
+                row(1, 4, {4, 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > {4, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > {4, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > {4, 2} ALLOW FILTERING"),
-                       row(1, 3, {6, 2}))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c > {4, 2} ALLOW FILTERING"
+                ),
+                row(1, 3, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b <= 3 AND c < {6, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b <= 3 AND c < {6, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b <= 3 AND c < {6, 2} ALLOW FILTERING"),
-                       row(1, 2, {2, 4}),
-                       row(2, 3, {1, 7}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b <= 3 AND c < {6, 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {2, 4}),
+                row(2, 3, {1, 7}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= {4, 2} AND c <= {6, 4}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= {4, 2} AND c <= {6, 4}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= {4, 2} AND c <= {6, 4} ALLOW FILTERING"),
-                       row(1, 2, {4, 2}),
-                       row(1, 3, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= {4, 2} AND c <= {6, 4} ALLOW FILTERING",
+                ),
+                row(1, 2, {4, 2}),
+                row(1, 3, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, {4, 2}),
-                       row(1, 3, {6, 2}))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"
+                ),
+                row(1, 2, {4, 2}),
+                row(1, 3, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, "Cannot use CONTAINS KEY on non-map column c",
-                                 "SELECT * FROM %s WHERE c CONTAINS KEY 2 ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Cannot use CONTAINS KEY on non-map column c",
+                "SELECT * FROM %s WHERE c CONTAINS KEY 2 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING"),
-                       row(1, 3, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING",
+                ),
+                row(1, 3, {6, 2}),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
 
     # Test COMPACT table without clustering columns
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c frozen<set<int>>) WITH COMPACT STORAGE") as table:
-
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c frozen<set<int>>) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, {4, 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, {6, 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 2, {4, 1})")
@@ -2511,142 +5303,362 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithSets(cql, test_keyspace):
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = {4, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = {4, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = {4, 2} ALLOW FILTERING"),
-                       row(1, 2, {4, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = {4, 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > {4, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > {4, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > {4, 2} ALLOW FILTERING"),
-                       row(2, 1, {6, 2}))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c > {4, 2} ALLOW FILTERING"
+                ),
+                row(2, 1, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b < 3 AND c <= {4, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b < 3 AND c <= {4, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b < 3 AND c <= {4, 2} ALLOW FILTERING"),
-                       row(1, 2, {4, 2}),
-                       row(4, 1, {1, 7}),
-                       row(3, 2, {4, 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b < 3 AND c <= {4, 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4, 2}),
+                row(4, 1, {1, 7}),
+                row(3, 2, {4, 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= {4, 3} AND c <= {7}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= {4, 3} AND c <= {7}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= {5, 2} AND c <= {7} ALLOW FILTERING"),
-                       row(2, 1, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= {5, 2} AND c <= {7} ALLOW FILTERING",
+                ),
+                row(2, 1, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, {4, 2}),
-                       row(2, 1, {6, 2}))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"
+                ),
+                row(1, 2, {4, 2}),
+                row(2, 1, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, "Cannot use CONTAINS KEY on non-map column c",
-                                 "SELECT * FROM %s WHERE c CONTAINS KEY 2 ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Cannot use CONTAINS KEY on non-map column c",
+                "SELECT * FROM %s WHERE c CONTAINS KEY 2 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING"),
-                       row(2, 1, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING",
+                ),
+                row(2, 1, {6, 2}),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
+
 
 def testAllowFilteringOnPartitionKeyWithDistinct(cql, test_keyspace):
     # Test a 'compact storage' table.
-    with create_table(cql, test_keyspace, "(pk0 int, pk1 int, val int, PRIMARY KEY ((pk0, pk1))) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk0 int, pk1 int, val int, PRIMARY KEY ((pk0, pk1))) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(3):
-            execute(cql, table, "INSERT INTO %s (pk0, pk1, val) VALUES (?, ?, ?)", i, i, i)
+            execute(
+                cql, table, "INSERT INTO %s (pk0, pk1, val) VALUES (?, ?, ?)", i, i, i
+            )
 
         for _ in before_and_after_flush(cql, table):
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 = 1 LIMIT 3")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 = 1 LIMIT 3",
+            )
 
-            assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 < 2 AND pk1 = 1 LIMIT 1 ALLOW FILTERING"),
-                       row(1, 1))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 < 2 AND pk1 = 1 LIMIT 1 ALLOW FILTERING",
+                ),
+                row(1, 1),
+            )
 
-            assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 > 1 LIMIT 3 ALLOW FILTERING"),
-                       row(2, 2))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 > 1 LIMIT 3 ALLOW FILTERING",
+                ),
+                row(2, 2),
+            )
 
     # Test a 'wide row' thrift table.
-    with create_table(cql, test_keyspace, "(pk int, name text, val int, PRIMARY KEY (pk, name)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk int, name text, val int, PRIMARY KEY (pk, name)) WITH COMPACT STORAGE",
+    ) as table:
         for i in range(3):
-            execute(cql, table, "INSERT INTO %s (pk, name, val) VALUES (?, 'name0', 0)", i)
-            execute(cql, table, "INSERT INTO %s (pk, name, val) VALUES (?, 'name1', 1)", i)
+            execute(
+                cql, table, "INSERT INTO %s (pk, name, val) VALUES (?, 'name0', 0)", i
+            )
+            execute(
+                cql, table, "INSERT INTO %s (pk, name, val) VALUES (?, 'name1', 1)", i
+            )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT DISTINCT pk FROM %s WHERE pk > 1 LIMIT 1 ALLOW FILTERING"),
-                       row(2))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT pk FROM %s WHERE pk > 1 LIMIT 1 ALLOW FILTERING",
+                ),
+                row(2),
+            )
 
-            assert_rows(execute(cql, table, "SELECT DISTINCT pk FROM %s WHERE pk > 0 LIMIT 3 ALLOW FILTERING"),
-                       row(1),
-                       row(2))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT pk FROM %s WHERE pk > 0 LIMIT 3 ALLOW FILTERING",
+                ),
+                row(1),
+                row(2),
+            )
+
 
 def executeFilteringOnly(cql, table, statement):
     assert_invalid(cql, table, statement)
     return execute_without_paging(cql, table, statement + " ALLOW FILTERING")
 
-@pytest.mark.xfail(reason="issue #12526")
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testAllowFilteringOnPartitionKeyWithCounters(cql, test_keyspace):
     for compactStorageClause in ["", " WITH COMPACT STORAGE"]:
-        with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY ((a, b), c)) " + compactStorageClause) as table:
-            execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 14, 11, 12, 13)
-            execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 24, 21, 22, 23)
-            execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 27, 21, 22, 26)
-            execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 34, 31, 32, 33)
-            execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 24, 41, 42, 43)
+        with create_table(
+            cql,
+            test_keyspace,
+            "(a int, b int, c int, cnt counter, PRIMARY KEY ((a, b), c)) "
+            + compactStorageClause,
+        ) as table:
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+                14,
+                11,
+                12,
+                13,
+            )
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+                24,
+                21,
+                22,
+                23,
+            )
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+                27,
+                21,
+                22,
+                26,
+            )
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+                34,
+                31,
+                32,
+                33,
+            )
+            execute(
+                cql,
+                table,
+                "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+                24,
+                41,
+                42,
+                43,
+            )
 
             for _ in before_and_after_flush(cql, table):
-                assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt = 24"),
-                           row(41, 42, 43, 24),
-                           row(21, 22, 23, 24))
-                assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 22 AND cnt = 24"),
-                           row(41, 42, 43, 24))
-                assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 10 AND b < 25 AND cnt = 24"),
-                           row(21, 22, 23, 24))
-                assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 10 AND c < 25 AND cnt = 24"),
-                           row(21, 22, 23, 24))
+                assert_rows(
+                    executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt = 24"),
+                    row(41, 42, 43, 24),
+                    row(21, 22, 23, 24),
+                )
+                assert_rows(
+                    executeFilteringOnly(
+                        cql, table, "SELECT * FROM %s WHERE b > 22 AND cnt = 24"
+                    ),
+                    row(41, 42, 43, 24),
+                )
+                assert_rows(
+                    executeFilteringOnly(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b > 10 AND b < 25 AND cnt = 24",
+                    ),
+                    row(21, 22, 23, 24),
+                )
+                assert_rows(
+                    executeFilteringOnly(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b > 10 AND c < 25 AND cnt = 24",
+                    ),
+                    row(21, 22, 23, 24),
+                )
 
-                assertInvalidMessage(cql, table,
-                "ORDER BY is only supported when the partition key is restricted by an EQ or an IN.",
-                "SELECT * FROM %s WHERE a = 21 AND b > 10 AND cnt > 23 ORDER BY c DESC ALLOW FILTERING")
+                assertInvalidMessage(
+                    cql,
+                    table,
+                    "ORDER BY is only supported when the partition key is restricted by an EQ or an IN.",
+                    "SELECT * FROM %s WHERE a = 21 AND b > 10 AND cnt > 23 ORDER BY c DESC ALLOW FILTERING",
+                )
 
-                assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a = 21 AND b = 22 AND cnt > 23 ORDER BY c DESC"),
-                           row(21, 22, 26, 27),
-                           row(21, 22, 23, 24))
+                assert_rows(
+                    executeFilteringOnly(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE a = 21 AND b = 22 AND cnt > 23 ORDER BY c DESC",
+                    ),
+                    row(21, 22, 26, 27),
+                    row(21, 22, 23, 24),
+                )
 
-                assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt > 20 AND cnt < 30"),
-                           row(41, 42, 43, 24),
-                           row(21, 22, 23, 24),
-                           row(21, 22, 26, 27))
+                assert_rows(
+                    executeFilteringOnly(
+                        cql, table, "SELECT * FROM %s WHERE cnt > 20 AND cnt < 30"
+                    ),
+                    row(41, 42, 43, 24),
+                    row(21, 22, 23, 24),
+                    row(21, 22, 26, 27),
+                )
 
-@pytest.mark.xfail(reason="issue #12526")
-def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
+def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithLists(
+    cql, test_keyspace
+):
     # Test COMPACT table with clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<list<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, [4, 2])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, [6, 2])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 4, [4, 1])")
@@ -2654,459 +5666,1084 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithLists(cq
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering
-            assertInvalidMessage(cql, table, "filtering",
-                                 "SELECT * FROM %s WHERE a >= 1 AND b = 4 AND c = [4, 1]")
+            assertInvalidMessage(
+                cql,
+                table,
+                "filtering",
+                "SELECT * FROM %s WHERE a >= 1 AND b = 4 AND c = [4, 1]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b >= 4 AND c = [4, 1] ALLOW FILTERING"),
-                       row(1, 4, [4, 1]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b >= 4 AND c = [4, 1] ALLOW FILTERING",
+                ),
+                row(1, 4, [4, 1]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 0 AND c > [4, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 0 AND c > [4, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c > [4, 2] ALLOW FILTERING"),
-                       row(1, 3, [6, 2]),
-                       row(2, 3, [7, 1]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c > [4, 2] ALLOW FILTERING",
+                ),
+                row(1, 3, [6, 2]),
+                row(2, 3, [7, 1]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 1 AND b <= 3 AND c < [6, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 1 AND b <= 3 AND c < [6, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 1 AND b <= 3 AND c < [6, 2] ALLOW FILTERING"),
-                       row(1, 2, [4, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 1 AND b <= 3 AND c < [6, 2] ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a <= 1 AND c >= [4, 2] AND c <= [6, 4]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a <= 1 AND c >= [4, 2] AND c <= [6, 4]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a > 0 AND b <= 3 AND c >= [4, 2] AND c <= [6, 4] ALLOW FILTERING"),
-                       row(1, 2, [4, 2]),
-                       row(1, 3, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 0 AND b <= 3 AND c >= [4, 2] AND c <= [6, 4] ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+                row(1, 3, [6, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 1 AND c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 1 AND c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a > 0 AND c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, [4, 2]),
-                       row(1, 3, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 0 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+                row(1, 3, [6, 2]),
+            )
 
-            assertInvalidMessage(cql, table, "Cannot use CONTAINS KEY on non-map column c",
-                                 "SELECT * FROM %s WHERE a > 1 AND c CONTAINS KEY 2 ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Cannot use CONTAINS KEY on non-map column c",
+                "SELECT * FROM %s WHERE a > 1 AND c CONTAINS KEY 2 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 2 AND c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING"),
-                       row(1, 3, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 2 AND c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING",
+                ),
+                row(1, 3, [6, 2]),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a > 1 AND c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a > 1 AND c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a > 1 AND c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a > 1 AND c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c CONTAINS ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
 
     # Test COMPACT table without clustering columns
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c frozen<list<int>>) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c frozen<list<int>>) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, [4, 2])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, [6, 2])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 2, [4, 1])")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (4, 1, [7, 1])")
 
         for _ in before_and_after_flush(cql, table):
-
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = [4, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = [4, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = [4, 2] ALLOW FILTERING"),
-                       row(1, 2, [4, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = [4, 2] ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 1 AND c > [4, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 1 AND c > [4, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a > 3 AND c > [4, 2] ALLOW FILTERING"),
-                       row(4, 1, [7, 1]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 3 AND c > [4, 2] ALLOW FILTERING",
+                ),
+                row(4, 1, [7, 1]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a < 1 AND b < 3 AND c <= [4, 2]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a < 1 AND b < 3 AND c <= [4, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 3 AND b < 3 AND c <= [4, 2] ALLOW FILTERING"),
-                       row(1, 2, [4, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 3 AND b < 3 AND c <= [4, 2] ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 1 AND c >= [4, 3] AND c <= [7]")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 1 AND c >= [4, 3] AND c <= [7]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 2 AND c >= [4, 3] AND c <= [7] ALLOW FILTERING"),
-                       row(2, 1, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 2 AND c >= [4, 3] AND c <= [7] ALLOW FILTERING",
+                ),
+                row(2, 1, [6, 2]),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 3 AND c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 3 AND c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, [4, 2]),
-                       row(2, 1, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                row(1, 2, [4, 2]),
+                row(2, 1, [6, 2]),
+            )
 
-            assertInvalidMessage(cql, table, "Cannot use CONTAINS KEY on non-map column c",
-                                 "SELECT * FROM %s WHERE a >=1 AND c CONTAINS KEY 2 ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Cannot use CONTAINS KEY on non-map column c",
+                "SELECT * FROM %s WHERE a >=1 AND c CONTAINS KEY 2 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 3 AND c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING"),
-                       row(2, 1, [6, 2]))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 3 AND c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING",
+                ),
+                row(2, 1, [6, 2]),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a > 1 AND c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a > 1 AND c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a > 1 AND c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a > 1 AND c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a > 1 AND c CONTAINS ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a > 1 AND c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
 
 
-@pytest.mark.xfail(reason="issue #12526")
-def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithMaps(cql, test_keyspace):
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
+def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithMaps(
+    cql, test_keyspace
+):
     # Test COMPACT table with clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<map<int, int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<map<int, int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, {4 : 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, {6 : 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 4, {4 : 1})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 3, {7 : 1})")
 
         for _ in before_and_after_flush(cql, table):
-
             # Checks filtering
-            assertInvalidMessage(cql, table, "filtering",
-                                 "SELECT * FROM %s WHERE a >= 1 AND b = 4 AND c = {4 : 1}")
+            assertInvalidMessage(
+                cql,
+                table,
+                "filtering",
+                "SELECT * FROM %s WHERE a >= 1 AND b = 4 AND c = {4 : 1}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 1 AND b = 4 AND c = {4 : 1} ALLOW FILTERING"),
-                       row(1, 4, {4: 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 1 AND b = 4 AND c = {4 : 1} ALLOW FILTERING",
+                ),
+                row(1, 4, {4: 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 1 AND c > {4 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 1 AND c > {4 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a > 1 AND c > {4 : 2} ALLOW FILTERING"),
-                       row(2, 3, {7: 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 1 AND c > {4 : 2} ALLOW FILTERING",
+                ),
+                row(2, 3, {7: 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 1 AND b <= 3 AND c < {6 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 1 AND b <= 3 AND c < {6 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b <= 3 AND c < {6 : 2} ALLOW FILTERING"),
-                       row(1, 2, {4: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b <= 3 AND c < {6 : 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 1 AND c >= {4 : 2} AND c <= {6 : 4}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 1 AND c >= {4 : 2} AND c <= {6 : 4}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a > 0 AND c >= {4 : 2} AND c <= {6 : 4} ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(1, 3, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 0 AND c >= {4 : 2} AND c <= {6 : 4} ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+                row(1, 3, {6: 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a > 10 AND c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a > 10 AND c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a > 0 AND c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(1, 3, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 0 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+                row(1, 3, {6: 2}),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 2 AND c CONTAINS KEY 6 ALLOW FILTERING"),
-                       row(1, 3, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 2 AND c CONTAINS KEY 6 ALLOW FILTERING",
+                ),
+                row(1, 3, {6: 2}),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2 AND c CONTAINS KEY 6 ALLOW FILTERING"),
-                       row(1, 3, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2 AND c CONTAINS KEY 6 ALLOW FILTERING",
+                ),
+                row(1, 3, {6: 2}),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY ? ALLOW FILTERING",
+            unset(),
+        )
 
     # Test COMPACT table without clustering columns
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c frozen<map<int, int>>) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c frozen<map<int, int>>) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, {4 : 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, {6 : 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 2, {4 : 1})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (4, 1, {7 : 1})")
 
         for _ in before_and_after_flush(cql, table):
-
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = {4 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = {4 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = {4 : 2} ALLOW FILTERING"),
-                       row(1, 2, {4: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = {4 : 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c > {4 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c > {4 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c > {4 : 2} ALLOW FILTERING"),
-                       row(2, 1, {6: 2}),
-                       row(4, 1, {7: 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c > {4 : 2} ALLOW FILTERING",
+                ),
+                row(2, 1, {6: 2}),
+                row(4, 1, {7: 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND b < 3 AND c <= {4 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND b < 3 AND c <= {4 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b < 3 AND c <= {4 : 2} ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(3, 2, {4: 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b < 3 AND c <= {4 : 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+                row(3, 2, {4: 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c >= {4 : 3} AND c <= {7 : 1}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c >= {4 : 3} AND c <= {7 : 1}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 2 AND c >= {5 : 2} AND c <= {7 : 0} ALLOW FILTERING"),
-                       row(2, 1, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 2 AND c >= {5 : 2} AND c <= {7 : 0} ALLOW FILTERING",
+                ),
+                row(2, 1, {6: 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(2, 1, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+                row(2, 1, {6: 2}),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a > 0 AND c CONTAINS KEY 4 ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(3, 2, {4: 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 0 AND c CONTAINS KEY 4 ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+                row(3, 2, {4: 1}),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 2 AND c CONTAINS 2 AND c CONTAINS KEY 6 ALLOW FILTERING"),
-                       row(2, 1, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 2 AND c CONTAINS 2 AND c CONTAINS KEY 6 ALLOW FILTERING",
+                ),
+                row(2, 1, {6: 2}),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY ? ALLOW FILTERING",
+            unset(),
+        )
 
-@pytest.mark.xfail(reason="issue #12526")
-def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithSets(cql, test_keyspace):
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
+def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithSets(
+    cql, test_keyspace
+):
     # Test COMPACT table with clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<set<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<set<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, {4, 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, {6, 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 4, {4, 1})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 3, {7, 1})")
 
         for _ in before_and_after_flush(cql, table):
-
             # Checks filtering
-            assertInvalidMessage(cql, table, "filtering",
-                                 "SELECT * FROM %s WHERE a >= 1 AND b = 4 AND c = {4, 1}")
+            assertInvalidMessage(
+                cql,
+                table,
+                "filtering",
+                "SELECT * FROM %s WHERE a >= 1 AND b = 4 AND c = {4, 1}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b = 4 AND c = {4, 1} ALLOW FILTERING"),
-                       row(1, 4, {4, 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b = 4 AND c = {4, 1} ALLOW FILTERING",
+                ),
+                row(1, 4, {4, 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c > {4, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c > {4, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c > {4, 2} ALLOW FILTERING"),
-                       row(1, 3, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c > {4, 2} ALLOW FILTERING",
+                ),
+                row(1, 3, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND b <= 3 AND c < {6, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND b <= 3 AND c < {6, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a > 0 AND b <= 3 AND c < {6, 2} ALLOW FILTERING"),
-                       row(1, 2, {2, 4}),
-                       row(2, 3, {1, 7}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 0 AND b <= 3 AND c < {6, 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {2, 4}),
+                row(2, 3, {1, 7}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c >= {4, 2} AND c <= {6, 4}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c >= {4, 2} AND c <= {6, 4}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 0 AND c >= {4, 2} AND c <= {6, 4} ALLOW FILTERING"),
-                       row(1, 2, {4, 2}),
-                       row(1, 3, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 0 AND c >= {4, 2} AND c <= {6, 4} ALLOW FILTERING",
+                ),
+                row(1, 2, {4, 2}),
+                row(1, 3, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 2 AND c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, {4, 2}),
-                       row(1, 3, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 2 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                row(1, 2, {4, 2}),
+                row(1, 3, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, "Cannot use CONTAINS KEY on non-map column c",
-                                 "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY 2 ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Cannot use CONTAINS KEY on non-map column c",
+                "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY 2 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING"),
-                       row(1, 3, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING",
+                ),
+                row(1, 3, {6, 2}),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
 
     # Test COMPACT table without clustering columns
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c frozen<set<int>>) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c frozen<set<int>>) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, {4, 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, {6, 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 2, {4, 1})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (4, 1, {7, 1})")
 
         for _ in before_and_after_flush(cql, table):
-
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = {4, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = {4, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = {4, 2} ALLOW FILTERING"),
-                       row(1, 2, {4, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b = 2 AND c = {4, 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c > {4, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c > {4, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c > {4, 2} ALLOW FILTERING"),
-                       row(2, 1, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c > {4, 2} ALLOW FILTERING",
+                ),
+                row(2, 1, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND b < 3 AND c <= {4, 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND b < 3 AND c <= {4, 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 4 AND b < 3 AND c <= {4, 2} ALLOW FILTERING"),
-                       row(1, 2, {4, 2}),
-                       row(4, 1, {1, 7}),
-                       row(3, 2, {4, 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 4 AND b < 3 AND c <= {4, 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4, 2}),
+                row(4, 1, {1, 7}),
+                row(3, 2, {4, 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c >= {4, 3} AND c <= {7}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c >= {4, 3} AND c <= {7}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 3 AND c >= {5, 2} AND c <= {7} ALLOW FILTERING"),
-                       row(2, 1, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 3 AND c >= {5, 2} AND c <= {7} ALLOW FILTERING",
+                ),
+                row(2, 1, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 0 AND c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, {4, 2}),
-                       row(2, 1, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 0 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                row(1, 2, {4, 2}),
+                row(2, 1, {6, 2}),
+            )
 
-            assertInvalidMessage(cql, table, "Cannot use CONTAINS KEY on non-map column c",
-                                 "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY 2 ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Cannot use CONTAINS KEY on non-map column c",
+                "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY 2 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 2 AND c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING"),
-                       row(2, 1, {6, 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 2 AND c CONTAINS 2 AND c CONTAINS 6 ALLOW FILTERING",
+                ),
+                row(2, 1, {6, 2}),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c > null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c > null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c > null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c > null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column c",
-                             "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c > ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column c",
+            "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
 
-@pytest.mark.xfail(reason="issue #12526")
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndices(cql, test_keyspace):
     # Test COMPACT table with clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY ((a, b), c)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, PRIMARY KEY ((a, b), c)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 2, 4, 5)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 3, 6, 7)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 4, 4, 5)")
@@ -3119,56 +6756,122 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndices(cql, test_keys
         execute(cql, table, "DELETE FROM %s WHERE a = 2 AND b = 2 AND c = 7")
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4"),
-                       row(1, 4, 4, 5))
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4"),
+                row(1, 4, 4, 5),
+            )
 
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4 AND d = 5")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4 AND d = 5",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4 ALLOW FILTERING"),
-                       row(1, 4, 4, 5))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4 ALLOW FILTERING",
+                ),
+                row(1, 4, 4, 5),
+            )
 
-            assertInvalidMessage(cql, table, "IN predicates on non-primary-key columns (d) is not yet supported",
-                                 "SELECT * FROM %s WHERE a IN (1, 2) AND b = 3 AND d IN (6, 7)")
+            assertInvalidMessage(
+                cql,
+                table,
+                "IN predicates on non-primary-key columns (d) is not yet supported",
+                "SELECT * FROM %s WHERE a IN (1, 2) AND b = 3 AND d IN (6, 7)",
+            )
 
-            assertInvalidMessage(cql, table, "IN predicates on non-primary-key columns (d) is not yet supported",
-                                 "SELECT * FROM %s WHERE a IN (1, 2) AND b = 3 AND d IN (6, 7) ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "IN predicates on non-primary-key columns (d) is not yet supported",
+                "SELECT * FROM %s WHERE a IN (1, 2) AND b = 3 AND d IN (6, 7) ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 2 AND c > 4 AND c <= 6 ALLOW FILTERING"),
-                       row(1, 3, 6, 7))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 2 AND c > 4 AND c <= 6 ALLOW FILTERING",
+                ),
+                row(1, 3, 6, 7),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 1 AND b >= 2 AND c >= 4 AND d <= 8 ALLOW FILTERING"),
-                       row(1, 3, 6, 7),
-                       row(1, 4, 4, 5),
-                       row(1, 2, 4, 5))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 1 AND b >= 2 AND c >= 4 AND d <= 8 ALLOW FILTERING",
+                ),
+                row(1, 3, 6, 7),
+                row(1, 4, 4, 5),
+                row(1, 2, 4, 5),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND c >= 4 AND d <= 8 ALLOW FILTERING"),
-                       row(1, 3, 6, 7),
-                       row(1, 4, 4, 5),
-                       row(1, 2, 4, 5))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND c >= 4 AND d <= 8 ALLOW FILTERING",
+                ),
+                row(1, 3, 6, 7),
+                row(1, 4, 4, 5),
+                row(1, 2, 4, 5),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 2 AND c >= 4 AND d <= 8 ALLOW FILTERING"),
-                       row(2, 3, 7, 8))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 2 AND c >= 4 AND d <= 8 ALLOW FILTERING",
+                ),
+                row(2, 3, 7, 8),
+            )
 
         # Checks filtering with null
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE d = null")
-        assertInvalidMessage(cql, table, "Unsupported null value for column a",
-                             "SELECT * FROM %s WHERE a = null ALLOW FILTERING")
-        assertInvalidMessage(cql, table, "Unsupported null value for column a",
-                             "SELECT * FROM %s WHERE a > null ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE d = null",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column a",
+            "SELECT * FROM %s WHERE a = null ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported null value for column a",
+            "SELECT * FROM %s WHERE a > null ALLOW FILTERING",
+        )
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "Unsupported unset value for column a",
-                             "SELECT * FROM %s WHERE a = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "Unsupported unset value for column a",
-                             "SELECT * FROM %s WHERE a > ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column a",
+            "SELECT * FROM %s WHERE a = ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Unsupported unset value for column a",
+            "SELECT * FROM %s WHERE a > ? ALLOW FILTERING",
+            unset(),
+        )
 
     # Test COMPACT table without clustering columns
-    with create_table(cql, test_keyspace, "(a int primary key, b int, c int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(a int primary key, b int, c int) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, 4)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, 6)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 2, 4)")
@@ -3182,974 +6885,2543 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndices(cql, test_keys
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 4 ALLOW FILTERING"),
-                       row(1, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 2 ALLOW FILTERING"),
-                       row(1, 2, 4))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 2 ALLOW FILTERING"
+                ),
+                row(1, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b >= 2 AND c <= 4 ALLOW FILTERING"),
-                       row(1, 2, 4),
-                       row(3, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b >= 2 AND c <= 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+                row(3, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 ALLOW FILTERING"),
-                       row(1, 2, 4))
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a = 1 ALLOW FILTERING"),
+                row(1, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b >= 2 ALLOW FILTERING"),
-                       row(1, 2, 4),
-                       row(3, 2, 4))
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE b >= 2 ALLOW FILTERING"),
+                row(1, 2, 4),
+                row(3, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 2 AND b <=1 ALLOW FILTERING"),
-                       row(2, 1, 6),
-                       row(4, 1, 7))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 2 AND b <=1 ALLOW FILTERING",
+                ),
+                row(2, 1, 6),
+                row(4, 1, 7),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND c >= 4 ALLOW FILTERING"),
-                       row(1, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND c >= 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+            )
 
-            assertInvalidMessage(cql, table, "IN predicates on non-primary-key columns (b) is not yet supported",
-                                 "SELECT * FROM %s WHERE a = 1 AND b IN (1, 2) AND c IN (6, 7)")
+            assertInvalidMessage(
+                cql,
+                table,
+                "IN predicates on non-primary-key columns (b) is not yet supported",
+                "SELECT * FROM %s WHERE a = 1 AND b IN (1, 2) AND c IN (6, 7)",
+            )
 
-            assertInvalidMessage(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
-                                 "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7) ALLOW FILTERING")
+            assertInvalidMessage(
+                cql,
+                table,
+                "IN predicates on non-primary-key columns (c) is not yet supported",
+                "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7) ALLOW FILTERING",
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > 4")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > 4 ALLOW FILTERING"),
-                       row(2, 1, 6),
-                       row(4, 1, 7))
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE c > 4 ALLOW FILTERING"),
+                row(2, 1, 6),
+                row(4, 1, 7),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b >= 2 AND c <= 4 ALLOW FILTERING"),
-                       row(1, 2, 4),
-                       row(3, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b >= 2 AND c <= 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+                row(3, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 3 AND c <= 4 ALLOW FILTERING"),
-                       row(1, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 3 AND c <= 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 3 AND b >= 2 AND c <= 4 ALLOW FILTERING"),
-                       row(1, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 3 AND b >= 2 AND c <= 4 ALLOW FILTERING",
+                ),
+                row(1, 2, 4),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= 3 AND c <= 6")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= 3 AND c <= 6",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c <=6 ALLOW FILTERING"),
-                       row(1, 2, 4),
-                       row(2, 1, 6),
-                       row(3, 2, 4))
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE c <=6 ALLOW FILTERING"),
+                row(1, 2, 4),
+                row(2, 1, 6),
+                row(3, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE token(a) >= token(2)"),
-                       row(2, 1, 6),
-                       row(4, 1, 7),
-                       row(3, 2, 4))
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE token(a) >= token(2)"),
+                row(2, 1, 6),
+                row(4, 1, 7),
+                row(3, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE token(a) >= token(2) ALLOW FILTERING"),
-                       row(2, 1, 6),
-                       row(4, 1, 7),
-                       row(3, 2, 4))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE token(a) >= token(2) ALLOW FILTERING",
+                ),
+                row(2, 1, 6),
+                row(4, 1, 7),
+                row(3, 2, 4),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE token(a) >= token(2) AND b = 1 ALLOW FILTERING"),
-                       row(2, 1, 6),
-                       row(4, 1, 7))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE token(a) >= token(2) AND b = 1 ALLOW FILTERING",
+                ),
+                row(2, 1, 6),
+                row(4, 1, 7),
+            )
+
 
 def testFilteringOnCompactTablesWithoutIndicesAndWithMaps(cql, test_keyspace):
     # Test COMPACT table with clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<map<int, int>>, PRIMARY KEY ((a, b))) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<map<int, int>>, PRIMARY KEY ((a, b))) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, {4 : 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 3, {6 : 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 4, {4 : 1})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 3, {7 : 1})")
 
         for _ in before_and_after_flush(cql, table):
-
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = {4 : 1}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = {4 : 1}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = {4 : 1} ALLOW FILTERING"),
-                       row(1, 4, {4: 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 4 AND c = {4 : 1} ALLOW FILTERING",
+                ),
+                row(1, 4, {4: 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > {4 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > {4 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > {4 : 2} ALLOW FILTERING"),
-                       row(1, 3, {6: 2}),
-                       row(2, 3, {7: 1}))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c > {4 : 2} ALLOW FILTERING"
+                ),
+                row(1, 3, {6: 2}),
+                row(2, 3, {7: 1}),
+            )
 
-            assertInvalidMessage(cql, table, 'FILTERING',
-                                 "SELECT * FROM %s WHERE b <= 3 AND c < {6 : 2}")
+            assertInvalidMessage(
+                cql, table, "FILTERING", "SELECT * FROM %s WHERE b <= 3 AND c < {6 : 2}"
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b <= 3 AND c < {6 : 2} ALLOW FILTERING"),
-                       row(1, 2, {4: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b <= 3 AND c < {6 : 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= {4 : 2} AND c <= {6 : 4}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= {4 : 2} AND c <= {6 : 4}",
+            )
 
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE c >= {4 : 2} AND c <= {6 : 4} ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(1, 3, {6: 2}))
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= {4 : 2} AND c <= {6 : 4} ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+                row(1, 3, {6: 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c CONTAINS 2",
+            )
 
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(1, 3, {6: 2}))
+            assert_rows_ignoring_order(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"
+                ),
+                row(1, 2, {4: 2}),
+                row(1, 3, {6: 2}),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS KEY 6 ALLOW FILTERING"),
-                       row(1, 3, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS KEY 6 ALLOW FILTERING",
+                ),
+                row(1, 3, {6: 2}),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS KEY 6 ALLOW FILTERING"),
-                       row(1, 3, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS KEY 6 ALLOW FILTERING",
+                ),
+                row(1, 3, {6: 2}),
+            )
 
         # Checks filtering with null
         # tests commented out because Scylla does support comparison with null
         # (returning nothing)
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c = null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c > null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c CONTAINS null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c CONTAINS KEY null ALLOW FILTERING")
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "unset",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "unset",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "unset",
-                             "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "unset",
-                             "SELECT * FROM %s WHERE c CONTAINS KEY ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql, table, "unset", "SELECT * FROM %s WHERE c = ? ALLOW FILTERING", unset()
+        )
+        assertInvalidMessage(
+            cql, table, "unset", "SELECT * FROM %s WHERE c > ? ALLOW FILTERING", unset()
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset",
+            "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset",
+            "SELECT * FROM %s WHERE c CONTAINS KEY ? ALLOW FILTERING",
+            unset(),
+        )
 
     # Test COMPACT table without clustering columns
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c frozen<map<int, int>>) WITH COMPACT STORAGE") as table:
-
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c frozen<map<int, int>>) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, {4 : 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, {6 : 2})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (3, 2, {4 : 1})")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (4, 1, {7 : 1})")
 
         for _ in before_and_after_flush(cql, table):
-
             # Checks filtering
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = {4 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = {4 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = {4 : 2} ALLOW FILTERING"),
-                       row(1, 2, {4: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = {4 : 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > {4 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > {4 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > {4 : 2} ALLOW FILTERING"),
-                       row(2, 1, {6: 2}),
-                       row(4, 1, {7: 1}))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c > {4 : 2} ALLOW FILTERING"
+                ),
+                row(2, 1, {6: 2}),
+                row(4, 1, {7: 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b < 3 AND c <= {4 : 2}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b < 3 AND c <= {4 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b < 3 AND c <= {4 : 2} ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(3, 2, {4: 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b < 3 AND c <= {4 : 2} ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+                row(3, 2, {4: 1}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= {4 : 3} AND c <= {7 : 1}")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= {4 : 3} AND c <= {7 : 1}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= {5 : 2} AND c <= {7 : 0} ALLOW FILTERING"),
-                       row(2, 1, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= {5 : 2} AND c <= {7 : 0} ALLOW FILTERING",
+                ),
+                row(2, 1, {6: 2}),
+            )
 
-            assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c CONTAINS 2")
+            assertInvalidMessage(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(2, 1, {6: 2}))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"
+                ),
+                row(1, 2, {4: 2}),
+                row(2, 1, {6: 2}),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS KEY 4 ALLOW FILTERING"),
-                       row(1, 2, {4: 2}),
-                       row(3, 2, {4: 1}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS KEY 4 ALLOW FILTERING",
+                ),
+                row(1, 2, {4: 2}),
+                row(3, 2, {4: 1}),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS KEY 6 ALLOW FILTERING"),
-                       row(2, 1, {6: 2}))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS KEY 6 ALLOW FILTERING",
+                ),
+                row(2, 1, {6: 2}),
+            )
 
         # Checks filtering with null
         # Checks filtering with null
         # tests commented out because Scylla does support comparison with null
         # (returning nothing)
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c = null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c > null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c CONTAINS null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING")
-        #assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
+        # assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
         #                     "SELECT * FROM %s WHERE c CONTAINS KEY null")
-        #assertInvalidMessage(cql, table, "Unsupported null value for column c",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c CONTAINS KEY null ALLOW FILTERING")
 
         # Checks filtering with unset
-        assertInvalidMessage(cql, table, "unset",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "unset",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "unset",
-                             "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
-                             unset())
-        assertInvalidMessage(cql, table, "unset",
-                             "SELECT * FROM %s WHERE c CONTAINS KEY ? ALLOW FILTERING",
-                             unset())
+        assertInvalidMessage(
+            cql, table, "unset", "SELECT * FROM %s WHERE c = ? ALLOW FILTERING", unset()
+        )
+        assertInvalidMessage(
+            cql, table, "unset", "SELECT * FROM %s WHERE c > ? ALLOW FILTERING", unset()
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset",
+            "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset",
+            "SELECT * FROM %s WHERE c CONTAINS KEY ? ALLOW FILTERING",
+            unset(),
+        )
 
-@pytest.mark.xfail(reason="issue #12526")
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringOnCompactTable(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, 13, 14)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 22, 23, 24)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 25, 26, 27)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 31, 32, 33, 34)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            11,
+            12,
+            13,
+            14,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            23,
+            24,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            25,
+            26,
+            27,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            31,
+            32,
+            33,
+            34,
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c > 13"),
-                       row(21, 22, 23, 24),
-                       row(21, 25, 26, 27),
-                       row(31, 32, 33, 34))
+            assert_rows(
+                executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c > 13"),
+                row(21, 22, 23, 24),
+                row(21, 25, 26, 27),
+                row(31, 32, 33, 34),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c > 13 AND c < 33"),
-                       row(21, 22, 23, 24),
-                       row(21, 25, 26, 27))
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE c > 13 AND c < 33"
+                ),
+                row(21, 22, 23, 24),
+                row(21, 25, 26, 27),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c > 13 AND b < 32"),
-                       row(21, 22, 23, 24),
-                       row(21, 25, 26, 27))
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE c > 13 AND b < 32"
+                ),
+                row(21, 22, 23, 24),
+                row(21, 25, 26, 27),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a = 21 AND c > 13 AND b < 32 ORDER BY b DESC"),
-                       row(21, 25, 26, 27),
-                       row(21, 22, 23, 24))
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 21 AND c > 13 AND b < 32 ORDER BY b DESC",
+                ),
+                row(21, 25, 26, 27),
+                row(21, 22, 23, 24),
+            )
 
             # (NYH: note that because the partition order isn't known, we can't
             # actually check the result order here, hence I added ignoring_order.
             # this makes this test weaker).
-            assert_rows_ignoring_order(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a IN (21, 31) AND c > 13 ORDER BY b DESC"),
-                       row(31, 32, 33, 34),
-                       row(21, 25, 26, 27),
-                       row(21, 22, 23, 24))
+            assert_rows_ignoring_order(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a IN (21, 31) AND c > 13 ORDER BY b DESC",
+                ),
+                row(31, 32, 33, 34),
+                row(21, 25, 26, 27),
+                row(21, 22, 23, 24),
+            )
 
             # Reproduces #12526:
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c > 13 AND d < 34"),
-                       row(21, 22, 23, 24),
-                       row(21, 25, 26, 27))
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE c > 13 AND d < 34"
+                ),
+                row(21, 22, 23, 24),
+                row(21, 25, 26, 27),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c > 13"),
-                       row(21, 22, 23, 24),
-                       row(21, 25, 26, 27),
-                       row(31, 32, 33, 34))
+            assert_rows(
+                executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c > 13"),
+                row(21, 22, 23, 24),
+                row(21, 25, 26, 27),
+                row(31, 32, 33, 34),
+            )
 
     # with frozen in clustering key
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, [1, 3], 14)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 22, [2, 3], 24)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 25, [2, 6], 27)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 31, 32, [3, 3], 34)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<list<int>>, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            11,
+            12,
+            [1, 3],
+            14,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            [2, 3],
+            24,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            25,
+            [2, 6],
+            27,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            31,
+            32,
+            [3, 3],
+            34,
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2"),
-                       row(21, 22, [2, 3], 24),
-                       row(21, 25, [2, 6], 27))
+            assert_rows(
+                executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2"),
+                row(21, 22, [2, 3], 24),
+                row(21, 25, [2, 6], 27),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND b < 25"),
-                       row(21, 22, [2, 3], 24))
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND b < 25"
+                ),
+                row(21, 22, [2, 3], 24),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 3"),
-                       row(21, 22, [2, 3], 24))
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 3"
+                ),
+                row(21, 22, [2, 3], 24),
+            )
 
             # Reproduces #12526:
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 12 AND c CONTAINS 2 AND d < 27"),
-                       row(21, 22, [2, 3], 24))
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b > 12 AND c CONTAINS 2 AND d < 27",
+                ),
+                row(21, 22, [2, 3], 24),
+            )
 
     # with frozen in value
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d frozen<list<int>>, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, 13, [1, 4])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 22, 23, [2, 4])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 25, 25, [2, 6])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 31, 32, 34, [3, 4])
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d frozen<list<int>>, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            11,
+            12,
+            13,
+            [1, 4],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            23,
+            [2, 4],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            25,
+            25,
+            [2, 6],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            31,
+            32,
+            34,
+            [3, 4],
+        )
 
         for _ in before_and_after_flush(cql, table):
             # Reproduces #12526:
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE d CONTAINS 2"),
-                       row(21, 22, 23, [2, 4]),
-                       row(21, 25, 25, [2, 6]))
+            assert_rows(
+                executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE d CONTAINS 2"),
+                row(21, 22, 23, [2, 4]),
+                row(21, 25, 25, [2, 6]),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE d CONTAINS 2 AND b < 25"),
-                       row(21, 22, 23, [2, 4]))
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE d CONTAINS 2 AND b < 25"
+                ),
+                row(21, 22, 23, [2, 4]),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE d CONTAINS 2 AND d CONTAINS 4"),
-                       row(21, 22, 23, [2, 4]))
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE d CONTAINS 2 AND d CONTAINS 4"
+                ),
+                row(21, 22, 23, [2, 4]),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 12 AND c < 25 AND d CONTAINS 2"),
-                       row(21, 22, 23, [2, 4]))
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b > 12 AND c < 25 AND d CONTAINS 2",
+                ),
+                row(21, 22, 23, [2, 4]),
+            )
 
-@pytest.mark.xfail(reason="issue #12526")
+
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringWithCounters(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 14, 11, 12, 13)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 24, 21, 22, 23)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 27, 21, 25, 26)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 34, 31, 32, 33)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 24, 41, 42, 43)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, cnt counter, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            14,
+            11,
+            12,
+            13,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            24,
+            21,
+            22,
+            23,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            27,
+            21,
+            25,
+            26,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            34,
+            31,
+            32,
+            33,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            24,
+            41,
+            42,
+            43,
+        )
 
         for _ in before_and_after_flush(cql, table):
+            assert_rows(
+                executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt = 24"),
+                row(21, 22, 23, 24),
+                row(41, 42, 43, 24),
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 22 AND cnt = 24"
+                ),
+                row(41, 42, 43, 24),
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 10 AND b < 25 AND cnt = 24"
+                ),
+                row(21, 22, 23, 24),
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 10 AND c < 25 AND cnt = 24"
+                ),
+                row(21, 22, 23, 24),
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 21 AND b > 10 AND cnt > 23 ORDER BY b DESC",
+                ),
+                row(21, 25, 26, 27),
+                row(21, 22, 23, 24),
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE cnt > 20 AND cnt < 30"
+                ),
+                row(21, 22, 23, 24),
+                row(21, 25, 26, 27),
+                row(41, 42, 43, 24),
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt = 24"),
-                       row(21, 22, 23, 24),
-                       row(41, 42, 43, 24))
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 22 AND cnt = 24"),
-                       row(41, 42, 43, 24))
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 10 AND b < 25 AND cnt = 24"),
-                       row(21, 22, 23, 24))
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 10 AND c < 25 AND cnt = 24"),
-                       row(21, 22, 23, 24))
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a = 21 AND b > 10 AND cnt > 23 ORDER BY b DESC"),
-                       row(21, 25, 26, 27),
-                       row(21, 22, 23, 24))
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt > 20 AND cnt < 30"),
-                       row(21, 22, 23, 24),
-                       row(21, 25, 26, 27),
-                       row(41, 42, 43, 24))
 
 # Check select with and without compact storage, with different column
 # order. See CASSANDRA-10988
 def testClusteringOrderWithSlice(cql, test_keyspace):
     # non-compound, ASC order
-    with create_table(cql, test_keyspace, "(a text, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b ASC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b ASC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES ('a', 2)")
         execute(cql, table, "INSERT INTO %s (a, b) VALUES ('a', 3)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
-                   row("a", 2),
-                   row("a", 3))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
+            row("a", 2),
+            row("a", 3),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b DESC"),
-                   row("a", 3),
-                   row("a", 2))
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b DESC"
+            ),
+            row("a", 3),
+            row("a", 2),
+        )
 
     # non-compound, DESC order
-    with create_table(cql, test_keyspace, "(a text, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b DESC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES ('a', 2)")
         execute(cql, table, "INSERT INTO %s (a, b) VALUES ('a', 3)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
-                   row("a", 3),
-                   row("a", 2))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
+            row("a", 3),
+            row("a", 2),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"),
-                   row("a", 2),
-                   row("a", 3))
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"
+            ),
+            row("a", 2),
+            row("a", 3),
+        )
 
     # compound, first column DESC order
-    with create_table(cql, test_keyspace, "(a text, b int, c int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, c int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b DESC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('a', 2, 4)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('a', 3, 5)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
-                   row("a", 3, 5),
-                   row("a", 2, 4))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
+            row("a", 3, 5),
+            row("a", 2, 4),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"),
-                   row("a", 2, 4),
-                   row("a", 3, 5))
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"
+            ),
+            row("a", 2, 4),
+            row("a", 3, 5),
+        )
 
     # compound, mixed order
-    with create_table(cql, test_keyspace, "(a text, b int, c int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b ASC, c DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, c int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE AND CLUSTERING ORDER BY (b ASC, c DESC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('a', 2, 4)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('a', 3, 5)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
-                   row("a", 2, 4),
-                   row("a", 3, 5))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
+            row("a", 2, 4),
+            row("a", 3, 5),
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"),
-                   row("a", 2, 4),
-                   row("a", 3, 5))
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"
+            ),
+            row("a", 2, 4),
+            row("a", 3, 5),
+        )
+
 
 EMPTY_BYTE_BUFFER = b""
 
-@pytest.mark.parametrize("options", ["", pytest.param(" WITH COMPACT STORAGE", marks=pytest.mark.xfail(reason="issue #12526, #12749"))])
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        "",
+        pytest.param(
+            " WITH COMPACT STORAGE",
+            marks=pytest.mark.xfail(
+                reason="Support filtering on COMPACT tables #12526, Unsupported empty clustering key in COMPACT table #12749"
+            ),
+        ),
+    ],
+)
 def testEmptyRestrictionValue(cql, test_keyspace, options):
-    with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))" + options) as table:
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123", b"2", b"2")
+    with create_table(
+        cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))" + options
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"2",
+            b"2",
+        )
 
         for _ in before_and_after_flush(cql, table):
             # Scylla *does* allow lookup of an empty partition key (see
             # test_mv_empty_string_partition_key_individual()), so we
             # comment out this check
-            #assertInvalidMessage(cql, table, "Key may not be empty", "SELECT * FROM %s WHERE pk = textAsBlob('');")
-            #assertInvalidMessage(cql, table, "Key may not be empty", "SELECT * FROM %s WHERE pk IN (textAsBlob(''), textAsBlob('1'));")
+            # assertInvalidMessage(cql, table, "Key may not be empty", "SELECT * FROM %s WHERE pk = textAsBlob('');")
+            # assertInvalidMessage(cql, table, "Key may not be empty", "SELECT * FROM %s WHERE pk IN (textAsBlob(''), textAsBlob('1'));")
 
-            assertInvalidMessage(cql, table, "Key may not be empty",
-                                 "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                                 EMPTY_BYTE_BUFFER, b"2", b"2")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Key may not be empty",
+                "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+                EMPTY_BYTE_BUFFER,
+                b"2",
+                b"2",
+            )
 
             # Test clustering columns restrictions
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');",
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) = (textAsBlob(''));"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) = (textAsBlob(''));",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));"),
-                       row(b"foo123", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));",
+                ),
+                row(b"foo123", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) IN ((textAsBlob('')), (textAsBlob('1')));"),
-                       row(b"foo123", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) IN ((textAsBlob('')), (textAsBlob('1')));",
+                ),
+                row(b"foo123", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('');"),
-                       row(b"foo123", b"1", b"1"),
-                       row(b"foo123", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('');",
+                ),
+                row(b"foo123", b"1", b"1"),
+                row(b"foo123", b"2", b"2"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) > (textAsBlob(''));"),
-                       row(b"foo123", b"1", b"1"),
-                       row(b"foo123", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) > (textAsBlob(''));",
+                ),
+                row(b"foo123", b"1", b"1"),
+                row(b"foo123", b"2", b"2"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('');"),
-                       row(b"foo123", b"1", b"1"),
-                       row(b"foo123", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('');",
+                ),
+                row(b"foo123", b"1", b"1"),
+                row(b"foo123", b"2", b"2"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) >= (textAsBlob(''));"),
-                       row(b"foo123", b"1", b"1"),
-                       row(b"foo123", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) >= (textAsBlob(''));",
+                ),
+                row(b"foo123", b"1", b"1"),
+                row(b"foo123", b"2", b"2"),
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('');"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('');",
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) <= (textAsBlob(''));"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) <= (textAsBlob(''));",
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('');"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('');",
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) < (textAsBlob(''));"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) < (textAsBlob(''));",
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('') AND c < textAsBlob('');"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('') AND c < textAsBlob('');",
+                )
+            )
 
         if "COMPACT" in options:
             # Reproduces #12749
-            assertInvalidMessage(cql, table, "Invalid empty or null value for column c",
-                                 "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                                 b"foo123", EMPTY_BYTE_BUFFER, b"4")
+            assertInvalidMessage(
+                cql,
+                table,
+                "Invalid empty or null value for column c",
+                "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+                b"foo123",
+                EMPTY_BYTE_BUFFER,
+                b"4",
+            )
         else:
-            execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                    b"foo123", EMPTY_BYTE_BUFFER, b"4")
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+                b"foo123",
+                EMPTY_BYTE_BUFFER,
+                b"4",
+            )
 
             for _ in before_and_after_flush(cql, table):
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');"),
-                           row(b"foo123", EMPTY_BYTE_BUFFER, b"4"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');",
+                    ),
+                    row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) = (textAsBlob(''));"),
-                           row(b"foo123", EMPTY_BYTE_BUFFER, b"4"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) = (textAsBlob(''));",
+                    ),
+                    row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));"),
-                           row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
-                           row(b"foo123", b"1", b"1"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));",
+                    ),
+                    row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
+                    row(b"foo123", b"1", b"1"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) IN ((textAsBlob('')), (textAsBlob('1')));"),
-                           row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
-                           row(b"foo123", b"1", b"1"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) IN ((textAsBlob('')), (textAsBlob('1')));",
+                    ),
+                    row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
+                    row(b"foo123", b"1", b"1"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('');"),
-                           row(b"foo123", b"1", b"1"),
-                           row(b"foo123", b"2", b"2"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('');",
+                    ),
+                    row(b"foo123", b"1", b"1"),
+                    row(b"foo123", b"2", b"2"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) > (textAsBlob(''));"),
-                           row(b"foo123", b"1", b"1"),
-                           row(b"foo123", b"2", b"2"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) > (textAsBlob(''));",
+                    ),
+                    row(b"foo123", b"1", b"1"),
+                    row(b"foo123", b"2", b"2"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('');"),
-                           row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
-                           row(b"foo123", b"1", b"1"),
-                           row(b"foo123", b"2", b"2"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('');",
+                    ),
+                    row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
+                    row(b"foo123", b"1", b"1"),
+                    row(b"foo123", b"2", b"2"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) >= (textAsBlob(''));"),
-                           row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
-                           row(b"foo123", b"1", b"1"),
-                           row(b"foo123", b"2", b"2"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) >= (textAsBlob(''));",
+                    ),
+                    row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
+                    row(b"foo123", b"1", b"1"),
+                    row(b"foo123", b"2", b"2"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('');"),
-                           row(b"foo123", EMPTY_BYTE_BUFFER, b"4"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('');",
+                    ),
+                    row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) <= (textAsBlob(''));"),
-                           row(b"foo123", EMPTY_BYTE_BUFFER, b"4"))
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) <= (textAsBlob(''));",
+                    ),
+                    row(b"foo123", EMPTY_BYTE_BUFFER, b"4"),
+                )
 
-                assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('');"))
+                assertEmpty(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('');",
+                    )
+                )
 
-                assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) < (textAsBlob(''));"))
+                assertEmpty(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) < (textAsBlob(''));",
+                    )
+                )
 
-                assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('') AND c < textAsBlob('');"))
+                assertEmpty(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('') AND c < textAsBlob('');",
+                    )
+                )
         # Test restrictions on non-primary key value
         # Reproduces #12526:
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;"))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;",
+            )
+        )
 
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123", b"3", EMPTY_BYTE_BUFFER)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"3",
+            EMPTY_BYTE_BUFFER,
+        )
 
         for _ in before_and_after_flush(cql, table):
             # Reproduces #12526:
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;"),
-                       row(b"foo123", b"3", EMPTY_BYTE_BUFFER))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;",
+                ),
+                row(b"foo123", b"3", EMPTY_BYTE_BUFFER),
+            )
 
-@pytest.mark.xfail(reason="issue #12749")
+
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749")
 def testEmptyRestrictionValueWithMultipleClusteringColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2)) WITH COMPACT STORAGE") as table:
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"2", b"2")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2)) WITH COMPACT STORAGE",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"2",
+            b"2",
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');",
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 = textAsBlob('');"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 = textAsBlob('');",
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) = (textAsBlob('1'), textAsBlob(''));"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) = (textAsBlob('1'), textAsBlob(''));",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');",
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 IN (textAsBlob(''), textAsBlob('1'));"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 IN (textAsBlob(''), textAsBlob('1'));",
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')));"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')));",
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('');"),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", b"1", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('');",
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", b"1", b"2", b"2"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 > textAsBlob('');"),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", b"1", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 > textAsBlob('');",
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", b"1", b"2", b"2"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'));"),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", b"1", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'));",
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", b"1", b"2", b"2"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 >= textAsBlob('');"),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", b"1", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 >= textAsBlob('');",
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", b"1", b"2", b"2"),
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 <= textAsBlob('');"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 <= textAsBlob('');",
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) <= (textAsBlob('1'), textAsBlob(''));"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) <= (textAsBlob('1'), textAsBlob(''));",
+                )
+            )
 
         # Reproduces #12749:
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
-                b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            EMPTY_BYTE_BUFFER,
+            b"1",
+            b"4",
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');",
+                ),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('') AND c2 = textAsBlob('1');"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('') AND c2 = textAsBlob('1');",
+                ),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) = (textAsBlob(''), textAsBlob('1'));"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) = (textAsBlob(''), textAsBlob('1'));",
+                ),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');",
+                ),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')));"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')));",
+                ),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'));"),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", b"1", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'));",
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", b"1", b"2", b"2"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) >= (textAsBlob(''), textAsBlob('1'));"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", b"1", b"2", b"2"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) >= (textAsBlob(''), textAsBlob('1'));",
+                ),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", b"1", b"2", b"2"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) <= (textAsBlob(''), textAsBlob('1'));"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) <= (textAsBlob(''), textAsBlob('1'));",
+                ),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) < (textAsBlob(''), textAsBlob('1'));"))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) < (textAsBlob(''), textAsBlob('1'));",
+                )
+            )
 
-@pytest.mark.xfail(reason="issue #12749")
-@pytest.mark.parametrize("options", [" WITH COMPACT STORAGE", " WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c DESC)"])
+
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749")
+@pytest.mark.parametrize(
+    "options",
+    [" WITH COMPACT STORAGE", " WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c DESC)"],
+)
 def testEmptyRestrictionValueWithOrderBy(cql, test_keyspace, options):
     orderingClause = "" if "ORDER" in options else "ORDER BY c DESC"
-    with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))" + options) as table:
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123",
-                b"1",
-                b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123",
-                b"2",
-                b"2")
+    with create_table(
+        cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))" + options
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"2",
+            b"2",
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')" + orderingClause),
-                       row(b"foo123", b"2", b"2"),
-                       row(b"foo123", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"2", b"2"),
+                row(b"foo123", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('')" + orderingClause),
-                       row(b"foo123", b"2", b"2"),
-                       row(b"foo123", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('')"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"2", b"2"),
+                row(b"foo123", b"1", b"1"),
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('')" + orderingClause))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('')"
+                    + orderingClause,
+                )
+            )
 
-            assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('')" + orderingClause))
+            assertEmpty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('')"
+                    + orderingClause,
+                )
+            )
 
         # Reproduces #12749:
-        assertInvalidMessage(cql, table, "Invalid empty or null value for column c",
-                             "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                             b"foo123",
-                             EMPTY_BYTE_BUFFER,
-                             b"4")
+        assertInvalidMessage(
+            cql,
+            table,
+            "Invalid empty or null value for column c",
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            EMPTY_BYTE_BUFFER,
+            b"4",
+        )
 
-@pytest.mark.xfail(reason="issue #12749")
-@pytest.mark.parametrize("options", [" WITH COMPACT STORAGE", " WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c1 DESC, c2 DESC)"])
-def testEmptyRestrictionValueWithMultipleClusteringColumnsAndOrderBy(cql, test_keyspace, options):
+
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749")
+@pytest.mark.parametrize(
+    "options",
+    [
+        " WITH COMPACT STORAGE",
+        " WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c1 DESC, c2 DESC)",
+    ],
+)
+def testEmptyRestrictionValueWithMultipleClusteringColumnsAndOrderBy(
+    cql, test_keyspace, options
+):
     orderingClause = "" if "ORDER" in options else "ORDER BY c1 DESC, c2 DESC"
-    with create_table(cql, test_keyspace, "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2))" + options) as table:
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"2", b"2")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2))" + options,
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"2",
+            b"2",
+        )
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('')" + orderingClause),
-                       row(b"foo123", b"1", b"2", b"2"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('')"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"1", b"2", b"2"),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 > textAsBlob('')" + orderingClause),
-                       row(b"foo123", b"1", b"2", b"2"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 > textAsBlob('')"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"1", b"2", b"2"),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'))" + orderingClause),
-                       row(b"foo123", b"1", b"2", b"2"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'))"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"1", b"2", b"2"),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 >= textAsBlob('')" + orderingClause),
-                       row(b"foo123", b"1", b"2", b"2"),
-                       row(b"foo123", b"1", b"1", b"1"))
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
-                b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 >= textAsBlob('')"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"1", b"2", b"2"),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            EMPTY_BYTE_BUFFER,
+            b"1",
+            b"4",
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1')" + orderingClause),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1')"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')))" + orderingClause),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')))"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'))" + orderingClause),
-                       row(b"foo123", b"1", b"2", b"2"),
-                       row(b"foo123", b"1", b"1", b"1"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'))"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"1", b"2", b"2"),
+                row(b"foo123", b"1", b"1", b"1"),
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) >= (textAsBlob(''), textAsBlob('1'))" + orderingClause),
-                       row(b"foo123", b"1", b"2", b"2"),
-                       row(b"foo123", b"1", b"1", b"1"),
-                       row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) >= (textAsBlob(''), textAsBlob('1'))"
+                    + orderingClause,
+                ),
+                row(b"foo123", b"1", b"2", b"2"),
+                row(b"foo123", b"1", b"1", b"1"),
+                row(b"foo123", EMPTY_BYTE_BUFFER, b"1", b"4"),
+            )
+
+
 # UpdateTest
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testUpdate(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, value int, PRIMARY KEY (partitionKey, clustering_1))" + compactOption) as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 2, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 3, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (1, 0, 4)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, value int, PRIMARY KEY (partitionKey, clustering_1))"
+        + compactOption,
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 2, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 3, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (1, 0, 4)",
+        )
 
         if forceFlush:
             nodetool.flush(cql, table)
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?", 7, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
-                           0, 1),
-                   row(7))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
+                0,
+                1,
+            ),
+            row(7),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1) = (?)", 8, 0, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1) = (?)",
+            8,
+            0,
+            2,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
-                           0, 2),
-                   row(8))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
+                0,
+                2,
+            ),
+            row(8),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey IN (?, ?) AND clustering_1 = ?", 9, 0, 1, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey IN (?, ?) AND clustering_1 = ?",
+            9,
+            0,
+            1,
+            0,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ?",
-                           0, 1, 0),
-                   row(0, 0, 9),
-                   row(1, 0, 9))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ?",
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 9),
+            row(1, 0, 9),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey IN ? AND clustering_1 = ?", 19, [0, 1], 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey IN ? AND clustering_1 = ?",
+            19,
+            [0, 1],
+            0,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN ? AND clustering_1 = ?",
-                           [0, 1], 0),
-                   row(0, 0, 19),
-                   row(1, 0, 19))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey IN ? AND clustering_1 = ?",
+                [0, 1],
+                0,
+            ),
+            row(0, 0, 19),
+            row(1, 0, 19),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 IN (?, ?)", 10, 0, 1, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
+            10,
+            0,
+            1,
+            0,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
-                           0, 1, 0),
-                   row(0, 0, 10),
-                   row(0, 1, 10))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 10),
+            row(0, 1, 10),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))", 20, 0, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
+            20,
+            0,
+            0,
+            1,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
-                           0, 0, 1),
-                   row(0, 0, 20),
-                   row(0, 1, 20))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
+                0,
+                0,
+                1,
+            ),
+            row(0, 0, 20),
+            row(0, 1, 20),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?", null, 0, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            null,
+            0,
+            0,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
-                           0, 0, 1),
-                   row(0, 1, 20))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
+                0,
+                0,
+                1,
+            ),
+            row(0, 1, 20),
+        )
         # test invalid queries. Scylla and Cassandra error messages are
         # different, so below we look for some common strings
 
         # missing primary key element
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "UPDATE %s SET value = ? WHERE clustering_1 = ? ", 7, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "UPDATE %s SET value = ? WHERE clustering_1 = ? ",
+            7,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_1",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ?", 7, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_1",
+            "UPDATE %s SET value = ? WHERE partitionKey = ?",
+            7,
+            0,
+        )
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses",
-                             "UPDATE %s SET value = ? WHERE token(partitionKey) = token(?) AND clustering_1 = ?",
-                             7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses",
+            "UPDATE %s SET value = ? WHERE token(partitionKey) = token(?) AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
         # multiple time the same value
         # Cassandra generates an InvalidSyntax here, Scylla InvalidRequest,
         # both are reasonable.
-        assertInvalidThrow(cql, table, (SyntaxException, InvalidRequest), "UPDATE %s SET value = ?, value = ? WHERE partitionKey = ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidThrow(
+            cql,
+            table,
+            (SyntaxException, InvalidRequest),
+            "UPDATE %s SET value = ?, value = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
         # multiple time same primary key element in WHERE clause
         # This is allowed in Scylla so the test is commented out.
-        #assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
         #                     "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_1 = ?", 7, 0, 1, 1)
 
         # Undefined column names
-        assertInvalidMessage(cql, table, "value1",
-                             "UPDATE %s SET value1 = ? WHERE partitionKey = ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "UPDATE %s SET value1 = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "UPDATE %s SET value = ? WHERE partitionKey1 = ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey1",
+            "UPDATE %s SET value = ? WHERE partitionKey1 = ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_3",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_3 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_3",
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_3 = ?",
+            7,
+            0,
+            1,
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key",
-                             "UPDATE %s SET value = ? WHERE partitionKey > ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key",
+            "UPDATE %s SET value = ? WHERE partitionKey > ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalidMessageRE(cql, table, "Cannot use CONTAINS on non-collection column|Cannot use UPDATE with CONTAINS",
-                             "UPDATE %s SET value = ? WHERE partitionKey CONTAINS ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "Cannot use CONTAINS on non-collection column|Cannot use UPDATE with CONTAINS",
+            "UPDATE %s SET value = ? WHERE partitionKey CONTAINS ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "value",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND value = ?", 7, 0, 1, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value",
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND value = ?",
+            7,
+            0,
+            1,
+            3,
+        )
 
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 > ?", 7, 0, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 > ?",
+            7,
+            0,
+            1,
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testUpdateWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))" + compactOption) as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 2, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 3, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 1, 4)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 2, 5)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 6)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))"
+        + compactOption,
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 2, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 3, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 1, 4)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 2, 5)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 6)",
+        )
         if forceFlush:
             nodetool.flush(cql, table)
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 1),
-                   row(7))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                1,
+            ),
+            row(7),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) = (?, ?)", 8, 0, 1, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) = (?, ?)",
+            8,
+            0,
+            1,
+            2,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 2),
-                   row(8))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                2,
+            ),
+            row(8),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?", 9, 0, 1, 0, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
+            9,
+            0,
+            1,
+            0,
+            0,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 0, 0),
-                   row(0, 0, 0, 9),
-                   row(1, 0, 0, 9))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 0, 0, 9),
+            row(1, 0, 0, 9),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey IN ? AND clustering_1 = ? AND clustering_2 = ?", 9, [0, 1], 0, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey IN ? AND clustering_1 = ? AND clustering_2 = ?",
+            9,
+            [0, 1],
+            0,
+            0,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN ? AND clustering_1 = ? AND clustering_2 = ?",
-                           [0, 1], 0, 0),
-                   row(0, 0, 0, 9),
-                   row(1, 0, 0, 9))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey IN ? AND clustering_1 = ? AND clustering_2 = ?",
+                [0, 1],
+                0,
+                0,
+            ),
+            row(0, 0, 0, 9),
+            row(1, 0, 0, 9),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)", 12, 0, 1, 1, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)",
+            12,
+            0,
+            1,
+            1,
+            2,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)",
-                           0, 1, 1, 2),
-                   row(0, 1, 1, 12),
-                   row(0, 1, 2, 12))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)",
+                0,
+                1,
+                1,
+                2,
+            ),
+            row(0, 1, 1, 12),
+            row(0, 1, 2, 12),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND clustering_2 IN (?, ?)", 10, 0, 1, 0, 1, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND clustering_2 IN (?, ?)",
+            10,
+            0,
+            1,
+            0,
+            1,
+            2,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND clustering_2 IN (?, ?)",
-                           0, 1, 0, 1, 2),
-                   row(0, 0, 1, 10),
-                   row(0, 0, 2, 10),
-                   row(0, 1, 1, 10),
-                   row(0, 1, 2, 10))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND clustering_2 IN (?, ?)",
+                0,
+                1,
+                0,
+                1,
+                2,
+            ),
+            row(0, 0, 1, 10),
+            row(0, 0, 2, 10),
+            row(0, 1, 1, 10),
+            row(0, 1, 2, 10),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))", 20, 0, 0, 2, 1, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
+            20,
+            0,
+            0,
+            2,
+            1,
+            2,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
-                           0, 0, 2, 1, 2),
-                   row(0, 0, 2, 20),
-                   row(0, 1, 2, 20))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
+                0,
+                0,
+                2,
+                1,
+                2,
+            ),
+            row(0, 0, 2, 20),
+            row(0, 1, 2, 20),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", null, 0, 0, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            null,
+            0,
+            0,
+            2,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
-                           0, 0, 2, 1, 2),
-                   row(0, 1, 2, 20))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
+                0,
+                0,
+                2,
+                1,
+                2,
+            ),
+            row(0, 1, 2, 20),
+        )
 
         # test invalid queries. Scylla and Cassandra error messages are
         # different, so below we look for some common strings
 
         # missing primary key element
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "UPDATE %s SET value = ? WHERE clustering_1 = ? AND clustering_2 = ?", 7, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "UPDATE %s SET value = ? WHERE clustering_1 = ? AND clustering_2 = ?",
+            7,
+            1,
+            1,
+        )
 
         errorMsg = 'PRIMARY KEY column "clustering_2" cannot be restricted as preceding column "clustering_1" is not restricted'
 
-        assertInvalidMessage(cql, table, errorMsg,
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_2 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            errorMsg,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_1",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ?", 7, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_1",
+            "UPDATE %s SET value = ? WHERE partitionKey = ?",
+            7,
+            0,
+        )
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses",
-                             "UPDATE %s SET value = ? WHERE token(partitionKey) = token(?) AND clustering_1 = ? AND clustering_2 = ?",
-                             7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses",
+            "UPDATE %s SET value = ? WHERE token(partitionKey) = token(?) AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
         # multiple time the same value
         # Cassandra generates an InvalidSyntax here, Scylla InvalidRequest,
         # both are reasonable.
-        assertInvalidThrow(cql, table, (SyntaxException, InvalidRequest), "UPDATE %s SET value = ?, value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidThrow(
+            cql,
+            table,
+            (SyntaxException, InvalidRequest),
+            "UPDATE %s SET value = ?, value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
         # multiple time same primary key element in WHERE clause
         # Scylla allows this, so test commented out.
-        #assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
         #                     "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND clustering_1 = ?", 7, 0, 1, 1, 1)
 
         # Undefined column names
-        assertInvalidMessage(cql, table, "value1",
-                             "UPDATE %s SET value1 = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "UPDATE %s SET value1 = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "UPDATE %s SET value = ? WHERE partitionKey1 = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey1",
+            "UPDATE %s SET value = ? WHERE partitionKey1 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_3",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_3 = ?", 7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_3",
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_3 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key",
-                             "UPDATE %s SET value = ? WHERE partitionKey > ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key",
+            "UPDATE %s SET value = ? WHERE partitionKey > ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessageRE(cql, table, "Cannot use CONTAINS on non-collection column|Cannot use UPDATE with CONTAINS",
-                             "UPDATE %s SET value = ? WHERE partitionKey CONTAINS ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "Cannot use CONTAINS on non-collection column|Cannot use UPDATE with CONTAINS",
+            "UPDATE %s SET value = ? WHERE partitionKey CONTAINS ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND value = ?", 7, 0, 1, 1, 3)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND value = ?",
+            7,
+            0,
+            1,
+            1,
+            3,
+        )
 
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 > ?", 7, 0, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 > ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) > (?, ?)", 7, 0, 1, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) > (?, ?)",
+            7,
+            0,
+            1,
+            1,
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testUpdateWithMultiplePartitionKeyComponents(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey_1 int, partitionKey_2 int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY ((partitionKey_1, partitionKey_2), clustering_1, clustering_2))" + compactOption) as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 1, 0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 1, 1, 1, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (1, 0, 0, 1, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (1, 1, 0, 1, 3)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey_1 int, partitionKey_2 int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY ((partitionKey_1, partitionKey_2), clustering_1, clustering_2))"
+        + compactOption,
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 1, 0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 1, 1, 1, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (1, 0, 0, 1, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (1, 1, 0, 1, 3)",
+        )
         if forceFlush:
             nodetool.flush(cql, table)
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey_1 = ? AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 0, 0, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey_1 = ? AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            0,
+            0,
+            0,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey_1 = ? AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 0, 0, 0),
-                   row(7))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey_1 = ? AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                0,
+                0,
+                0,
+            ),
+            row(7),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?", 9, 0, 1, 1, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            9,
+            0,
+            1,
+            1,
+            0,
+            1,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 1, 0, 1),
-                   row(0, 1, 0, 1, 9),
-                   row(1, 1, 0, 1, 9))
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                1,
+                0,
+                1,
+            ),
+            row(0, 1, 0, 1, 9),
+            row(1, 1, 0, 1, 9),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?", 10, 0, 1, 0, 1, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
+            10,
+            0,
+            1,
+            0,
+            1,
+            0,
+            1,
+        )
         if forceFlush:
             nodetool.flush(cql, table)
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, 0, 0, 0, 7),
-                   row(0, 0, 0, 1, 10),
-                   row(0, 1, 0, 1, 10),
-                   row(0, 1, 1, 1, 2),
-                   row(1, 0, 0, 1, 10),
-                   row(1, 1, 0, 1, 10))
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(0, 0, 0, 0, 7),
+            row(0, 0, 0, 1, 10),
+            row(0, 1, 0, 1, 10),
+            row(0, 1, 1, 1, 2),
+            row(1, 0, 0, 1, 10),
+            row(1, 1, 0, 1, 10),
+        )
 
         # missing primary key element
         # There are two ways to fix the following broken request. Cassandra
@@ -4157,267 +9429,457 @@ def testUpdateWithMultiplePartitionKeyComponents(cql, test_keyspace, forceFlush)
         # component is missing - and Scylla mentions a different fix in the
         # error message - that ALLOW FILTERING can be used. Let's just agree
         # there should be an error.
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey_1 = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 1, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey_1 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            1,
+            1,
+        )
+
 
 # AlterTest
 
+
 # Test for CASSANDRA-13917
 def testAlterWithCompactStaticFormat(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "column1",
-                             "ALTER TABLE %s RENAME column1 TO column2")
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE"
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "column1", "ALTER TABLE %s RENAME column1 TO column2"
+        )
+
 
 # Test for CASSANDRA-13917
 def testAlterWithCompactNonStaticFormat(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "column1",
-                             "ALTER TABLE %s RENAME column1 TO column2")
+    with create_table(
+        cql, test_keyspace, "(a int, b int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE"
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "column1", "ALTER TABLE %s RENAME column1 TO column2"
+        )
 
-    with create_table(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "column1",
-                             "ALTER TABLE %s RENAME column1 TO column2")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, v int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE",
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "column1", "ALTER TABLE %s RENAME column1 TO column2"
+        )
+
 
 # CreateTest
 
+
 # Test for CASSANDRA-13917
 def testCreateIndextWithCompactStaticFormat(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "column1",
-                             "CREATE INDEX column1_index on %s (column1)")
-        assertInvalidMessage(cql, table, "value",
-                             "CREATE INDEX value_index on %s (value)")
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE"
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "column1", "CREATE INDEX column1_index on %s (column1)"
+        )
+        assertInvalidMessage(
+            cql, table, "value", "CREATE INDEX value_index on %s (value)"
+        )
+
 
 # DeleteTest
 
+
 # Test for CASSANDRA-13917
 def testDeleteWithCompactStaticFormat(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE"
+    ) as table:
         do_testDeleteWithCompactFormat(cql, table)
 
     # if column1 is present, hidden column is called column2
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int, column1 int) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "column2",
-                             "DELETE FROM %s WHERE a = 1 AND column2= 1")
-        assertInvalidMessage(cql, table, "column2",
-                             "DELETE FROM %s WHERE a = 1 AND column2 = 1 AND value1 = 1")
-        assertInvalidMessage(cql, table, "column2",
-                             "DELETE column2 FROM %s WHERE a = 1")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c int, column1 int) WITH COMPACT STORAGE",
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "column2", "DELETE FROM %s WHERE a = 1 AND column2= 1"
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "column2",
+            "DELETE FROM %s WHERE a = 1 AND column2 = 1 AND value1 = 1",
+        )
+        assertInvalidMessage(
+            cql, table, "column2", "DELETE column2 FROM %s WHERE a = 1"
+        )
 
     # if value is present, hidden column is called value1
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int, value int) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "value1",
-                             "DELETE FROM %s WHERE a = 1 AND value1 = 1")
-        assertInvalidMessage(cql, table, "value1",
-                             "DELETE FROM %s WHERE a = 1 AND value1 = 1 AND column1 = 1")
-        assertInvalidMessage(cql, table, "value1",
-                             "DELETE value1 FROM %s WHERE a = 1")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c int, value int) WITH COMPACT STORAGE",
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "value1", "DELETE FROM %s WHERE a = 1 AND value1 = 1"
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "DELETE FROM %s WHERE a = 1 AND value1 = 1 AND column1 = 1",
+        )
+        assertInvalidMessage(cql, table, "value1", "DELETE value1 FROM %s WHERE a = 1")
+
 
 # Test for CASSANDRA-13917
 # Reproduces #12815
-@pytest.mark.xfail(reason="issue #12815")
+@pytest.mark.xfail(
+    reason='Hidden column "value" in compact table isn\'t completely hidden #12815'
+)
 def testDeleteWithCompactNonStaticFormat(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (2, 1)")
-        assert_rows(execute(cql, table, "SELECT a, b FROM %s"),
-                   row(1, 1),
-                   row(2, 1))
+        assert_rows(execute(cql, table, "SELECT a, b FROM %s"), row(1, 1), row(2, 1))
         do_testDeleteWithCompactFormat(cql, table)
 
-    with create_table(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, v) VALUES (1, 1, 3)")
         execute(cql, table, "INSERT INTO %s (a, b, v) VALUES (2, 1, 4)")
-        assert_rows(execute(cql, table, "SELECT a, b, v FROM %s"),
-                   row(1, 1, 3),
-                   row(2, 1, 4))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, v FROM %s"), row(1, 1, 3), row(2, 1, 4)
+        )
         do_testDeleteWithCompactFormat(cql, table)
 
+
 def do_testDeleteWithCompactFormat(cql, table):
-    assertInvalidMessage(cql, table, "value",
-                         "DELETE FROM %s WHERE a = 1 AND value = 1")
-    assertInvalidMessage(cql, table, "column1",
-                         "DELETE FROM %s WHERE a = 1 AND column1= 1")
-    assertInvalidMessage(cql, table, "value",
-                         "DELETE FROM %s WHERE a = 1 AND value = 1 AND column1 = 1")
-    assertInvalidMessage(cql, table, "value",
-                         "DELETE value FROM %s WHERE a = 1")
-    assertInvalidMessage(cql, table, "column1",
-                         "DELETE column1 FROM %s WHERE a = 1")
+    assertInvalidMessage(
+        cql, table, "value", "DELETE FROM %s WHERE a = 1 AND value = 1"
+    )
+    assertInvalidMessage(
+        cql, table, "column1", "DELETE FROM %s WHERE a = 1 AND column1= 1"
+    )
+    assertInvalidMessage(
+        cql, table, "value", "DELETE FROM %s WHERE a = 1 AND value = 1 AND column1 = 1"
+    )
+    assertInvalidMessage(cql, table, "value", "DELETE value FROM %s WHERE a = 1")
+    assertInvalidMessage(cql, table, "column1", "DELETE column1 FROM %s WHERE a = 1")
+
 
 # InsertTest
 
+
 # Test for CASSANDRA-13917
 def testInsertWithCompactStaticFormat(cql, test_keyspace):
-    do_testInsertWithCompactTable(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE")
+    do_testInsertWithCompactTable(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE"
+    )
     # if column1 is present, hidden column is called column2
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int, column1 int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c int, column1 int) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, column1) VALUES (1, 1, 1, 1)")
-        assertInvalidMessage(cql, table, "column2",
-                             "INSERT INTO %s (a, b, c, column2) VALUES (1, 1, 1, 1)")
+        assertInvalidMessage(
+            cql,
+            table,
+            "column2",
+            "INSERT INTO %s (a, b, c, column2) VALUES (1, 1, 1, 1)",
+        )
 
     # if value is present, hidden column is called value1
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int, value int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c int, value int) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, value) VALUES (1, 1, 1, 1)")
-        assertInvalidMessage(cql, table, "value1",
-                             "INSERT INTO %s (a, b, c, value1) VALUES (1, 1, 1, 1)")
+        assertInvalidMessage(
+            cql, table, "value1", "INSERT INTO %s (a, b, c, value1) VALUES (1, 1, 1, 1)"
+        )
+
 
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(
+    reason='Hidden column "value" in compact table isn\'t completely hidden #12815'
+)
 def testInsertWithCompactNonStaticFormat(cql, test_keyspace):
-    do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
-    do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
+    do_testInsertWithCompactTable(
+        cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE"
+    )
+    do_testInsertWithCompactTable(
+        cql,
+        test_keyspace,
+        "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    )
+
 
 def do_testInsertWithCompactTable(cql, test_keyspace, create):
     with create_table(cql, test_keyspace, create) as table:
-
         # pass correct types to the hidden columns
-        assertInvalidMessage(cql, table, "column1",
-                             "INSERT INTO %s (a, b, column1) VALUES (?, ?, ?)",
-                             1, 1, 1, b'a')
-        assertInvalidMessage(cql, table, "value",
-                             "INSERT INTO %s (a, b, value) VALUES (?, ?, ?)",
-                             1, 1, 1, b'a')
-        assertInvalidMessage(cql, table, "column1",
-                             "INSERT INTO %s (a, b, column1, value) VALUES (?, ?, ?, ?)",
-                             1, 1, 1, b'a', b'b')
-        assertInvalidMessage(cql, table, "value",
-                             "INSERT INTO %s (a, b, value, column1) VALUES (?, ?, ?, ?)",
-                             1, 1, 1, b'a', b'b')
+        assertInvalidMessage(
+            cql,
+            table,
+            "column1",
+            "INSERT INTO %s (a, b, column1) VALUES (?, ?, ?)",
+            1,
+            1,
+            1,
+            b"a",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "value",
+            "INSERT INTO %s (a, b, value) VALUES (?, ?, ?)",
+            1,
+            1,
+            1,
+            b"a",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "column1",
+            "INSERT INTO %s (a, b, column1, value) VALUES (?, ?, ?, ?)",
+            1,
+            1,
+            1,
+            b"a",
+            b"b",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "value",
+            "INSERT INTO %s (a, b, value, column1) VALUES (?, ?, ?, ?)",
+            1,
+            1,
+            1,
+            b"a",
+            b"b",
+        )
 
         # pass incorrect types to the hidden columns
-        assertInvalidMessage(cql, table, "value",
-                             "INSERT INTO %s (a, b, value) VALUES (?, ?, ?)",
-                             1, 1, 1, 1)
-        assertInvalidMessage(cql, table, "column1",
-                             "INSERT INTO %s (a, b, column1) VALUES (?, ?, ?)",
-                             1, 1, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value",
+            "INSERT INTO %s (a, b, value) VALUES (?, ?, ?)",
+            1,
+            1,
+            1,
+            1,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "column1",
+            "INSERT INTO %s (a, b, column1) VALUES (?, ?, ?)",
+            1,
+            1,
+            1,
+            1,
+        )
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
         # pass null to the hidden columns
-        assertInvalidMessage(cql, table, "value",
-                             "INSERT INTO %s (a, b, value) VALUES (?, ?, ?)",
-                             1, 1, None)
-        assertInvalidMessage(cql, table, "column1",
-                             "INSERT INTO %s (a, b, column1) VALUES (?, ?, ?)",
-                             1, 1, None)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value",
+            "INSERT INTO %s (a, b, value) VALUES (?, ?, ?)",
+            1,
+            1,
+            None,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "column1",
+            "INSERT INTO %s (a, b, column1) VALUES (?, ?, ?)",
+            1,
+            1,
+            None,
+        )
+
 
 # SelectTest
 
+
 # Test for CASSANDRA-13917
 def testSelectWithCompactStaticFormat(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 1, 1)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (2, 1, 1)")
-        assert_rows(execute(cql, table, "SELECT a, b, c FROM %s"),
-                   row(1, 1, 1),
-                   row(2, 1, 1))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c FROM %s"), row(1, 1, 1), row(2, 1, 1)
+        )
         do_testSelectWithCompactFormat(cql, table)
 
     # if column column1 is present, hidden column is called column2
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int, column1 int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c int, column1 int) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, column1) VALUES (1, 1, 1, 1)")
         execute(cql, table, "INSERT INTO %s (a, b, c, column1) VALUES (2, 1, 1, 2)")
-        assert_rows(execute(cql, table, "SELECT a, b, c, column1 FROM %s"),
-                   row(1, 1, 1, 1),
-                   row(2, 1, 1, 2))
-        assertInvalidMessage(cql, table, "column2",
-                             "SELECT a, column2, value FROM %s")
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c, column1 FROM %s"),
+            row(1, 1, 1, 1),
+            row(2, 1, 1, 2),
+        )
+        assertInvalidMessage(cql, table, "column2", "SELECT a, column2, value FROM %s")
 
     # if column value is present, hidden column is called value1
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int, value int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c int, value int) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, value) VALUES (1, 1, 1, 1)")
         execute(cql, table, "INSERT INTO %s (a, b, c, value) VALUES (2, 1, 1, 2)")
-        assert_rows(execute(cql, table, "SELECT a, b, c, value FROM %s"),
-                   row(1, 1, 1, 1),
-                   row(2, 1, 1, 2))
-        assertInvalidMessage(cql, table, "value1",
-                             "SELECT a, value1, value FROM %s")
+        assert_rows(
+            execute(cql, table, "SELECT a, b, c, value FROM %s"),
+            row(1, 1, 1, 1),
+            row(2, 1, 1, 2),
+        )
+        assertInvalidMessage(cql, table, "value1", "SELECT a, value1, value FROM %s")
+
 
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(
+    reason='Hidden column "value" in compact table isn\'t completely hidden #12815'
+)
 def testSelectWithCompactNonStaticFormat(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (2, 1)")
-        assert_rows(execute(cql, table, "SELECT a, b FROM %s"),
-                   row(1, 1),
-                   row(2, 1))
+        assert_rows(execute(cql, table, "SELECT a, b FROM %s"), row(1, 1), row(2, 1))
         do_testSelectWithCompactFormat(cql, table)
 
-    with create_table(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, v int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, v) VALUES (1, 1, 3)")
         execute(cql, table, "INSERT INTO %s (a, b, v) VALUES (2, 1, 4)")
-        assert_rows(execute(cql, table, "SELECT a, b, v FROM %s"),
-                   row(1, 1, 3),
-                   row(2, 1, 4))
+        assert_rows(
+            execute(cql, table, "SELECT a, b, v FROM %s"), row(1, 1, 3), row(2, 1, 4)
+        )
         do_testSelectWithCompactFormat(cql, table)
 
+
 def do_testSelectWithCompactFormat(cql, table):
-    assertInvalidMessage(cql, table, "column1",
-                         "SELECT column1 FROM %s")
-    assertInvalidMessage(cql, table, "value",
-                         "SELECT value FROM %s")
-    assertInvalidMessage(cql, table, "value",
-                         "SELECT value, column1 FROM %s")
-    assertInvalidMessage(cql, table, "column1",
-                  "SELECT * FROM %s WHERE column1 = null ALLOW FILTERING")
-    assertInvalidMessage(cql, table, "value",
-                  "SELECT * FROM %s WHERE value = null ALLOW FILTERING")
-    assertInvalidMessage(cql, table, "column1",
-                         "SELECT WRITETIME(column1) FROM %s")
-    assertInvalidMessage(cql, table, "value",
-                         "SELECT WRITETIME(value) FROM %s")
+    assertInvalidMessage(cql, table, "column1", "SELECT column1 FROM %s")
+    assertInvalidMessage(cql, table, "value", "SELECT value FROM %s")
+    assertInvalidMessage(cql, table, "value", "SELECT value, column1 FROM %s")
+    assertInvalidMessage(
+        cql, table, "column1", "SELECT * FROM %s WHERE column1 = null ALLOW FILTERING"
+    )
+    assertInvalidMessage(
+        cql, table, "value", "SELECT * FROM %s WHERE value = null ALLOW FILTERING"
+    )
+    assertInvalidMessage(cql, table, "column1", "SELECT WRITETIME(column1) FROM %s")
+    assertInvalidMessage(cql, table, "value", "SELECT WRITETIME(value) FROM %s")
+
 
 # UpdateTest
 
+
 # Test for CASSANDRA-13917
 def testUpdateWithCompactStaticFormat(cql, test_keyspace):
-    do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE")
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE") as table:
-        assertInvalidMessage(cql, table, "column1",
-                             "UPDATE %s SET b = 1 WHERE column1 = ?",
-                             b'a')
-        assertInvalidMessage(cql, table, "value",
-                             "UPDATE %s SET b = 1 WHERE value = ?",
-                             b'a')
+    do_testUpdateWithCompactFormat(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE"
+    )
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c int) WITH COMPACT STORAGE"
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "column1", "UPDATE %s SET b = 1 WHERE column1 = ?", b"a"
+        )
+        assertInvalidMessage(
+            cql, table, "value", "UPDATE %s SET b = 1 WHERE value = ?", b"a"
+        )
 
     # if column1 is present, hidden column is called column2
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int, column1 int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c int, column1 int) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, column1) VALUES (1, 1, 1, 1)")
         execute(cql, table, "UPDATE %s SET column1 = 6 WHERE a = 1")
-        assertInvalidMessage(cql, table, "column2", "UPDATE %s SET column2 = 6 WHERE a = 0")
+        assertInvalidMessage(
+            cql, table, "column2", "UPDATE %s SET column2 = 6 WHERE a = 0"
+        )
         assertInvalidMessage(cql, table, "value", "UPDATE %s SET value = 6 WHERE a = 0")
 
     # if value is present, hidden column is called value1
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c int, value int) WITH COMPACT STORAGE") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b int, c int, value int) WITH COMPACT STORAGE",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, value) VALUES (1, 1, 1, 1)")
         execute(cql, table, "UPDATE %s SET value = 6 WHERE a = 1")
-        assertInvalidMessage(cql, table, "column1", "UPDATE %s SET column1 = 6 WHERE a = 1")
-        assertInvalidMessage(cql, table, "value1", "UPDATE %s SET value1 = 6 WHERE a = 1")
+        assertInvalidMessage(
+            cql, table, "column1", "UPDATE %s SET column1 = 6 WHERE a = 1"
+        )
+        assertInvalidMessage(
+            cql, table, "value1", "UPDATE %s SET value1 = 6 WHERE a = 1"
+        )
+
 
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(
+    reason='Hidden column "value" in compact table isn\'t completely hidden #12815'
+)
 def testUpdateWithCompactNonStaticFormat(cql, test_keyspace):
-    do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
-    do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
+    do_testUpdateWithCompactFormat(
+        cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE"
+    )
+    do_testUpdateWithCompactFormat(
+        cql,
+        test_keyspace,
+        "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE",
+    )
+
 
 def do_testUpdateWithCompactFormat(cql, test_keyspace, create):
     with create_table(cql, test_keyspace, create) as table:
         # pass correct types to hidden columns
-        assertInvalidMessage(cql, table, "column1",
-                             "UPDATE %s SET column1 = ? WHERE a = 0",
-                             b'a')
-        assertInvalidMessage(cql, table, "value",
-                             "UPDATE %s SET value = ? WHERE a = 0",
-                             b'a')
+        assertInvalidMessage(
+            cql, table, "column1", "UPDATE %s SET column1 = ? WHERE a = 0", b"a"
+        )
+        assertInvalidMessage(
+            cql, table, "value", "UPDATE %s SET value = ? WHERE a = 0", b"a"
+        )
 
         # pass incorrect types to hidden columns
-        assertInvalidMessage(cql, table, "column1", "UPDATE %s SET column1 = 6 WHERE a = 0")
+        assertInvalidMessage(
+            cql, table, "column1", "UPDATE %s SET column1 = 6 WHERE a = 0"
+        )
         assertInvalidMessage(cql, table, "value", "UPDATE %s SET value = 6 WHERE a = 0")

--- a/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
@@ -13,12 +13,14 @@ from cassandra.connection import DRIVER_NAME, DRIVER_VERSION
 
 # Some of the lines in these tests are commented out because Scylla doesn't support arithmetic operations in literals (issue #2693).
 
+
 @pytest.fixture(scope="function")
 def skip_if_driver_doesnt_support_variable_width_types():
-    scylla_driver = 'Scylla' in DRIVER_NAME
-    driver_version = tuple(int(x) for x in DRIVER_VERSION.split('.'))
+    scylla_driver = "Scylla" in DRIVER_NAME
+    driver_version = tuple(int(x) for x in DRIVER_VERSION.split("."))
     if scylla_driver or (not scylla_driver and driver_version < (3, 29, 2)):
         pytest.skip("The driver doesn't support variable width types in vectors.")
+
 
 def test_select(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk vector<int, 2> primary key)") as table:
@@ -32,31 +34,53 @@ def test_select(cql, test_keyspace):
         # assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = [1, 1 + 1]"), row)
 
         assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = [1, ?]", 2), row)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = [1, (int) ?]", 2), row)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE pk = [1, (int) ?]", 2), row
+        )
         # assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk = [1, 1 + (int) ?]", 1), row)
 
         assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk IN ([1, 2])"), row)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk IN ([1, 2], [1, 2])"), row)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE pk IN ([1, 2], [1, 2])"), row
+        )
         assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk IN (?)", vector), row)
         assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk IN ?", [vector]), row)
         # assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk IN ([1, 1 + 1])"), row)
         assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk IN ([1, ?])", 2), row)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk IN ([1, (int) ?])", 2), row)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE pk IN ([1, (int) ?])", 2), row
+        )
         # assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk IN ([1, 1 + (int) ?])", 1), row)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk > [0, 0] AND pk < [1, 3] ALLOW FILTERING"), row)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE token(pk) = token([1, 2])"), row)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk > [0, 0] AND pk < [1, 3] ALLOW FILTERING",
+            ),
+            row,
+        )
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE token(pk) = token([1, 2])"), row
+        )
 
         assertRows(execute(cql, table, "SELECT * FROM %s"), row)
 
 
 def test_selectNonPk(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int primary key, value vector<int, 2>)") as table:
+    with create_table(
+        cql, test_keyspace, "(pk int primary key, value vector<int, 2>)"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (pk, value) VALUES (0, [1, 2])")
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE value=[1, 2] ALLOW FILTERING"), [0, [1, 2]])
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE value=[1, 2] ALLOW FILTERING"),
+            [0, [1, 2]],
+        )
+
 
 def test_insert(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk vector<int, 2> primary key)") as table:
+
         def test():
             assertRows(execute(cql, table, "SELECT * FROM %s"), [[1, 2]])
             execute(cql, table, "TRUNCATE %s")
@@ -80,8 +104,12 @@ def test_insert(cql, test_keyspace):
         # execute(cql, table, "INSERT INTO %s (pk) VALUES ([1, 1 + (int) ?])", 1)
         # test()
 
+
 def test_insertNonPK(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int primary key, value vector<int, 2>)") as table:
+    with create_table(
+        cql, test_keyspace, "(pk int primary key, value vector<int, 2>)"
+    ) as table:
+
         def test():
             assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, [1, 2]))
             execute(cql, table, "TRUNCATE %s")
@@ -104,13 +132,20 @@ def test_insertNonPK(cql, test_keyspace):
 
         # execute(cql, table, "INSERT INTO %s (pk, value) VALUES (0, [1, 1 + (int) ?])", 1);
         # test()
-    
-def test_invalidNumberOfDimensionsFixedWidth(cql, test_keyspace):
-    with create_table(cql, test_keyspace,"(pk int primary key, value vector<int, 2>)") as table:
 
+
+def test_invalidNumberOfDimensionsFixedWidth(cql, test_keyspace):
+    with create_table(
+        cql, test_keyspace, "(pk int primary key, value vector<int, 2>)"
+    ) as table:
         # fewer values than expected, with literals and bind markers
-        assertInvalidThrowMessage(cql, table, "Invalid vector literal",InvalidRequest,
-                                    "INSERT INTO %s (pk, value) VALUES (0, [1])")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "Invalid vector literal",
+            InvalidRequest,
+            "INSERT INTO %s (pk, value) VALUES (0, [1])",
+        )
         # Not translated because the Python driver refuses to send incorrect
         # parameters for prepared statements
         # assertInvalidThrowMessage("Not enough bytes to read a vector<int, 2>",
@@ -118,8 +153,13 @@ def test_invalidNumberOfDimensionsFixedWidth(cql, test_keyspace):
         #                   "INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1));
 
         # more values than expected, with literals and bind markers
-        assertInvalidThrowMessage(cql, table,  "Invalid vector literal",InvalidRequest,
-                                    "INSERT INTO %s (pk, value) VALUES (0, [1, 2, 3])")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "Invalid vector literal",
+            InvalidRequest,
+            "INSERT INTO %s (pk, value) VALUES (0, [1, 2, 3])",
+        )
 
         # Not translated because the Python driver refuses to send incorrect
         # parameters for prepared statements
@@ -128,12 +168,20 @@ def test_invalidNumberOfDimensionsFixedWidth(cql, test_keyspace):
         #                           "INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, 2, 3));
 
 
-def test_invalidNumberOfDimensionsVariableWidth(cql, test_keyspace, skip_if_driver_doesnt_support_variable_width_types):
-    with create_table(cql, test_keyspace, "(pk int primary key, value vector<text, 2>)") as table:
-
+def test_invalidNumberOfDimensionsVariableWidth(
+    cql, test_keyspace, skip_if_driver_doesnt_support_variable_width_types
+):
+    with create_table(
+        cql, test_keyspace, "(pk int primary key, value vector<text, 2>)"
+    ) as table:
         # fewer values than expected, with literals and bind markers
-        assertInvalidThrowMessage(cql, table, "Invalid vector literal", InvalidRequest,
-                                    "INSERT INTO %s (pk, value) VALUES (0, ['a'])")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "Invalid vector literal",
+            InvalidRequest,
+            "INSERT INTO %s (pk, value) VALUES (0, ['a'])",
+        )
 
         # Not translated because the Python driver refuses to send incorrect
         # parameters for prepared statements
@@ -142,29 +190,52 @@ def test_invalidNumberOfDimensionsVariableWidth(cql, test_keyspace, skip_if_driv
         #                           "INSERT INTO %s (pk, value) VALUES (0, ?)", vector("a"));
 
         # more values than expected, with literals and bind markers
-        assertInvalidThrowMessage(cql, table,"Invalid vector literal", InvalidRequest,
-                                    "INSERT INTO %s (pk, value) VALUES (0, ['a', 'b', 'c'])")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "Invalid vector literal",
+            InvalidRequest,
+            "INSERT INTO %s (pk, value) VALUES (0, ['a', 'b', 'c'])",
+        )
 
         # Not translated because the Python driver refuses to send incorrect
         # parameters for prepared statements
         # assertInvalidThrowMessage(cql, table,"bytes", InvalidRequest,
         #                             "INSERT INTO %s (pk, value) VALUES (0, ?)", ["a", "b", "c"])
 
-def test_sandwichBetweenUDTs(cql, test_keyspace, skip_if_driver_doesnt_support_variable_width_types):
+
+def test_sandwichBetweenUDTs(
+    cql, test_keyspace, skip_if_driver_doesnt_support_variable_width_types
+):
     with create_type(cql, test_keyspace, "(y int)") as b:
         with create_type(cql, test_keyspace, f"(z vector<frozen<{b}>, 2>)") as a:
-            with create_table(cql, test_keyspace, f"(pk int primary key, value {a})") as table:
+            with create_table(
+                cql, test_keyspace, f"(pk int primary key, value {a})"
+            ) as table:
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (pk, value) VALUES (0, ?)",
+                    user_type("z", [user_type("y", 1), user_type("y", 2)]),
+                )
+                assertRows(
+                    execute(cql, table, "SELECT * FROM %s"),
+                    [0, user_type("z", [user_type("y", 1), user_type("y", 2)])],
+                )
 
-                execute(cql, table, "INSERT INTO %s (pk, value) VALUES (0, ?)", user_type("z", [user_type("y", 1), user_type("y", 2)]))
-                assertRows(execute(cql, table, "SELECT * FROM %s"),
-                            [0, user_type("z", [user_type("y", 1), user_type("y", 2)])])
 
-def test_invalidElementTypeFixedWidth(cql,test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int primary key, value vector<int, 2>)") as table:
-
+def test_invalidElementTypeFixedWidth(cql, test_keyspace):
+    with create_table(
+        cql, test_keyspace, "(pk int primary key, value vector<int, 2>)"
+    ) as table:
         # fixed-length bigint instead of int, with literals and bind markers
-        assertInvalidThrowMessage(cql, table,"Invalid vector literal", InvalidRequest,
-                                    "INSERT INTO %s (pk, value) VALUES (0, [(bigint) 1, (bigint) 2])")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "Invalid vector literal",
+            InvalidRequest,
+            "INSERT INTO %s (pk, value) VALUES (0, [(bigint) 1, (bigint) 2])",
+        )
 
         # Not translated because the Python driver refuses to send incorrect
         # parameters for prepared statements
@@ -173,8 +244,13 @@ def test_invalidElementTypeFixedWidth(cql,test_keyspace):
         #                           "INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1L, Long.MAX_VALUE));
 
         #  variable-length text instead of int, with literals and bind markers
-        assertInvalidThrowMessage(cql, table,"Invalid vector literal", InvalidRequest,
-                                    "INSERT INTO %s (pk, value) VALUES (0, ['a', 'b'])")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "Invalid vector literal",
+            InvalidRequest,
+            "INSERT INTO %s (pk, value) VALUES (0, ['a', 'b'])",
+        )
 
         # Not translated because the Python driver refuses to send incorrect
         # parameters for prepared statements
@@ -183,13 +259,20 @@ def test_invalidElementTypeFixedWidth(cql,test_keyspace):
         #                         "INSERT INTO %s (pk, value) VALUES (0, ?)", vector("a", "b"));
 
 
-def test_invalidElementTypeVariableWidth(cql, test_keyspace,skip_if_driver_doesnt_support_variable_width_types):
-    with create_table(cql, test_keyspace, "(pk int primary key, value vector<text, 2>)") as table:
-
+def test_invalidElementTypeVariableWidth(
+    cql, test_keyspace, skip_if_driver_doesnt_support_variable_width_types
+):
+    with create_table(
+        cql, test_keyspace, "(pk int primary key, value vector<text, 2>)"
+    ) as table:
         # fixed-length int instead of text, with literals and bind markers
-        assertInvalidThrowMessage(cql, table, "Invalid vector literal",
-                                  InvalidRequest,
-                                  "INSERT INTO %s (pk, value) VALUES (0, [1, 2])")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "Invalid vector literal",
+            InvalidRequest,
+            "INSERT INTO %s (pk, value) VALUES (0, [1, 2])",
+        )
         # Not translated because the Python driver refuses to send incorrect
         # parameters for prepared statements
         # assertInvalidThrowMessage("Unexpected 6 extraneous bytes after vector<text, 2> value",
@@ -197,9 +280,13 @@ def test_invalidElementTypeVariableWidth(cql, test_keyspace,skip_if_driver_doesn
         #                           "INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1, 2));
 
         # variable-length varint instead of text, with literals and bind markers
-        assertInvalidThrowMessage(cql, table, "Invalid vector literal",
-                                  InvalidRequest,
-                                  "INSERT INTO %s (pk, value) VALUES (0, [(varint) 1, (varint) 2])")
+        assertInvalidThrowMessage(
+            cql,
+            table,
+            "Invalid vector literal",
+            InvalidRequest,
+            "INSERT INTO %s (pk, value) VALUES (0, [(varint) 1, (varint) 2])",
+        )
 
         # Not translated because the Python driver refuses to send incorrect
         # parameters for prepared statements
@@ -207,14 +294,18 @@ def test_invalidElementTypeVariableWidth(cql, test_keyspace,skip_if_driver_doesn
         #                           InvalidRequestException.class,
         #                           "INSERT INTO %s (pk, value) VALUES (0, ?)",
         #                           vector(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE), BigInteger.ONE));
+
+
 def test_update(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int primary key, value vector<int, 2>)") as table:
+    with create_table(
+        cql, test_keyspace, "(pk int primary key, value vector<int, 2>)"
+    ) as table:
+
         def test():
             assertRows(execute(cql, table, "SELECT * FROM %s"), [0, [1, 2]])
             execute(cql, table, "TRUNCATE %s")
             assertRows(execute(cql, table, "SELECT * FROM %s"))
 
-        
         execute(cql, table, "UPDATE %s SET value = [1, 2] WHERE pk = 0")
         test()
 
@@ -233,9 +324,12 @@ def test_update(cql, test_keyspace):
         # execute(cql, table, "UPDATE %s SET value = [1, 1 + (int) ?] WHERE pk = 0", 1)
         # test()
 
+
 def test_nullValues(cql, test_keyspace):
     def assertAcceptsNullValues(t):
-        with create_table(cql, test_keyspace, f"(k int primary key, v vector<{t}, 2>)") as table:
+        with create_table(
+            cql, test_keyspace, f"(k int primary key, v vector<{t}, 2>)"
+        ) as table:
             execute(cql, table, "INSERT INTO %s (k, v) VALUES (0, null)")
             assertRows(execute(cql, table, "SELECT * FROM %s"), [0, None])
 
@@ -251,10 +345,16 @@ def test_nullValues(cql, test_keyspace):
 
 def test_emptyValues(cql, test_keyspace):
     def assertRejectsEmptyValues(t):
-        with create_table(cql, test_keyspace, f"(k int primary key, v vector<{t}, 2>)") as table:
-            assertInvalidThrowMessage(cql, table, f"Invalid HEX constant (0x) for \"v\" of type vector<{t}, 2>",
-                                      InvalidRequest,
-                                      "INSERT INTO %s (k, v) VALUES (0, 0x)")
+        with create_table(
+            cql, test_keyspace, f"(k int primary key, v vector<{t}, 2>)"
+        ) as table:
+            assertInvalidThrowMessage(
+                cql,
+                table,
+                f'Invalid HEX constant (0x) for "v" of type vector<{t}, 2>',
+                InvalidRequest,
+                "INSERT INTO %s (k, v) VALUES (0, 0x)",
+            )
 
             # Not translated because the Python driver refuses to send incorrect
             # parameters for prepared statements
@@ -265,10 +365,10 @@ def test_emptyValues(cql, test_keyspace):
 
     assertRejectsEmptyValues("int")  # fixed length
     assertRejectsEmptyValues("float")  # fixed length with special/optimized treatment
-    
+
     # The Python driver doesn't support variable width types in vectors yet.
     # assertRejectsEmptyValues("text")  # variable length
-    
+
 
 # Test commented out because it uses internal Cassandra Java APIs, not CQL
 #     @Test
@@ -338,14 +438,17 @@ def test_emptyValues(cql, test_keyspace):
 #         assertRows(execute("SELECT f([1.0, 2.0], value) FROM %s"), expected);
 #     }
 
-@pytest.mark.xfail(reason="Issue #5411")
-def test_token(cql , test_keyspace):
-    with create_table(cql, test_keyspace, "(pk vector<int, 2> primary key)") as table:
 
-        execute(cql, table,"INSERT INTO %s (pk) VALUES (?)", "abcd")
+@pytest.mark.xfail(
+    reason="Allow using terms in selection clause within SELECT statement #5411"
+)
+def test_token(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk vector<int, 2> primary key)") as table:
+        execute(cql, table, "INSERT INTO %s (pk) VALUES (?)", "abcd")
         tokenColumn = execute(cql, table, "SELECT token(pk) as t FROM %s")
         tokenTerminal = execute(cql, table, "SELECT token([1, 2]) as t FROM %s")
         assertRows(tokenColumn, tokenTerminal)
+
 
 # FIXME Scylla doesn't support java as a language for UDFs, so this test is commented out.
 # @Test

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -61,7 +61,7 @@ def testCreateTinyintColumns(cql, test_keyspace):
         #assertInvalidMessage(cql, table, "Expected 1 byte for a tinyint (0)",
         #                     "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", "3", (byte) 1, ByteBufferUtil.EMPTY_BYTE_BUFFER)
 
-@pytest.mark.xfail(reason="Issue #8001")
+@pytest.mark.xfail(reason="Documented unit \"µs\" not supported for assigning a \"duration\" type #8001")
 def testCreateTableWithDurationColumns(cql, test_keyspace):
     t = unique_name()
     # Messages in Scylla and Cassandra are slightly different - Cassandra
@@ -336,7 +336,7 @@ def testCreateKeyspaceWithNetworkTopologyStrategyNoOptions(cql):
 # Test {@link ConfigurationException} is not thrown on create SimpleStrategy keyspace without any options.
 # Reproduces one aspect of #8892 (a default_keyspace_rf allows creating
 # a keyspace without specifying a replication factor).
-@pytest.mark.xfail(reason="Issue #8892")
+@pytest.mark.xfail(reason="Forbid re-adding static columns as regular and vice versa #8892")
 def testCreateKeyspaceWithSimpleStrategyNoOptions(cql):
     n = unique_name()
     execute(cql, n, "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy' }")
@@ -587,7 +587,7 @@ def assertSchemaOption(cql, table, option, expected):
     [ks, cf] = table.split('.')
     assertRows(execute(cql, table, "SELECT " + option + " FROM system_schema.tables WHERE keyspace_name = '" + ks + "' and table_name = '" + cf + "';"), row(expected))
 
-@pytest.mark.xfail(reason="Issue #8948, #6442")
+@pytest.mark.xfail(reason="Cassandra 3.11.10 uses \"class\" instead of \"sstable_compression\" for compression settings by default #8948, Always print all schema parameters (including default values) #6442")
 def testCreateTableWithCompression(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b int, c int, primary key (a, b))") as table:
         assertSchemaOption(cql, table, "compression", {"chunk_length_in_kb": "16", "class": "org.apache.cassandra.io.compress.LZ4Compressor"})

--- a/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
@@ -11,24 +11,33 @@
 from ...porting import *
 import random
 
+
 # Test for cassandra 8558
 @pytest.mark.parametrize("flushData", [False, True])
 @pytest.mark.parametrize("flushTombstone", [False, True])
 def testRangeDeletion(cql, test_keyspace, flushData, flushTombstone):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 1, 1, 1, 1)
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c))"
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 1, 1, 1, 1
+        )
         if flushData:
             flush(cql, table)
         execute(cql, table, "DELETE FROM %s WHERE a=? AND b=?", 1, 1)
         if flushTombstone:
             flush(cql, table)
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 1, 1, 1))
+        assertEmpty(
+            execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND c=?", 1, 1, 1)
+        )
+
 
 @pytest.mark.parametrize("flushData", [False, True])
 @pytest.mark.parametrize("flushTombstone", [False, True])
 def testDeleteRange(cql, test_keyspace, flushData, flushTombstone):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, primary key (a, b))") as table:
-
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, primary key (a, b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 1, 1)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 2, 1, 2)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 2, 2, 3)
@@ -40,20 +49,24 @@ def testDeleteRange(cql, test_keyspace, flushData, flushTombstone):
         if flushTombstone:
             flush(cql, table)
 
-        assertRowsIgnoringOrder(execute(cql, table, "SELECT * FROM %s"),
-                                row(1, 1, 1),
-                                row(2, 1, 2))
+        assertRowsIgnoringOrder(
+            execute(cql, table, "SELECT * FROM %s"), row(1, 1, 1), row(2, 1, 2)
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?", 2, 1),
-                   row(2, 1, 2))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?", 2, 1),
+            row(2, 1, 2),
+        )
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?", 2, 2))
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?", 2, 3))
+
 
 @pytest.mark.parametrize("flushData", [False, True])
 @pytest.mark.parametrize("flushTombstone", [False, True])
 def testCrossMemSSTableMultiColumn(cql, test_keyspace, flushData, flushTombstone):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, primary key (a, b))") as table:
-
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, primary key (a, b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 1, 1)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 2, 1, 2)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 2, 2, 2)
@@ -67,55 +80,94 @@ def testCrossMemSSTableMultiColumn(cql, test_keyspace, flushData, flushTombstone
         if flushTombstone:
             flush(cql, table)
 
-        assertRowsIgnoringOrder(execute(cql, table, "SELECT * FROM %s"),
-                                row(1, 1, 1),
-                                row(2, 1, 2))
+        assertRowsIgnoringOrder(
+            execute(cql, table, "SELECT * FROM %s"), row(1, 1, 1), row(2, 1, 2)
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?", 2, 1),
-                   row(2, 1, 2))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?", 2, 1),
+            row(2, 1, 2),
+        )
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?", 2, 2))
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?", 2, 3))
+
 
 # Test simple deletion and in particular check for cassandra-4193 bug
 # migrated from cql_tests.py:TestCQL.deletion_test()
 def testDeletion(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(username varchar, id int, name varchar, stuff varchar, primary key (username, id))") as table:
-        execute(cql, table, "INSERT INTO %s (username, id, name, stuff) VALUES (?, ?, ?, ?)", "abc", 2, "rst", "some value")
-        execute(cql, table, "INSERT INTO %s (username, id, name, stuff) VALUES (?, ?, ?, ?)", "abc", 4, "xyz", "some other value")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(username varchar, id int, name varchar, stuff varchar, primary key (username, id))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (username, id, name, stuff) VALUES (?, ?, ?, ?)",
+            "abc",
+            2,
+            "rst",
+            "some value",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (username, id, name, stuff) VALUES (?, ?, ?, ?)",
+            "abc",
+            4,
+            "xyz",
+            "some other value",
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row("abc", 2, "rst", "some value"),
-                   row("abc", 4, "xyz", "some other value"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row("abc", 2, "rst", "some value"),
+            row("abc", 4, "xyz", "some other value"),
+        )
 
         execute(cql, table, "DELETE FROM %s WHERE username='abc' AND id=2")
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row("abc", 4, "xyz", "some other value"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row("abc", 4, "xyz", "some other value"),
+        )
+
 
 def testDeletionWithContainsAndContainsKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b frozen<map<int, int>>, c int, primary key (a, b))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b frozen<map<int, int>>, c int, primary key (a, b))",
+    ) as table:
         row = [1, {1: 1, 2: 2}, 3]
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", *row)
 
         assertRows(execute(cql, table, "SELECT * FROM %s"), row)
 
         # Cassandra's and Scylla's error message are different
-        assertInvalidMessage(cql, table, "CONTAINS",
-                             "DELETE FROM %s WHERE a=1 AND b CONTAINS 1")
+        assertInvalidMessage(
+            cql, table, "CONTAINS", "DELETE FROM %s WHERE a=1 AND b CONTAINS 1"
+        )
 
         assertRows(execute(cql, table, "SELECT * FROM %s"), row)
 
         # Cassandra's and Scylla's error message are different
-        assertInvalidMessage(cql, table, "CONTAINS",
-                             "DELETE FROM %s WHERE a=1 AND b CONTAINS KEY 1")
+        assertInvalidMessage(
+            cql, table, "CONTAINS", "DELETE FROM %s WHERE a=1 AND b CONTAINS KEY 1"
+        )
 
         assertRows(execute(cql, table, "SELECT * FROM %s"), row)
+
 
 # Test deletion by 'composite prefix' (range tombstones)
 # migrated from cql_tests.py:TestCQL.range_tombstones_test()
 def testDeleteByCompositePrefix(cql, test_keyspace):
     # This test used 3 nodes just to make sure RowMutation are correctly serialized
-    with create_table(cql, test_keyspace, "(k int, c1 int, c2 int, v1 int, v2 int, primary key (k, c1, c2))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, c1 int, c2 int, v1 int, v2 int, primary key (k, c1, c2))",
+    ) as table:
         numRows = 5
         col1 = 2
         col2 = 2
@@ -125,7 +177,16 @@ def testDeleteByCompositePrefix(cql, test_keyspace):
             for j in range(col1):
                 for k in range(col2):
                     n = (i * cpr) + (j * col2) + k
-                    execute(cql, table, "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)", i, j, k, n, n)
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)",
+                        i,
+                        j,
+                        k,
+                        n,
+                        n,
+                    )
 
         for i in range(numRows):
             rows = list(execute(cql, table, "SELECT v1, v2 FROM %s where k = ?", i))
@@ -148,13 +209,23 @@ def testDeleteByCompositePrefix(cql, test_keyspace):
                 assert x == rows[x - i * cpr - col1][0]
                 assert x == rows[x - i * cpr - col1][1]
 
+
 # Test deletion by 'composite prefix' (range tombstones) with compaction
 # migrated from cql_tests.py:TestCQL.range_tombstones_compaction_test()
 def testDeleteByCompositePrefixWithCompaction(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c1 int, c2 int, v1 text, primary key (k, c1, c2))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, c1 int, c2 int, v1 text, primary key (k, c1, c2))"
+    ) as table:
         for c1 in range(4):
             for c2 in range(2):
-                execute(cql, table, "INSERT INTO %s (k, c1, c2, v1) VALUES (0, ?, ?, ?)", c1, c2, f"{c1}{c2}")
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (k, c1, c2, v1) VALUES (0, ?, ?, ?)",
+                    c1,
+                    c2,
+                    f"{c1}{c2}",
+                )
         flush(cql, table)
         execute(cql, table, "DELETE FROM %s WHERE k = 0 AND c1 = 1")
         flush(cql, table)
@@ -167,43 +238,84 @@ def testDeleteByCompositePrefixWithCompaction(cql, test_keyspace):
                     assert f"{c1}{c2}" == rows[idx][0]
                     idx += 1
 
+
 # Test deletion of rows
 # migrated from cql_tests.py:TestCQL.delete_row_test()
 def testRowDeletion(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c1 int, c2 int, v1 int, v2 int, primary key (k, c1, c2))") as table:
-        execute(cql, table, "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)", 0, 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)", 0, 0, 1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)", 0, 0, 2, 2, 2)
-        execute(cql, table, "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 3, 3)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, c1 int, c2 int, v1 int, v2 int, primary key (k, c1, c2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            2,
+            2,
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, c1, c2, v1, v2) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            3,
+            3,
+        )
 
         execute(cql, table, "DELETE FROM %s WHERE k = 0 AND c1 = 0 AND c2 = 0")
 
         assertRowCount(execute(cql, table, "SELECT * FROM %s"), 3)
 
+
 # Check the semantic of CQL row existence (part of CASSANDRA-4361),
 # migrated from cql_tests.py:TestCQL.row_existence_test()
 def testRowExistence(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c int, v1 int, v2 int, primary key (k, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, c int, v1 int, v2 int, primary key (k, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, c, v1, v2) VALUES (1, 1, 1, 1)")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 1, 1, 1))
+        assertRows(execute(cql, table, "SELECT * FROM %s"), row(1, 1, 1, 1))
 
         assertInvalid(cql, table, "DELETE c FROM %s WHERE k = 1 AND c = 1")
 
         execute(cql, table, "DELETE v2 FROM %s WHERE k = 1 AND c = 1")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 1, 1, null))
+        assertRows(execute(cql, table, "SELECT * FROM %s"), row(1, 1, 1, null))
 
         execute(cql, table, "DELETE v1 FROM %s WHERE k = 1 AND c = 1")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 1, null, null))
+        assertRows(execute(cql, table, "SELECT * FROM %s"), row(1, 1, null, null))
 
         execute(cql, table, "DELETE FROM %s WHERE k = 1 AND c = 1")
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
         execute(cql, table, "INSERT INTO %s (k, c) VALUES (2, 2)")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(2, 2, null, null))
+        assertRows(execute(cql, table, "SELECT * FROM %s"), row(2, 2, null, null))
+
 
 # Migrated from cql_tests.py:TestCQL.remove_range_slice_test()
 def testRemoveRangeSlice(cql, test_keyspace):
@@ -212,9 +324,8 @@ def testRemoveRangeSlice(cql, test_keyspace):
             execute(cql, table, "INSERT INTO %s (k, v) VALUES (?, ?)", i, i)
 
         execute(cql, table, "DELETE FROM %s WHERE k = 1")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, 0),
-                   row(2, 2))
+        assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, 0), row(2, 2))
+
 
 # Test deletions
 # migrated from cql_tests.py:TestCQL.no_range_ghost_test()
@@ -241,20 +352,34 @@ def testNoRangeGhost(cql, test_keyspace):
                 idx += 1
 
     # Example from CASSANDRA-3505
-    with create_table(cql, test_keyspace, "(KEY varchar PRIMARY KEY, password varchar, gender varchar, birth_year bigint)") as table:
-        execute(cql, table, "INSERT INTO %s (KEY, password) VALUES ('user1', 'ch@ngem3a')")
-        execute(cql, table, "UPDATE %s SET gender = 'm', birth_year = 1980 WHERE KEY = 'user1'")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(KEY varchar PRIMARY KEY, password varchar, gender varchar, birth_year bigint)",
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (KEY, password) VALUES ('user1', 'ch@ngem3a')"
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET gender = 'm', birth_year = 1980 WHERE KEY = 'user1'",
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE KEY='user1'"),
-                   row("user1", 1980, "m", "ch@ngem3a"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE KEY='user1'"),
+            row("user1", 1980, "m", "ch@ngem3a"),
+        )
 
         execute(cql, table, "TRUNCATE %s")
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE KEY='user1'"))
 
+
 def sortIntRows(rows):
     return sorted([rows[i][0] for i in range(len(rows))])
+
 
 # Migrated from cql_tests.py:TestCQL.range_with_deletes_test()
 def testRandomDeletions(cql, test_keyspace):
@@ -271,12 +396,18 @@ def testRandomDeletions(cql, test_keyspace):
         for i in range(nb_deletes):
             execute(cql, table, "DELETE FROM %s WHERE k = ?", deletions[i])
 
-        assertRowCount(execute(cql, table, "SELECT * FROM %s LIMIT ?", (nb_keys // 2)), nb_keys // 2)
+        assertRowCount(
+            execute(cql, table, "SELECT * FROM %s LIMIT ?", (nb_keys // 2)),
+            nb_keys // 2,
+        )
+
 
 # Test for CASSANDRA-8558, deleted row still can be selected out
 # migrated from cql_tests.py:TestCQL.bug_8558_test()
 def testDeletedRowCannotBeSelected(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c text, primary key (a,b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c text, primary key (a,b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c) VALUES(1,1,'1')")
         flush(cql, table)
 
@@ -285,9 +416,12 @@ def testDeletedRowCannotBeSelected(cql, test_keyspace):
 
         assertEmpty(execute(cql, table, "select * from %s  where a=1 and b=1"))
 
-# Test that two deleted rows for the same partition but on different sstables do not resurface 
+
+# Test that two deleted rows for the same partition but on different sstables do not resurface
 def testDeletedRowsDoNotResurface(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c text, primary key (a,b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c text, primary key (a,b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES(1, 1, '1')")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES(1, 2, '2')")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES(1, 3, '3')")
@@ -299,13 +433,16 @@ def testDeletedRowsDoNotResurface(cql, test_keyspace):
         execute(cql, table, "DELETE FROM %s where a=1 and b = 2")
         flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ?", 1),
-                   row(1, 3, "3"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ?", 1), row(1, 3, "3")
+        )
 
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithNoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int PRIMARY KEY, value int)") as table:
+    with create_table(
+        cql, test_keyspace, "(partitionKey int PRIMARY KEY, value int)"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (partitionKey, value) VALUES (0, 0)")
         execute(cql, table, "INSERT INTO %s (partitionKey, value) VALUES (1, 1)")
         execute(cql, table, "INSERT INTO %s (partitionKey, value) VALUES (2, 2)")
@@ -317,229 +454,537 @@ def testDeleteWithNoClusteringColumns(cql, test_keyspace, forceFlush):
         if forceFlush:
             flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
-                   row(0, null))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
+            row(0, null),
+        )
 
         execute(cql, table, "DELETE FROM %s WHERE partitionKey IN (?, ?)", 0, 1)
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(2, 2),
-                   row(3, 3))
+        assertRows(execute(cql, table, "SELECT * FROM %s"), row(2, 2), row(3, 3))
 
         # test invalid queries
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses for",
-                             "DELETE FROM %s WHERE token(partitionKey) = token(?)", 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses for",
+            "DELETE FROM %s WHERE token(partitionKey) = token(?)",
+            0,
+        )
 
         # multiple time same primary key element in WHERE clause
         # Scylla does allow silly queries using the same partition key
         # more than once, so this check is commented out. See #12472.
-        #assertInvalidMessage(cql, table, "partitionkey cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "partitionkey cannot be restricted by more than one relation if it includes an Equal",
         #                     "DELETE FROM %s WHERE partitionKey = ? AND partitionKey = ?", 0, 1)
 
         # unknown identifiers
-        assertInvalidMessage(cql, table, "unknown",
-                             "DELETE unknown FROM %s WHERE partitionKey = ?", 0)
+        assertInvalidMessage(
+            cql, table, "unknown", "DELETE unknown FROM %s WHERE partitionKey = ?", 0
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "DELETE FROM %s WHERE partitionKey1 = ?", 0)
+        assertInvalidMessage(
+            cql, table, "partitionkey1", "DELETE FROM %s WHERE partitionKey1 = ?", 0
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key (unless you use the token() function",
-                             "DELETE FROM %s WHERE partitionKey > ? ", 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key (unless you use the token() function",
+            "DELETE FROM %s WHERE partitionKey > ? ",
+            0,
+        )
 
-        assertInvalidMessage(cql, table, "CONTAINS",
-                             "DELETE FROM %s WHERE partitionKey CONTAINS ?", 0)
+        assertInvalidMessage(
+            cql, table, "CONTAINS", "DELETE FROM %s WHERE partitionKey CONTAINS ?", 0
+        )
 
         # Non primary key in the where clause
         # Reproduces #12474:
-        assertInvalidMessage(cql, table, "where clause",
-                             "DELETE FROM %s WHERE partitionKey = ? AND value = ?", 0, 1)
-
+        assertInvalidMessage(
+            cql,
+            table,
+            "where clause",
+            "DELETE FROM %s WHERE partitionKey = ? AND value = ?",
+            0,
+            1,
+        )
 
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithOneClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 2, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 3, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 4, 4)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 5, 5)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (1, 0, 6)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 2, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 3, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 4, 4)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 5, 5)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (1, 0, 6)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        execute(cql, table, "DELETE value FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1)
+        execute(
+            cql,
+            table,
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering = ?",
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1),
-                   row(0, 1, null))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering = ?",
+                0,
+                1,
+            ),
+            row(0, 1, null),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1)
+        execute(
+            cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1
+        )
         if forceFlush:
             flush(cql, table)
-        assertEmpty(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering = ?",
+                0,
+                1,
+            )
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey IN (?, ?) AND clustering = ?", 0, 1, 0)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey IN (?, ?) AND clustering = ?",
+            0,
+            1,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 2, 2),
-                   row(0, 3, 3),
-                   row(0, 4, 4),
-                   row(0, 5, 5))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 2, 2),
+            row(0, 3, 3),
+            row(0, 4, 4),
+            row(0, 5, 5),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering) IN ((?), (?))", 0, 4, 5)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering) IN ((?), (?))",
+            0,
+            4,
+            5,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 2, 2),
-                   row(0, 3, 3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 2, 2),
+            row(0, 3, 3),
+        )
 
         # test invalid queries
 
         # missing primary key element
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "DELETE FROM %s WHERE clustering = ?", 1)
+        assertInvalidMessage(
+            cql, table, "partitionkey", "DELETE FROM %s WHERE clustering = ?", 1
+        )
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses for",
-                             "DELETE FROM %s WHERE token(partitionKey) = token(?) AND clustering = ? ", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses for",
+            "DELETE FROM %s WHERE token(partitionKey) = token(?) AND clustering = ? ",
+            0,
+            1,
+        )
 
         # multiple time same primary key element in WHERE clause
         # Scylla does allow silly queries using the same partition key
         # more than once, so this check is commented out. See #12472.
-        #assertInvalidMessage(cql, table, "clustering cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "clustering cannot be restricted by more than one relation if it includes an Equal",
         #                     "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND clustering = ?", 0, 1, 1)
 
         # unknown identifiers
-        assertInvalidMessage(cql, table, "value1",
-                             "DELETE value1 FROM %s WHERE partitionKey = ? AND clustering = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "DELETE value1 FROM %s WHERE partitionKey = ? AND clustering = ?",
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "DELETE FROM %s WHERE partitionKey1 = ? AND clustering = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey1",
+            "DELETE FROM %s WHERE partitionKey1 = ? AND clustering = ?",
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_3",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_3 = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_3",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_3 = ?",
+            0,
+            1,
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key (unless you use the token() function",
-                             "DELETE FROM %s WHERE partitionKey > ? AND clustering = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key (unless you use the token() function",
+            "DELETE FROM %s WHERE partitionKey > ? AND clustering = ?",
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "CONTAINS",
-                             "DELETE FROM %s WHERE partitionKey CONTAINS ? AND clustering = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "CONTAINS",
+            "DELETE FROM %s WHERE partitionKey CONTAINS ? AND clustering = ?",
+            0,
+            1,
+        )
 
         # Non primary key in the where clause
         # Reproduces #12474:
-        assertInvalidMessage(cql, table, "where clause",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND value = ?", 0, 1, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "where clause",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND value = ?",
+            0,
+            1,
+            3,
+        )
 
-@pytest.mark.xfail(reason="#4244")
+
+@pytest.mark.xfail(
+    reason="Add support for mixing token, multi- and single-column restrictions #4244"
+)
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 2, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 3, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 1, 4)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 2, 5)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 6)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 2, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 3, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 1, 4)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 2, 5)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 6)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        execute(cql, table, "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        execute(
+            cql,
+            table,
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 1),
-                   row(0, 1, 1, null))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                1,
+            ),
+            row(0, 1, 1, null),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) = (?, ?)", 0, 1, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) = (?, ?)",
+            0,
+            1,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertEmpty(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                            0, 1, 1))
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                1,
+            )
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 0, 0)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            0,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 2, 2),
-                   row(0, 0, 3, 3),
-                   row(0, 1, 2, 5))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 0, 1, 1),
+            row(0, 0, 2, 2),
+            row(0, 0, 3, 3),
+            row(0, 1, 2, 5),
+        )
 
-        execute(cql, table, "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)", 0, 0, 2, 3)
+        execute(
+            cql,
+            table,
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)",
+            0,
+            0,
+            2,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1), row(0, 0, 1, 1),
-                   row(0, 0, 2, null),
-                   row(0, 0, 3, null),
-                   row(0, 1, 2, 5))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 0, 1, 1),
+            row(0, 0, 2, null),
+            row(0, 0, 3, null),
+            row(0, 1, 2, 5),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))", 0, 0, 2, 1, 2)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
+            0,
+            0,
+            2,
+            1,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 3, null))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 0, 1, 1),
+            row(0, 0, 3, null),
+        )
 
         # Reproduces #4244:
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?)) AND clustering_2 = ?", 0, 0, 2, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?)) AND clustering_2 = ?",
+            0,
+            0,
+            2,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(0, 0, 1, 1))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
+            row(0, 0, 1, 1),
+        )
 
         # test invalid queries
 
         # missing primary key element
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "DELETE FROM %s WHERE clustering_1 = ? AND clustering_2 = ?", 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "DELETE FROM %s WHERE clustering_1 = ? AND clustering_2 = ?",
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "PRIMARY KEY column \"clustering_2\" cannot be restricted as preceding column \"clustering_1\" is not restricted",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_2 = ?", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            'PRIMARY KEY column "clustering_2" cannot be restricted as preceding column "clustering_1" is not restricted',
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_2 = ?",
+            0,
+            1,
+        )
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses for",
-                             "DELETE FROM %s WHERE token(partitionKey) = token(?) AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses for",
+            "DELETE FROM %s WHERE token(partitionKey) = token(?) AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
         # multiple time same primary key element in WHERE clause
         # Scylla does allow silly queries using the same partition key
         # more than once, so this check is commented out. See #12472.
-        #assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
         #                     "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND clustering_1 = ?", 0, 1, 1, 1)
 
         # unknown identifiers
-        assertInvalidMessage(cql, table, "value1",
-                             "DELETE value1 FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "DELETE value1 FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "DELETE FROM %s WHERE partitionKey1 = ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey1",
+            "DELETE FROM %s WHERE partitionKey1 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_3",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_3 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_3",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_3 = ?",
+            0,
+            1,
+            1,
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key (unless you use the token() function",
-                             "DELETE FROM %s WHERE partitionKey > ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key (unless you use the token() function",
+            "DELETE FROM %s WHERE partitionKey > ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "CONTAINS",
-                             "DELETE FROM %s WHERE partitionKey CONTAINS ? AND clustering_1 = ? AND clustering_2 = ?", 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "CONTAINS",
+            "DELETE FROM %s WHERE partitionKey CONTAINS ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            1,
+            1,
+        )
 
         # Non primary key in the where clause
         # Reproduces #12474:
-        assertInvalidMessage(cql, table, "where clause",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND value = ?", 0, 1, 1, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "where clause",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND value = ?",
+            0,
+            1,
+            1,
+            3,
+        )
+
 
 def testDeleteWithNonoverlappingRange(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c text, primary key (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c text, primary key (a, b))"
+    ) as table:
         for i in range(10):
             execute(cql, table, "INSERT INTO %s (a, b, c) VALUES(1, ?, 'abc')", i)
         flush(cql, table)
@@ -550,8 +995,11 @@ def testDeleteWithNonoverlappingRange(cql, test_keyspace):
         # this query does not overlap the tombstone range above and caused the rows to be resurrected
         assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a=1 and b <= 2"))
 
+
 def testDeleteWithIntermediateRangeAndOneClusteringColumn(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c text, primary key (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c text, primary key (a, b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES(1, 1, '1')")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES(1, 3, '3')")
         execute(cql, table, "DELETE FROM %s where a=1 and b >= 2 and b <= 3")
@@ -561,17 +1009,29 @@ def testDeleteWithIntermediateRangeAndOneClusteringColumn(cql, test_keyspace):
         execute(cql, table, "DELETE FROM %s where a=1 and b >= 2 and b <= 3")
         flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ?", 1),
-                   row(1, 1, "1"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ?", 1), row(1, 1, "1")
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithRangeAndOneClusteringColumn(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, primary key (partitionKey, clustering))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering int, value int, primary key (partitionKey, clustering))",
+    ) as table:
         value = 0
         for partitionKey in range(5):
             for clustering1 in range(5):
-                execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (?, ?, ?)",
-                        partitionKey, clustering1, value)
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (partitionKey, clustering, value) VALUES (?, ?, ?)",
+                    partitionKey,
+                    clustering1,
+                    value,
+                )
                 value += 1
 
         if forceFlush:
@@ -585,111 +1045,224 @@ def testDeleteWithRangeAndOneClusteringColumn(cql, test_keyspace, forceFlush):
 
         # test slices on the first clustering column
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering >= ?", 0, 4)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering >= ?",
+            0,
+            4,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
-                   row(0, 0, 0),
-                   row(0, 1, 1),
-                   row(0, 2, 2),
-                   row(0, 3, 3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
+            row(0, 0, 0),
+            row(0, 1, 1),
+            row(0, 2, 2),
+            row(0, 3, 3),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering > ?", 0, 2)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering > ?",
+            0,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
-                   row(0, 0, 0),
-                   row(0, 1, 1),
-                   row(0, 2, 2))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
+            row(0, 0, 0),
+            row(0, 1, 1),
+            row(0, 2, 2),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering <= ?", 0, 0)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering <= ?",
+            0,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
-                   row(0, 1, 1),
-                   row(0, 2, 2))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
+            row(0, 1, 1),
+            row(0, 2, 2),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering < ?", 0, 2)
+        execute(
+            cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering < ?", 0, 2
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
-                   row(0, 2, 2))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
+            row(0, 2, 2),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering >= ? AND clustering < ?", 2, 0, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering >= ? AND clustering < ?",
+            2,
+            0,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 13),
-                   row(2, 4, 14))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 13),
+            row(2, 4, 14),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering > ? AND clustering <= ?", 2, 3, 5)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering > ? AND clustering <= ?",
+            2,
+            3,
+            5,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 13))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 13),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering < ? AND clustering > ?", 2, 3, 5)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering < ? AND clustering > ?",
+            2,
+            3,
+            5,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 13))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 13),
+        )
 
         # test multi-column slices
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering) > (?)", 3, 2)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering) > (?)",
+            3,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 3),
-                   row(3, 0, 15),
-                   row(3, 1, 16),
-                   row(3, 2, 17))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 3),
+            row(3, 0, 15),
+            row(3, 1, 16),
+            row(3, 2, 17),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering) < (?)", 3, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering) < (?)",
+            3,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 3),
-                   row(3, 1, 16),
-                   row(3, 2, 17))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 3),
+            row(3, 1, 16),
+            row(3, 2, 17),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering) >= (?) AND (clustering) <= (?)", 3, 0, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering) >= (?) AND (clustering) <= (?)",
+            3,
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 3),
-                   row(3, 2, 17))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 3),
+            row(3, 2, 17),
+        )
 
         # Test invalid queries
-        assertInvalidMessage(cql, table, "Range deletions are not supported for specific columns",
-                             "DELETE value FROM %s WHERE partitionKey = ? AND clustering >= ?", 2, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Range deletions are not supported for specific columns",
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering >= ?",
+            2,
+            1,
+        )
         # Scylla and Cassandra give different errors in this case - Cassandra
         # says "Range deletions are not supported for specific columns" and
         # Scylla says "Primary key column 'clustering' must be specified in
         # order to modify column 'value'
-        assertInvalid(cql, table,
-                             "DELETE value FROM %s WHERE partitionKey = ?", 2)
+        assertInvalid(cql, table, "DELETE value FROM %s WHERE partitionKey = ?", 2)
 
-@pytest.mark.xfail(reason="#13250")
+
+@pytest.mark.xfail(
+    reason="one-element multi-column restriction should be handled like a single-column restriction #13250"
+)
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithRangeAndTwoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, primary key (partitionKey, clustering_1, clustering_2))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, primary key (partitionKey, clustering_1, clustering_2))",
+    ) as table:
         value = 0
         for partitionKey in range(5):
             for clustering1 in range(5):
                 for clustering2 in range(5):
-                    execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (?, ?, ?, ?)",
-                            partitionKey, clustering1, clustering2, value)
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (?, ?, ?, ?)",
+                        partitionKey,
+                        clustering1,
+                        clustering2,
+                        value,
+                    )
                     value += 1
         if forceFlush:
             flush(cql, table)
 
         # test unspecified second clustering column
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ?", 0, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 < ?", 0, 2),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 2, 2),
-                   row(0, 0, 3, 3),
-                   row(0, 0, 4, 4))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 < ?",
+                0,
+                2,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 0, 2, 2),
+            row(0, 0, 3, 3),
+            row(0, 0, 4, 4),
+        )
 
         # test delete partition
         execute(cql, table, "DELETE FROM %s WHERE partitionKey = ?", 1)
@@ -699,256 +1272,616 @@ def testDeleteWithRangeAndTwoClusteringColumns(cql, test_keyspace, forceFlush):
 
         # test slices on the second clustering column
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 < ?", 0, 0, 2)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 < ?",
+            0,
+            0,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 < ?", 0, 2),
-                   row(0, 0, 2, 2),
-                   row(0, 0, 3, 3),
-                   row(0, 0, 4, 4))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 < ?",
+                0,
+                2,
+            ),
+            row(0, 0, 2, 2),
+            row(0, 0, 3, 3),
+            row(0, 0, 4, 4),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 <= ?", 0, 0, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 <= ?",
+            0,
+            0,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 < ?", 0, 2),
-                   row(0, 0, 4, 4))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 < ?",
+                0,
+                2,
+            ),
+            row(0, 0, 4, 4),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 > ? ", 0, 2, 2)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 > ? ",
+            0,
+            2,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?", 0, 2),
-                   row(0, 2, 0, 10),
-                   row(0, 2, 1, 11),
-                   row(0, 2, 2, 12))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?",
+                0,
+                2,
+            ),
+            row(0, 2, 0, 10),
+            row(0, 2, 1, 11),
+            row(0, 2, 2, 12),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 >= ? ", 0, 2, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 >= ? ",
+            0,
+            2,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?", 0, 2),
-                   row(0, 2, 0, 10))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?",
+                0,
+                2,
+            ),
+            row(0, 2, 0, 10),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 > ? AND clustering_2 < ? ",
-                0, 3, 1, 4)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 > ? AND clustering_2 < ? ",
+            0,
+            3,
+            1,
+            4,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?", 0, 3),
-                   row(0, 3, 0, 15),
-                   row(0, 3, 1, 16),
-                   row(0, 3, 4, 19))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?",
+                0,
+                3,
+            ),
+            row(0, 3, 0, 15),
+            row(0, 3, 1, 16),
+            row(0, 3, 4, 19),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 > ? AND clustering_2 < ? ",
-                0, 3, 4, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 > ? AND clustering_2 < ? ",
+            0,
+            3,
+            4,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?", 0, 3),
-                   row(0, 3, 0, 15),
-                   row(0, 3, 1, 16),
-                   row(0, 3, 4, 19))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?",
+                0,
+                3,
+            ),
+            row(0, 3, 0, 15),
+            row(0, 3, 1, 16),
+            row(0, 3, 4, 19),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 >= ? AND clustering_2 <= ? ",
-                0, 3, 1, 4)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 = ? AND clustering_2 >= ? AND clustering_2 <= ? ",
+            0,
+            3,
+            1,
+            4,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?", 0, 3),
-                   row(0, 3, 0, 15))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND  clustering_1 = ?",
+                0,
+                3,
+            ),
+            row(0, 3, 0, 15),
+        )
 
         # test slices on the first clustering column
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 >= ?", 0, 4)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 >= ?",
+            0,
+            4,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
-                   row(0, 0, 4, 4),
-                   row(0, 2, 0, 10),
-                   row(0, 3, 0, 15))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
+            row(0, 0, 4, 4),
+            row(0, 2, 0, 10),
+            row(0, 3, 0, 15),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 > ?", 0, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND  clustering_1 > ?",
+            0,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
-                   row(0, 0, 4, 4),
-                   row(0, 2, 0, 10),
-                   row(0, 3, 0, 15))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
+            row(0, 0, 4, 4),
+            row(0, 2, 0, 10),
+            row(0, 3, 0, 15),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 < ?", 0, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 < ?",
+            0,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
-                   row(0, 3, 0, 15))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 0),
+            row(0, 3, 0, 15),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 >= ? AND clustering_1 < ?", 2, 0, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 >= ? AND clustering_1 < ?",
+            2,
+            0,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 0, 65),
-                   row(2, 3, 1, 66),
-                   row(2, 3, 2, 67),
-                   row(2, 3, 3, 68),
-                   row(2, 3, 4, 69),
-                   row(2, 4, 0, 70),
-                   row(2, 4, 1, 71),
-                   row(2, 4, 2, 72),
-                   row(2, 4, 3, 73),
-                   row(2, 4, 4, 74))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 0, 65),
+            row(2, 3, 1, 66),
+            row(2, 3, 2, 67),
+            row(2, 3, 3, 68),
+            row(2, 3, 4, 69),
+            row(2, 4, 0, 70),
+            row(2, 4, 1, 71),
+            row(2, 4, 2, 72),
+            row(2, 4, 3, 73),
+            row(2, 4, 4, 74),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 > ? AND clustering_1 <= ?", 2, 3, 5)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 > ? AND clustering_1 <= ?",
+            2,
+            3,
+            5,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 0, 65),
-                   row(2, 3, 1, 66),
-                   row(2, 3, 2, 67),
-                   row(2, 3, 3, 68),
-                   row(2, 3, 4, 69))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 0, 65),
+            row(2, 3, 1, 66),
+            row(2, 3, 2, 67),
+            row(2, 3, 3, 68),
+            row(2, 3, 4, 69),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 < ? AND clustering_1 > ?", 2, 3, 5)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 < ? AND clustering_1 > ?",
+            2,
+            3,
+            5,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 0, 65),
-                   row(2, 3, 1, 66),
-                   row(2, 3, 2, 67),
-                   row(2, 3, 3, 68),
-                   row(2, 3, 4, 69))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 0, 65),
+            row(2, 3, 1, 66),
+            row(2, 3, 2, 67),
+            row(2, 3, 3, 68),
+            row(2, 3, 4, 69),
+        )
 
         # test multi-column slices
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) > (?, ?)", 2, 3, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) > (?, ?)",
+            2,
+            3,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 0, 65),
-                   row(2, 3, 1, 66),
-                   row(2, 3, 2, 67),
-                   row(2, 3, 3, 68))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 0, 65),
+            row(2, 3, 1, 66),
+            row(2, 3, 2, 67),
+            row(2, 3, 3, 68),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) < (?, ?)", 2, 3, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) < (?, ?)",
+            2,
+            3,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 1, 66),
-                   row(2, 3, 2, 67),
-                   row(2, 3, 3, 68))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 1, 66),
+            row(2, 3, 2, 67),
+            row(2, 3, 3, 68),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) >= (?, ?) AND (clustering_1) <= (?)", 2, 3, 2, 4)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) >= (?, ?) AND (clustering_1) <= (?)",
+            2,
+            3,
+            2,
+            4,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
-                   row(2, 3, 1, 66))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ?", 2),
+            row(2, 3, 1, 66),
+        )
 
         # Test with a mix of single column and multi-column restrictions
         # Reproduces #13250:
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND (clustering_2) < (?)", 3, 0, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND (clustering_2) < (?)",
+            3,
+            0,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ?", 3, 0),
-                   row(3, 0, 3, 78),
-                   row(3, 0, 4, 79))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
+                3,
+                0,
+            ),
+            row(3, 0, 3, 78),
+            row(3, 0, 4, 79),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND (clustering_2) >= (?)", 3, 0, 1, 3)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND (clustering_2) >= (?)",
+            3,
+            0,
+            1,
+            3,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)", 3, 0, 1),
-                   row(3, 1, 0, 80),
-                   row(3, 1, 1, 81),
-                   row(3, 1, 2, 82))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
+                3,
+                0,
+                1,
+            ),
+            row(3, 1, 0, 80),
+            row(3, 1, 1, 81),
+            row(3, 1, 2, 82),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?)) AND clustering_2 < ?", 3, 0, 1, 1)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?)) AND clustering_2 < ?",
+            3,
+            0,
+            1,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)", 3, 0, 1),
-                   row(3, 1, 1, 81),
-                   row(3, 1, 2, 82))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
+                3,
+                0,
+                1,
+            ),
+            row(3, 1, 1, 81),
+            row(3, 1, 2, 82),
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1) = (?) AND clustering_2 >= ?", 3, 1, 2)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND (clustering_1) = (?) AND clustering_2 >= ?",
+            3,
+            1,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)", 3, 0, 1),
-                   row(3, 1, 1, 81))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
+                3,
+                0,
+                1,
+            ),
+            row(3, 1, 1, 81),
+        )
 
         # Test invalid queries
-        assertInvalidMessage(cql, table, "Range deletions are not supported for specific columns",
-                             "DELETE value FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) >= (?, ?)", 2, 3, 1)
-        assertInvalidMessage(cql, table, "Range deletions are not supported for specific columns",
-                             "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 >= ?", 2, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Range deletions are not supported for specific columns",
+            "DELETE value FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) >= (?, ?)",
+            2,
+            3,
+            1,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Range deletions are not supported for specific columns",
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 >= ?",
+            2,
+            3,
+        )
         # Different error messages in Scylla and Cassandra
-        assertInvalid(cql, table,
-                             "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ?", 2, 3)
-        assertInvalid(cql, table,
-                             "DELETE value FROM %s WHERE partitionKey = ?", 2)
+        assertInvalid(
+            cql,
+            table,
+            "DELETE value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
+            2,
+            3,
+        )
+        assertInvalid(cql, table, "DELETE value FROM %s WHERE partitionKey = ?", 2)
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithAStaticColumn(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, staticValue text static, primary key (partitionKey, clustering_1, clustering_2))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value, staticValue) VALUES (0, 0, 0, 0, 'A')")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value, staticValue) VALUES (1, 0, 0, 6, 'B')")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, staticValue text static, primary key (partitionKey, clustering_1, clustering_2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value, staticValue) VALUES (0, 0, 0, 0, 'A')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value, staticValue) VALUES (1, 0, 0, 6, 'B')",
+        )
         if forceFlush:
             flush(cql, table)
 
         execute(cql, table, "DELETE staticValue FROM %s WHERE partitionKey = ?", 0)
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT DISTINCT staticValue FROM %s WHERE partitionKey IN (?, ?)", 0, 1),
-                   row(None), row("B"))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT DISTINCT staticValue FROM %s WHERE partitionKey IN (?, ?)",
+                0,
+                1,
+            ),
+            row(None),
+            row("B"),
+        )
 
-        execute(cql, table, "DELETE staticValue, value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                1, 0, 0)
+        execute(
+            cql,
+            table,
+            "DELETE staticValue, value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            1,
+            0,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 0, 0, null, null),
-                   row(0, 0, 0, null, 0),
-                   row(0, 0, 1, null, 1))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 0, 0, null, null),
+            row(0, 0, 0, null, 0),
+            row(0, 0, 1, null, 1),
+        )
 
-        assertInvalidMessage(cql, table, "Invalid restrictions on clustering columns since the DELETE statement modifies only static columns",
-                             "DELETE staticValue FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                             0, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Invalid restrictions on clustering columns since the DELETE statement modifies only static columns",
+            "DELETE staticValue FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            0,
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "Invalid restrictions on clustering columns since the DELETE statement modifies only static columns",
-                             "DELETE staticValue FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) >= (?, ?)",
-                             0, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Invalid restrictions on clustering columns since the DELETE statement modifies only static columns",
+            "DELETE staticValue FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) >= (?, ?)",
+            0,
+            0,
+            1,
+        )
 
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithSecondaryIndices(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, value int, values set<int>, primary key (partitionKey, clustering_1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, value int, values set<int>, primary key (partitionKey, clustering_1))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (value)")
         execute(cql, table, "CREATE INDEX ON %s (clustering_1)")
         execute(cql, table, "CREATE INDEX ON %s (values)")
 
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 0, 0, {0})")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 1, 1, {0, 1})")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 2, 2, {0, 1, 2})")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 3, 3, {0, 1, 2, 3})")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (1, 0, 4, {0, 1, 2, 3, 4})")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 0, 0, {0})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 1, 1, {0, 1})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 2, 2, {0, 1, 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 3, 3, {0, 1, 2, 3})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (1, 0, 4, {0, 1, 2, 3, 4})",
+        )
 
         if forceFlush:
             flush(cql, table)
 
         # Reproduces #12474:
-        assertInvalidMessage(cql, table, "where clause",
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND value = ?", 3, 3, 3)
-        # Different error message returned, changed to assertInvalid instead of assertInvalidMessage 
-        assertInvalid(cql, table,
-                             "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND values CONTAINS ?", 3, 3, 3)
-        assertInvalidMessage(cql, table, "where clause",
-                             "DELETE FROM %s WHERE partitionKey = ? AND value = ?", 3, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "where clause",
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND value = ?",
+            3,
+            3,
+            3,
+        )
         # Different error message returned, changed to assertInvalid instead of assertInvalidMessage
-        assertInvalid(cql, table,
-                             "DELETE FROM %s WHERE partitionKey = ? AND values CONTAINS ?", 3, 3)
+        assertInvalid(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND values CONTAINS ?",
+            3,
+            3,
+            3,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "where clause",
+            "DELETE FROM %s WHERE partitionKey = ? AND value = ?",
+            3,
+            3,
+        )
         # Different error message returned, changed to assertInvalid instead of assertInvalidMessage
-        assertInvalid(cql, table,
-                             "DELETE FROM %s WHERE clustering_1 = ?", 3)
+        assertInvalid(
+            cql,
+            table,
+            "DELETE FROM %s WHERE partitionKey = ? AND values CONTAINS ?",
+            3,
+            3,
+        )
+        # Different error message returned, changed to assertInvalid instead of assertInvalidMessage
+        assertInvalid(cql, table, "DELETE FROM %s WHERE clustering_1 = ?", 3)
         # Reproduces #12474:
         # Different error message returned, changed to assertInvalid instead of assertInvalidMessage
-        assertInvalid(cql, table,
-                             "DELETE FROM %s WHERE value = ?", 3)
+        assertInvalid(cql, table, "DELETE FROM %s WHERE value = ?", 3)
         # Different error messages in Scylla and Cassandra
-        assertInvalid(cql, table,
-                             "DELETE FROM %s WHERE values CONTAINS ?", 3)
+        assertInvalid(cql, table, "DELETE FROM %s WHERE values CONTAINS ?", 3)
+
 
 def testDeleteWithOnlyPK(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, v int, primary key (k, v)) WITH gc_grace_seconds=1") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, v int, primary key (k, v)) WITH gc_grace_seconds=1"
+    ) as table:
         # This is a regression test for CASSANDRA-11102
         execute(cql, table, "INSERT INTO %s(k, v) VALUES (?, ?)", 1, 2)
 
@@ -971,8 +1904,11 @@ def testDeleteWithOnlyPK(cql, test_keyspace):
 
         assertRows(execute(cql, table, "SELECT * FROM %s"), row(1, 2))
 
+
 def testDeleteColumnNoClustering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int primary key, v int) WITH gc_grace_seconds=0") as table:
+    with create_table(
+        cql, test_keyspace, "(k int primary key, v int) WITH gc_grace_seconds=0"
+    ) as table:
         # This is a regression test for CASSANDRA-11068 (and ultimately another test for CASSANDRA-11102)
         # Creates a table without clustering, insert a row (with a column) and only remove the column.
         # We should still have a row (with a null column value) even post-compaction.
@@ -988,8 +1924,11 @@ def testDeleteColumnNoClustering(cql, test_keyspace):
         compact(cql, table)
         assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, null))
 
+
 def testDeleteAndReverseQueries(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k text, i int, primary key (k, i))") as table:
+    with create_table(
+        cql, test_keyspace, "(k text, i int, primary key (k, i))"
+    ) as table:
         # This test insert rows in one sstable and a range tombstone covering some of those rows in another, and it
         # validates we correctly get only the non-removed rows when doing reverse queries.
         for i in range(10):
@@ -997,105 +1936,321 @@ def testDeleteAndReverseQueries(cql, test_keyspace):
 
         flush(cql, table)
 
-        execute(cql, table, "DELETE FROM %s WHERE k = ? AND i >= ? AND i <= ?", "a", 2, 7)
+        execute(
+            cql, table, "DELETE FROM %s WHERE k = ? AND i >= ? AND i <= ?", "a", 2, 7
+        )
 
-        assertRows(execute(cql, table, "SELECT i FROM %s WHERE k = ? ORDER BY i DESC", "a"),
-            row(9), row(8), row(1), row(0)
+        assertRows(
+            execute(cql, table, "SELECT i FROM %s WHERE k = ? ORDER BY i DESC", "a"),
+            row(9),
+            row(8),
+            row(1),
+            row(0),
         )
 
         flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT i FROM %s WHERE k = ? ORDER BY i DESC", "a"),
-            row(9), row(8), row(1), row(0)
+        assertRows(
+            execute(cql, table, "SELECT i FROM %s WHERE k = ? ORDER BY i DESC", "a"),
+            row(9),
+            row(8),
+            row(1),
+            row(0),
         )
 
+
 def testDeleteWithEmptyRestrictionValue(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, primary key (pk, c))") as table:
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"", b"1")
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');")
+    with create_table(
+        cql, test_keyspace, "(pk blob, c blob, v blob, primary key (pk, c))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');",
+        )
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"", b"1")
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));",
+        )
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"2", b"2")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"2",
+            b"2",
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')",
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(b"foo123", b"", b"1"))
+        assertRows(execute(cql, table, "SELECT * FROM %s"), row(b"foo123", b"", b"1"))
 
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('')")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('')",
+        )
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"2", b"2")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"2",
+            b"2",
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')",
+        )
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)", b"foo123", b"2", b"2")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"2",
+            b"2",
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('')")
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('')")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('')",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('')",
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(b"foo123", b"1", b"1"),
-                   row(b"foo123", b"2", b"2"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(b"foo123", b"1", b"1"),
+            row(b"foo123", b"2", b"2"),
+        )
+
 
 def testDeleteWithMultipleClusteringColumnsAndEmptyRestrictionValue(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk blob, c1 blob, c2 blob, v blob, primary key (pk, c1, c2))") as table:
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"", b"1", b"1")
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk blob, c1 blob, c2 blob, v blob, primary key (pk, c1, c2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');",
+        )
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"", b"1", b"1")
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');",
+        )
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"", b"1", b"0")
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"2", b"3")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"",
+            b"1",
+            b"0",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"2",
+            b"3",
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('')")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('')",
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(b"foo123", b"", b"1", b"0"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"), row(b"foo123", b"", b"1", b"0")
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 >= textAsBlob('')")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 >= textAsBlob('')",
+        )
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"2", b"3")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"2",
+            b"3",
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('')")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('')",
+        )
 
         assertEmpty(execute(cql, table, "SELECT * FROM %s"))
 
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"2", b"3")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"2",
+            b"3",
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 <= textAsBlob('')")
-        execute(cql, table, "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 < textAsBlob('')")
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 <= textAsBlob('')",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE pk = textAsBlob('foo123') AND c1 < textAsBlob('')",
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(b"foo123", b"1", b"1", b"1"),
-                   row(b"foo123", b"1", b"2", b"3"))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(b"foo123", b"1", b"1", b"1"),
+            row(b"foo123", b"1", b"2", b"3"),
+        )
+
 
 # Test for CASSANDRA-12829
 def testDeleteWithEmptyInRestriction(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, primary key (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, primary key (a, b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)", 1, 1, 1)
         execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)", 1, 2, 2)
         execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)", 1, 3, 3)
@@ -1104,182 +2259,399 @@ def testDeleteWithEmptyInRestriction(cql, test_keyspace):
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b = 1;")
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b IN ();")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 1, 1),
-                   row(1, 2, 2),
-                   row(1, 3, 3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 1, 1),
+            row(1, 2, 2),
+            row(1, 3, 3),
+        )
 
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, s int static, primary key ((a,b),c))") as table:
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 2, 2, 1)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 3, 3, 1)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, s int static, primary key ((a,b),c))",
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 1, 1, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 2, 2, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 3, 3, 1
+        )
 
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b IN () AND c IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b = 1 AND c IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1;")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 1, 1, 1, 1),
-                   row(1, 1, 2, 1, 2),
-                   row(1, 1, 3, 1, 3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 1, 1, 1, 1),
+            row(1, 1, 2, 1, 2),
+            row(1, 1, 3, 1, 3),
+        )
 
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, primary key ((a,b),c,d))") as table:
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 2, 2)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 3, 3)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 4, 4)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, primary key ((a,b),c,d))",
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 1, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 2, 2
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 3, 3
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 4, 4
+        )
 
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c = 1 AND d IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c IN () AND d IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b IN () AND c IN () AND d IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c IN () AND d IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c IN () AND d = 1;")
-        execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1 AND d = 1;")
-        execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1 AND d IN ();")
+        execute(
+            cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c = 1 AND d IN ();"
+        )
+        execute(
+            cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c IN () AND d IN ();"
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a = 1 AND b IN () AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a IN () AND b IN () AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a IN () AND b IN () AND c IN () AND d = 1;",
+        )
+        execute(
+            cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1 AND d = 1;"
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1 AND d IN ();",
+        )
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b = 1")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 1, 1, 1, 1),
-                   row(1, 1, 1, 2, 2),
-                   row(1, 1, 1, 3, 3),
-                   row(1, 1, 1, 4, 4))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 1, 1, 1, 1),
+            row(1, 1, 1, 2, 2),
+            row(1, 1, 1, 3, 3),
+            row(1, 1, 1, 4, 4),
+        )
+
 
 # Test for CASSANDRA-13152
 def testThatDeletesWithEmptyInRestrictionDoNotCreateMutations(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, primary key (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, primary key (a, b))"
+    ) as table:
         execute(cql, table, "DELETE FROM %s WHERE a IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b = 1;")
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b IN ();")
 
         # TODO: think if there's a way for us to test this via REST API
-        #assertTrue("The memtable should be empty but is not", isMemtableEmpty())
+        # assertTrue("The memtable should be empty but is not", isMemtableEmpty())
 
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, s int static, primary key ((a, b), c))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, s int static, primary key ((a, b), c))",
+    ) as table:
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b IN () AND c IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b = 1 AND c IN ();")
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1;")
 
-        #assertTrue("The memtable should be empty but is not", isMemtableEmpty())
+        # assertTrue("The memtable should be empty but is not", isMemtableEmpty())
 
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, primary key ((a, b), c, d))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, primary key ((a, b), c, d))",
+    ) as table:
         execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c = 1 AND d IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c IN () AND d IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a = 1 AND b IN () AND c IN () AND d IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c IN () AND d IN ();")
-        execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c IN () AND d = 1;")
-        execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1 AND d = 1;")
-        execute(cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1 AND d IN ();")
+        execute(
+            cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c = 1 AND d IN ();"
+        )
+        execute(
+            cql, table, "DELETE FROM %s WHERE a = 1 AND b = 1 AND c IN () AND d IN ();"
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a = 1 AND b IN () AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a IN () AND b IN () AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a IN () AND b IN () AND c IN () AND d = 1;",
+        )
+        execute(
+            cql, table, "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1 AND d = 1;"
+        )
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s WHERE a IN () AND b IN () AND c = 1 AND d IN ();",
+        )
         execute(cql, table, "DELETE FROM %s WHERE a IN () AND b = 1")
 
-        #assertTrue("The memtable should be empty but is not", isMemtableEmpty())
+        # assertTrue("The memtable should be empty but is not", isMemtableEmpty())
+
 
 def testQueryingOnRangeTombstoneBoundForward(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k text, i int, primary key (k, i))") as table:
+    with create_table(
+        cql, test_keyspace, "(k text, i int, primary key (k, i))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, i) VALUES (?, ?)", "a", 0)
 
-        execute(cql, table, "DELETE FROM %s WHERE k = ? AND i > ? AND i <= ?", "a", 0, 1)
+        execute(
+            cql, table, "DELETE FROM %s WHERE k = ? AND i > ? AND i <= ?", "a", 0, 1
+        )
         execute(cql, table, "DELETE FROM %s WHERE k = ? AND i > ?", "a", 1)
 
         flush(cql, table)
 
-        assertEmpty(execute(cql, table, "SELECT i FROM %s WHERE k = ? AND i = ?", "a", 1))
+        assertEmpty(
+            execute(cql, table, "SELECT i FROM %s WHERE k = ? AND i = ?", "a", 1)
+        )
+
 
 def testQueryingOnRangeTombstoneBoundReverse(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k text, i int, primary key (k, i))") as table:
+    with create_table(
+        cql, test_keyspace, "(k text, i int, primary key (k, i))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, i) VALUES (?, ?)", "a", 0)
 
-        execute(cql, table, "DELETE FROM %s WHERE k = ? AND i > ? AND i <= ?", "a", 0, 1)
+        execute(
+            cql, table, "DELETE FROM %s WHERE k = ? AND i > ? AND i <= ?", "a", 0, 1
+        )
         execute(cql, table, "DELETE FROM %s WHERE k = ? AND i > ?", "a", 1)
 
         flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT i FROM %s WHERE k = ? AND i <= ? ORDER BY i DESC", "a", 1), row(0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT i FROM %s WHERE k = ? AND i <= ? ORDER BY i DESC",
+                "a",
+                1,
+            ),
+            row(0),
+        )
+
 
 def testReverseQueryWithRangeTombstoneOnMultipleBlocks(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k text, i int, v text, primary key (k, i))") as table:
-        longText = 'a'*1200
+    with create_table(
+        cql, test_keyspace, "(k text, i int, v text, primary key (k, i))"
+    ) as table:
+        longText = "a" * 1200
 
         for i in range(10):
-            execute(cql, table, "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 3", "a", i*2, longText)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 3",
+                "a",
+                i * 2,
+                longText,
+            )
 
-        execute(cql, table, "DELETE FROM %s USING TIMESTAMP 1 WHERE k = ? AND i >= ? AND i <= ?", "a", 12, 16)
+        execute(
+            cql,
+            table,
+            "DELETE FROM %s USING TIMESTAMP 1 WHERE k = ? AND i >= ? AND i <= ?",
+            "a",
+            12,
+            16,
+        )
 
         flush(cql, table)
 
-        execute(cql, table, "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 0", "a", 3, longText)
-        execute(cql, table, "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 3", "a", 11, longText)
-        execute(cql, table, "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 0", "a", 15, longText)
-        execute(cql, table, "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 0", "a", 17, longText)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 0",
+            "a",
+            3,
+            longText,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 3",
+            "a",
+            11,
+            longText,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 0",
+            "a",
+            15,
+            longText,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(k, i, v) VALUES (?, ?, ?) USING TIMESTAMP 0",
+            "a",
+            17,
+            longText,
+        )
 
         flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT i FROM %s WHERE k = ? ORDER BY i DESC", "a"),
-                   row(18),
-                   row(17),
-                   row(16),
-                   row(14),
-                   row(12),
-                   row(11),
-                   row(10),
-                   row(8),
-                   row(6),
-                   row(4),
-                   row(3),
-                   row(2),
-                   row(0))
+        assertRows(
+            execute(cql, table, "SELECT i FROM %s WHERE k = ? ORDER BY i DESC", "a"),
+            row(18),
+            row(17),
+            row(16),
+            row(14),
+            row(12),
+            row(11),
+            row(10),
+            row(8),
+            row(6),
+            row(4),
+            row(3),
+            row(2),
+            row(0),
+        )
+
 
 # Test for CASSANDRA-13305
 def testWithEmptyRange(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k text, a int, b int, primary key (k, a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(k text, a int, b int, primary key (k, a, b))"
+    ) as table:
         # Both of the following should be doing nothing, but before CASSANDRA-13305 this inserted broken ranges. We do it twice
         # and the follow-up delete mainly as a way to show the bug as the combination of this will trigger an assertion
         # in RangeTombstoneList pre-CASSANDRA-13305 showing that something wrong happened.
-        execute(cql, table, "DELETE FROM %s WHERE k = ? AND a >= ? AND a < ?", "a", 1, 1)
-        execute(cql, table, "DELETE FROM %s WHERE k = ? AND a >= ? AND a < ?", "a", 1, 1)
+        execute(
+            cql, table, "DELETE FROM %s WHERE k = ? AND a >= ? AND a < ?", "a", 1, 1
+        )
+        execute(
+            cql, table, "DELETE FROM %s WHERE k = ? AND a >= ? AND a < ?", "a", 1, 1
+        )
 
-        execute(cql, table, "DELETE FROM %s WHERE k = ? AND a >= ? AND a < ?", "a", 0, 2)
+        execute(
+            cql, table, "DELETE FROM %s WHERE k = ? AND a >= ? AND a < ?", "a", 0, 2
+        )
+
 
 def testStaticColumnDeletionWithMultipleStaticColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int, ck int, s1 int static, s2 int static, v int, primary key (pk, ck))") as table:
-        execute(cql, table, "INSERT INTO %s (pk, s1, s2) VALUES (1, 1, 1) USING TIMESTAMP 1000")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk int, ck int, s1 int static, s2 int static, v int, primary key (pk, ck))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, s1, s2) VALUES (1, 1, 1) USING TIMESTAMP 1000",
+        )
         flush(cql, table)
-        execute(cql, table, "INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000")
+        execute(
+            cql, table, "INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000"
+        )
         flush(cql, table)
         execute(cql, table, "DELETE s1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1")
         flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk=1"), row(1, null, null, 1, null))
-        assertRows(execute(cql, table, "SELECT pk, s1, s2 FROM %s WHERE pk=1"), row(1, null, 1))
-        assertRows(execute(cql, table, "SELECT s1, s2 FROM %s WHERE pk=1"), row(null, 1))
-        assertRows(execute(cql, table, "SELECT pk, s1 FROM %s WHERE pk=1"), row(1, null))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE pk=1"),
+            row(1, null, null, 1, null),
+        )
+        assertRows(
+            execute(cql, table, "SELECT pk, s1, s2 FROM %s WHERE pk=1"), row(1, null, 1)
+        )
+        assertRows(
+            execute(cql, table, "SELECT s1, s2 FROM %s WHERE pk=1"), row(null, 1)
+        )
+        assertRows(
+            execute(cql, table, "SELECT pk, s1 FROM %s WHERE pk=1"), row(1, null)
+        )
         assertRows(execute(cql, table, "SELECT s1 FROM %s WHERE pk=1"), row(null))
         assertRows(execute(cql, table, "SELECT pk, s2 FROM %s WHERE pk=1"), row(1, 1))
         assertRows(execute(cql, table, "SELECT s2 FROM %s WHERE pk=1"), row(1))
-        assertRows(execute(cql, table, "SELECT pk, ck FROM %s WHERE pk=1"), row(1, null))
+        assertRows(
+            execute(cql, table, "SELECT pk, ck FROM %s WHERE pk=1"), row(1, null)
+        )
         assertRows(execute(cql, table, "SELECT ck FROM %s WHERE pk=1"), row(null))
-        assertRows(execute(cql, table, "SELECT DISTINCT pk, s1, s2 FROM %s WHERE pk=1"), row(1, null, 1))
-        assertRows(execute(cql, table, "SELECT DISTINCT s1, s2 FROM %s WHERE pk=1"), row(null, 1))
-        assertRows(execute(cql, table, "SELECT DISTINCT pk, s1 FROM %s WHERE pk=1"), row(1, null))
-        assertRows(execute(cql, table, "SELECT DISTINCT pk, s2 FROM %s WHERE pk=1"), row(1, 1))
-        assertRows(execute(cql, table, "SELECT DISTINCT s1 FROM %s WHERE pk=1"), row(null))
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT pk, s1, s2 FROM %s WHERE pk=1"),
+            row(1, null, 1),
+        )
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT s1, s2 FROM %s WHERE pk=1"),
+            row(null, 1),
+        )
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT pk, s1 FROM %s WHERE pk=1"),
+            row(1, null),
+        )
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT pk, s2 FROM %s WHERE pk=1"), row(1, 1)
+        )
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT s1 FROM %s WHERE pk=1"), row(null)
+        )
         assertRows(execute(cql, table, "SELECT DISTINCT s2 FROM %s WHERE pk=1"), row(1))
 
-def testStaticColumnDeletionWithMultipleStaticColumnsAndRegularColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int, ck int, s1 int static, s2 int static, v int, primary key (pk, ck))") as table:
-        execute(cql, table, "INSERT INTO %s (pk, ck, v, s2) VALUES (1, 1, 1, 1) USING TIMESTAMP 1000")
+
+def testStaticColumnDeletionWithMultipleStaticColumnsAndRegularColumns(
+    cql, test_keyspace
+):
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk int, ck int, s1 int static, s2 int static, v int, primary key (pk, ck))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, ck, v, s2) VALUES (1, 1, 1, 1) USING TIMESTAMP 1000",
+        )
         flush(cql, table)
-        execute(cql, table, "INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000")
+        execute(
+            cql, table, "INSERT INTO %s (pk, s1) VALUES (1, 2) USING TIMESTAMP 2000"
+        )
         flush(cql, table)
         execute(cql, table, "DELETE s1 FROM %s USING TIMESTAMP 3000 WHERE pk = 1")
         flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE pk=1"), row(1, 1, null, 1, 1))
-        assertRows(execute(cql, table, "SELECT s1, s2 FROM %s WHERE pk=1"), row(null, 1))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE pk=1"), row(1, 1, null, 1, 1)
+        )
+        assertRows(
+            execute(cql, table, "SELECT s1, s2 FROM %s WHERE pk=1"), row(null, 1)
+        )
         assertRows(execute(cql, table, "SELECT s1 FROM %s WHERE pk=1"), row(null))
-        assertRows(execute(cql, table, "SELECT DISTINCT s1, s2 FROM %s WHERE pk=1"), row(null, 1))
-        assertRows(execute(cql, table, "SELECT DISTINCT s1 FROM %s WHERE pk=1"), row(null))
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT s1, s2 FROM %s WHERE pk=1"),
+            row(null, 1),
+        )
+        assertRows(
+            execute(cql, table, "SELECT DISTINCT s1 FROM %s WHERE pk=1"), row(null)
+        )

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_invalidate_sized_records_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_invalidate_sized_records_test.py
@@ -24,68 +24,117 @@
 
 from ...porting import *
 
-LARGE_BLOB = b'x' * (2**16)
-MEDIUM_BLOB = b'x' * (2**15 + 9)
+LARGE_BLOB = b"x" * (2**16)
+MEDIUM_BLOB = b"x" * (2**15 + 9)
 
-@pytest.mark.xfail(reason="issue #12247")
+
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def testsingleValuePk(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob PRIMARY KEY)") as table:
         # reproduces #12247:
-        with pytest.raises(InvalidRequest, match=f'Key length of {len(LARGE_BLOB)} is longer than maximum of 65535'):
-             execute(cql, table, "INSERT INTO %s (a) VALUES (?)", LARGE_BLOB)
+        with pytest.raises(
+            InvalidRequest,
+            match=f"Key length of {len(LARGE_BLOB)} is longer than maximum of 65535",
+        ):
+            execute(cql, table, "INSERT INTO %s (a) VALUES (?)", LARGE_BLOB)
 
         # null / empty checks
-        with pytest.raises(InvalidRequest, match='Invalid null value.* for column a'):
+        with pytest.raises(InvalidRequest, match="Invalid null value.* for column a"):
             execute(cql, table, "INSERT INTO %s (a) VALUES (?)", None)
-        with pytest.raises(InvalidRequest, match='Key may not be empty'):
-            execute(cql, table, "INSERT INTO %s (a) VALUES (?)", b'')
+        with pytest.raises(InvalidRequest, match="Key may not be empty"):
+            execute(cql, table, "INSERT INTO %s (a) VALUES (?)", b"")
 
-@pytest.mark.xfail(reason="issue #12247")
+
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 # Currently fails on Cassandra due to CASSANDRA-19270
 def testcompositeValuePk(cql, test_keyspace, cassandra_bug):
-    with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY ((a, b)))") as table:
+    with create_table(
+        cql, test_keyspace, "(a blob, b blob, PRIMARY KEY ((a, b)))"
+    ) as table:
         # sum of columns is too large
-        with pytest.raises(InvalidRequest, match=f'Key length of {len(MEDIUM_BLOB)*2} is longer than maximum of 65535'):
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, MEDIUM_BLOB)
+        with pytest.raises(
+            InvalidRequest,
+            match=f"Key length of {len(MEDIUM_BLOB) * 2} is longer than maximum of 65535",
+        ):
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a, b) VALUES (?, ?)",
+                MEDIUM_BLOB,
+                MEDIUM_BLOB,
+            )
 
         # single column is too large
         # Fails on Cassandra for an unknown reason, see CASSANDRA-19270
-        with pytest.raises(InvalidRequest, match=f'Key length of {len(MEDIUM_BLOB)+len(LARGE_BLOB)} is longer than maximum of 65535'):
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, LARGE_BLOB)
+        with pytest.raises(
+            InvalidRequest,
+            match=f"Key length of {len(MEDIUM_BLOB) + len(LARGE_BLOB)} is longer than maximum of 65535",
+        ):
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a, b) VALUES (?, ?)",
+                MEDIUM_BLOB,
+                LARGE_BLOB,
+            )
 
         # null / empty checks
         # this is an inconsistent behavior... null is blocked by org.apache.cassandra.db.MultiCBuilder.OneClusteringBuilder.addElementToAll
         # but this does not count empty as null, and doesn't check for this case...  We have a requirement in cqlsh that empty is allowed when
         # user opts-in to allow it (NULL='-'), so we will find that null is blocked, but empty is allowed!
         # Fails on Cassandra for an unknown reason, see CASSANDRA-19270
-        with pytest.raises(InvalidRequest, match='Invalid null value.* for column a'):
+        with pytest.raises(InvalidRequest, match="Invalid null value.* for column a"):
             execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", None, None)
         # Fails on Cassandra for an unknown reason, see CASSANDRA-19270
-        with pytest.raises(InvalidRequest, match='Invalid null value.* for column b'):
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, None)
+        with pytest.raises(InvalidRequest, match="Invalid null value.* for column b"):
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, None
+            )
         # Fails on Cassandra for an unknown reason, see CASSANDRA-19270
-        with pytest.raises(InvalidRequest, match='Invalid null value.* for column a'):
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", None, MEDIUM_BLOB)
+        with pytest.raises(InvalidRequest, match="Invalid null value.* for column a"):
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", None, MEDIUM_BLOB
+            )
 
         # empty is allowed when composite partition columns...
-        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", b'', b'')
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", b"", b"")
         execute(cql, table, "TRUNCATE %s")
 
-        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, b'')
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, b"")
         execute(cql, table, "TRUNCATE %s")
 
-        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", b'', MEDIUM_BLOB)
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", b"", MEDIUM_BLOB)
 
-@pytest.mark.xfail(reason="issue #12247")
+
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def testsingleValueClustering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a blob, b blob, PRIMARY KEY (a, b))"
+    ) as table:
         # reproduces #12247:
-        with pytest.raises(InvalidRequest, match=f'Key length of {len(LARGE_BLOB)} is longer than maximum of 65535'):
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, LARGE_BLOB)
+        with pytest.raises(
+            InvalidRequest,
+            match=f"Key length of {len(LARGE_BLOB)} is longer than maximum of 65535",
+        ):
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a, b) VALUES (?, ?)",
+                MEDIUM_BLOB,
+                LARGE_BLOB,
+            )
 
         # null / empty checks
-        with pytest.raises(InvalidRequest, match='Invalid null value.* for column b'):
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, None)
+        with pytest.raises(InvalidRequest, match="Invalid null value.* for column b"):
+            execute(
+                cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, None
+            )
 
         # org.apache.cassandra.db.MultiCBuilder.OneClusteringBuilder.addElementToAll defines "null" differently than most of the code
         # most of the code defines null as:
@@ -94,25 +143,64 @@ def testsingleValueClustering(cql, test_keyspace):
         #   value == null
         # In CASSANDRA-18504 a new isNull method was added to the type, as blob and text both "should" allow empty, but this scattered null logic doesn't allow...
         # For backwards compatability reasons, need to keep empty support
-        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, b'')
+        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, b"")
 
-@pytest.mark.xfail(reason="issue #12247")
+
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def testcompositeValueClustering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a blob, b blob, c blob, PRIMARY KEY (a, b, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(a blob, b blob, c blob, PRIMARY KEY (a, b, c))"
+    ) as table:
         # sum of columns is too large
         # reproduces #12247:
-        with pytest.raises(InvalidRequest, match=f'Key length of {len(MEDIUM_BLOB)*2} is longer than maximum of 65535'):
-            execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", MEDIUM_BLOB, MEDIUM_BLOB, MEDIUM_BLOB)
+        with pytest.raises(
+            InvalidRequest,
+            match=f"Key length of {len(MEDIUM_BLOB) * 2} is longer than maximum of 65535",
+        ):
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+                MEDIUM_BLOB,
+                MEDIUM_BLOB,
+                MEDIUM_BLOB,
+            )
 
         # single column is too large
         # the logic prints the total clustering size and not the single column's size that was too large
         # reproduces #12247:
-        with pytest.raises(InvalidRequest, match=f'Key length of {len(MEDIUM_BLOB)+len(LARGE_BLOB)} is longer than maximum of 65535'):
-            execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", MEDIUM_BLOB, MEDIUM_BLOB, LARGE_BLOB)
+        with pytest.raises(
+            InvalidRequest,
+            match=f"Key length of {len(MEDIUM_BLOB) + len(LARGE_BLOB)} is longer than maximum of 65535",
+        ):
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+                MEDIUM_BLOB,
+                MEDIUM_BLOB,
+                LARGE_BLOB,
+            )
 
-@pytest.mark.xfail(reason="issue #8627")
+
+@pytest.mark.xfail(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627"
+)
 def testsingleValueIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY (a))") as table:
         execute(cql, table, "CREATE INDEX single_value_index ON %s (b)")
-        with pytest.raises(InvalidRequest, match=re.escape(f'Cannot index value of size {len(LARGE_BLOB)} for index single_value_index on {table}(b) (maximum allowed size=65535)')):
-            execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, LARGE_BLOB)
+        with pytest.raises(
+            InvalidRequest,
+            match=re.escape(
+                f"Cannot index value of size {len(LARGE_BLOB)} for index single_value_index on {table}(b) (maximum allowed size=65535)"
+            ),
+        ):
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a, b) VALUES (?, ?)",
+                MEDIUM_BLOB,
+                LARGE_BLOB,
+            )

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
@@ -24,159 +24,295 @@
 
 from ...porting import *
 
+
 def testInsertWithUnset(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)") as table:
+    with create_table(
+        cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)"
+    ) as table:
         # insert using nulls
         execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (10, ?, ?)", "text", 10)
         execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (10, ?, ?)", null, null)
-        assertRows(execute(cql, table, "SELECT s, i FROM %s WHERE k = 10"),
-                   row(null, null) # sending null deletes the data
+        assertRows(
+            execute(cql, table, "SELECT s, i FROM %s WHERE k = 10"),
+            row(null, null),  # sending null deletes the data
         )
         # insert using UNSET
         execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (11, ?, ?)", "text", 10)
-        execute(cql, table, "INSERT INTO %s (k, s, i) VALUES (11, ?, ?)", unset(), unset())
-        assertRows(execute(cql, table, "SELECT s, i FROM %s WHERE k=11"),
-                   row("text", 10) # unset columns does not delete the existing data
+        execute(
+            cql, table, "INSERT INTO %s (k, s, i) VALUES (11, ?, ?)", unset(), unset()
+        )
+        assertRows(
+            execute(cql, table, "SELECT s, i FROM %s WHERE k=11"),
+            row("text", 10),  # unset columns does not delete the existing data
         )
 
         # The Python driver doesn't allow unset() as partition key (needed
         # for selecting the coordinator), so we can't test this:
-        #assertInvalidMessage(cql, table, "Invalid unset value for column k", "UPDATE %s SET i = 0 WHERE k = ?", unset())
-        #assertInvalidMessage(cql, table, "Invalid unset value for column k", "DELETE FROM %s WHERE k = ?", unset())
+        # assertInvalidMessage(cql, table, "Invalid unset value for column k", "UPDATE %s SET i = 0 WHERE k = ?", unset())
+        # assertInvalidMessage(cql, table, "Invalid unset value for column k", "DELETE FROM %s WHERE k = ?", unset())
         # Scylla and Cassandra have slightly different messages here. Cassandra
         # has "Invalid unset value for argument in call to function blobasint"
         # Scylla has "Invalid null or unset value for argument to
         # system.blobasint : (blob) -> int"
-        assertInvalidMessageRE(cql, table, "unset", "SELECT * FROM %s WHERE k = blobAsInt(?)", unset())
+        assertInvalidMessageRE(
+            cql, table, "unset", "SELECT * FROM %s WHERE k = blobAsInt(?)", unset()
+        )
+
 
 # Both Scylla and Cassandra define MAX_TTL or max_ttl with the same formula,
 # 20 years in seconds. In both systems, it is not configurable.
 MAX_TTL = 20 * 365 * 24 * 60 * 60
 
+
 # Reproduces #12243:
-@pytest.mark.xfail(reason="Issue #12243")
+@pytest.mark.xfail(reason='Setting USING TTL of "null" should be allowed #12243')
 def testInsertWithTtl(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v int)") as table:
         # test with unset
-        execute(cql, table, "INSERT INTO %s (k, v) VALUES (1, 1) USING TTL ?", unset()); # treat as 'unlimited'
+        execute(
+            cql, table, "INSERT INTO %s (k, v) VALUES (1, 1) USING TTL ?", unset()
+        )  # treat as 'unlimited'
         assertRows(execute(cql, table, "SELECT ttl(v) FROM %s"), row(null))
 
         # test with null
         # Reproduces #12243:
-        execute(cql, table, "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, null)
+        execute(
+            cql, table, "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, null
+        )
         assertRows(execute(cql, table, "SELECT k, v, TTL(v) FROM %s"), row(1, 1, null))
 
         # test error handling
-        assertInvalidMessage(cql, table, "TTL must be greater or equal to 0",
-                             "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, -5)
+        assertInvalidMessage(
+            cql,
+            table,
+            "TTL must be greater or equal to 0",
+            "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?",
+            1,
+            1,
+            -5,
+        )
 
-        assertInvalidMessage(cql, table, "ttl is too large.",
-                             "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?", 1, 1, MAX_TTL + 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "ttl is too large.",
+            "INSERT INTO %s (k, v) VALUES (?, ?) USING TTL ?",
+            1,
+            1,
+            MAX_TTL + 1,
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testInsert(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering int, value int, PRIMARY KEY (partitionKey, clustering))",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (partitionKey, clustering) VALUES (0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering, value) VALUES (0, 1, 1)",
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, 0, null),
-                   row(0, 1, 1))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"), row(0, 0, null), row(0, 1, 1)
+        )
 
         # Missing primary key columns
-        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
-                             "INSERT INTO %s (clustering, value) VALUES (0, 1)")
-        assertInvalidMessageRE(cql, table, "[Mm]issing.*clustering",
-                             "INSERT INTO %s (partitionKey, value) VALUES (0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "[Mm]issing.*partitionkey",
+            "INSERT INTO %s (clustering, value) VALUES (0, 1)",
+        )
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "[Mm]issing.*clustering",
+            "INSERT INTO %s (partitionKey, value) VALUES (0, 2)",
+        )
 
         # multiple time the same value
-        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
-                             "INSERT INTO %s (partitionKey, clustering, value, value) VALUES (0, 0, 2, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "Multiple|duplicates",
+            "INSERT INTO %s (partitionKey, clustering, value, value) VALUES (0, 0, 2, 2)",
+        )
 
         # multiple time same primary key element in WHERE clause
-        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
-                             "INSERT INTO %s (partitionKey, clustering, clustering, value) VALUES (0, 0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "Multiple|duplicates",
+            "INSERT INTO %s (partitionKey, clustering, clustering, value) VALUES (0, 0, 0, 2)",
+        )
 
         # unknown identifiers
-        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*clusteringx",
-                             "INSERT INTO %s (partitionKey, clusteringx, value) VALUES (0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "(Undefined|Unknown).*clusteringx",
+            "INSERT INTO %s (partitionKey, clusteringx, value) VALUES (0, 0, 2)",
+        )
 
-        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*valuex",
-                             "INSERT INTO %s (partitionKey, clustering, valuex) VALUES (0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "(Undefined|Unknown).*valuex",
+            "INSERT INTO %s (partitionKey, clustering, valuex) VALUES (0, 0, 2)",
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testInsertWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2) VALUES (0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2) VALUES (0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, 0, 0, null),
-                   row(0, 0, 1, 1))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"), row(0, 0, 0, null), row(0, 0, 1, 1)
+        )
 
         # Missing primary key columns
-        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
-                             "INSERT INTO %s (clustering_1, clustering_2, value) VALUES (0, 0, 1)")
-        assertInvalidMessageRE(cql, table, "clustering_1",
-                             "INSERT INTO %s (partitionKey, clustering_2, value) VALUES (0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "[Mm]issing.*partitionkey",
+            "INSERT INTO %s (clustering_1, clustering_2, value) VALUES (0, 0, 1)",
+        )
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "clustering_1",
+            "INSERT INTO %s (partitionKey, clustering_2, value) VALUES (0, 0, 2)",
+        )
 
         # multiple time the same value
-        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
-                             "INSERT INTO %s (partitionKey, clustering_1, value, clustering_2, value) VALUES (0, 0, 2, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "Multiple|duplicates",
+            "INSERT INTO %s (partitionKey, clustering_1, value, clustering_2, value) VALUES (0, 0, 2, 0, 2)",
+        )
 
         # multiple time same primary key element in WHERE clause
-        assertInvalidMessageRE(cql, table, "Multiple|duplicates",
-                             "INSERT INTO %s (partitionKey, clustering_1, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "Multiple|duplicates",
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 2)",
+        )
 
         # unknown identifiers
-        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*clustering_1x",
-                             "INSERT INTO %s (partitionKey, clustering_1x, clustering_2, value) VALUES (0, 0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "(Undefined|Unknown).*clustering_1x",
+            "INSERT INTO %s (partitionKey, clustering_1x, clustering_2, value) VALUES (0, 0, 0, 2)",
+        )
 
-        assertInvalidMessageRE(cql, table, "(Undefined|Unknown).*valuex",
-                             "INSERT INTO %s (partitionKey, clustering_1, clustering_2, valuex) VALUES (0, 0, 0, 2)")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "(Undefined|Unknown).*valuex",
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, valuex) VALUES (0, 0, 0, 2)",
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testInsertWithAStaticColumn(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, staticValue text static, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, staticValue) VALUES (0, 0, 0, 'A')")
-        execute(cql, table, "INSERT INTO %s (partitionKey, staticValue) VALUES (1, 'B')")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, staticValue text static, PRIMARY KEY (partitionKey, clustering_1, clustering_2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, staticValue) VALUES (0, 0, 0, 'A')",
+        )
+        execute(
+            cql, table, "INSERT INTO %s (partitionKey, staticValue) VALUES (1, 'B')"
+        )
         if forceFlush:
             flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, null, null, "B", null),
-                   row(0, 0, 0, "A", null))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, null, null, "B", null),
+            row(0, 0, 0, "A", null),
+        )
 
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 0)")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 0)",
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, 0, 0, "B", 0),
-                   row(0, 0, 0, "A", null))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 0, 0, "B", 0),
+            row(0, 0, 0, "A", null),
+        )
 
         # Missing primary key columns
-        assertInvalidMessageRE(cql, table, "[Mm]issing.*partitionkey",
-                             "INSERT INTO %s (clustering_1, clustering_2, staticValue) VALUES (0, 0, 'A')")
-        assertInvalidMessageRE(cql, table, "clustering_1",
-                             "INSERT INTO %s (partitionKey, clustering_2, staticValue) VALUES (0, 0, 'A')")
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "[Mm]issing.*partitionkey",
+            "INSERT INTO %s (clustering_1, clustering_2, staticValue) VALUES (0, 0, 'A')",
+        )
+        assertInvalidMessageRE(
+            cql,
+            table,
+            "clustering_1",
+            "INSERT INTO %s (partitionKey, clustering_2, staticValue) VALUES (0, 0, 'A')",
+        )
+
 
 # Reproduces #6447 and #12243:
-@pytest.mark.xfail(reason="Issue #12243")
+@pytest.mark.xfail(reason='Setting USING TTL of "null" should be allowed #12243')
 def testInsertWithDefaultTtl(cql, test_keyspace):
     secondsPerMinute = 60
-    with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10*secondsPerMinute}") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10 * secondsPerMinute}",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
         results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 1"))
         assert len(results) == 1
-        assert getattr(results[0], 'ttl_b') >= 9 * secondsPerMinute
+        assert getattr(results[0], "ttl_b") >= 9 * secondsPerMinute
 
-        execute(cql, table, "INSERT INTO %s (a, b) VALUES (2, 2) USING TTL ?", (5 * secondsPerMinute))
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b) VALUES (2, 2) USING TTL ?",
+            (5 * secondsPerMinute),
+        )
         results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 2"))
         assert len(results) == 1
-        assert getattr(results[0], 'ttl_b') <= 5 * secondsPerMinute
+        assert getattr(results[0], "ttl_b") <= 5 * secondsPerMinute
 
         # Reproduces #6447:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (3, 3) USING TTL ?", 0)
@@ -185,25 +321,47 @@ def testInsertWithDefaultTtl(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (4, 4) USING TTL ?", unset())
         results = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 4"))
         assert len(results) == 1
-        assert getattr(results[0], 'ttl_b') >= 9 * secondsPerMinute
+        assert getattr(results[0], "ttl_b") >= 9 * secondsPerMinute
 
         # Reproduces #12243:
-        execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?) USING TTL ?", 4, 4, null)
+        execute(
+            cql, table, "INSERT INTO %s (a, b) VALUES (?, ?) USING TTL ?", 4, 4, null
+        )
         assertRows(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 4"), row(null))
 
 
 TOO_BIG = 1024 * 65
 
-# Reproduces #12247:
-@pytest.mark.xfail(reason="Issue #12247")
-def testPKInsertWithValueOver64K(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
-        assertInvalidThrow(cql, table, InvalidRequest,
-                           "INSERT INTO %s (a, b) VALUES (?, 'foo')", 'x'*TOO_BIG)
 
 # Reproduces #12247:
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
+def testPKInsertWithValueOver64K(cql, test_keyspace):
+    with create_table(
+        cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))"
+    ) as table:
+        assertInvalidThrow(
+            cql,
+            table,
+            InvalidRequest,
+            "INSERT INTO %s (a, b) VALUES (?, 'foo')",
+            "x" * TOO_BIG,
+        )
+
+
+# Reproduces #12247:
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def testCKInsertWithValueOver64K(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
-        assertInvalidThrow(cql, table, InvalidRequest,
-                           "INSERT INTO %s (a, b) VALUES ('foo', ?)", 'x'*TOO_BIG)
+    with create_table(
+        cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))"
+    ) as table:
+        assertInvalidThrow(
+            cql,
+            table,
+            InvalidRequest,
+            "INSERT INTO %s (a, b) VALUES ('foo', ?)",
+            "x" * TOO_BIG,
+        )

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
@@ -36,7 +36,7 @@ def testInsertSetIfNotExists(cql, test_keyspace, is_scylla):
                    row(True,None,None) if is_scylla else row(True))
         assertRows(execute(cql, table, "SELECT * FROM %s "), row(0, {1, 2, 3}))
 
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:   
@@ -266,7 +266,7 @@ def checkInvalidUDT(cql, table, condition, value, expected):
     assertInvalidThrow(cql, table, expected, "DELETE FROM %s WHERE k = 0 IF " + condition)
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, value))
 
-@pytest.mark.xfail(reason="Issue #13624")
+@pytest.mark.xfail(reason="Add support for UDT subfields in LWT expression #13624")
 def testUDTField(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:   
@@ -395,7 +395,7 @@ def testUDTField(cql, test_keyspace):
                 checkDoesNotApplyUDT(cql, table, "v.b != null AND v.b IN ()", v)
 
 # Migrated from cql_tests.py:TestCQL.whole_list_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeList(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "list<text>"
@@ -553,7 +553,7 @@ def testExpandedListItem(cql, test_keyspace):
             #check_invalid_list(cql, table, "l[null] = null", InvalidRequest)
 
 # Migrated from cql_tests.py:TestCQL.whole_set_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeSet(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "set<text>"
@@ -632,7 +632,7 @@ def check_invalid_set(cql, table, condition, expected):
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, {"bar", "foo"}))
 
 # Migrated from cql_tests.py:TestCQL.whole_map_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeMap(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "map<text,text>"
@@ -800,7 +800,7 @@ def check_invalid_map(cql, table, condition, expected):
     assertInvalidThrow(cql, table, expected, "DELETE FROM %s WHERE k=0 IF " + condition)
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, {"foo": "bar"}))
 
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testInMarkerWithUDTs(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:
@@ -856,7 +856,7 @@ def testInMarkerWithUDTs(cql, test_keyspace):
                 assertInvalidMessage(cql, table, "unset",
                                  "UPDATE %s SET v = {a: 0, b: 'bc'} WHERE k = 0 IF v.a IN ?", unset())
 
-@pytest.mark.xfail(reason="Issues #13586, #5855")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586, lwt: comparing NULL collection with empty value in IF condition yields incorrect results #5855")
 def testNonFrozenEmptyCollection(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, l list<text>)") as table:
         execute(cql, table, "INSERT INTO %s (k, l) VALUES (0, null)")

--- a/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
@@ -10,7 +10,7 @@
 
 from ...porting import *
 
-@pytest.mark.xfail(reason="Issue #2060, #13109")
+@pytest.mark.xfail(reason="Allow mixing token and partition key restrictions #2060, Incorrect sort order when combining IN, GROUP BY and ORDER BY #13109")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, primary key (a, b, c, d))") as table:
 
@@ -605,7 +605,7 @@ def testGroupByWithRangeNamesQueryWithoutPaging(cql, test_keyspace):
                    row(1, 1, 2, 2, 2),
                    row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #13109")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, GROUP BY and ORDER BY #13109")
 def testGroupByWithStaticColumnsWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------
@@ -1570,7 +1570,7 @@ def testGroupByWithRangeNamesQueryWithPaging(cql, test_keyspace):
                           row(1, 1, 2, 2, 2),
                           row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #21267")
+@pytest.mark.xfail(reason="Group By + Order By + Limit produces incorrect results #21267")
 def testGroupByWithStaticColumnsWithPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------

--- a/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
@@ -10,524 +10,1062 @@
 
 from ...porting import *
 
+
 # Test limit queries on a sparse table,
 # migrated from cql_tests.py:TestCQL.limit_sparse_test()
 def testSparseTable(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(userid int, url text, day int, month text, year int, PRIMARY KEY (userid, url))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(userid int, url text, day int, month text, year int, PRIMARY KEY (userid, url))",
+    ) as table:
         for i in range(100):
             for tld in ["com", "org", "net"]:
-                execute(cql, table, "INSERT INTO %s (userid, url, day, month, year) VALUES (?, ?, 1, 'jan', 2012)", i, f"http://foo.{tld}")
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (userid, url, day, month, year) VALUES (?, ?, 1, 'jan', 2012)",
+                    i,
+                    f"http://foo.{tld}",
+                )
         assertRowCount(execute(cql, table, "SELECT * FROM %s LIMIT 4"), 4)
 
-@pytest.mark.xfail(reason="issues #15099")
+
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, and ORDER BY #15099")
 def testPerPartitionLimit(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b))"
+    ) as table:
         for i in range(5):
             for j in range(5):
-                execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", i, j, j)
+                execute(
+                    cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", i, j, j
+                )
 
-        assertInvalidMessage(cql, table, "LIMIT must be strictly positive",
-                             "SELECT * FROM %s PER PARTITION LIMIT ?", 0)
-        assertInvalidMessage(cql, table, "LIMIT must be strictly positive",
-                             "SELECT * FROM %s PER PARTITION LIMIT ?", -1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "LIMIT must be strictly positive",
+            "SELECT * FROM %s PER PARTITION LIMIT ?",
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "LIMIT must be strictly positive",
+            "SELECT * FROM %s PER PARTITION LIMIT ?",
+            -1,
+        )
 
-        assertRowsIgnoringOrder(execute(cql, table, "SELECT * FROM %s PER PARTITION LIMIT ?", 2),
-                                row(0, 0, 0),
-                                row(0, 1, 1),
-                                row(1, 0, 0),
-                                row(1, 1, 1),
-                                row(2, 0, 0),
-                                row(2, 1, 1),
-                                row(3, 0, 0),
-                                row(3, 1, 1),
-                                row(4, 0, 0),
-                                row(4, 1, 1))
+        assertRowsIgnoringOrder(
+            execute(cql, table, "SELECT * FROM %s PER PARTITION LIMIT ?", 2),
+            row(0, 0, 0),
+            row(0, 1, 1),
+            row(1, 0, 0),
+            row(1, 1, 1),
+            row(2, 0, 0),
+            row(2, 1, 1),
+            row(3, 0, 0),
+            row(3, 1, 1),
+            row(4, 0, 0),
+            row(4, 1, 1),
+        )
 
         # Combined Per Partition and "global" limit
-        assertRowCount(execute(cql, table, "SELECT * FROM %s PER PARTITION LIMIT ? LIMIT ?", 2, 6),
-                       6)
+        assertRowCount(
+            execute(cql, table, "SELECT * FROM %s PER PARTITION LIMIT ? LIMIT ?", 2, 6),
+            6,
+        )
 
         # odd amount of results
-        assertRowCount(execute(cql, table, "SELECT * FROM %s PER PARTITION LIMIT ? LIMIT ?", 2, 5),
-                       5)
+        assertRowCount(
+            execute(cql, table, "SELECT * FROM %s PER PARTITION LIMIT ? LIMIT ?", 2, 5),
+            5,
+        )
 
         # IN query
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (2,3) PER PARTITION LIMIT ?", 2),
-                   row(2, 0, 0),
-                   row(2, 1, 1),
-                   row(3, 0, 0),
-                   row(3, 1, 1))
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a IN (2,3) PER PARTITION LIMIT ?", 2
+            ),
+            row(2, 0, 0),
+            row(2, 1, 1),
+            row(3, 0, 0),
+            row(3, 1, 1),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (2,3) PER PARTITION LIMIT ? LIMIT 3", 2),
-                   row(2, 0, 0),
-                   row(2, 1, 1),
-                   row(3, 0, 0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (2,3) PER PARTITION LIMIT ? LIMIT 3",
+                2,
+            ),
+            row(2, 0, 0),
+            row(2, 1, 1),
+            row(3, 0, 0),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (1,2,3) PER PARTITION LIMIT ? LIMIT 3", 2),
-                   row(1, 0, 0),
-                   row(1, 1, 1),
-                   row(2, 0, 0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (1,2,3) PER PARTITION LIMIT ? LIMIT 3",
+                2,
+            ),
+            row(1, 0, 0),
+            row(1, 1, 1),
+            row(2, 0, 0),
+        )
 
         # with restricted partition key
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? PER PARTITION LIMIT ?", 2, 3),
-                   row(2, 0, 0),
-                   row(2, 1, 1),
-                   row(2, 2, 2))
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? PER PARTITION LIMIT ?", 2, 3
+            ),
+            row(2, 0, 0),
+            row(2, 1, 1),
+            row(2, 2, 2),
+        )
 
         # with ordering
         # Reproduces #15099:
-        assertRows(execute_without_paging(cql, table, "SELECT * FROM %s WHERE a IN (3, 2) ORDER BY b DESC PER PARTITION LIMIT ?", 2),
-                   row(2, 4, 4),
-                   row(3, 4, 4),
-                   row(2, 3, 3),
-                   row(3, 3, 3))
+        assertRows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (3, 2) ORDER BY b DESC PER PARTITION LIMIT ?",
+                2,
+            ),
+            row(2, 4, 4),
+            row(3, 4, 4),
+            row(2, 3, 3),
+            row(3, 3, 3),
+        )
 
         # Reproduces #15099:
-        assertRows(execute_without_paging(cql, table, "SELECT * FROM %s WHERE a IN (3, 2) ORDER BY b DESC PER PARTITION LIMIT ? LIMIT ?", 3, 4),
-                   row(2, 4, 4),
-                   row(3, 4, 4),
-                   row(2, 3, 3),
-                   row(3, 3, 3))
+        assertRows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (3, 2) ORDER BY b DESC PER PARTITION LIMIT ? LIMIT ?",
+                3,
+                4,
+            ),
+            row(2, 4, 4),
+            row(3, 4, 4),
+            row(2, 3, 3),
+            row(3, 3, 3),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? ORDER BY b DESC PER PARTITION LIMIT ?", 2, 3),
-                   row(2, 4, 4),
-                   row(2, 3, 3),
-                   row(2, 2, 2))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? ORDER BY b DESC PER PARTITION LIMIT ?",
+                2,
+                3,
+            ),
+            row(2, 4, 4),
+            row(2, 3, 3),
+            row(2, 2, 2),
+        )
 
         # with filtering
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b > ? PER PARTITION LIMIT ? ALLOW FILTERING", 2, 0, 2),
-                   row(2, 1, 1),
-                   row(2, 2, 2))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b > ? PER PARTITION LIMIT ? ALLOW FILTERING",
+                2,
+                0,
+                2,
+            ),
+            row(2, 1, 1),
+            row(2, 2, 2),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b > ? ORDER BY b DESC PER PARTITION LIMIT ? ALLOW FILTERING", 2, 2, 2),
-                   row(2, 4, 4),
-                   row(2, 3, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b > ? ORDER BY b DESC PER PARTITION LIMIT ? ALLOW FILTERING",
+                2,
+                2,
+                2,
+            ),
+            row(2, 4, 4),
+            row(2, 3, 3),
+        )
 
         # Reproduces #15109:
-        assertInvalidMessage(cql, table, "PER PARTITION LIMIT is not allowed with SELECT DISTINCT queries",
-                             "SELECT DISTINCT a FROM %s PER PARTITION LIMIT ?", 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "PER PARTITION LIMIT is not allowed with SELECT DISTINCT queries",
+            "SELECT DISTINCT a FROM %s PER PARTITION LIMIT ?",
+            3,
+        )
         # Reproduces #15109:
-        assertInvalidMessage(cql, table, "PER PARTITION LIMIT is not allowed with SELECT DISTINCT queries",
-                             "SELECT DISTINCT a FROM %s PER PARTITION LIMIT ? LIMIT ?", 3, 4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "PER PARTITION LIMIT is not allowed with SELECT DISTINCT queries",
+            "SELECT DISTINCT a FROM %s PER PARTITION LIMIT ? LIMIT ?",
+            3,
+            4,
+        )
         # Reproduces #9879:
-        assertInvalidMessage(cql, table, "PER PARTITION LIMIT is not allowed with aggregate queries.",
-                             "SELECT COUNT(*) FROM %s PER PARTITION LIMIT ?", 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "PER PARTITION LIMIT is not allowed with aggregate queries.",
+            "SELECT COUNT(*) FROM %s PER PARTITION LIMIT ?",
+            3,
+        )
+
 
 def testPerPartitionLimitWithStaticDataAndPaging(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, s int static, c int, PRIMARY KEY (a, b))"
+    ) as table:
         for i in range(5):
             execute(cql, table, "INSERT INTO %s (a, s) VALUES (?, ?)", i, i)
 
         for pageSize in range(1, 8):
-            assert_rows_ignoring_order(execute_with_paging(cql, table, "SELECT * FROM %s PER PARTITION LIMIT 2", pageSize),
-                          row(0, None, 0, None),
-                          row(1, None, 1, None),
-                          row(2, None, 2, None),
-                          row(3, None, 3, None),
-                          row(4, None, 4, None))
+            assert_rows_ignoring_order(
+                execute_with_paging(
+                    cql, table, "SELECT * FROM %s PER PARTITION LIMIT 2", pageSize
+                ),
+                row(0, None, 0, None),
+                row(1, None, 1, None),
+                row(2, None, 2, None),
+                row(3, None, 3, None),
+                row(4, None, 4, None),
+            )
 
             # Combined Per Partition and "global" limit
             # Note that which partitions get returned depend on the token order...
-            assert_rows_ignoring_order(execute_with_paging(cql, table, "SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 4", pageSize),
-                          row(0, None, 0, None),
-                          row(1, None, 1, None),
-                          row(2, None, 2, None),
-                          row(4, None, 4, None))
+            assert_rows_ignoring_order(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 4",
+                    pageSize,
+                ),
+                row(0, None, 0, None),
+                row(1, None, 1, None),
+                row(2, None, 2, None),
+                row(4, None, 4, None),
+            )
 
             # odd amount of results
             # Note that which partitions get returned depend on the token order...
-            assert_rows_ignoring_order(execute_with_paging(cql, table, "SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 3", pageSize),
-                          row(0, None, 0, None),
-                          row(1, None, 1, None),
-                          row(2, None, 2, None))
+            assert_rows_ignoring_order(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 3",
+                    pageSize,
+                ),
+                row(0, None, 0, None),
+                row(1, None, 1, None),
+                row(2, None, 2, None),
+            )
 
             # IN query
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a IN (1,3,4) PER PARTITION LIMIT 2", pageSize),
-                          row(1, None, 1, None),
-                          row(3, None, 3, None),
-                          row(4, None, 4, None))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a IN (1,3,4) PER PARTITION LIMIT 2",
+                    pageSize,
+                ),
+                row(1, None, 1, None),
+                row(3, None, 3, None),
+                row(4, None, 4, None),
+            )
 
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a IN (1,3,4) PER PARTITION LIMIT 2 LIMIT 2",
-                                               pageSize),
-                          row(1, None, 1, None),
-                          row(3, None, 3, None))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a IN (1,3,4) PER PARTITION LIMIT 2 LIMIT 2",
+                    pageSize,
+                ),
+                row(1, None, 1, None),
+                row(3, None, 3, None),
+            )
 
             # with restricted partition key
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a = 2 PER PARTITION LIMIT 3", pageSize),
-                          row(2, None, 2, None))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 2 PER PARTITION LIMIT 3",
+                    pageSize,
+                ),
+                row(2, None, 2, None),
+            )
 
             # with ordering
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a = 2 ORDER BY b DESC PER PARTITION LIMIT 3",
-                                               pageSize),
-                          row(2, None, 2, None))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 2 ORDER BY b DESC PER PARTITION LIMIT 3",
+                    pageSize,
+                ),
+                row(2, None, 2, None),
+            )
 
             # with filtering
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a = 2 AND s > 0 PER PARTITION LIMIT 2 ALLOW FILTERING",
-                                               pageSize),
-                          row(2, None, 2, None))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 2 AND s > 0 PER PARTITION LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(2, None, 2, None),
+            )
 
         for i in range(5):
             if i != 1:
                 for j in range(5):
-                    execute(cql, table, "INSERT INTO %s (a, b, s, c) VALUES (?, ?, ?, ?)", i, j, i, j)
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (a, b, s, c) VALUES (?, ?, ?, ?)",
+                        i,
+                        j,
+                        i,
+                        j,
+                    )
 
-        assertInvalidMessage(cql, table, "LIMIT must be strictly positive",
-                             "SELECT * FROM %s PER PARTITION LIMIT ?", 0)
-        assertInvalidMessage(cql, table, "LIMIT must be strictly positive",
-                             "SELECT * FROM %s PER PARTITION LIMIT ?", -1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "LIMIT must be strictly positive",
+            "SELECT * FROM %s PER PARTITION LIMIT ?",
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "LIMIT must be strictly positive",
+            "SELECT * FROM %s PER PARTITION LIMIT ?",
+            -1,
+        )
 
-        for pageSize in range(1,8):
-            assert_rows_ignoring_order(execute_with_paging(cql, table, "SELECT * FROM %s PER PARTITION LIMIT 2", pageSize),
-                          row(0, 0, 0, 0),
-                          row(0, 1, 0, 1),
-                          row(1, None, 1, None),
-                          row(2, 0, 2, 0),
-                          row(2, 1, 2, 1),
-                          row(3, 0, 3, 0),
-                          row(3, 1, 3, 1),
-                          row(4, 0, 4, 0),
-                          row(4, 1, 4, 1))
+        for pageSize in range(1, 8):
+            assert_rows_ignoring_order(
+                execute_with_paging(
+                    cql, table, "SELECT * FROM %s PER PARTITION LIMIT 2", pageSize
+                ),
+                row(0, 0, 0, 0),
+                row(0, 1, 0, 1),
+                row(1, None, 1, None),
+                row(2, 0, 2, 0),
+                row(2, 1, 2, 1),
+                row(3, 0, 3, 0),
+                row(3, 1, 3, 1),
+                row(4, 0, 4, 0),
+                row(4, 1, 4, 1),
+            )
 
             # Combined Per Partition and "global" limit
-            assert_rows_ignoring_order(execute_with_paging(cql, table, "SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 4", pageSize),
-                          row(0, 0, 0, 0),
-                          row(0, 1, 0, 1),
-                          row(1, None, 1, None),
-                          row(2, 0, 2, 0))
+            assert_rows_ignoring_order(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 4",
+                    pageSize,
+                ),
+                row(0, 0, 0, 0),
+                row(0, 1, 0, 1),
+                row(1, None, 1, None),
+                row(2, 0, 2, 0),
+            )
 
             # odd amount of results
-            assert_rows_ignoring_order(execute_with_paging(cql, table, "SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 5", pageSize),
-                          row(0, 0, 0, 0),
-                          row(0, 1, 0, 1),
-                          row(1, None, 1, None),
-                          row(2, 0, 2, 0),
-                          row(2, 1, 2, 1))
+            assert_rows_ignoring_order(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s PER PARTITION LIMIT 2 LIMIT 5",
+                    pageSize,
+                ),
+                row(0, 0, 0, 0),
+                row(0, 1, 0, 1),
+                row(1, None, 1, None),
+                row(2, 0, 2, 0),
+                row(2, 1, 2, 1),
+            )
 
             # IN query
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a IN (2,3) PER PARTITION LIMIT 2", pageSize),
-                          row(2, 0, 2, 0),
-                          row(2, 1, 2, 1),
-                          row(3, 0, 3, 0),
-                          row(3, 1, 3, 1))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a IN (2,3) PER PARTITION LIMIT 2",
+                    pageSize,
+                ),
+                row(2, 0, 2, 0),
+                row(2, 1, 2, 1),
+                row(3, 0, 3, 0),
+                row(3, 1, 3, 1),
+            )
 
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a IN (2,3) PER PARTITION LIMIT 2 LIMIT 3",
-                                               pageSize),
-                          row(2, 0, 2, 0),
-                          row(2, 1, 2, 1),
-                          row(3, 0, 3, 0))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a IN (2,3) PER PARTITION LIMIT 2 LIMIT 3",
+                    pageSize,
+                ),
+                row(2, 0, 2, 0),
+                row(2, 1, 2, 1),
+                row(3, 0, 3, 0),
+            )
 
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a IN (1,2,3) PER PARTITION LIMIT 2 LIMIT 3",
-                                               pageSize),
-                          row(1, null, 1, null),
-                          row(2, 0, 2, 0),
-                          row(2, 1, 2, 1))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a IN (1,2,3) PER PARTITION LIMIT 2 LIMIT 3",
+                    pageSize,
+                ),
+                row(1, null, 1, null),
+                row(2, 0, 2, 0),
+                row(2, 1, 2, 1),
+            )
 
             # with restricted partition key
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a = 2 PER PARTITION LIMIT 3", pageSize),
-                          row(2, 0, 2, 0),
-                          row(2, 1, 2, 1),
-                          row(2, 2, 2, 2))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 2 PER PARTITION LIMIT 3",
+                    pageSize,
+                ),
+                row(2, 0, 2, 0),
+                row(2, 1, 2, 1),
+                row(2, 2, 2, 2),
+            )
 
             # with ordering
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a = 2 ORDER BY b DESC PER PARTITION LIMIT 3",
-                                               pageSize),
-                          row(2, 4, 2, 4),
-                          row(2, 3, 2, 3),
-                          row(2, 2, 2, 2))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 2 ORDER BY b DESC PER PARTITION LIMIT 3",
+                    pageSize,
+                ),
+                row(2, 4, 2, 4),
+                row(2, 3, 2, 3),
+                row(2, 2, 2, 2),
+            )
 
             # with filtering
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a = 2 AND b > 0 PER PARTITION LIMIT 2 ALLOW FILTERING",
-                                               pageSize),
-                          row(2, 1, 2, 1),
-                          row(2, 2, 2, 2))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 2 AND b > 0 PER PARTITION LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(2, 1, 2, 1),
+                row(2, 2, 2, 2),
+            )
 
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE a = 2 AND b > 2 ORDER BY b DESC PER PARTITION LIMIT 2 ALLOW FILTERING",
-                                               pageSize),
-                          row(2, 4, 2, 4),
-                          row(2, 3, 2, 3))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 2 AND b > 2 ORDER BY b DESC PER PARTITION LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(2, 4, 2, 4),
+                row(2, 3, 2, 3),
+            )
 
         # Reproduces #15109:
-        assertInvalidMessage(cql, table, "PER PARTITION LIMIT is not allowed with SELECT DISTINCT queries",
-                             "SELECT DISTINCT a FROM %s PER PARTITION LIMIT ?", 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "PER PARTITION LIMIT is not allowed with SELECT DISTINCT queries",
+            "SELECT DISTINCT a FROM %s PER PARTITION LIMIT ?",
+            3,
+        )
         # Reproduces #15109:
-        assertInvalidMessage(cql, table, "PER PARTITION LIMIT is not allowed with SELECT DISTINCT queries",
-                             "SELECT DISTINCT a FROM %s PER PARTITION LIMIT ? LIMIT ?", 3, 4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "PER PARTITION LIMIT is not allowed with SELECT DISTINCT queries",
+            "SELECT DISTINCT a FROM %s PER PARTITION LIMIT ? LIMIT ?",
+            3,
+            4,
+        )
         # Reproduces #9879:
-        assertInvalidMessage(cql, table, "PER PARTITION LIMIT is not allowed with aggregate queries.",
-                             "SELECT COUNT(*) FROM %s PER PARTITION LIMIT ?", 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "PER PARTITION LIMIT is not allowed with aggregate queries.",
+            "SELECT COUNT(*) FROM %s PER PARTITION LIMIT ?",
+            3,
+        )
+
 
 def testLimitWithDeletedRowsAndStaticColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int, c int, v int, s int static, PRIMARY KEY (pk, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(pk int, c int, v int, s int static, PRIMARY KEY (pk, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (pk, c, v, s) VALUES (1, -1, 1, 1)")
         execute(cql, table, "INSERT INTO %s (pk, c, v, s) VALUES (2, -1, 1, 1)")
         execute(cql, table, "INSERT INTO %s (pk, c, v, s) VALUES (3, -1, 1, 1)")
         execute(cql, table, "INSERT INTO %s (pk, c, v, s) VALUES (4, -1, 1, 1)")
         execute(cql, table, "INSERT INTO %s (pk, c, v, s) VALUES (5, -1, 1, 1)")
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, -1, 1, 1),
-                   row(2, -1, 1, 1),
-                   row(3, -1, 1, 1),
-                   row(4, -1, 1, 1),
-                   row(5, -1, 1, 1))
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, -1, 1, 1),
+            row(2, -1, 1, 1),
+            row(3, -1, 1, 1),
+            row(4, -1, 1, 1),
+            row(5, -1, 1, 1),
+        )
 
         execute(cql, table, "DELETE FROM %s WHERE pk = 2")
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s"),
-                   row(1, -1, 1, 1),
-                   row(3, -1, 1, 1),
-                   row(4, -1, 1, 1),
-                   row(5, -1, 1, 1))
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, -1, 1, 1),
+            row(3, -1, 1, 1),
+            row(4, -1, 1, 1),
+            row(5, -1, 1, 1),
+        )
 
         # Note that which partitions get returned depend on the token order...
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s LIMIT 2"),
-                   row(1, -1, 1, 1),
-                   row(5, -1, 1, 1))
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s LIMIT 2"),
+            row(1, -1, 1, 1),
+            row(5, -1, 1, 1),
+        )
 
-@pytest.mark.xfail(reason="issue #15099")
+
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, and ORDER BY #15099")
 def testFilteringOnClusteringColumnsWithLimitAndStaticColumns(cql, test_keyspace):
     # With only one clustering column
-    with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, s int static, c int, PRIMARY KEY (a, b))"
+    ) as table:
         for i in range(4):
             execute(cql, table, "INSERT INTO %s (a, s) VALUES (?, ?)", i, i)
             for j in range(3):
-                if (not ((i == 0 or i == 3) and j == 1)):
-                    execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", i, j, i + j)
+                if not ((i == 0 or i == 3) and j == 1):
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+                        i,
+                        j,
+                        i + j,
+                    )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s"),
-                       row(0, 0, 0, 0),
-                       row(0, 2, 0, 2),
-                       row(1, 0, 1, 1),
-                       row(1, 1, 1, 2),
-                       row(1, 2, 1, 3),
-                       row(2, 0, 2, 2),
-                       row(2, 1, 2, 3),
-                       row(2, 2, 2, 4),
-                       row(3, 0, 3, 3),
-                       row(3, 2, 3, 5))
+            assert_rows_ignoring_order(
+                execute(cql, table, "SELECT * FROM %s"),
+                row(0, 0, 0, 0),
+                row(0, 2, 0, 2),
+                row(1, 0, 1, 1),
+                row(1, 1, 1, 2),
+                row(1, 2, 1, 3),
+                row(2, 0, 2, 2),
+                row(2, 1, 2, 3),
+                row(2, 2, 2, 4),
+                row(3, 0, 3, 3),
+                row(3, 2, 3, 5),
+            )
 
-            assertRows(execute(cql, table, "SELECT * FROM %s WHERE b = 1 ALLOW FILTERING"),
-                       row(1, 1, 1, 2),
-                       row(2, 1, 2, 3))
+            assertRows(
+                execute(cql, table, "SELECT * FROM %s WHERE b = 1 ALLOW FILTERING"),
+                row(1, 1, 1, 2),
+                row(2, 1, 2, 3),
+            )
 
             # The problem was that the static row of the partition 0 used to be only filtered in SelectStatement and was
             # by consequence counted as a row. In which case the query was returning one row less.
-            assertRows(execute(cql, table, "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING"),
-                       row(1, 1, 1, 2),
-                       row(2, 1, 2, 3))
+            assertRows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING"
+                ),
+                row(1, 1, 1, 2),
+                row(2, 1, 2, 3),
+            )
 
-            assertRows(execute(cql, table, "SELECT * FROM %s WHERE b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING"),
-                       row(1, 1, 1, 2),
-                       row(2, 1, 2, 3))
+            assertRows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING",
+                ),
+                row(1, 1, 1, 2),
+                row(2, 1, 2, 3),
+            )
 
             # Test with paging
-            for pageSize in range(1,4):
-                assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                              row(1, 1, 1, 2),
-                              row(2, 1, 2, 3))
+            for pageSize in range(1, 4):
+                assertRowsNet(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING",
+                        pageSize,
+                    ),
+                    row(1, 1, 1, 2),
+                    row(2, 1, 2, 3),
+                )
 
-                assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                              row(1, 1, 1, 2),
-                              row(2, 1, 2, 3))
+                assertRowsNet(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING",
+                        pageSize,
+                    ),
+                    row(1, 1, 1, 2),
+                    row(2, 1, 2, 3),
+                )
 
-                assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b = 1 GROUP BY a LIMIT 2 ALLOW FILTERING", pageSize),
-                              row(1, 1, 1, 2),
-                              row(2, 1, 2, 3))
+                assertRowsNet(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b = 1 GROUP BY a LIMIT 2 ALLOW FILTERING",
+                        pageSize,
+                    ),
+                    row(1, 1, 1, 2),
+                    row(2, 1, 2, 3),
+                )
 
-                assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b >= 1 AND b <= 1 GROUP BY a LIMIT 2 ALLOW FILTERING", pageSize),
-                              row(1, 1, 1, 2),
-                              row(2, 1, 2, 3))
+                assertRowsNet(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b >= 1 AND b <= 1 GROUP BY a LIMIT 2 ALLOW FILTERING",
+                        pageSize,
+                    ),
+                    row(1, 1, 1, 2),
+                    row(2, 1, 2, 3),
+                )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2, 3) AND b = 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 2),
-                   row(2, 1, 2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (0, 1, 2, 3) AND b = 1 LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 2),
+            row(2, 1, 2, 3),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2, 3) AND b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 2),
-                   row(2, 1, 2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (0, 1, 2, 3) AND b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 2),
+            row(2, 1, 2, 3),
+        )
 
         # Reproduces #15099:
-        assertRows(execute_without_paging(cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2, 3) AND b = 1 ORDER BY b DESC LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 2),
-                   row(2, 1, 2, 3))
+        assertRows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (0, 1, 2, 3) AND b = 1 ORDER BY b DESC LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 2),
+            row(2, 1, 2, 3),
+        )
 
         # Reproduces #15099:
-        assertRows(execute_without_paging(cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2, 3) AND b >= 1 AND b <= 1 ORDER BY b DESC LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 2),
-                   row(2, 1, 2, 3))
+        assertRows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (0, 1, 2, 3) AND b >= 1 AND b <= 1 ORDER BY b DESC LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 2),
+            row(2, 1, 2, 3),
+        )
 
-        execute(cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2, 3)"); # Load all data in the row cache
+        execute(
+            cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2, 3)"
+        )  # Load all data in the row cache
 
         # Partition range queries
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 2),
-                   row(2, 1, 2, 3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING"),
+            row(1, 1, 1, 2),
+            row(2, 1, 2, 3),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 2),
-                   row(2, 1, 2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 2),
+            row(2, 1, 2, 3),
+        )
 
         # Multiple partitions queries
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2) AND b = 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 2),
-                   row(2, 1, 2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (0, 1, 2) AND b = 1 LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 2),
+            row(2, 1, 2, 3),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2) AND b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 2),
-                   row(2, 1, 2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (0, 1, 2) AND b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 2),
+            row(2, 1, 2, 3),
+        )
 
         # Test with paging
-        for pageSize in range(1,4):
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                          row(1, 1, 1, 2),
-                          row(2, 1, 2, 3))
+        for pageSize in range(1, 4):
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(1, 1, 1, 2),
+                row(2, 1, 2, 3),
+            )
 
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                          row(1, 1, 1, 2),
-                          row(2, 1, 2, 3))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b >= 1 AND b <= 1 LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(1, 1, 1, 2),
+                row(2, 1, 2, 3),
+            )
 
     # With multiple clustering columns
-    with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, PRIMARY KEY (a, b, c))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, s int static, d int, PRIMARY KEY (a, b, c))",
+    ) as table:
         for i in range(3):
             execute(cql, table, "INSERT INTO %s (a, s) VALUES (?, ?)", i, i)
             for j in range(3):
-                if (not(i == 0 and j == 1)):
-                    execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", i, j, j, i + j)
+                if not (i == 0 and j == 1):
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+                        i,
+                        j,
+                        j,
+                        i + j,
+                    )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s"),
-                       row(0, 0, 0, 0, 0),
-                       row(0, 2, 2, 0, 2),
-                       row(1, 0, 0, 1, 1),
-                       row(1, 1, 1, 1, 2),
-                       row(1, 2, 2, 1, 3),
-                       row(2, 0, 0, 2, 2),
-                       row(2, 1, 1, 2, 3),
-                       row(2, 2, 2, 2, 4))
+            assert_rows_ignoring_order(
+                execute(cql, table, "SELECT * FROM %s"),
+                row(0, 0, 0, 0, 0),
+                row(0, 2, 2, 0, 2),
+                row(1, 0, 0, 1, 1),
+                row(1, 1, 1, 1, 2),
+                row(1, 2, 2, 1, 3),
+                row(2, 0, 0, 2, 2),
+                row(2, 1, 1, 2, 3),
+                row(2, 2, 2, 2, 4),
+            )
 
-            assertRows(execute(cql, table, "SELECT * FROM %s WHERE b = 1 ALLOW FILTERING"),
-                       row(1, 1, 1, 1, 2),
-                       row(2, 1, 1, 2, 3))
+            assertRows(
+                execute(cql, table, "SELECT * FROM %s WHERE b = 1 ALLOW FILTERING"),
+                row(1, 1, 1, 1, 2),
+                row(2, 1, 1, 2, 3),
+            )
 
-            assertRows(execute(cql, table, "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING"),
-                       row(1, 1, 1, 1, 2),
-                       row(2, 1, 1, 2, 3))
+            assertRows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING",
+                ),
+                row(1, 1, 1, 1, 2),
+                row(2, 1, 1, 2, 3),
+            )
 
             # Test with paging
-            for pageSize in range(1,4):
-                assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                              row(1, 1, 1, 1, 2),
-                              row(2, 1, 1, 2, 3))
+            for pageSize in range(1, 4):
+                assertRowsNet(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING",
+                        pageSize,
+                    ),
+                    row(1, 1, 1, 1, 2),
+                    row(2, 1, 1, 2, 3),
+                )
 
-                assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                              row(1, 1, 1, 1, 2),
-                              row(2, 1, 1, 2, 3))
+                assertRowsNet(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING",
+                        pageSize,
+                    ),
+                    row(1, 1, 1, 1, 2),
+                    row(2, 1, 1, 2, 3),
+                )
 
-                assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b = 1 GROUP BY a, b LIMIT 2 ALLOW FILTERING", pageSize),
-                              row(1, 1, 1, 1, 2),
-                              row(2, 1, 1, 2, 3))
+                assertRowsNet(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b = 1 GROUP BY a, b LIMIT 2 ALLOW FILTERING",
+                        pageSize,
+                    ),
+                    row(1, 1, 1, 1, 2),
+                    row(2, 1, 1, 2, 3),
+                )
 
-                assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 GROUP BY a, b LIMIT 2 ALLOW FILTERING", pageSize),
-                              row(1, 1, 1, 1, 2),
-                              row(2, 1, 1, 2, 3))
+                assertRowsNet(
+                    execute_with_paging(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 GROUP BY a, b LIMIT 2 ALLOW FILTERING",
+                        pageSize,
+                    ),
+                    row(1, 1, 1, 1, 2),
+                    row(2, 1, 1, 2, 3),
+                )
 
-        execute(cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2)"); # Load data in the row cache
+        execute(
+            cql, table, "SELECT * FROM %s WHERE a IN (0, 1, 2)"
+        )  # Load data in the row cache
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE b = 1 ALLOW FILTERING"),
-                   row(1, 1, 1, 1, 2),
-                   row(2, 1, 1, 2, 3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE b = 1 ALLOW FILTERING"),
+            row(1, 1, 1, 1, 2),
+            row(2, 1, 1, 2, 3),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 1, 2),
-                   row(2, 1, 1, 2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 1, 2),
+            row(2, 1, 1, 2, 3),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 3, 4) AND b = 1 ALLOW FILTERING"),
-                   row(1, 1, 1, 1, 2),
-                   row(2, 1, 1, 2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (1, 2, 3, 4) AND b = 1 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 1, 2),
+            row(2, 1, 1, 2, 3),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (1, 2, 3, 4) AND b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING"),
-                   row(1, 1, 1, 1, 2),
-                   row(2, 1, 1, 2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (1, 2, 3, 4) AND b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING",
+            ),
+            row(1, 1, 1, 1, 2),
+            row(2, 1, 1, 2, 3),
+        )
 
         # Test with paging
-        for pageSize in range(1,4):
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                          row(1, 1, 1, 1, 2),
-                          row(2, 1, 1, 2, 3))
+        for pageSize in range(1, 4):
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b = 1 LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(1, 1, 1, 1, 2),
+                row(2, 1, 1, 2, 3),
+            )
 
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                          row(1, 1, 1, 1, 2),
-                          row(2, 1, 1, 2, 3))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b IN (1, 2, 3, 4) AND c >= 1 AND c <= 1 LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(1, 1, 1, 1, 2),
+                row(2, 1, 1, 2, 3),
+            )
+
 
 def testIndexOnRegularColumnWithPartitionWithoutRows(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int, c int, s int static, v int, PRIMARY KEY (pk, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(pk int, c int, s int static, v int, PRIMARY KEY (pk, c))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (v)")
 
-        execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 1, 9, 1)
-        execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 2, 9, 2)
-        execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 3, 1, 9, 1)
-        execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 4, 1, 9, 1)
+        execute(
+            cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 1, 9, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 2, 9, 2
+        )
+        execute(
+            cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 3, 1, 9, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 4, 1, 9, 1
+        )
         flush(cql, table)
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE v = ?", 1),
-                   row(1, 1, 9, 1),
-                   row(3, 1, 9, 1),
-                   row(4, 1, 9, 1))
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE v = ?", 1),
+            row(1, 1, 9, 1),
+            row(3, 1, 9, 1),
+            row(4, 1, 9, 1),
+        )
 
         execute(cql, table, "DELETE FROM %s WHERE pk = ? and c = ?", 3, 1)
 
         # Test without paging
-        assertRows(execute_without_paging(cql, table, "SELECT * FROM %s WHERE v = ? LIMIT 2", 1),
-                   row(1, 1, 9, 1),
-                   row(4, 1, 9, 1))
+        assertRows(
+            execute_without_paging(
+                cql, table, "SELECT * FROM %s WHERE v = ? LIMIT 2", 1
+            ),
+            row(1, 1, 9, 1),
+            row(4, 1, 9, 1),
+        )
 
-        assertRows(execute_without_paging(cql, table, "SELECT * FROM %s WHERE v = ? GROUP BY pk LIMIT 2", 1),
-                   row(1, 1, 9, 1),
-                   row(4, 1, 9, 1))
+        assertRows(
+            execute_without_paging(
+                cql, table, "SELECT * FROM %s WHERE v = ? GROUP BY pk LIMIT 2", 1
+            ),
+            row(1, 1, 9, 1),
+            row(4, 1, 9, 1),
+        )
 
         # Test with paging
-        for pageSize in range(1,4):
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE v = 1 LIMIT 2", pageSize),
-                          row(1, 1, 9, 1),
-                          row(4, 1, 9, 1))
+        for pageSize in range(1, 4):
+            assertRowsNet(
+                execute_with_paging(
+                    cql, table, "SELECT * FROM %s WHERE v = 1 LIMIT 2", pageSize
+                ),
+                row(1, 1, 9, 1),
+                row(4, 1, 9, 1),
+            )
 
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE v = 1 GROUP BY pk LIMIT 2", pageSize),
-                          row(1, 1, 9, 1),
-                          row(4, 1, 9, 1))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE v = 1 GROUP BY pk LIMIT 2",
+                    pageSize,
+                ),
+                row(1, 1, 9, 1),
+                row(4, 1, 9, 1),
+            )
+
 
 def testFilteringWithPartitionWithoutRows(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int, c int, s int static, v int, PRIMARY KEY (pk, c))") as table:
-        execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 1, 9, 1)
-        execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 2, 9, 2)
-        execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 3, 1, 9, 1)
-        execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 4, 1, 9, 1)
+    with create_table(
+        cql, test_keyspace, "(pk int, c int, s int static, v int, PRIMARY KEY (pk, c))"
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 1, 9, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 2, 9, 2
+        )
+        execute(
+            cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 3, 1, 9, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 4, 1, 9, 1
+        )
         flush(cql, table)
 
-        assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE v = ? ALLOW FILTERING", 1),
-                   row(1, 1, 9, 1),
-                   row(3, 1, 9, 1),
-                   row(4, 1, 9, 1))
+        assert_rows_ignoring_order(
+            execute(cql, table, "SELECT * FROM %s WHERE v = ? ALLOW FILTERING", 1),
+            row(1, 1, 9, 1),
+            row(3, 1, 9, 1),
+            row(4, 1, 9, 1),
+        )
 
         execute(cql, table, "DELETE FROM %s WHERE pk = ? and c = ?", 3, 1)
 
         # Test without paging
-        assertRows(execute_without_paging(cql, table, "SELECT * FROM %s WHERE v = ? LIMIT 2 ALLOW FILTERING", 1),
-                   row(1, 1, 9, 1),
-                   row(4, 1, 9, 1))
+        assertRows(
+            execute_without_paging(
+                cql, table, "SELECT * FROM %s WHERE v = ? LIMIT 2 ALLOW FILTERING", 1
+            ),
+            row(1, 1, 9, 1),
+            row(4, 1, 9, 1),
+        )
 
         # Reproduces #10357 (matches a row that was already deleted and only a static row was left and no v=1)
-        assertRows(execute_without_paging(cql, table, "SELECT * FROM %s WHERE pk IN ? AND v = ? LIMIT 3 ALLOW FILTERING", [1, 3, 4], 1),
-                   row(1, 1, 9, 1),
-                   row(4, 1, 9, 1))
+        assertRows(
+            execute_without_paging(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk IN ? AND v = ? LIMIT 3 ALLOW FILTERING",
+                [1, 3, 4],
+                1,
+            ),
+            row(1, 1, 9, 1),
+            row(4, 1, 9, 1),
+        )
 
         # Test with paging
-        for pageSize in range(1,4):
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE v = 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                          row(1, 1, 9, 1),
-                          row(4, 1, 9, 1))
+        for pageSize in range(1, 4):
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE v = 1 LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(1, 1, 9, 1),
+                row(4, 1, 9, 1),
+            )
 
             # Reproduces #10357 (matches a row that was already deleted and only a static row was left and no v=1)
-            assertRowsNet(execute_with_paging(cql, table, "SELECT * FROM %s WHERE pk IN (1, 3, 4) AND v = 1 LIMIT 2 ALLOW FILTERING", pageSize),
-                          row(1, 1, 9, 1),
-                          row(4, 1, 9, 1))
+            assertRowsNet(
+                execute_with_paging(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk IN (1, 3, 4) AND v = 1 LIMIT 2 ALLOW FILTERING",
+                    pageSize,
+                ),
+                row(1, 1, 9, 1),
+                row(4, 1, 9, 1),
+            )

--- a/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
@@ -10,73 +10,180 @@
 
 from ...porting import *
 
-TOO_BIG = bytearray([1])*1024*65
+TOO_BIG = bytearray([1]) * 1024 * 65
 REQUIRES_ALLOW_FILTERING_MESSAGE = "Cannot execute this query as it might involve data filtering and thus may have unpredictable performance. If you want to execute this query despite the performance unpredictability, use ALLOW FILTERING"
 
+
 def testSingleClusteringInvalidQueries(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, primary key (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, primary key (a, b))"
+    ) as table:
         assertInvalidSyntax(cql, table, "SELECT * FROM %s WHERE () = (?, ?)", 1, 2)
-        assertInvalidMessage(cql, table, "cannot be restricted by",
-                             "SELECT * FROM %s WHERE a = 0 AND (b) = (?) AND (b) > (?)", 0, 0)
-        assertInvalidMessage(cql, table, "More than one restriction was found for the start bound on b",
-                             "SELECT * FROM %s WHERE a = 0 AND (b) > (?) AND (b) > (?)", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "cannot be restricted by",
+            "SELECT * FROM %s WHERE a = 0 AND (b) = (?) AND (b) > (?)",
+            0,
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "More than one restriction was found for the start bound on b",
+            "SELECT * FROM %s WHERE a = 0 AND (b) > (?) AND (b) > (?)",
+            0,
+            1,
+        )
         # Cassandra complains that "More than one restriction was found for
         # the start bound on b", but Scylla because of #4244 complains
         # that single- and multi-column relations are mixed
-        assertInvalid(cql, table,
-                             "SELECT * FROM %s WHERE a = 0 AND (b) > (?) AND b > ?", 0, 1)
-        assertInvalidMessage(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: a",
-                             "SELECT * FROM %s WHERE (a, b) = (?, ?)", 0, 0)
+        assertInvalid(
+            cql, table, "SELECT * FROM %s WHERE a = 0 AND (b) > (?) AND b > ?", 0, 1
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: a",
+            "SELECT * FROM %s WHERE (a, b) = (?, ?)",
+            0,
+            0,
+        )
+
 
 # We need to skip this test because issue #13241 causes it to frequently
 # crash Scylla, and not just fail cleanly.
-@pytest.mark.skip(reason="Issue #13241")
-@pytest.mark.xfail(reason="Issue #4244")
+@pytest.mark.skip(
+    reason="Multi-column IN restriction with tuples of different lengths crashes Scylla #13241"
+)
+@pytest.mark.xfail(
+    reason="one-element multi-column restriction should be handled like a single-column restriction #4244"
+)
 def testMultiClusteringInvalidQueries(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))"
+    ) as table:
         assertInvalidSyntax(cql, table, "SELECT * FROM %s WHERE a = 0 AND (b, c) > ()")
-        assertInvalidMessage(cql, table, "Expected 2 elements in value tuple, but got 3: (?, ?, ?)",
-                             "SELECT * FROM %s WHERE a = 0 AND (b, c) > (?, ?, ?)", 1, 2, 3)
-        assertInvalidMessage(cql, table, "Invalid null value in condition for column c",
-                             "SELECT * FROM %s WHERE a = 0 AND (b, c) > (?, ?)", 1, None)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Expected 2 elements in value tuple, but got 3: (?, ?, ?)",
+            "SELECT * FROM %s WHERE a = 0 AND (b, c) > (?, ?, ?)",
+            1,
+            2,
+            3,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Invalid null value in condition for column c",
+            "SELECT * FROM %s WHERE a = 0 AND (b, c) > (?, ?)",
+            1,
+            None,
+        )
 
         # Wrong order of columns
-        assertInvalidMessage(cql, table, "PRIMARY KEY order",
-                             "SELECT * FROM %s WHERE a = 0 AND (d, c, b) = (?, ?, ?)", 0, 0, 0)
-        assertInvalidMessage(cql, table, "PRIMARY KEY order",
-                             "SELECT * FROM %s WHERE a = 0 AND (d, c, b) > (?, ?, ?)", 0, 0, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "PRIMARY KEY order",
+            "SELECT * FROM %s WHERE a = 0 AND (d, c, b) = (?, ?, ?)",
+            0,
+            0,
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "PRIMARY KEY order",
+            "SELECT * FROM %s WHERE a = 0 AND (d, c, b) > (?, ?, ?)",
+            0,
+            0,
+            0,
+        )
 
         # Wrong number of values
         # Reproduces #13241:
-        assertInvalidMessage(cql, table, "Expected 3 elements in value tuple, but got 2: (?, ?)",
-                             "SELECT * FROM %s WHERE a=0 AND (b, c, d) IN ((?, ?))", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Expected 3 elements in value tuple, but got 2: (?, ?)",
+            "SELECT * FROM %s WHERE a=0 AND (b, c, d) IN ((?, ?))",
+            0,
+            1,
+        )
         # Scylla and Cassandra have very different error messages here, but
         # both mention "tuple"
-        assertInvalidMessage(cql, table, "tuple",
-                             "SELECT * FROM %s WHERE a=0 AND (b, c, d) IN ((?, ?, ?, ?, ?))", 0, 1, 2, 3, 4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "tuple",
+            "SELECT * FROM %s WHERE a=0 AND (b, c, d) IN ((?, ?, ?, ?, ?))",
+            0,
+            1,
+            2,
+            3,
+            4,
+        )
 
         # Missing first clustering column
         # Scylla and Cassandra have very different error messages here
         # with barely the word "column" in common
-        assertInvalidMessage(cql, table, "column",
-                             "SELECT * FROM %s WHERE a = 0 AND (c, d) = (?, ?)", 0, 0)
-        assertInvalidMessage(cql, table, "column",
-                             "SELECT * FROM %s WHERE a = 0 AND (c, d) > (?, ?)", 0, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "column",
+            "SELECT * FROM %s WHERE a = 0 AND (c, d) = (?, ?)",
+            0,
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "column",
+            "SELECT * FROM %s WHERE a = 0 AND (c, d) > (?, ?)",
+            0,
+            0,
+        )
 
         # Nulls
-        assertInvalidMessage(cql, table, "Invalid null value",
-                             "SELECT * FROM %s WHERE a = 0 AND (b, c, d) = (?, ?, ?)", 1, 2, None)
-        assertInvalidMessage(cql, table, "Invalid null value",
-                             "SELECT * FROM %s WHERE a = 0 AND (b, c, d) IN ((?, ?, ?))", 1, 2, None)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Invalid null value",
+            "SELECT * FROM %s WHERE a = 0 AND (b, c, d) = (?, ?, ?)",
+            1,
+            2,
+            None,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Invalid null value",
+            "SELECT * FROM %s WHERE a = 0 AND (b, c, d) IN ((?, ?, ?))",
+            1,
+            2,
+            None,
+        )
         # Reproduces #13217
-        assertInvalidMessage(cql, table, "Invalid null value in condition for column",
-                             "SELECT * FROM %s WHERE a = 0 AND (b, c, d) IN ((?, ?, ?), (?, ?, ?))", 1, 2, None, 2, 1, 4)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Invalid null value in condition for column",
+            "SELECT * FROM %s WHERE a = 0 AND (b, c, d) IN ((?, ?, ?), (?, ?, ?))",
+            1,
+            2,
+            None,
+            2,
+            1,
+            4,
+        )
 
         # Wrong type for 'd'
         # Cannot be tested in Python (the driver recognizes the wrong type
         # in the bound variable) - so commented out
-        #assertInvalid(cql, table, "SELECT * FROM %s WHERE a = 0 AND (b, c, d) = (?, ?, ?)", 1, 2, "foobar")
-        #assertInvalid(cql, table, "SELECT * FROM %s WHERE a = 0 AND b = (?, ?, ?)", 1, 2, 3)
+        # assertInvalid(cql, table, "SELECT * FROM %s WHERE a = 0 AND (b, c, d) = (?, ?, ?)", 1, 2, "foobar")
+        # assertInvalid(cql, table, "SELECT * FROM %s WHERE a = 0 AND b = (?, ?, ?)", 1, 2, 3)
 
         # Mix single and tuple inequalities
         # All of these tests reproduce #4244 - because of this issue Scylla
@@ -85,1388 +192,3710 @@ def testMultiClusteringInvalidQueries(cql, test_keyspace):
         # When #4244 is fixed, it is quite likely we'll need to change this
         # test to accept Scylla's error messages, which might be different
         # from Cassandra's.
-        assertInvalidMessage(cql, table, "Column \"c\" cannot be restricted by two inequalities not starting with the same column",
-                             "SELECT * FROM %s WHERE a = 0 AND (b, c, d) > (?, ?, ?) AND c < ?", 0, 1, 0, 1)
-        assertInvalidMessage(cql, table, "Column \"c\" cannot be restricted by two inequalities not starting with the same column",
-                            "SELECT * FROM %s WHERE a = 0 AND c > ? AND (b, c, d) < (?, ?, ?)", 1, 1, 1, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            'Column "c" cannot be restricted by two inequalities not starting with the same column',
+            "SELECT * FROM %s WHERE a = 0 AND (b, c, d) > (?, ?, ?) AND c < ?",
+            0,
+            1,
+            0,
+            1,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            'Column "c" cannot be restricted by two inequalities not starting with the same column',
+            "SELECT * FROM %s WHERE a = 0 AND c > ? AND (b, c, d) < (?, ?, ?)",
+            1,
+            1,
+            1,
+            0,
+        )
 
-        assertInvalidMessage(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: a",
-                             "SELECT * FROM %s WHERE (a, b, c, d) IN ((?, ?, ?, ?))", 0, 1, 2, 3)
-        assertInvalidMessage(cql, table, "PRIMARY KEY column \"c\" cannot be restricted as preceding column \"b\" is not restricted",
-                             "SELECT * FROM %s WHERE (c, d) IN ((?, ?))", 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: a",
+            "SELECT * FROM %s WHERE (a, b, c, d) IN ((?, ?, ?, ?))",
+            0,
+            1,
+            2,
+            3,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            'PRIMARY KEY column "c" cannot be restricted as preceding column "b" is not restricted',
+            "SELECT * FROM %s WHERE (c, d) IN ((?, ?))",
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                             "SELECT * FROM %s WHERE a = ? AND b > ?  AND (c, d) IN ((?, ?))", 0, 0, 0, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+            "SELECT * FROM %s WHERE a = ? AND b > ?  AND (c, d) IN ((?, ?))",
+            0,
+            0,
+            0,
+            0,
+        )
 
-        assertInvalidMessage(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                             "SELECT * FROM %s WHERE a = ? AND b > ?  AND (c, d) > (?, ?)", 0, 0, 0, 0)
-        assertInvalidMessage(cql, table, "PRIMARY KEY column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                             "SELECT * FROM %s WHERE a = ? AND (c, d) > (?, ?) AND b > ?  ", 0, 0, 0, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+            "SELECT * FROM %s WHERE a = ? AND b > ?  AND (c, d) > (?, ?)",
+            0,
+            0,
+            0,
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            'PRIMARY KEY column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+            "SELECT * FROM %s WHERE a = ? AND (c, d) > (?, ?) AND b > ?  ",
+            0,
+            0,
+            0,
+            0,
+        )
 
-        assertInvalidMessage(cql, table, "Column \"c\" cannot be restricted by two inequalities not starting with the same column",
-                             "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?) AND (b) < (?) AND (c) < (?)", 0, 0, 0, 0, 0)
-        assertInvalidMessage(cql, table, "Column \"c\" cannot be restricted by two inequalities not starting with the same column",
-                             "SELECT * FROM %s WHERE a = ? AND (c) < (?) AND (b, c) > (?, ?) AND (b) < (?)", 0, 0, 0, 0, 0)
-        assertInvalidMessage(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                             "SELECT * FROM %s WHERE a = ? AND (b) < (?) AND (c) < (?) AND (b, c) > (?, ?)", 0, 0, 0, 0, 0)
-        assertInvalidMessage(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                             "SELECT * FROM %s WHERE a = ? AND (b) < (?) AND c < ? AND (b, c) > (?, ?)", 0, 0, 0, 0, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            'Column "c" cannot be restricted by two inequalities not starting with the same column',
+            "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?) AND (b) < (?) AND (c) < (?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            'Column "c" cannot be restricted by two inequalities not starting with the same column',
+            "SELECT * FROM %s WHERE a = ? AND (c) < (?) AND (b, c) > (?, ?) AND (b) < (?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+            "SELECT * FROM %s WHERE a = ? AND (b) < (?) AND (c) < (?) AND (b, c) > (?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+            "SELECT * FROM %s WHERE a = ? AND (b) < (?) AND c < ? AND (b, c) > (?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
 
-        assertInvalidMessage(cql, table, "Column \"c\" cannot be restricted by two inequalities not starting with the same column",
-                             "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?) AND (c) < (?)", 0, 0, 0, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            'Column "c" cannot be restricted by two inequalities not starting with the same column',
+            "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?) AND (c) < (?)",
+            0,
+            0,
+            0,
+            0,
+        )
 
-@pytest.mark.xfail(reason="Issue #64, #4244")
+
+@pytest.mark.xfail(
+    reason="CQL Multi column restrictions are allowed only on a clustering key prefix #64, Add support for mixing token, multi- and single-column restrictions #4244"
+)
 def testMultiAndSingleColumnRelationMix(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 1)
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))"
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 1
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 1)
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 1
+        )
 
         # Reproduces #64:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) = (?, ?)", 0, 1, 0, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b IN (?, ?) and (c, d) = (?, ?)", 0, 0, 1, 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c) IN ((?))", 0, 1, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b IN (?, ?) and (c) IN ((?))", 0, 0, 1, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c) IN ((?), (?))", 0, 1, 0, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) IN ((?, ?))", 0, 1, 0, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) IN ((?, ?), (?, ?))", 0, 1, 0, 0, 1, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b IN (?, ?) and (c, d) IN ((?, ?), (?, ?))", 0, 0, 1, 0, 0, 1, 1),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) > (?, ?)", 0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b IN (?, ?) and (c, d) > (?, ?)", 0, 0, 1, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) > (?, ?) and (c) <= (?) ", 0, 1, 0, 0, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) > (?, ?) and c <= ? ", 0, 1, 0, 0, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) >= (?, ?) and (c, d) < (?, ?)", 0, 1, 0, 0, 1, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b, c) = (?, ?) and d = ?", 0, 0, 1, 0),
-                   row(0, 0, 1, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b, c) IN ((?, ?), (?, ?)) and d = ?", 0, 0, 1, 0, 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c) = (?) and d = ?", 0, 0, 1, 0),
-                   row(0, 0, 1, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b, c) = (?, ?) and d IN (?, ?)", 0, 0, 1, 0, 2),
-                   row(0, 0, 1, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and b = ? and (c) = (?) and d IN (?, ?)", 0, 0, 1, 0, 2),
-                   row(0, 0, 1, 0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) = (?, ?)",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b IN (?, ?) and (c, d) = (?, ?)",
+                0,
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c) IN ((?))",
+                0,
+                1,
+                0,
+            ),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b IN (?, ?) and (c) IN ((?))",
+                0,
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c) IN ((?), (?))",
+                0,
+                1,
+                0,
+                1,
+            ),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) IN ((?, ?))",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) IN ((?, ?), (?, ?))",
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b IN (?, ?) and (c, d) IN ((?, ?), (?, ?))",
+                0,
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) > (?, ?)",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b IN (?, ?) and (c, d) > (?, ?)",
+                0,
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) > (?, ?) and (c) <= (?) ",
+                0,
+                1,
+                0,
+                0,
+                1,
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) > (?, ?) and c <= ? ",
+                0,
+                1,
+                0,
+                0,
+                1,
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c, d) >= (?, ?) and (c, d) < (?, ?)",
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b, c) = (?, ?) and d = ?",
+                0,
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 1, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b, c) IN ((?, ?), (?, ?)) and d = ?",
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c) = (?) and d = ?",
+                0,
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 1, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b, c) = (?, ?) and d IN (?, ?)",
+                0,
+                0,
+                1,
+                0,
+                2,
+            ),
+            row(0, 0, 1, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and b = ? and (c) = (?) and d IN (?, ?)",
+                0,
+                0,
+                1,
+                0,
+                2,
+            ),
+            row(0, 0, 1, 0),
+        )
 
         # Reproduces #4244:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b, c) = (?, ?) and d >= ?", 0, 0, 1, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b, c) = (?, ?) and d >= ?",
+                0,
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and d < 1 and (b, c) = (?, ?) and d >= ?", 0, 0, 1, 0),
-                   row(0, 0, 1, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and d < 1 and (b, c) IN ((?, ?), (?, ?)) and d >= ?", 0, 0, 1, 0, 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and d < 1 and (b, c) = (?, ?) and d >= ?",
+                0,
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 1, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and d < 1 and (b, c) IN ((?, ?), (?, ?)) and d >= ?",
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+        )
 
-@pytest.mark.xfail(reason="Issue #64, #4244")
+
+@pytest.mark.xfail(
+    reason="CQL Multi column restrictions are allowed only on a clustering key prefix #64, Add support for mixing token, multi- and single-column restrictions #4244"
+)
 def testSeveralMultiColumnRelation(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 1)
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))"
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 1
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 1)
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 1
+        )
 
         # Reproduces #64:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) = (?, ?)", 0, 1, 0, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) IN ((?), (?)) and (c, d) = (?, ?)", 0, 0, 1, 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c) IN ((?))", 0, 1, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) IN ((?),(?)) and (c) IN ((?))", 0, 0, 1, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c) IN ((?), (?))", 0, 1, 0, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) IN ((?, ?))", 0, 1, 0, 0),
-                   row(0, 1, 0, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) IN ((?, ?), (?, ?))", 0, 1, 0, 0, 1, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) IN ((?), (?)) and (c, d) IN ((?, ?), (?, ?))", 0, 0, 1, 0, 0, 1, 1),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) > (?, ?)", 0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) IN ((?),(?)) and (c, d) > (?, ?)", 0, 0, 1, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) > (?, ?) and (c) <= (?) ", 0, 1, 0, 0, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) > (?, ?) and c <= ? ", 0, 1, 0, 0, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) >= (?, ?) and (c, d) < (?, ?)", 0, 1, 0, 0, 1, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) = (?, ?)",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) IN ((?), (?)) and (c, d) = (?, ?)",
+                0,
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c) IN ((?))",
+                0,
+                1,
+                0,
+            ),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) IN ((?),(?)) and (c) IN ((?))",
+                0,
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c) IN ((?), (?))",
+                0,
+                1,
+                0,
+                1,
+            ),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) IN ((?, ?))",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 1, 0, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) IN ((?, ?), (?, ?))",
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) IN ((?), (?)) and (c, d) IN ((?, ?), (?, ?))",
+                0,
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) > (?, ?)",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) IN ((?),(?)) and (c, d) > (?, ?)",
+                0,
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) > (?, ?) and (c) <= (?) ",
+                0,
+                1,
+                0,
+                0,
+                1,
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) > (?, ?) and c <= ? ",
+                0,
+                1,
+                0,
+                0,
+                1,
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b) = (?) and (c, d) >= (?, ?) and (c, d) < (?, ?)",
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+        )
 
         # Reproduces #4244:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b, c) = (?, ?) and d = ?", 0, 0, 1, 0),
-                   row(0, 0, 1, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b, c) IN ((?, ?), (?, ?)) and d = ?", 0, 0, 1, 0, 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b, c) = (?, ?) and d = ?",
+                0,
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 1, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b, c) IN ((?, ?), (?, ?)) and d = ?",
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+        )
 
         # Reproduces #64:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (d) < (1) and (b, c) = (?, ?) and (d) >= (?)", 0, 0, 1, 0),
-                   row(0, 0, 1, 0))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (d) < (1) and (b, c) IN ((?, ?), (?, ?)) and (d) >= (?)", 0, 0, 1, 0, 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (d) < (1) and (b, c) = (?, ?) and (d) >= (?)",
+                0,
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 1, 0),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (d) < (1) and (b, c) IN ((?, ?), (?, ?)) and (d) >= (?)",
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+        )
+
 
 def testSinglePartitionInvalidQueries(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int primary key, b int)") as table:
-        assertInvalidMessage(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: a",
-                             "SELECT * FROM %s WHERE (a) > (?)", 0)
-        assertInvalidMessage(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: a",
-                             "SELECT * FROM %s WHERE (a) = (?)", 0)
-        assertInvalidMessage(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: b",
-                             "SELECT * FROM %s WHERE (b) = (?)", 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: a",
+            "SELECT * FROM %s WHERE (a) > (?)",
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: a",
+            "SELECT * FROM %s WHERE (a) = (?)",
+            0,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: b",
+            "SELECT * FROM %s WHERE (b) = (?)",
+            0,
+        )
 
-@pytest.mark.xfail(reason="Issue #4244")
+
+@pytest.mark.xfail(
+    reason="one-element multi-column restriction should be handled like a single-column restriction #4244"
+)
 def testSingleClustering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, primary key (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, primary key (a, b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 0, 0)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 1, 0)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 2, 0)
 
         # Equalities
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = (?)", 0, 1),
-                   row(0, 1, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = (?)", 0, 1),
+            row(0, 1, 0),
         )
 
         # Same but check the whole tuple can be prepared
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = ?", 0, (1,)),
-                   row(0, 1, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = ?", 0, (1,)),
+            row(0, 1, 0),
         )
 
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = (?)", 0, 3))
+        assertEmpty(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = (?)", 0, 3)
+        )
 
         # Inequalities
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?)", 0, 0),
-                   row(0, 1, 0),
-                   row(0, 2, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?)", 0, 0),
+            row(0, 1, 0),
+            row(0, 2, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) >= (?)", 0, 1),
-                   row(0, 1, 0),
-                   row(0, 2, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) >= (?)", 0, 1),
+            row(0, 1, 0),
+            row(0, 2, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) < (?)", 0, 2),
-                   row(0, 0, 0),
-                   row(0, 1, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) < (?)", 0, 2),
+            row(0, 0, 0),
+            row(0, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) <= (?)", 0, 1),
-                   row(0, 0, 0),
-                   row(0, 1, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) <= (?)", 0, 1),
+            row(0, 0, 0),
+            row(0, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?) AND (b) < (?)", 0, 0, 2),
-                   row(0, 1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b) > (?) AND (b) < (?)",
+                0,
+                0,
+                2,
+            ),
+            row(0, 1, 0),
         )
 
         # Reproduces #4244:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?) AND b < ?", 0, 0, 2),
-                   row(0, 1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b) > (?) AND b < ?",
+                0,
+                0,
+                2,
+            ),
+            row(0, 1, 0),
         )
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b > ? AND (b) < (?)", 0, 0, 2),
-                   row(0, 1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b > ? AND (b) < (?)",
+                0,
+                0,
+                2,
+            ),
+            row(0, 1, 0),
         )
+
 
 def testNonEqualsRelation(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int primary key, b int)") as table:
-        assertInvalidMessage(cql, table, "Unsupported \"!=\" relation: (b) != (0)",
-                             "SELECT * FROM %s WHERE a = 0 AND (b) != (0)")
+        assertInvalidMessage(
+            cql,
+            table,
+            'Unsupported "!=" relation: (b) != (0)',
+            "SELECT * FROM %s WHERE a = 0 AND (b) != (0)",
+        )
 
-@pytest.mark.xfail(reason="Issue #4244")
+
+@pytest.mark.xfail(
+    reason="one-element multi-column restriction should be handled like a single-column restriction #4244"
+)
 def testMultipleClustering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c, d))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 1)
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c, d))"
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 1
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 1)
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 1
+        )
 
         # Empty query
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a = 0 AND (b, c, d) IN ()"))
+        assertEmpty(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 0 AND (b, c, d) IN ()")
+        )
 
         # Equalities
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = (?)", 0, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = (?)", 0, 1),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
         # Same with whole tuple prepared
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = ?", 0, (1,)),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) = ?", 0, (1,)),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) = (?, ?)", 0, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
-        )
-
-        # Same with whole tuple prepared
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) = ?", 0, (1, 1)),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
-        )
-
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) = (?, ?, ?)", 0, 1, 1, 1),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) = (?, ?)", 0, 1, 1
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
         # Same with whole tuple prepared
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) = ?", 0, (1, 1, 1)),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) = ?", 0, (1, 1)
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
+        )
+
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) = (?, ?, ?)",
+                0,
+                1,
+                1,
+                1,
+            ),
+            row(0, 1, 1, 1),
+        )
+
+        # Same with whole tuple prepared
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) = ?",
+                0,
+                (1, 1, 1),
+            ),
+            row(0, 1, 1, 1),
         )
 
         # Inequalities
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?)", 0, 0),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?)", 0, 0),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) >= (?)", 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) >= (?)", 0, 0),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?)", 0, 1, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?)", 0, 1, 0
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) >= (?, ?)", 0, 1, 0),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) >= (?, ?)", 0, 1, 0
+            ),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?)", 0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?)",
+                0,
+                1,
+                1,
+                0,
+            ),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) >= (?, ?, ?)", 0, 1, 1, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) >= (?, ?, ?)",
+                0,
+                1,
+                1,
+                0,
+            ),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) < (?)", 0, 1),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) < (?)", 0, 1),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) <= (?)", 0, 1),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) <= (?)", 0, 1),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 0),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) < (?, ?)", 0, 0, 1),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) < (?, ?)", 0, 0, 1
+            ),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) <= (?, ?)", 0, 0, 1),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) <= (?, ?)", 0, 0, 1
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) < (?, ?, ?)", 0, 0, 1, 1),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) < (?, ?, ?)",
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) <= (?, ?, ?)", 0, 0, 1, 1),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) <= (?, ?, ?)",
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b) < (?)", 0, 0, 1, 0, 1),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b) < (?)",
+                0,
+                0,
+                1,
+                0,
+                1,
+            ),
+            row(0, 0, 1, 1),
         )
 
         # Reproduces #4244:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND b < ?", 0, 0, 1, 0, 1),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND b < ?",
+                0,
+                0,
+                1,
+                0,
+                1,
+            ),
+            row(0, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b, c) < (?, ?)", 0, 0, 1, 1, 1, 1),
-                   row(0, 1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b, c) < (?, ?)",
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+            ),
+            row(0, 1, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b, c, d) < (?, ?, ?)", 0, 0, 1, 1, 1, 1, 0),
-                   row(0, 1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b, c, d) < (?, ?, ?)",
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+                0,
+            ),
+            row(0, 1, 0, 0),
         )
 
         # Same with whole tuple prepared
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > ? AND (b, c, d) < ?", 0, (0, 1, 1), (1, 1, 0)),
-                   row(0, 1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > ? AND (b, c, d) < ?",
+                0,
+                (0, 1, 1),
+                (1, 1, 0),
+            ),
+            row(0, 1, 0, 0),
         )
 
         # reversed
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?) ORDER BY b DESC, c DESC, d DESC", 0, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b) > (?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+            ),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 1, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) >= (?) ORDER BY b DESC, c DESC, d DESC", 0, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b) >= (?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+            ),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 1, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 1, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                1,
+                0,
+            ),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) >= (?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 1, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c) >= (?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                1,
+                0,
+            ),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 1, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 1, 1, 0),
-                   row(0, 1, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                1,
+                1,
+                0,
+            ),
+            row(0, 1, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) >= (?, ?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 1, 1, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) >= (?, ?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                1,
+                1,
+                0,
+            ),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) < (?) ORDER BY b DESC, c DESC, d DESC", 0, 1),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b) < (?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                1,
+            ),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) <= (?) ORDER BY b DESC, c DESC, d DESC", 0, 1),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 1, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b) <= (?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                1,
+            ),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 1, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) < (?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 0, 1),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c) < (?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+            ),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) <= (?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 0, 1),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c) <= (?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+            ),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) < (?, ?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 0, 1, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) < (?, ?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) <= (?, ?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 0, 1, 1),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) <= (?, ?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b) < (?) ORDER BY b DESC, c DESC, d DESC", 0, 0, 1, 0, 1),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b) < (?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+                0,
+                1,
+            ),
+            row(0, 0, 1, 1),
         )
 
         # Reproduces #4244:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND b < ? ORDER BY b DESC, c DESC, d DESC", 0, 0, 1, 0, 1),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND b < ? ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+                0,
+                1,
+            ),
+            row(0, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b, c) < (?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 0, 1, 1, 1, 1),
-                   row(0, 1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b, c) < (?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+            ),
+            row(0, 1, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b, c, d) < (?, ?, ?) ORDER BY b DESC, c DESC, d DESC", 0, 0, 1, 1, 1, 1, 0),
-                   row(0, 1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) > (?, ?, ?) AND (b, c, d) < (?, ?, ?) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+                0,
+            ),
+            row(0, 1, 0, 0),
         )
 
         # IN
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN ((?, ?, ?), (?, ?, ?))", 0, 0, 1, 0, 0, 1, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN ((?, ?, ?), (?, ?, ?))",
+                0,
+                0,
+                1,
+                0,
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
         # same query but with whole tuple prepared
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN (?, ?)", 0, (0, 1, 0), (0, 1, 1)),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN (?, ?)",
+                0,
+                (0, 1, 0),
+                (0, 1, 1),
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
         # same query but with whole IN list prepared
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN ?", 0, [(0, 1, 0), (0, 1, 1)]),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN ?",
+                0,
+                [(0, 1, 0), (0, 1, 1)],
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
         # same query, but reversed order for the IN values
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN (?, ?)", 0, (0, 1, 1), (0, 1, 0)),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN (?, ?)",
+                0,
+                (0, 1, 1),
+                (0, 1, 0),
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b, c) IN ((?, ?))", 0, 0, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? and (b, c) IN ((?, ?))",
+                0,
+                0,
+                1,
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) IN ((?))", 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) IN ((?))", 0, 0),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
         )
 
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) IN ()", 0))
-
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) IN ((?, ?)) ORDER BY b DESC, c DESC, d DESC", 0, 0, 1),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0)
+        assertEmpty(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? and (b) IN ()", 0)
         )
 
-        assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) IN () ORDER BY b DESC, c DESC, d DESC", 0))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c) IN ((?, ?)) ORDER BY b DESC, c DESC, d DESC",
+                0,
+                0,
+                1,
+            ),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
+        )
+
+        assertEmpty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c) IN () ORDER BY b DESC, c DESC, d DESC",
+                0,
+            )
+        )
 
         # IN on both partition key and clustering key
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 1, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 1, 0, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 1, 0, 1, 1)
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 1, 0, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 1, 0, 1, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 1, 0, 1, 1
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (?, ?) AND (b, c, d) IN (?, ?)", 0, 1, (0, 1, 0), (0, 1, 1)),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(1, 0, 1, 0),
-                   row(1, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (?, ?) AND (b, c, d) IN (?, ?)",
+                0,
+                1,
+                (0, 1, 0),
+                (0, 1, 1),
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(1, 0, 1, 0),
+            row(1, 0, 1, 1),
         )
 
         # same but with whole IN lists prepared
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN ? AND (b, c, d) IN ?", [0, 1], [(0, 1, 0), (0, 1, 1)]),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(1, 0, 1, 0),
-                   row(1, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN ? AND (b, c, d) IN ?",
+                [0, 1],
+                [(0, 1, 0), (0, 1, 1)],
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(1, 0, 1, 0),
+            row(1, 0, 1, 1),
         )
 
         # same query, but reversed order for the IN values
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (?, ?) AND (b, c, d) IN (?, ?)", 1, 0, (0, 1, 1), (0, 1, 0)),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(1, 0, 1, 0),
-                   row(1, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (?, ?) AND (b, c, d) IN (?, ?)",
+                1,
+                0,
+                (0, 1, 1),
+                (0, 1, 0),
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(1, 0, 1, 0),
+            row(1, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (?, ?) and (b, c) IN ((?, ?))", 0, 1, 0, 1),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(1, 0, 1, 0),
-                   row(1, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (?, ?) and (b, c) IN ((?, ?))",
+                0,
+                1,
+                0,
+                1,
+            ),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(1, 0, 1, 0),
+            row(1, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a IN (?, ?) and (b) IN ((?))", 0, 1, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 0),
-                   row(0, 0, 1, 1),
-                   row(1, 0, 0, 0),
-                   row(1, 0, 1, 0),
-                   row(1, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a IN (?, ?) and (b) IN ((?))",
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 0),
+            row(0, 0, 1, 1),
+            row(1, 0, 0, 0),
+            row(1, 0, 1, 0),
+            row(1, 0, 1, 1),
         )
+
 
 def testMultipleClusteringReversedComponents(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c, d)) WITH CLUSTERING ORDER BY (b DESC, c ASC, d DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, PRIMARY KEY (a, b, c, d)) WITH CLUSTERING ORDER BY (b DESC, c ASC, d DESC)",
+    ) as table:
         # b and d are reversed in the clustering order
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 0)
-
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 0)
-
-
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?)", 0, 0),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0)
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, 0
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) >= (?)", 0, 0),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0)
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, 0
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) < (?)", 0, 1),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) > (?)", 0, 0),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) <= (?)", 0, 1),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) >= (?)", 0, 0),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND (b, c, d) IN ((?, ?, ?), (?, ?, ?))", 0, 1, 1, 1, 0, 1, 1),
-                   row(0, 1, 1, 1),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) < (?)", 0, 1),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
+        )
+
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) <= (?)", 0, 1),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
+        )
+
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND (b, c, d) IN ((?, ?, ?), (?, ?, ?))",
+                0,
+                1,
+                1,
+                1,
+                0,
+                1,
+                1,
+            ),
+            row(0, 1, 1, 1),
+            row(0, 0, 1, 1),
         )
 
         # same query, but reversed order for the IN values
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND (b, c, d) IN ((?, ?, ?), (?, ?, ?))", 0, 0, 1, 1, 1, 1, 1),
-                   row(0, 1, 1, 1),
-                   row(0, 0, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a=? AND (b, c, d) IN ((?, ?, ?), (?, ?, ?))",
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+                1,
+            ),
+            row(0, 1, 1, 1),
+            row(0, 0, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN (?, ?, ?, ?, ?, ?)",
-                           0, (1, 0, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0), (0, 1, 1), (0, 1, 0)),
-                   row(0, 1, 0, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c, d) IN (?, ?, ?, ?, ?, ?)",
+                0,
+                (1, 0, 0),
+                (1, 1, 1),
+                (1, 1, 0),
+                (0, 0, 0),
+                (0, 1, 1),
+                (0, 1, 0),
+            ),
+            row(0, 1, 0, 0),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) IN (?)", 0, (0, 1)),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) IN (?)", 0, (0, 1)
+            ),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) IN (?)", 0, (0, 0)),
-                   row(0, 0, 0, 0)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) IN (?)", 0, (0, 0)
+            ),
+            row(0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) IN ((?))", 0, 0),
-                   row(0, 0, 0, 0),
-                   row(0, 0, 1, 1),
-                   row(0, 0, 1, 0)
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) IN ((?))", 0, 0),
+            row(0, 0, 0, 0),
+            row(0, 0, 1, 1),
+            row(0, 0, 1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?)", 0, 1, 0),
-                   row(0, 1, 1, 1),
-                   row(0, 1, 1, 0)
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?)", 0, 1, 0
+            ),
+            row(0, 1, 1, 1),
+            row(0, 1, 1, 0),
         )
 
-@pytest.mark.xfail(reason="Issue #4178, #13250")
+
+@pytest.mark.xfail(
+    reason="Not covered corner case for key prefix optimization in filtering #4178, one-element multi-column restriction should be handled like a single-column restriction #13250"
+)
 def testMultipleClusteringWithIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
         execute(cql, table, "CREATE INDEX ON %s (e)")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 0, 1, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 0, 1, 1, 2)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 1, 2)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, 0, 0)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a= ? AND (b) = (?)", 0, 1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, 1, 2))
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            1,
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            1,
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            0,
+            0,
+        )
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE a= ? AND (b) = (?)", 0, 1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, 1, 2),
+        )
         # Reproduces #13250:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b) = (?)", 1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, 1, 2))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s WHERE (b) = (?)", 1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, 1, 2),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE (b, c) = (?, ?)", 1, 1)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) = (?, ?)", 0, 1, 1),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, 1, 2))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b, c) = (?, ?) ALLOW FILTERING", 1, 1),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, 1, 2))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE (b, c) = (?, ?)",
+            1,
+            1,
+        )
+        assertRows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) = (?, ?)", 0, 1, 1
+            ),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, 1, 2),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE (b, c) = (?, ?) ALLOW FILTERING",
+                1,
+                1,
+            ),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, 1, 2),
+        )
 
         # Reproduces #4178:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b, c) = (?, ?) AND e = ?", 0, 1, 1, 2),
-                   row(0, 1, 1, 1, 2))
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE (b, c) = (?, ?) AND e = ?", 1, 1, 2)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b, c) = (?, ?) AND e = ? ALLOW FILTERING", 1, 1, 2),
-                   row(0, 1, 1, 1, 2))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b, c) = (?, ?) AND e = ?",
+                0,
+                1,
+                1,
+                2,
+            ),
+            row(0, 1, 1, 1, 2),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE (b, c) = (?, ?) AND e = ?",
+            1,
+            1,
+            2,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE (b, c) = (?, ?) AND e = ? ALLOW FILTERING",
+                1,
+                1,
+                2,
+            ),
+            row(0, 1, 1, 1, 2),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b) IN ((?)) AND e = ? ALLOW FILTERING", 0, 1, 2),
-                   row(0, 1, 1, 1, 2))
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE (b) IN ((?)) AND e = ?", 1, 2)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b) IN ((?)) AND e = ? ALLOW FILTERING", 1, 2),
-                   row(0, 1, 1, 1, 2))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b) IN ((?)) AND e = ? ALLOW FILTERING",
+                0,
+                1,
+                2,
+            ),
+            row(0, 1, 1, 1, 2),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE (b) IN ((?)) AND e = ?",
+            1,
+            2,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE (b) IN ((?)) AND e = ? ALLOW FILTERING",
+                1,
+                2,
+            ),
+            row(0, 1, 1, 1, 2),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE (b) IN ((?), (?)) AND e = ?", 0, 1, 2)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b) IN ((?), (?)) AND e = ? ALLOW FILTERING", 0, 1, 2),
-                   row(0, 0, 1, 1, 2),
-                   row(0, 1, 1, 1, 2))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE (b) IN ((?), (?)) AND e = ?",
+            0,
+            1,
+            2,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE (b) IN ((?), (?)) AND e = ? ALLOW FILTERING",
+                0,
+                1,
+                2,
+            ),
+            row(0, 0, 1, 1, 2),
+            row(0, 1, 1, 1, 2),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE (b, c) IN ((?, ?)) AND e = ?", 0, 1, 2)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b, c) IN ((?, ?)) AND e = ? ALLOW FILTERING", 0, 1, 2),
-                   row(0, 0, 1, 1, 2))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE (b, c) IN ((?, ?)) AND e = ?",
+            0,
+            1,
+            2,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE (b, c) IN ((?, ?)) AND e = ? ALLOW FILTERING",
+                0,
+                1,
+                2,
+            ),
+            row(0, 0, 1, 1, 2),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE (b, c) IN ((?, ?), (?, ?)) AND e = ?", 0, 1, 1, 1, 2)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b, c) IN ((?, ?), (?, ?)) AND e = ? ALLOW FILTERING", 0, 1, 1, 1, 2),
-                   row(0, 0, 1, 1, 2),
-                   row(0, 1, 1, 1, 2))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE (b, c) IN ((?, ?), (?, ?)) AND e = ?",
+            0,
+            1,
+            1,
+            1,
+            2,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE (b, c) IN ((?, ?), (?, ?)) AND e = ? ALLOW FILTERING",
+                0,
+                1,
+                1,
+                1,
+                2,
+            ),
+            row(0, 0, 1, 1, 2),
+            row(0, 1, 1, 1, 2),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE (b) >= (?) AND e = ?", 1, 2)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b) >= (?) AND e = ? ALLOW FILTERING", 1, 2),
-                   row(0, 1, 1, 1, 2))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE (b) >= (?) AND e = ?",
+            1,
+            2,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE (b) >= (?) AND e = ? ALLOW FILTERING",
+                1,
+                2,
+            ),
+            row(0, 1, 1, 1, 2),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE (b, c) >= (?, ?) AND e = ?", 1, 1, 2)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE (b, c) >= (?, ?) AND e = ? ALLOW FILTERING", 1, 1, 2),
-                   row(0, 1, 1, 1, 2))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE (b, c) >= (?, ?) AND e = ?",
+            1,
+            1,
+            2,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE (b, c) >= (?, ?) AND e = ? ALLOW FILTERING",
+                1,
+                1,
+                2,
+            ),
+            row(0, 1, 1, 1, 2),
+        )
 
         # Scylla allows comparison with null, so this check is commented out:
-        #assertInvalidMessage(cql, table, "Unsupported null value for column e",
+        # assertInvalidMessage(cql, table, "Unsupported null value for column e",
         #                     "SELECT * FROM %s WHERE (b, c) >= (?, ?) AND e = ?  ALLOW FILTERING", 1, 1, None)
 
-        assertInvalidMessage(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE (b, c) >= (?, ?) AND e = ?  ALLOW FILTERING", 1, 1, UNSET_VALUE)
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE (b, c) >= (?, ?) AND e = ?  ALLOW FILTERING",
+            1,
+            1,
+            UNSET_VALUE,
+        )
 
-@pytest.mark.xfail(reason="Issue #8627")
+
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 def testMultipleClusteringWithIndexAndValueOver64K(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b blob, c int, d int, PRIMARY KEY (a, b, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b blob, c int, d int, PRIMARY KEY (a, b, c))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, b'x', 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, b'xx', 1, 0)
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, b"x", 0, 0
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            b"xx",
+            1,
+            0,
+        )
 
         # Reproduces #8627:
-        assertInvalidMessage(cql, table, "Index expression values may not be larger than 64K",
-                             "SELECT * FROM %s WHERE (b, c) = (?, ?) AND d = ?  ALLOW FILTERING", TOO_BIG, 1, 2)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Index expression values may not be larger than 64K",
+            "SELECT * FROM %s WHERE (b, c) = (?, ?) AND d = ?  ALLOW FILTERING",
+            TOO_BIG,
+            1,
+            2,
+        )
+
 
 def testMultiColumnRestrictionsWithIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, v int, PRIMARY KEY (a, b, c, d, e))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, v int, PRIMARY KEY (a, b, c, d, e))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (v)")
-        for i in range(1,6):
-            execute(cql, table, "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)", 0, i, 0, 0, 0, 0)
-            execute(cql, table, "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)", 0, i, i, 0, 0, 0)
-            execute(cql, table, "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)", 0, i, i, i, 0, 0)
-            execute(cql, table, "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)", 0, i, i, i, i, 0)
-            execute(cql, table, "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)", 0, i, i, i, i, i)
+        for i in range(1, 6):
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)",
+                0,
+                i,
+                0,
+                0,
+                0,
+                0,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)",
+                0,
+                i,
+                i,
+                0,
+                0,
+                0,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)",
+                0,
+                i,
+                i,
+                i,
+                0,
+                0,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)",
+                0,
+                i,
+                i,
+                i,
+                i,
+                0,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (a,b,c,d,e,v) VALUES (?,?,?,?,?,?)",
+                0,
+                i,
+                i,
+                i,
+                i,
+                i,
+            )
 
         # Scylla and Cassandra give different error messages here. Cassandra
         # says "Multi-column slice restrictions cannot be used for filtering."
         # and Scylla: "Clustering columns may not be skipped in multi-column
         # relations. They should appear in the PRIMARY KEY order".
         errorMsg = "ulti-column"
-        assertInvalidMessage(cql, table, errorMsg,
-                             "SELECT * FROM %s WHERE a = 0 AND (c,d) < (2,2) AND v = 0 ALLOW FILTERING")
-        assertInvalidMessage(cql, table, errorMsg,
-                             "SELECT * FROM %s WHERE a = 0 AND (d,e) < (2,2) AND b = 1 AND v = 0 ALLOW FILTERING")
-        assertInvalidMessage(cql, table, errorMsg,
-                             "SELECT * FROM %s WHERE a = 0 AND b = 1 AND (d,e) < (2,2) AND v = 0 ALLOW FILTERING")
-        assertInvalidMessage(cql, table, errorMsg,
-                             "SELECT * FROM %s WHERE a = 0 AND b > 1 AND (d,e) < (2,2) AND v = 0 ALLOW FILTERING")
-        assertInvalidMessage(cql, table, errorMsg,
-                             "SELECT * FROM %s WHERE a = 0 AND (b,c) > (1,0) AND (d,e) < (2,2) AND v = 0 ALLOW FILTERING")
+        assertInvalidMessage(
+            cql,
+            table,
+            errorMsg,
+            "SELECT * FROM %s WHERE a = 0 AND (c,d) < (2,2) AND v = 0 ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            errorMsg,
+            "SELECT * FROM %s WHERE a = 0 AND (d,e) < (2,2) AND b = 1 AND v = 0 ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            errorMsg,
+            "SELECT * FROM %s WHERE a = 0 AND b = 1 AND (d,e) < (2,2) AND v = 0 ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            errorMsg,
+            "SELECT * FROM %s WHERE a = 0 AND b > 1 AND (d,e) < (2,2) AND v = 0 ALLOW FILTERING",
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            errorMsg,
+            "SELECT * FROM %s WHERE a = 0 AND (b,c) > (1,0) AND (d,e) < (2,2) AND v = 0 ALLOW FILTERING",
+        )
 
-@pytest.mark.xfail(reason="Issue #4178")
+
+@pytest.mark.xfail(
+    reason="one-element multi-column restriction should be handled like a single-column restriction #4178"
+)
 def testMultiplePartitionKeyAndMultiClusteringWithIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, f int, PRIMARY KEY ((a, b), c, d, e))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, f int, PRIMARY KEY ((a, b), c, d, e))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (c)")
         execute(cql, table, "CREATE INDEX ON %s (f)")
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 0, 1, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 0, 1, 1, 2)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            1,
+            1,
+            2,
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 1, 0, 0, 3)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 1, 1, 0, 4)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 1, 1, 1, 5)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            0,
+            0,
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            1,
+            0,
+            4,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            1,
+            1,
+            5,
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 2, 0, 0, 5)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            2,
+            0,
+            0,
+            5,
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND (c) = (?)")
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c) = (?) ALLOW FILTERING", 0, 1),
-                   row(0, 0, 1, 0, 0, 3),
-                   row(0, 0, 1, 1, 0, 4),
-                   row(0, 0, 1, 1, 1, 5))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND (c) = (?)",
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c) = (?) ALLOW FILTERING",
+                0,
+                1,
+            ),
+            row(0, 0, 1, 0, 0, 3),
+            row(0, 0, 1, 1, 0, 4),
+            row(0, 0, 1, 1, 1, 5),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND (c, d) = (?, ?)", 0, 1, 1)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c, d) = (?, ?) ALLOW FILTERING", 0, 1, 1),
-                   row(0, 0, 1, 1, 0, 4),
-                   row(0, 0, 1, 1, 1, 5))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND (c, d) = (?, ?)",
+            0,
+            1,
+            1,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c, d) = (?, ?) ALLOW FILTERING",
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 1, 1, 0, 4),
+            row(0, 0, 1, 1, 1, 5),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c, d) IN ((?, ?)) ALLOW FILTERING", 0, 1, 1),
-                row(0, 0, 1, 1, 0, 4),
-                row(0, 0, 1, 1, 1, 5))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c, d) IN ((?, ?)) ALLOW FILTERING",
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 1, 1, 0, 4),
+            row(0, 0, 1, 1, 1, 5),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) ALLOW FILTERING", 0, 1, 1),
-                row(0, 0, 1, 1, 0, 4),
-                row(0, 0, 1, 1, 1, 5),
-                row(0, 0, 2, 0, 0, 5))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) ALLOW FILTERING",
+                0,
+                1,
+                1,
+            ),
+            row(0, 0, 1, 1, 0, 4),
+            row(0, 0, 1, 1, 1, 5),
+            row(0, 0, 2, 0, 0, 5),
+        )
 
         # Reproduces #4178:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ? AND (c) IN ((?)) AND f = ?", 0, 0, 1, 5),
-                   row(0, 0, 1, 1, 1, 5))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b = ? AND (c) IN ((?)) AND f = ?",
+                0,
+                0,
+                1,
+                5,
+            ),
+            row(0, 0, 1, 1, 1, 5),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND (c) IN ((?), (?)) AND f = ?", 0, 1, 3, 5)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c) IN ((?), (?)) AND f = ? ALLOW FILTERING", 0, 1, 3, 5),
-                   row(0, 0, 1, 1, 1, 5))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND (c) IN ((?), (?)) AND f = ?",
+            0,
+            1,
+            3,
+            5,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c) IN ((?), (?)) AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                3,
+                5,
+            ),
+            row(0, 0, 1, 1, 1, 5),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND (c) IN ((?), (?)) AND f = ?", 0, 1, 2, 5)
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND (c) IN ((?), (?)) AND f = ?",
+            0,
+            1,
+            2,
+            5,
+        )
 
         # Reproduces #4178:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ? AND (c) IN ((?), (?)) AND f = ?", 0, 0, 1, 2, 5),
-                   row(0, 0, 1, 1, 1, 5),
-                   row(0, 0, 2, 0, 0, 5))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b = ? AND (c) IN ((?), (?)) AND f = ?",
+                0,
+                0,
+                1,
+                2,
+                5,
+            ),
+            row(0, 0, 1, 1, 1, 5),
+            row(0, 0, 2, 0, 0, 5),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c) IN ((?), (?)) AND f = ? ALLOW FILTERING", 0, 1, 2, 5),
-                   row(0, 0, 1, 1, 1, 5),
-                   row(0, 0, 2, 0, 0, 5))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c) IN ((?), (?)) AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                2,
+                5,
+            ),
+            row(0, 0, 1, 1, 1, 5),
+            row(0, 0, 2, 0, 0, 5),
+        )
 
         # Reproduces #4178:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ? AND (c, d) IN ((?, ?)) AND f = ?", 0, 0, 1, 0, 3),
-                   row(0, 0, 1, 0, 0, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b = ? AND (c, d) IN ((?, ?)) AND f = ?",
+                0,
+                0,
+                1,
+                0,
+                3,
+            ),
+            row(0, 0, 1, 0, 0, 3),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND (c, d) IN ((?, ?)) AND f = ?", 0, 1, 0, 3)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c, d) IN ((?, ?)) AND f = ? ALLOW FILTERING", 0, 1, 0, 3),
-                   row(0, 0, 1, 0, 0, 3))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND (c, d) IN ((?, ?)) AND f = ?",
+            0,
+            1,
+            0,
+            3,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c, d) IN ((?, ?)) AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                0,
+                3,
+            ),
+            row(0, 0, 1, 0, 0, 3),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND (c) >= (?) AND f = ?", 0, 1, 5)
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND (c) >= (?) AND f = ?",
+            0,
+            1,
+            5,
+        )
 
         # Reproduces #4178:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ? AND (c) >= (?) AND f = ?", 0, 0, 1, 5),
-                   row(0, 0, 1, 1, 1, 5),
-                   row(0, 0, 2, 0, 0, 5))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b = ? AND (c) >= (?) AND f = ?",
+                0,
+                0,
+                1,
+                5,
+            ),
+            row(0, 0, 1, 1, 1, 5),
+            row(0, 0, 2, 0, 0, 5),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c) >= (?) AND f = ? ALLOW FILTERING", 0, 1, 5),
-                   row(0, 0, 1, 1, 1, 5),
-                   row(0, 0, 2, 0, 0, 5))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c) >= (?) AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                5,
+            ),
+            row(0, 0, 1, 1, 1, 5),
+            row(0, 0, 2, 0, 0, 5),
+        )
 
         # Reproduces #4178:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ? AND (c, d) >= (?, ?) AND f = ?", 0, 0, 1, 1, 5),
-                   row(0, 0, 1, 1, 1, 5),
-                   row(0, 0, 2, 0, 0, 5))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b = ? AND (c, d) >= (?, ?) AND f = ?",
+                0,
+                0,
+                1,
+                1,
+                5,
+            ),
+            row(0, 0, 1, 1, 1, 5),
+            row(0, 0, 2, 0, 0, 5),
+        )
 
-        assertInvalidMessage(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) AND f = ?", 0, 1, 1, 5)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) AND f = ? ALLOW FILTERING", 0, 1, 1, 5),
-                   row(0, 0, 1, 1, 1, 5),
-                   row(0, 0, 2, 0, 0, 5))
+        assertInvalidMessage(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) AND f = ?",
+            0,
+            1,
+            1,
+            5,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                1,
+                5,
+            ),
+            row(0, 0, 1, 1, 1, 5),
+            row(0, 0, 2, 0, 0, 5),
+        )
+
 
 def testINWithDuplicateValue(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))") as table:
+    with create_table(
+        cql, test_keyspace, "(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k1,  k2, v) VALUES (?, ?, ?)", 1, 1, 1)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE k1 IN (?, ?) AND (k2) IN ((?), (?))", 1, 1, 1, 2),
-                   row(1, 1, 1))
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE k1 = ? AND (k2) IN ((?), (?))", 1, 1, 1),
-                   row(1, 1, 1))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE k1 IN (?, ?) AND (k2) IN ((?), (?))",
+                1,
+                1,
+                1,
+                2,
+            ),
+            row(1, 1, 1),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE k1 = ? AND (k2) IN ((?), (?))",
+                1,
+                1,
+                1,
+            ),
+            row(1, 1, 1),
+        )
 
-@pytest.mark.xfail(reason="Issue #13250")
+
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #13250")
 def testWithUnsetValues(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, i int, j int, s text, PRIMARY KEY (k,i,j))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, i int, j int, s text, PRIMARY KEY (k,i,j))"
+    ) as table:
         execute(cql, table, "CREATE INDEX s_index ON %s (s)")
 
-        assertInvalidMessage(cql, table, "unset value",
-                             "SELECT * from %s WHERE (i, j) = (?,?) ALLOW FILTERING", unset(), 1)
-        assertInvalidMessage(cql, table, "unset value",
-                             "SELECT * from %s WHERE (i, j) IN ((?,?)) ALLOW FILTERING", unset(), 1)
-        assertInvalidMessage(cql, table, "unset value",
-                             "SELECT * from %s WHERE (i, j) > (1,?) ALLOW FILTERING", unset())
-        assertInvalidMessage(cql, table, "unset value",
-                             "SELECT * from %s WHERE (i, j) = ? ALLOW FILTERING", unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE (i, j) = (?,?) ALLOW FILTERING",
+            unset(),
+            1,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE (i, j) IN ((?,?)) ALLOW FILTERING",
+            unset(),
+            1,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE (i, j) > (1,?) ALLOW FILTERING",
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE (i, j) = ? ALLOW FILTERING",
+            unset(),
+        )
         # Reproduces 13250:
-        assertInvalidMessage(cql, table, "unset value",
-                             "SELECT * from %s WHERE i = ? AND (j) > ? ALLOW FILTERING", 1, unset())
-        assertInvalidMessage(cql, table, "unset value",
-                             "SELECT * from %s WHERE (i, j) IN (?, ?) ALLOW FILTERING", unset(), (1, 1))
-        assertInvalidMessage(cql, table, "unset value",
-                             "SELECT * from %s WHERE (i, j) IN ? ALLOW FILTERING", unset())
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE i = ? AND (j) > ? ALLOW FILTERING",
+            1,
+            unset(),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE (i, j) IN (?, ?) ALLOW FILTERING",
+            unset(),
+            (1, 1),
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE (i, j) IN ? ALLOW FILTERING",
+            unset(),
+        )
+
 
 def testMixedOrderColumns1(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e)) WITH CLUSTERING ORDER BY (b DESC, c ASC, d DESC, e ASC)") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, -1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, -1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 1, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, -1, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, -1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, -1, 0, -1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, -1, 0, 0, 0)
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b)>(?)", 0, 2, 0, 1, 1, -1),
-
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e)) WITH CLUSTERING ORDER BY (b DESC, c ASC, d DESC, e ASC)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            -1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            -1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            1,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            -1,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            -1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            -1,
+            0,
+            -1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            -1,
+            0,
+            0,
+            0,
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)<=(?,?,?,?) "
+                + "AND (b)>(?)",
+                0,
+                2,
+                0,
+                1,
+                1,
+                -1,
+            ),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
         )
 
-
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b)>=(?)", 0, 2, 0, 1, 1, -1),
-
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)<=(?,?,?,?) "
+                + "AND (b)>=(?)",
+                0,
+                2,
+                0,
+                1,
+                1,
+                -1,
+            ),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d)>=(?,?,?)" +
-        "AND (b,c,d,e)<(?,?,?,?) ", 0, 1, 1, 0, 1, 1, 0, 1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0)
-
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d)>=(?,?,?)"
+                + "AND (b,c,d,e)<(?,?,?,?) ",
+                0,
+                1,
+                1,
+                0,
+                1,
+                1,
+                0,
+                1,
+            ),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)>(?,?,?,?)" +
-        "AND (b,c,d)<=(?,?,?) ", 0, -1, 0, -1, -1, 2, 0, -1),
-
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)>(?,?,?,?)"
+                + "AND (b,c,d)<=(?,?,?) ",
+                0,
+                -1,
+                0,
+                -1,
+                -1,
+                2,
+                0,
+                -1,
+            ),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) < (?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
-                   row(0, 1, 0, 0, -1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e) < (?,?,?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 1, 0, 0, -1),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) <= (?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e) <= (?,?,?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b)<(?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, -1, 0, -1, -1),
-
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
-
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b)<(?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b)<(?) " +
-        "AND (b)>(?)", 0, 2, -1),
-
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0)
-
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s" + " WHERE a = ? " + "AND (b)<(?) " + "AND (b)>(?)",
+                0,
+                2,
+                -1,
+            ),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b)<(?) " +
-        "AND (b)>=(?)", 0, 2, -1),
-
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s" + " WHERE a = ? " + "AND (b)<(?) " + "AND (b)>=(?)",
+                0,
+                2,
+                -1,
+            ),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
-
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)<=(?,?,?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                1,
+                1,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<=(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
-
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c)<=(?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d)<=(?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, -1, 0, -1, -1),
-
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d)<=(?,?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                -1,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)>(?,?,?,?)" +
-        "AND (b,c,d)<=(?,?,?) ", 0, -1, 0, -1, -1, 2, 0, -1),
-
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)>(?,?,?,?)"
+                + "AND (b,c,d)<=(?,?,?) ",
+                0,
+                -1,
+                0,
+                -1,
+                -1,
+                2,
+                0,
+                -1,
+            ),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d)>=(?,?,?)" +
-        "AND (b,c,d,e)<(?,?,?,?) ", 0, 1, 1, 0, 1, 1, 0, 1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d)>=(?,?,?)"
+                + "AND (b,c,d,e)<(?,?,?,?) ",
+                0,
+                1,
+                1,
+                0,
+                1,
+                1,
+                0,
+                1,
+            ),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
         )
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<(?,?,?,?) " +
-        "AND (b,c,d)>=(?,?,?)", 0, 1, 1, 0, 1, 1, 1, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0)
-
-        )
-
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
-        )
-
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)<(?,?,?,?) "
+                + "AND (b,c,d)>=(?,?,?)",
+                0,
+                1,
+                1,
+                0,
+                1,
+                1,
+                1,
+                0,
+            ),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) <= (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 0, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c)<(?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) > (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c)<(?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) >= (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) <= (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, -1, -1),
+            row(0, 0, 0, 0, 0),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d) >= (?,?,?)", 0, 1, 0, 0),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) > (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d) > (?,?,?)", 0, 1, 0, 0),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) >= (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
         )
+
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d) >= (?,?,?)",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+        )
+
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d) > (?,?,?)",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+        )
+
 
 def testMixedOrderColumns2(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e)) WITH CLUSTERING ORDER BY (b DESC, c ASC, d ASC, e ASC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e)) WITH CLUSTERING ORDER BY (b DESC, c ASC, d ASC, e ASC)",
+    ) as table:
         # b and d are reversed in the clustering order
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, -1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, -1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 1, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, -1, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, -1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 0, 0, 0, 0)
-
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) <= (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 0, 0, 0, 0)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            -1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            -1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            1,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            -1,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            -1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) > (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) <= (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 1, -1, 0, 0),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 0, 0, 0, 0),
         )
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) >= (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1)
+
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) > (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
         )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) >= (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+        )
+
 
 def testMixedOrderColumns3(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?,?,?);", 0, 2, 3)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?,?,?);", 0, 2, 4)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?,?,?);", 0, 4, 4)
@@ -1474,336 +3903,762 @@ def testMixedOrderColumns3(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?,?,?);", 0, 4, 5)
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?,?,?);", 0, 4, 6)
 
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c)>=(?,?) AND (b,c)<(?,?) ALLOW FILTERING",
+                0,
+                2,
+                3,
+                4,
+                5,
+            ),
+            row(0, 4, 4),
+            row(0, 3, 4),
+            row(0, 2, 3),
+            row(0, 2, 4),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c)>=(?,?) AND (b,c)<=(?,?) ALLOW FILTERING",
+                0,
+                2,
+                3,
+                4,
+                5,
+            ),
+            row(0, 4, 4),
+            row(0, 4, 5),
+            row(0, 3, 4),
+            row(0, 2, 3),
+            row(0, 2, 4),
+        )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c)<(?,?) ALLOW FILTERING",
+                0,
+                4,
+                5,
+            ),
+            row(0, 4, 4),
+            row(0, 3, 4),
+            row(0, 2, 3),
+            row(0, 2, 4),
+        )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c)>=(?,?) AND (b,c)<(?,?) ALLOW FILTERING", 0, 2, 3, 4, 5),
-                   row(0, 4, 4), row(0, 3, 4), row(0, 2, 3), row(0, 2, 4)
-        )
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c)>=(?,?) AND (b,c)<=(?,?) ALLOW FILTERING", 0, 2, 3, 4, 5),
-                   row(0, 4, 4), row(0, 4, 5), row(0, 3, 4), row(0, 2, 3), row(0, 2, 4)
-        )
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c)<(?,?) ALLOW FILTERING", 0, 4, 5),
-                   row(0, 4, 4), row(0, 3, 4), row(0, 2, 3), row(0, 2, 4)
-        )
-
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c)>(?,?) ALLOW FILTERING", 0, 4, 5),
-                   row(0, 4, 6)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c)>(?,?) ALLOW FILTERING",
+                0,
+                4,
+                5,
+            ),
+            row(0, 4, 6),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b)<(?) and (b)>(?) ALLOW FILTERING", 0, 4, 2),
-                   row(0, 3, 4)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b)<(?) and (b)>(?) ALLOW FILTERING",
+                0,
+                4,
+                2,
+            ),
+            row(0, 3, 4),
         )
+
 
 def testMixedOrderColumns4(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e)) WITH CLUSTERING ORDER BY (b ASC, c DESC, d DESC, e ASC)") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, -1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, -1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, 0, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, -1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 2, -3, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, -1, 1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 1, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 1, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 0, -1, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, -1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 1, 1, -1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, -1, 0, -1, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)", 0, -1, 0, 0, 0)
-
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<(?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
-
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
-
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e)) WITH CLUSTERING ORDER BY (b ASC, c DESC, d DESC, e ASC)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            -1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            -1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            0,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            -1,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            2,
+            -3,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            -1,
+            1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            1,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            -1,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            -1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            -1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            -1,
+            0,
+            -1,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)",
+            0,
+            -1,
+            0,
+            0,
+            0,
         )
 
-
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) < (?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
-                   row(0, 1, 0, 0, -1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)<(?,?,?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                1,
+                1,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) <= (?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 1, 0, 0, 0, 1, 0, -1, -1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e) < (?,?,?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 1, 0, 0, -1),
         )
 
-
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, 1, 1, -1, 0, -1, -1),
-
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e) <= (?,?,?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<=(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
-
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)<=(?,?,?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                1,
+                1,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c)<(?,?) " +
-        "AND (b,c,d,e)>(?,?,?,?)", 0, 2, 0, -1, 0, -1, -1),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c)<=(?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b)>=(?)", 0, 2, 0, 1, 1, -1),
-
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c)<(?,?) "
+                + "AND (b,c,d,e)>(?,?,?,?)",
+                0,
+                2,
+                0,
+                -1,
+                0,
+                -1,
+                -1,
+            ),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e)<=(?,?,?,?) " +
-        "AND (b)>(?)", 0, 2, 0, 1, 1, -1),
-
-                   row(0, 0, 0, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)<=(?,?,?,?) "
+                + "AND (b)>=(?)",
+                0,
+                2,
+                0,
+                1,
+                1,
+                -1,
+            ),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) <= (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, -1, 0, 0, 0),
-                   row(0, -1, 0, -1, 0),
-                   row(0, 0, 0, 0, 0),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, -1, -1),
-                   row(0, 1, -1, 1, 0),
-                   row(0, 1, -1, 1, 1),
-                   row(0, 1, -1, 0, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e)<=(?,?,?,?) "
+                + "AND (b)>(?)",
+                0,
+                2,
+                0,
+                1,
+                1,
+                -1,
+            ),
+            row(0, 0, 0, 0, 0),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) > (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
-
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) <= (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
+            row(0, 0, 0, 0, 0),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, -1, -1),
+            row(0, 1, -1, 1, 0),
+            row(0, 1, -1, 1, 1),
+            row(0, 1, -1, 0, 0),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) >= (?,?,?,?)", 0, 1, 0, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) > (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, 1),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d) >= (?,?,?)", 0, 1, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 1, 0, 0, -1),
-                   row(0, 1, 0, 0, 0),
-                   row(0, 1, 0, 0, 1),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d,e) >= (?,?,?,?)",
+                0,
+                1,
+                0,
+                0,
+                0,
+            ),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (b,c,d) > (?,?,?)", 0, 1, 0, 0),
-                   row(0, 1, 1, 0, -1),
-                   row(0, 1, 1, 0, 0),
-                   row(0, 1, 1, 0, 1),
-                   row(0, 1, 1, -1, 0),
-                   row(0, 1, 0, 1, -1),
-                   row(0, 1, 0, 1, 1),
-                   row(0, 2, 0, 1, 1),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1),
-                   row(0, 2, -3, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d) >= (?,?,?)",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 1, 0, 0, -1),
+            row(0, 1, 0, 0, 0),
+            row(0, 1, 0, 0, 1),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
 
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b) < (?) ", 0, 0),
-                   row(0, -1, 0, 0, 0), row(0, -1, 0, -1, 0)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (b,c,d) > (?,?,?)",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 1, 1, 0, -1),
+            row(0, 1, 1, 0, 0),
+            row(0, 1, 1, 0, 1),
+            row(0, 1, 1, -1, 0),
+            row(0, 1, 0, 1, -1),
+            row(0, 1, 0, 1, 1),
+            row(0, 2, 0, 1, 1),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+            row(0, 2, -3, 1, 1),
         )
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b) <= (?) ", 0, -1),
-                   row(0, -1, 0, 0, 0), row(0, -1, 0, -1, 0)
+
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s" + " WHERE a = ? " + "AND (b) < (?) ",
+                0,
+                0,
+            ),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
-        assertRows(execute(cql, table, 
-        "SELECT * FROM %s" +
-        " WHERE a = ? " +
-        "AND (b,c,d,e) < (?,?,?,?) and (b,c,d,e) > (?,?,?,?) ", 0, 2, 0, 0, 0, 2, -2, 0, 0),
-                   row(0, 2, 0, -1, 0),
-                   row(0, 2, 0, -1, 1),
-                   row(0, 2, -1, 1, 1)
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s" + " WHERE a = ? " + "AND (b) <= (?) ",
+                0,
+                -1,
+            ),
+            row(0, -1, 0, 0, 0),
+            row(0, -1, 0, -1, 0),
         )
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s"
+                + " WHERE a = ? "
+                + "AND (b,c,d,e) < (?,?,?,?) and (b,c,d,e) > (?,?,?,?) ",
+                0,
+                2,
+                0,
+                0,
+                0,
+                2,
+                -2,
+                0,
+                0,
+            ),
+            row(0, 2, 0, -1, 0),
+            row(0, 2, 0, -1, 1),
+            row(0, 2, -1, 1, 1),
+        )
+
 
 def testMixedOrderColumnsInReverse(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b ASC, c DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b ASC, c DESC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (0, 1, 3)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (0, 1, 2)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (0, 1, 1)")
@@ -1816,18 +4671,31 @@ def testMixedOrderColumnsInReverse(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (0, 3, 2)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (0, 3, 1)")
 
-        assertRows(execute(cql, table, "SELECT b, c FROM %s WHERE a = 0 AND (b, c) >= (2, 2) ORDER BY b DESC, c ASC;"),
-                   row(3, 1),
-                   row(3, 2),
-                   row(3, 3),
-                   row(2, 2),
-                   row(2, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT b, c FROM %s WHERE a = 0 AND (b, c) >= (2, 2) ORDER BY b DESC, c ASC;",
+            ),
+            row(3, 1),
+            row(3, 2),
+            row(3, 3),
+            row(2, 2),
+            row(2, 3),
+        )
+
 
 # Check select on tuple relations, see CASSANDRA-8613
 # migrated from cql_tests.py:TestCQL.simple_tuple_query_test()
-@pytest.mark.xfail(reason="Issue #64")
+@pytest.mark.xfail(
+    reason="CQL Multi column restrictions are allowed only on a clustering key prefix. #64"
+)
 def testSimpleTupleQuery(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e))",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (0, 2, 0, 0, 0)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (0, 1, 0, 0, 0)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (0, 0, 0, 0, 0)")
@@ -1837,19 +4705,38 @@ def testSimpleTupleQuery(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (0, 0, 1, 1, 1)")
 
         # Reproduces #64:
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE b=0 AND (c, d, e) > (1, 1, 1) ALLOW FILTERING"),
-                   row(0, 0, 2, 2, 2),
-                   row(0, 0, 3, 3, 3))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE b=0 AND (c, d, e) > (1, 1, 1) ALLOW FILTERING",
+            ),
+            row(0, 0, 2, 2, 2),
+            row(0, 0, 3, 3, 3),
+        )
+
 
 def testInvalidColumnNames(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c))") as table:
-        assertInvalidMessage(cql, table, "name e", "SELECT * FROM %s WHERE (b, e) = (0, 0)")
-        assertInvalidMessage(cql, table, "name e", "SELECT * FROM %s WHERE (b, e) IN ((0, 1), (2, 4))")
-        assertInvalidMessage(cql, table, "name e", "SELECT * FROM %s WHERE (b, e) > (0, 1) and b <= 2")
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c))"
+    ) as table:
+        assertInvalidMessage(
+            cql, table, "name e", "SELECT * FROM %s WHERE (b, e) = (0, 0)"
+        )
+        assertInvalidMessage(
+            cql, table, "name e", "SELECT * FROM %s WHERE (b, e) IN ((0, 1), (2, 4))"
+        )
+        assertInvalidMessage(
+            cql, table, "name e", "SELECT * FROM %s WHERE (b, e) > (0, 1) and b <= 2"
+        )
         # Scylla and Cassandra complain about different things in the following
         # queries. Cassandra complains that undefined e is used in the WHERE.
         # Scylla complains that this e is an alias (defined by AS) and can't
         # be used in the where.
         assertInvalid(cql, table, "SELECT c AS e FROM %s WHERE (b, e) = (0, 0)")
-        assertInvalid(cql, table, "SELECT c AS e FROM %s WHERE (b, e) IN ((0, 1), (2, 4))")
-        assertInvalid(cql, table, "SELECT c AS e FROM %s WHERE (b, e) > (0, 1) and b <= 2")
+        assertInvalid(
+            cql, table, "SELECT c AS e FROM %s WHERE (b, e) IN ((0, 1), (2, 4))"
+        )
+        assertInvalid(
+            cql, table, "SELECT c AS e FROM %s WHERE (b, e) > (0, 1) and b <= 2"
+        )

--- a/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -11,233 +11,704 @@
 from ...porting import *
 from cassandra.query import UNSET_VALUE
 
+
 def testInvalidCollectionEqualityRelation(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c list<int>, d map<int, int>)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int PRIMARY KEY, b set<int>, c list<int>, d map<int, int>)",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
         execute(cql, table, "CREATE INDEX ON %s (c)")
         execute(cql, table, "CREATE INDEX ON %s (d)")
-        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '=' relation",
-                             "SELECT * FROM %s WHERE a = 0 AND b=?", {0})
-        assert_invalid_message(cql, table, "Collection column 'c' (list<int>) cannot be restricted by a '=' relation",
-                             "SELECT * FROM %s WHERE a = 0 AND c=?", [0])
-        assert_invalid_message(cql, table, "Collection column 'd' (map<int, int>) cannot be restricted by a '=' relation",
-                             "SELECT * FROM %s WHERE a = 0 AND d=?", {0: 0})
+        assert_invalid_message(
+            cql,
+            table,
+            "Collection column 'b' (set<int>) cannot be restricted by a '=' relation",
+            "SELECT * FROM %s WHERE a = 0 AND b=?",
+            {0},
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Collection column 'c' (list<int>) cannot be restricted by a '=' relation",
+            "SELECT * FROM %s WHERE a = 0 AND c=?",
+            [0],
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Collection column 'd' (map<int, int>) cannot be restricted by a '=' relation",
+            "SELECT * FROM %s WHERE a = 0 AND d=?",
+            {0: 0},
+        )
+
 
 def testInvalidCollectionNonEQRelation(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c int)") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c int)"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (c)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (0, {0}, 0)")
 
         # non-EQ operators
-        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '>' relation",
-                             "SELECT * FROM %s WHERE c = 0 AND b > ?", {0})
-        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '>=' relation",
-                             "SELECT * FROM %s WHERE c = 0 AND b >= ?", {0})
-        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '<' relation",
-                             "SELECT * FROM %s WHERE c = 0 AND b < ?", {0})
-        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a '<=' relation",
-                             "SELECT * FROM %s WHERE c = 0 AND b <= ?", {0})
+        assert_invalid_message(
+            cql,
+            table,
+            "Collection column 'b' (set<int>) cannot be restricted by a '>' relation",
+            "SELECT * FROM %s WHERE c = 0 AND b > ?",
+            {0},
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Collection column 'b' (set<int>) cannot be restricted by a '>=' relation",
+            "SELECT * FROM %s WHERE c = 0 AND b >= ?",
+            {0},
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Collection column 'b' (set<int>) cannot be restricted by a '<' relation",
+            "SELECT * FROM %s WHERE c = 0 AND b < ?",
+            {0},
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Collection column 'b' (set<int>) cannot be restricted by a '<=' relation",
+            "SELECT * FROM %s WHERE c = 0 AND b <= ?",
+            {0},
+        )
         # Reproduces #10631:
-        assert_invalid_message(cql, table, "Collection column 'b' (set<int>) cannot be restricted by a 'IN' relation",
-                             "SELECT * FROM %s WHERE c = 0 AND b IN (?)", {0})
-        assert_invalid_message(cql, table, "Unsupported \"!=\" relation: b != 5",
-                "SELECT * FROM %s WHERE c = 0 AND b != 5")
+        assert_invalid_message(
+            cql,
+            table,
+            "Collection column 'b' (set<int>) cannot be restricted by a 'IN' relation",
+            "SELECT * FROM %s WHERE c = 0 AND b IN (?)",
+            {0},
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            'Unsupported "!=" relation: b != 5',
+            "SELECT * FROM %s WHERE c = 0 AND b != 5",
+        )
         # different error message in Scylla and Cassandra. Note that in the
         # future, Scylla may want to support this restriction so the error
         # message will change again.
-        assert_invalid_message(cql, table, "IS NOT",
-                "SELECT * FROM %s WHERE c = 0 AND b IS NOT NULL")
+        assert_invalid_message(
+            cql, table, "IS NOT", "SELECT * FROM %s WHERE c = 0 AND b IS NOT NULL"
+        )
+
 
 def testClusteringColumnRelations(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b int, c int, d int, primary key (a, b, c))") as table:
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 1, 5, 1)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 2, 6, 2)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 3, 7, 3)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "second", 4, 8, 4)
+    with create_table(
+        cql, test_keyspace, "(a text, b int, c int, d int, primary key (a, b, c))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            1,
+            5,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            2,
+            6,
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            3,
+            7,
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "second",
+            4,
+            8,
+            4,
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a in (?, ?)", "first", "second"),
-                   ["first", 1, 5, 1],
-                   ["first", 2, 6, 2],
-                   ["first", 3, 7, 3],
-                   ["second", 4, 8, 4])
+        assert_rows(
+            execute(
+                cql, table, "select * from %s where a in (?, ?)", "first", "second"
+            ),
+            ["first", 1, 5, 1],
+            ["first", 2, 6, 2],
+            ["first", 3, 7, 3],
+            ["second", 4, 8, 4],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b = ? and c in (?, ?)", "first", 2, 6, 7),
-                   ["first", 2, 6, 2])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b = ? and c in (?, ?)",
+                "first",
+                2,
+                6,
+                7,
+            ),
+            ["first", 2, 6, 2],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in (?, ?) and c in (?, ?)", "first", 2, 3, 6, 7),
-                   ["first", 2, 6, 2],
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in (?, ?) and c in (?, ?)",
+                "first",
+                2,
+                3,
+                6,
+                7,
+            ),
+            ["first", 2, 6, 2],
+            ["first", 3, 7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in (?, ?) and c in (?, ?)", "first", 3, 2, 7, 6),
-                   ["first", 2, 6, 2],
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in (?, ?) and c in (?, ?)",
+                "first",
+                3,
+                2,
+                7,
+                6,
+            ),
+            ["first", 2, 6, 2],
+            ["first", 3, 7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c in (?, ?) and b in (?, ?)", "first", 7, 6, 3, 2),
-                   ["first", 2, 6, 2],
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c in (?, ?) and b in (?, ?)",
+                "first",
+                7,
+                6,
+                3,
+                2,
+            ),
+            ["first", 2, 6, 2],
+            ["first", 3, 7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select c, d from %s where a = ? and c in (?, ?) and b in (?, ?)", "first", 7, 6, 3, 2),
-                   [6, 2],
-                   [7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select c, d from %s where a = ? and c in (?, ?) and b in (?, ?)",
+                "first",
+                7,
+                6,
+                3,
+                2,
+            ),
+            [6, 2],
+            [7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select c, d from %s where a = ? and c in (?, ?) and b in (?, ?, ?)", "first", 7, 6, 3, 2, 3),
-                   [6, 2],
-                   [7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select c, d from %s where a = ? and c in (?, ?) and b in (?, ?, ?)",
+                "first",
+                7,
+                6,
+                3,
+                2,
+                3,
+            ),
+            [6, 2],
+            [7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in (?, ?) and c = ?", "first", 3, 2, 7),
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in (?, ?) and c = ?",
+                "first",
+                3,
+                2,
+                7,
+            ),
+            ["first", 3, 7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in ? and c in ?",
-                           "first", [3, 2], [7, 6]),
-                   ["first", 2, 6, 2],
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in ? and c in ?",
+                "first",
+                [3, 2],
+                [7, 6],
+            ),
+            ["first", 2, 6, 2],
+            ["first", 3, 7, 3],
+        )
 
         # Scylla does allow IN NULL (see commit 52bbc1065c8) so this test
         # is commented out
-        #assert_invalid_message(cql, table, "Invalid null value for column b",
+        # assert_invalid_message(cql, table, "Invalid null value for column b",
         #                     "select * from %s where a = ? and b in ? and c in ?", "first", None, [7, 6])
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c >= ? and b in (?, ?)", "first", 6, 3, 2),
-                   ["first", 2, 6, 2],
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c >= ? and b in (?, ?)",
+                "first",
+                6,
+                3,
+                2,
+            ),
+            ["first", 2, 6, 2],
+            ["first", 3, 7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c > ? and b in (?, ?)", "first", 6, 3, 2),
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c > ? and b in (?, ?)",
+                "first",
+                6,
+                3,
+                2,
+            ),
+            ["first", 3, 7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c <= ? and b in (?, ?)", "first", 6, 3, 2),
-                   ["first", 2, 6, 2])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c <= ? and b in (?, ?)",
+                "first",
+                6,
+                3,
+                2,
+            ),
+            ["first", 2, 6, 2],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c < ? and b in (?, ?)", "first", 7, 3, 2),
-                   ["first", 2, 6, 2])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c < ? and b in (?, ?)",
+                "first",
+                7,
+                3,
+                2,
+            ),
+            ["first", 2, 6, 2],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c >= ? and c <= ? and b in (?, ?)", "first", 6, 7, 3, 2),
-                   ["first", 2, 6, 2],
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c >= ? and c <= ? and b in (?, ?)",
+                "first",
+                6,
+                7,
+                3,
+                2,
+            ),
+            ["first", 2, 6, 2],
+            ["first", 3, 7, 3],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c > ? and c <= ? and b in (?, ?)", "first", 6, 7, 3, 2),
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c > ? and c <= ? and b in (?, ?)",
+                "first",
+                6,
+                7,
+                3,
+                2,
+            ),
+            ["first", 3, 7, 3],
+        )
 
-        assert_empty(execute(cql, table, "select * from %s where a = ? and c > ? and c < ? and b in (?, ?)", "first", 6, 7, 3, 2))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c > ? and c < ? and b in (?, ?)",
+                "first",
+                6,
+                7,
+                3,
+                2,
+            )
+        )
 
         # Scylla does allow such queries, and their correctness is tested in
         # test_filtering.py::test_multiple_restrictions_on_same_column
-        #assert_invalid_message(cql, table, "Column \"c\" cannot be restricted by both an equality and an inequality relation",
+        # assert_invalid_message(cql, table, "Column \"c\" cannot be restricted by both an equality and an inequality relation",
         #                     "select * from %s where a = ? and c > ? and c = ? and b in (?, ?)", "first", 6, 7, 3, 2)
 
-        #assert_invalid_message(cql, table, "c cannot be restricted by more than one relation if it includes an Equal",
+        # assert_invalid_message(cql, table, "c cannot be restricted by more than one relation if it includes an Equal",
         #                     "select * from %s where a = ? and c = ? and c > ?  and b in (?, ?)", "first", 6, 7, 3, 2)
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c in (?, ?) and b in (?, ?) order by b DESC",
-                           "first", 7, 6, 3, 2),
-                   ["first", 3, 7, 3],
-                   ["first", 2, 6, 2])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c in (?, ?) and b in (?, ?) order by b DESC",
+                "first",
+                7,
+                6,
+                3,
+                2,
+            ),
+            ["first", 3, 7, 3],
+            ["first", 2, 6, 2],
+        )
 
         # Scylla does allow such queries, and their correctness is tested in
         # test_filtering.py::test_multiple_restrictions_on_same_column
-        #assert_invalid_message(cql, table, "More than one restriction was found for the start bound on b",
+        # assert_invalid_message(cql, table, "More than one restriction was found for the start bound on b",
         #                     "select * from %s where a = ? and b > ? and b > ?", "first", 6, 3, 2)
 
-        #assert_invalid_message(cql, table, "More than one restriction was found for the end bound on b",
+        # assert_invalid_message(cql, table, "More than one restriction was found for the end bound on b",
         #                     "select * from %s where a = ? and b < ? and b <= ?", "first", 6, 3, 2)
+
 
 REQUIRES_ALLOW_FILTERING_MESSAGE = "Cannot execute this query as it might involve data filtering and thus may have unpredictable performance. If you want to execute this query despite the performance unpredictability, use ALLOW FILTERING"
 
+
 def testPartitionKeyColumnRelations(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b int, c int, d int, primary key ((a, b), c))") as table:
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 1, 1, 1)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 2, 2, 2)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 3, 3, 3)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 4, 4, 4)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "second", 1, 1, 1)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "second", 4, 4, 4)
+    with create_table(
+        cql, test_keyspace, "(a text, b int, c int, d int, primary key ((a, b), c))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            1,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            2,
+            2,
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            3,
+            3,
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            4,
+            4,
+            4,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "second",
+            1,
+            1,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "second",
+            4,
+            4,
+            4,
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b = ?", "first", 2),
-                   ["first", 2, 2, 2])
+        assert_rows(
+            execute(cql, table, "select * from %s where a = ? and b = ?", "first", 2),
+            ["first", 2, 2, 2],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a in (?, ?) and b in (?, ?)", "first", "second", 2, 3),
-                   ["first", 2, 2, 2],
-                   ["first", 3, 3, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a in (?, ?) and b in (?, ?)",
+                "first",
+                "second",
+                2,
+                3,
+            ),
+            ["first", 2, 2, 2],
+            ["first", 3, 3, 3],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a in (?, ?) and b = ?", "first", "second", 4),
-                   ["first", 4, 4, 4],
-                   ["second", 4, 4, 4])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a in (?, ?) and b = ?",
+                "first",
+                "second",
+                4,
+            ),
+            ["first", 4, 4, 4],
+            ["second", 4, 4, 4],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and b in (?, ?)", "first", 3, 4),
-                   ["first", 3, 3, 3],
-                   ["first", 4, 4, 4])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and b in (?, ?)",
+                "first",
+                3,
+                4,
+            ),
+            ["first", 3, 3, 3],
+            ["first", 4, 4, 4],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a in (?, ?) and b in (?, ?)", "first", "second", 1, 4),
-                   ["first", 1, 1, 1],
-                   ["first", 4, 4, 4],
-                   ["second", 1, 1, 1],
-                   ["second", 4, 4, 4])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a in (?, ?) and b in (?, ?)",
+                "first",
+                "second",
+                1,
+                4,
+            ),
+            ["first", 1, 1, 1],
+            ["first", 4, 4, 4],
+            ["second", 1, 1, 1],
+            ["second", 4, 4, 4],
+        )
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "select * from %s where a in (?, ?)", "first", "second")
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "select * from %s where a = ?", "first")
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "select * from %s where a in (?, ?)",
+            "first",
+            "second",
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "select * from %s where a = ?",
+            "first",
+        )
         # Scylla does allow such queries, and their correctness is tested in
         # test_filtering.py::test_multiple_restrictions_on_same_column
-        #assert_invalid_message(cql, table, "b cannot be restricted by more than one relation if it includes a IN",
+        # assert_invalid_message(cql, table, "b cannot be restricted by more than one relation if it includes a IN",
         #                     "select * from %s where a = ? AND b IN (?, ?) AND b = ?", "first", 2, 2, 3)
-        #assert_invalid_message(cql, table, "b cannot be restricted by more than one relation if it includes an Equal",
+        # assert_invalid_message(cql, table, "b cannot be restricted by more than one relation if it includes an Equal",
         #                     "select * from %s where a = ? AND b = ? AND b IN (?, ?)", "first", 2, 2, 3)
-        #assert_invalid_message(cql, table, "a cannot be restricted by more than one relation if it includes a IN",
+        # assert_invalid_message(cql, table, "a cannot be restricted by more than one relation if it includes a IN",
         #                     "select * from %s where a IN (?, ?) AND a = ? AND b = ?", "first", "second", "first", 3)
-        #assert_invalid_message(cql, table, "a cannot be restricted by more than one relation if it includes an Equal",
+        # assert_invalid_message(cql, table, "a cannot be restricted by more than one relation if it includes an Equal",
         #                     "select * from %s where a = ? AND a IN (?, ?) AND b IN (?, ?)", "first", "second", "first", 2, 3)
 
+
 def testClusteringColumnRelationsWithClusteringOrder(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b int, c int, d int, primary key (a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC)") as table:
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 1, 5, 1)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 2, 6, 2)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "first", 3, 7, 3)
-        execute(cql, table, "insert into %s (a, b, c, d) values (?, ?, ?, ?)", "second", 4, 8, 4)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, c int, d int, primary key (a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            1,
+            5,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            2,
+            6,
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "first",
+            3,
+            7,
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (a, b, c, d) values (?, ?, ?, ?)",
+            "second",
+            4,
+            8,
+            4,
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c in (?, ?) and b in (?, ?) order by b DESC",
-                           "first", 7, 6, 3, 2),
-                   ["first", 3, 7, 3],
-                   ["first", 2, 6, 2])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c in (?, ?) and b in (?, ?) order by b DESC",
+                "first",
+                7,
+                6,
+                3,
+                2,
+            ),
+            ["first", 3, 7, 3],
+            ["first", 2, 6, 2],
+        )
 
-        assert_rows(execute(cql, table, "select * from %s where a = ? and c in (?, ?) and b in (?, ?) order by b ASC",
-                           "first", 7, 6, 3, 2),
-                   ["first", 2, 6, 2],
-                   ["first", 3, 7, 3])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "select * from %s where a = ? and c in (?, ?) and b in (?, ?) order by b ASC",
+                "first",
+                7,
+                6,
+                3,
+                2,
+            ),
+            ["first", 2, 6, 2],
+            ["first", 3, 7, 3],
+        )
+
 
 def testAllowFilteringWithClusteringColumn(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c int, v int, primary key (k, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, c int, v int, primary key (k, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, c, v) VALUES(?, ?, ?)", 1, 2, 1)
         execute(cql, table, "INSERT INTO %s (k, c, v) VALUES(?, ?, ?)", 1, 3, 2)
         execute(cql, table, "INSERT INTO %s (k, c, v) VALUES(?, ?, ?)", 2, 2, 3)
 
         # Don't require filtering, always allowed
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 1),
-                   [1, 2, 1],
-                   [1, 3, 2])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k = ?", 1), [1, 2, 1], [1, 3, 2]
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ? AND c > ?", 1, 2), [1, 3, 2])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k = ? AND c > ?", 1, 2),
+            [1, 3, 2],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ? AND c = ?", 1, 2), [1, 2, 1])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k = ? AND c = ?", 1, 2),
+            [1, 2, 1],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ? ALLOW FILTERING", 1),
-                   [1, 2, 1],
-                   [1, 3, 2])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k = ? ALLOW FILTERING", 1),
+            [1, 2, 1],
+            [1, 3, 2],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ? AND c > ? ALLOW FILTERING", 1, 2), [1, 3, 2])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE k = ? AND c > ? ALLOW FILTERING",
+                1,
+                2,
+            ),
+            [1, 3, 2],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ? AND c = ? ALLOW FILTERING", 1, 2), [1, 2, 1])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE k = ? AND c = ? ALLOW FILTERING",
+                1,
+                2,
+            ),
+            [1, 2, 1],
+        )
 
         # Require filtering, allowed only with ALLOW FILTERING
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c = ?", 2)
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c > ? AND c <= ?", 2, 4)
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c = ?",
+            2,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c > ? AND c <= ?",
+            2,
+            4,
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c = ? ALLOW FILTERING", 2),
-                   [1, 2, 1],
-                   [2, 2, 3])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE c = ? ALLOW FILTERING", 2),
+            [1, 2, 1],
+            [2, 2, 3],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > ? AND c <= ? ALLOW FILTERING", 2, 4), [1, 3, 2])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE c > ? AND c <= ? ALLOW FILTERING",
+                2,
+                4,
+            ),
+            [1, 3, 2],
+        )
+
 
 def testAllowFilteringWithIndexedColumn(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, a int, b int)") as table:
@@ -249,16 +720,38 @@ def testAllowFilteringWithIndexedColumn(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s(k, a, b) VALUES(?, ?, ?)", 4, 40, 400)
 
         # Don't require filtering, always allowed
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ?", 1), [1, 10, 100])
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ?", 20), [2, 20, 200])
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k = ? ALLOW FILTERING", 1), [1, 10, 100])
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? ALLOW FILTERING", 20), [2, 20, 200])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k = ?", 1), [1, 10, 100]
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ?", 20), [2, 20, 200]
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k = ? ALLOW FILTERING", 1),
+            [1, 10, 100],
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = ? ALLOW FILTERING", 20),
+            [2, 20, 200],
+        )
 
         assert_invalid(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ?")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ? ALLOW FILTERING", 20, 200), [2, 20, 200])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b = ? ALLOW FILTERING",
+                20,
+                200,
+            ),
+            [2, 20, 200],
+        )
+
 
 def testAllowFilteringWithIndexedColumnAndStaticColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, s int static, PRIMARY KEY (a, b))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(c)")
 
         execute(cql, table, "INSERT INTO %s(a, b, c, s) VALUES(?, ?, ?, ?)", 1, 1, 1, 1)
@@ -266,69 +759,225 @@ def testAllowFilteringWithIndexedColumnAndStaticColumns(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s(a, s) VALUES(?, ?)", 3, 3)
         execute(cql, table, "INSERT INTO %s(a, b, c, s) VALUES(?, ?, ?, ?)", 2, 1, 1, 2)
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c = ? AND s > ? ALLOW FILTERING", 1, 1),
-                   [2, 1, 2, 1])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE c = ? AND s > ? ALLOW FILTERING",
+                1,
+                1,
+            ),
+            [2, 1, 2, 1],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c = ? AND s < ? ALLOW FILTERING", 1, 2),
-                   [1, 1, 1, 1],
-                   [1, 2, 1, 1])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE c = ? AND s < ? ALLOW FILTERING",
+                1,
+                2,
+            ),
+            [1, 1, 1, 1],
+            [1, 2, 1, 1],
+        )
+
 
 def testIndexQueriesOnComplexPrimaryKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk0 int, pk1 int, ck0 int, ck1 int, ck2 int, value int, PRIMARY KEY ((pk0, pk1), ck0, ck1, ck2))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk0 int, pk1 int, ck0 int, ck1 int, ck2 int, value int, PRIMARY KEY ((pk0, pk1), ck0, ck1, ck2))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(ck1)")
         execute(cql, table, "CREATE INDEX ON %s(ck2)")
         execute(cql, table, "CREATE INDEX ON %s(pk0)")
         execute(cql, table, "CREATE INDEX ON %s(ck0)")
 
-        execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)", 0, 1, 2, 3, 4, 5)
-        execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)", 1, 2, 3, 4, 5, 0)
-        execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)", 2, 3, 4, 5, 0, 1)
-        execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)", 3, 4, 5, 0, 1, 2)
-        execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)", 4, 5, 0, 1, 2, 3)
-        execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)", 5, 0, 1, 2, 3, 4)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)",
+            1,
+            2,
+            3,
+            4,
+            5,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)",
+            2,
+            3,
+            4,
+            5,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)",
+            3,
+            4,
+            5,
+            0,
+            1,
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)",
+            4,
+            5,
+            0,
+            1,
+            2,
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk0, pk1, ck0, ck1, ck2, value) VALUES (?, ?, ?, ?, ?, ?)",
+            5,
+            0,
+            1,
+            2,
+            3,
+            4,
+        )
 
         assert_rows(execute(cql, table, "SELECT value FROM %s WHERE pk0 = 2"), [1])
         assert_rows(execute(cql, table, "SELECT value FROM %s WHERE ck0 = 0"), [3])
-        assert_rows(execute(cql, table, "SELECT value FROM %s WHERE pk0 = 3 AND pk1 = 4 AND ck1 = 0"), [2])
-        assert_rows(execute(cql, table, "SELECT value FROM %s WHERE pk0 = 5 AND pk1 = 0 AND ck0 = 1 AND ck2 = 3 ALLOW FILTERING"), [4])
+        assert_rows(
+            execute(
+                cql, table, "SELECT value FROM %s WHERE pk0 = 3 AND pk1 = 4 AND ck1 = 0"
+            ),
+            [2],
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE pk0 = 5 AND pk1 = 0 AND ck0 = 1 AND ck2 = 3 ALLOW FILTERING",
+            ),
+            [4],
+        )
+
 
 def testIndexOnClusteringColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id1 int, id2 int, author text, time bigint, v1 text, v2 text, PRIMARY KEY ((id1, id2), author, time))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(id1 int, id2 int, author text, time bigint, v1 text, v2 text, PRIMARY KEY ((id1, id2), author, time))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(time)")
         execute(cql, table, "CREATE INDEX ON %s(id2)")
 
-        execute(cql, table, "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 0, 'bob', 0, 'A', 'A')")
-        execute(cql, table, "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 0, 'bob', 1, 'B', 'B')")
-        execute(cql, table, "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 1, 'bob', 2, 'C', 'C')")
-        execute(cql, table, "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 0, 'tom', 0, 'D', 'D')")
-        execute(cql, table, "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 1, 'tom', 1, 'E', 'E')")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 0, 'bob', 0, 'A', 'A')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 0, 'bob', 1, 'B', 'B')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 1, 'bob', 2, 'C', 'C')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 0, 'tom', 0, 'D', 'D')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(id1, id2, author, time, v1, v2) VALUES(0, 1, 'tom', 1, 'E', 'E')",
+        )
 
-        assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE time = 1"), ["B"], ["E"])
+        assert_rows(
+            execute(cql, table, "SELECT v1 FROM %s WHERE time = 1"), ["B"], ["E"]
+        )
 
-        assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE id2 = 1"), ["C"], ["E"])
+        assert_rows(
+            execute(cql, table, "SELECT v1 FROM %s WHERE id2 = 1"), ["C"], ["E"]
+        )
 
-        assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE id1 = 0 AND id2 = 0 AND author = 'bob' AND time = 0"), ["A"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT v1 FROM %s WHERE id1 = 0 AND id2 = 0 AND author = 'bob' AND time = 0",
+            ),
+            ["A"],
+        )
 
         # Test for CASSANDRA-8206
-        execute(cql, table, "UPDATE %s SET v2 = null WHERE id1 = 0 AND id2 = 0 AND author = 'bob' AND time = 1")
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET v2 = null WHERE id1 = 0 AND id2 = 0 AND author = 'bob' AND time = 1",
+        )
 
-        assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE id2 = 0"), ["A"], ["B"], ["D"])
+        assert_rows(
+            execute(cql, table, "SELECT v1 FROM %s WHERE id2 = 0"), ["A"], ["B"], ["D"]
+        )
 
-        assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE time = 1"), ["B"], ["E"])
+        assert_rows(
+            execute(cql, table, "SELECT v1 FROM %s WHERE time = 1"), ["B"], ["E"]
+        )
 
         # Scylla does support IN restrictions of any column when ALLOW
         # FILTERING is used, so the following does work. See
         # test_filtering.py::test_filter_in_restriction for a test that
         # this support is correct.
-        #assert_invalid_message(cql, table, "IN restrictions are not supported on indexed columns",
+        # assert_invalid_message(cql, table, "IN restrictions are not supported on indexed columns",
         #                     "SELECT v1 FROM %s WHERE id2 = 0 and time IN (1, 2) ALLOW FILTERING")
 
-        assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE author > 'ted' AND time = 1 ALLOW FILTERING"), ["E"])
-        assert_rows(execute(cql, table, "SELECT v1 FROM %s WHERE author > 'amy' AND author < 'zoe' AND time = 0 ALLOW FILTERING"),
-                           ["A"], ["D"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT v1 FROM %s WHERE author > 'ted' AND time = 1 ALLOW FILTERING",
+            ),
+            ["E"],
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT v1 FROM %s WHERE author > 'amy' AND author < 'zoe' AND time = 0 ALLOW FILTERING",
+            ),
+            ["A"],
+            ["D"],
+        )
+
 
 def testCompositeIndexWithPrimaryKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(blog_id int, time1 int, time2 int, author text, content text,  PRIMARY KEY (blog_id, time1, time2))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(blog_id int, time1 int, time2 int, author text, content text,  PRIMARY KEY (blog_id, time1, time2))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(author)")
         req = "INSERT INTO %s (blog_id, time1, time2, author, content) VALUES (?, ?, ?, ?, ?)"
         execute(cql, table, req, 1, 0, 0, "foo", "bar1")
@@ -336,26 +985,64 @@ def testCompositeIndexWithPrimaryKey(cql, test_keyspace):
         execute(cql, table, req, 2, 1, 0, "foo", "baz")
         execute(cql, table, req, 3, 0, 1, "gux", "qux")
 
-        assert_rows(execute(cql, table, "SELECT blog_id, content FROM %s WHERE author='foo'"),
-                   [1, "bar1"],
-                   [1, "bar2"],
-                   [2, "baz"])
-        assert_rows(execute(cql, table, "SELECT blog_id, content FROM %s WHERE time1 > 0 AND author='foo' ALLOW FILTERING"), [2, "baz"])
-        assert_rows(execute(cql, table, "SELECT blog_id, content FROM %s WHERE time1 = 1 AND author='foo' ALLOW FILTERING"), [2, "baz"])
-        assert_rows(execute(cql, table, "SELECT blog_id, content FROM %s WHERE time1 = 1 AND time2 = 0 AND author='foo' ALLOW FILTERING"),
-                   [2, "baz"])
-        assert_empty(execute(cql, table, "SELECT content FROM %s WHERE time1 = 1 AND time2 = 1 AND author='foo' ALLOW FILTERING"))
-        assert_empty(execute(cql, table, "SELECT content FROM %s WHERE time1 = 1 AND time2 > 0 AND author='foo' ALLOW FILTERING"))
+        assert_rows(
+            execute(cql, table, "SELECT blog_id, content FROM %s WHERE author='foo'"),
+            [1, "bar1"],
+            [1, "bar2"],
+            [2, "baz"],
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT blog_id, content FROM %s WHERE time1 > 0 AND author='foo' ALLOW FILTERING",
+            ),
+            [2, "baz"],
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT blog_id, content FROM %s WHERE time1 = 1 AND author='foo' ALLOW FILTERING",
+            ),
+            [2, "baz"],
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT blog_id, content FROM %s WHERE time1 = 1 AND time2 = 0 AND author='foo' ALLOW FILTERING",
+            ),
+            [2, "baz"],
+        )
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT content FROM %s WHERE time1 = 1 AND time2 = 1 AND author='foo' ALLOW FILTERING",
+            )
+        )
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT content FROM %s WHERE time1 = 1 AND time2 > 0 AND author='foo' ALLOW FILTERING",
+            )
+        )
 
         # Scylla and Cassandra chose to print different errors in this case -
         # Cassandra says that ALLOW FILTERING would have made this query
         # work, while Scylla says that time1 should have also been
         # restricted.
-        assert_invalid(cql, table,
-                             "SELECT content FROM %s WHERE time2 >= 0 AND author='foo'")
+        assert_invalid(
+            cql, table, "SELECT content FROM %s WHERE time2 >= 0 AND author='foo'"
+        )
+
 
 def testRangeQueryOnIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(id int primary key, row int, setid int)") as table:
+    with create_table(
+        cql, test_keyspace, "(id int primary key, row int, setid int)"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(setid)")
 
         q = "INSERT INTO %s (id, row, setid) VALUES (?, ?, ?);"
@@ -364,208 +1051,584 @@ def testRangeQueryOnIndex(cql, test_keyspace):
         execute(cql, table, q, 2, 2, 0)
         execute(cql, table, q, 3, 3, 0)
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE setid = 0 AND row < 1;")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE setid = 0 AND row < 1 ALLOW FILTERING;"), [0, 0, 0])
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE setid = 0 AND row < 1;",
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE setid = 0 AND row < 1 ALLOW FILTERING;",
+            ),
+            [0, 0, 0],
+        )
+
 
 def testEmptyIN(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))") as table:
+    with create_table(
+        cql, test_keyspace, "(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))"
+    ) as table:
         for i in range(3):
             for j in range(3):
-                execute(cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", i, j, i + j)
+                execute(
+                    cql,
+                    table,
+                    "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)",
+                    i,
+                    j,
+                    i + j,
+                )
 
         assert_empty(execute(cql, table, "SELECT v FROM %s WHERE k1 IN ()"))
         assert_empty(execute(cql, table, "SELECT v FROM %s WHERE k1 = 0 AND k2 IN ()"))
 
+
 def testINWithDuplicateValue(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))") as table:
+    with create_table(
+        cql, test_keyspace, "(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k1,  k2, v) VALUES (?, ?, ?)", 1, 1, 1)
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k1 IN (?, ?)", 1, 1),
-                   [1, 1, 1])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k1 IN (?, ?)", 1, 1), [1, 1, 1]
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k1 IN (?, ?) AND k2 IN (?, ?)", 1, 1, 1, 1),
-                   [1, 1, 1])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE k1 IN (?, ?) AND k2 IN (?, ?)",
+                1,
+                1,
+                1,
+                1,
+            ),
+            [1, 1, 1],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k1 = ? AND k2 IN (?, ?)", 1, 1, 1),
-                   [1, 1, 1])
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE k1 = ? AND k2 IN (?, ?)", 1, 1, 1
+            ),
+            [1, 1, 1],
+        )
 
-@pytest.mark.xfail(reason="#10577 - max-clustering-key-restrictions-per-query is too low for this test")
+
+@pytest.mark.xfail(
+    reason="Is max-clustering-key-restrictions-per-query too low? #10577"
+)
 def testLargeClusteringINValues(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (0, 0, 0)")
         inValues = list(range(10000))
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k=? AND c IN ?", 0, inValues),
-                [0, 0, 0])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k=? AND c IN ?", 0, inValues),
+            [0, 0, 0],
+        )
+
 
 def testMultiplePartitionKeyWithIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, f int, PRIMARY KEY ((a, b), c, d, e))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, f int, PRIMARY KEY ((a, b), c, d, e))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (c)")
         execute(cql, table, "CREATE INDEX ON %s (f)")
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 0, 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 0, 1, 0, 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 0, 1, 1, 2)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            1,
+            1,
+            2,
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 1, 0, 0, 3)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 1, 1, 0, 4)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 1, 1, 1, 5)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            0,
+            0,
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            1,
+            0,
+            4,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            1,
+            1,
+            5,
+        )
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)", 0, 0, 2, 0, 0, 5)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)",
+            0,
+            0,
+            2,
+            0,
+            0,
+            5,
+        )
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND c = ?", 0, 1)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c = ? ALLOW FILTERING", 0, 1),
-                   [0, 0, 1, 0, 0, 3],
-                   [0, 0, 1, 1, 0, 4],
-                   [0, 0, 1, 1, 1, 5])
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND c = ?",
+            0,
+            1,
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c = ? ALLOW FILTERING",
+                0,
+                1,
+            ),
+            [0, 0, 1, 0, 0, 3],
+            [0, 0, 1, 1, 0, 4],
+            [0, 0, 1, 1, 1, 5],
+        )
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND c = ? AND d = ?", 0, 1, 1)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c = ? AND d = ? ALLOW FILTERING", 0, 1, 1),
-                   [0, 0, 1, 1, 0, 4],
-                   [0, 0, 1, 1, 1, 5])
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND c = ? AND d = ?",
+            0,
+            1,
+            1,
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c = ? AND d = ? ALLOW FILTERING",
+                0,
+                1,
+                1,
+            ),
+            [0, 0, 1, 1, 0, 4],
+            [0, 0, 1, 1, 1, 5],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c IN (?) AND  d IN (?) ALLOW FILTERING", 0, 1, 1),
-                [0, 0, 1, 1, 0, 4],
-                [0, 0, 1, 1, 1, 5])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c IN (?) AND  d IN (?) ALLOW FILTERING",
+                0,
+                1,
+                1,
+            ),
+            [0, 0, 1, 1, 0, 4],
+            [0, 0, 1, 1, 1, 5],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) ALLOW FILTERING", 0, 1, 1),
-                [0, 0, 1, 1, 0, 4],
-                [0, 0, 1, 1, 1, 5],
-                [0, 0, 2, 0, 0, 5])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND (c, d) >= (?, ?) ALLOW FILTERING",
+                0,
+                1,
+                1,
+            ),
+            [0, 0, 1, 1, 0, 4],
+            [0, 0, 1, 1, 1, 5],
+            [0, 0, 2, 0, 0, 5],
+        )
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ?", 0, 0, 1, 5)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ? ALLOW FILTERING", 0, 1, 3, 5),
-                   [0, 0, 1, 1, 1, 5])
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ?",
+            0,
+            0,
+            1,
+            5,
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                3,
+                5,
+            ),
+            [0, 0, 1, 1, 1, 5],
+        )
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ?", 0, 1, 2, 5)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ? ALLOW FILTERING", 0, 1, 2, 5),
-                   [0, 0, 1, 1, 1, 5],
-                   [0, 0, 2, 0, 0, 5])
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ?",
+            0,
+            1,
+            2,
+            5,
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                2,
+                5,
+            ),
+            [0, 0, 1, 1, 1, 5],
+            [0, 0, 2, 0, 0, 5],
+        )
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND d IN (?) AND f = ?", 0, 1, 3, 0, 3)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND d IN (?) AND f = ? ALLOW FILTERING", 0, 1, 3, 0, 3),
-                   [0, 0, 1, 0, 0, 3])
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND d IN (?) AND f = ?",
+            0,
+            1,
+            3,
+            0,
+            3,
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c IN (?, ?) AND d IN (?) AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                3,
+                0,
+                3,
+            ),
+            [0, 0, 1, 0, 0, 3],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c >= ? ALLOW FILTERING", 0, 1),
-                [0, 0, 1, 0, 0, 3],
-                [0, 0, 1, 1, 0, 4],
-                [0, 0, 1, 1, 1, 5],
-                [0, 0, 2, 0, 0, 5])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c >= ? ALLOW FILTERING",
+                0,
+                1,
+            ),
+            [0, 0, 1, 0, 0, 3],
+            [0, 0, 1, 1, 0, 4],
+            [0, 0, 1, 1, 1, 5],
+            [0, 0, 2, 0, 0, 5],
+        )
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND c >= ? AND f = ?", 0, 1, 5)
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ? AND c >= ? AND f = ?", 0, 0, 1, 5),
-                   [0, 0, 1, 1, 1, 5],
-                   [0, 0, 2, 0, 0, 5])
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND c >= ? AND f = ?",
+            0,
+            1,
+            5,
+        )
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b = ? AND c >= ? AND f = ?",
+                0,
+                0,
+                1,
+                5,
+            ),
+            [0, 0, 1, 1, 1, 5],
+            [0, 0, 2, 0, 0, 5],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c >= ? AND f = ? ALLOW FILTERING", 0, 1, 5),
-                   [0, 0, 1, 1, 1, 5],
-                   [0, 0, 2, 0, 0, 5])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c >= ? AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                5,
+            ),
+            [0, 0, 1, 1, 1, 5],
+            [0, 0, 2, 0, 0, 5],
+        )
 
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE a = ? AND c = ? AND d >= ? AND f = ?", 0, 1, 1, 5)
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE a = ? AND c = ? AND d >= ? AND f = ?",
+            0,
+            1,
+            1,
+            5,
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = ? AND c = ? AND d >= ? AND f = ?", 0, 0, 1, 1, 5),
-                   [0, 0, 1, 1, 1, 5])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND b = ? AND c = ? AND d >= ? AND f = ?",
+                0,
+                0,
+                1,
+                1,
+                5,
+            ),
+            [0, 0, 1, 1, 1, 5],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND c = ? AND d >= ? AND f = ? ALLOW FILTERING", 0, 1, 1, 5),
-                   [0, 0, 1, 1, 1, 5])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE a = ? AND c = ? AND d >= ? AND f = ? ALLOW FILTERING",
+                0,
+                1,
+                1,
+                5,
+            ),
+            [0, 0, 1, 1, 1, 5],
+        )
+
 
 def testFunctionCallWithUnset(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)") as table:
+    with create_table(
+        cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)"
+    ) as table:
         # The error messages in Scylla and Cassandra here are slightly
         # different.
-        assert_invalid_message(cql, table, "unset",
-                             "SELECT * FROM %s WHERE token(k) >= token(?)", UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset",
-                             "SELECT * FROM %s WHERE k = blobAsInt(?)", UNSET_VALUE)
+        assert_invalid_message(
+            cql,
+            table,
+            "unset",
+            "SELECT * FROM %s WHERE token(k) >= token(?)",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql, table, "unset", "SELECT * FROM %s WHERE k = blobAsInt(?)", UNSET_VALUE
+        )
+
 
 def testLimitWithUnset(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, i int)") as table:
         execute(cql, table, "INSERT INTO %s (k, i) VALUES (1, 1)")
         execute(cql, table, "INSERT INTO %s (k, i) VALUES (2, 1)")
-        assert_rows(execute(cql, table, "SELECT k FROM %s LIMIT ?", UNSET_VALUE), # treat as 'unlimited'
-                [1],
-                [2]
+        assert_rows(
+            execute(
+                cql, table, "SELECT k FROM %s LIMIT ?", UNSET_VALUE
+            ),  # treat as 'unlimited'
+            [1],
+            [2],
         )
 
+
 def testWithUnsetValues(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, i int, j int, s text, PRIMARY KEY (k,i,j))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, i int, j int, s text, PRIMARY KEY (k,i,j))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (s)")
         # partition key
         # Test commented out because the Python driver can't send an
         # UNSET_VALUE for the partition key (it is needed to decide
         # which coordinator to send the request to!)
-        #assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = ?", UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k IN ?", UNSET_VALUE)
+        # assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = ?", UNSET_VALUE)
+        assert_invalid_message(
+            cql, table, "unset value", "SELECT * from %s WHERE k IN ?", UNSET_VALUE
+        )
         # Test commented out because the Python driver can't send an
         # UNSET_VALUE for the partition key (it is needed to decide
         # which coordinator to send the request to!)
-        #assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k IN(?)", UNSET_VALUE)
-        #assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k IN(?,?)", 1, UNSET_VALUE)
+        # assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k IN(?)", UNSET_VALUE)
+        # assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k IN(?,?)", 1, UNSET_VALUE)
         # clustering column
         # Reproduces #10358:
-        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i = ?", UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i IN ?", UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i IN(?)", UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i IN(?,?)", 1, UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE i = ? ALLOW FILTERING", UNSET_VALUE)
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE k = 1 AND i = ?",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE k = 1 AND i IN ?",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE k = 1 AND i IN(?)",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE k = 1 AND i IN(?,?)",
+            1,
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE i = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
         # indexed column
-        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE s = ?", UNSET_VALUE)
+        assert_invalid_message(
+            cql, table, "unset value", "SELECT * from %s WHERE s = ?", UNSET_VALUE
+        )
         # range
-        assert_invalid_message(cql, table, "unset value", "SELECT * from %s WHERE k = 1 AND i > ?", UNSET_VALUE)
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * from %s WHERE k = 1 AND i > ?",
+            UNSET_VALUE,
+        )
+
 
 def testInvalidSliceRestrictionOnPartitionKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b int, c text)") as table:
+    with create_table(
+        cql, test_keyspace, "(a int PRIMARY KEY, b int, c text)"
+    ) as table:
         # Scylla and Cassandra choose to print a different error message
         # here: Cassandra tells you this query would have worked with
         # ALLOW FILTERING, while Scylla *also* tells you that this
         # query would have worked with EQ or IN relations or with token().
         # The word "filtering" is common to both messages.
-        assert_invalid_message(cql, table, 'FILTERING',
-                             "SELECT * FROM %s WHERE a >= 1 and a < 4")
+        assert_invalid_message(
+            cql, table, "FILTERING", "SELECT * FROM %s WHERE a >= 1 and a < 4"
+        )
         # Again, different error messages. Cassandra says "Multi-column
         # relations can only be applied to clustering columns but was
         # applied to: a", Scylla says "Only EQ and IN relation are supported
         # on the partition key (unless you use the token() function or allow
         # filtering)". There is no word in common :-(
-        assert_invalid(cql, table,
-                             "SELECT * FROM %s WHERE (a) >= (1) and (a) < (4)")
+        assert_invalid(cql, table, "SELECT * FROM %s WHERE (a) >= (1) and (a) < (4)")
+
 
 def testInvalidMulticolumnSliceRestrictionOnPartitionKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c text, PRIMARY KEY ((a, b)))") as table:
-        assert_invalid_message(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: a",
-                             "SELECT * FROM %s WHERE (a, b) >= (1, 1) and (a, b) < (4, 1)")
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c text, PRIMARY KEY ((a, b)))"
+    ) as table:
+        assert_invalid_message(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: a",
+            "SELECT * FROM %s WHERE (a, b) >= (1, 1) and (a, b) < (4, 1)",
+        )
         # Again, different error messages. Cassandra says "Multi-column
         # relations can only be applied to clustering columns but was
         # applied to: a", Scylla says "Only EQ and IN relation are supported
         # on the partition key (unless you use the token() function or allow
         # filtering)". There is no word in common :-(
-        assert_invalid(cql, table,
-                             "SELECT * FROM %s WHERE a >= 1 and (a, b) < (4, 1)")
-        assert_invalid(cql, table,
-                             "SELECT * FROM %s WHERE b >= 1 and (a, b) < (4, 1)")
-        assert_invalid_message(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: a",
-                             "SELECT * FROM %s WHERE (a, b) >= (1, 1) and (b) < (4)")
-        assert_invalid_message(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: b",
-                             "SELECT * FROM %s WHERE (b) < (4) and (a, b) >= (1, 1)")
-        assert_invalid_message(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: a",
-                             "SELECT * FROM %s WHERE (a, b) >= (1, 1) and a = 1")
+        assert_invalid(cql, table, "SELECT * FROM %s WHERE a >= 1 and (a, b) < (4, 1)")
+        assert_invalid(cql, table, "SELECT * FROM %s WHERE b >= 1 and (a, b) < (4, 1)")
+        assert_invalid_message(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: a",
+            "SELECT * FROM %s WHERE (a, b) >= (1, 1) and (b) < (4)",
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: b",
+            "SELECT * FROM %s WHERE (b) < (4) and (a, b) >= (1, 1)",
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Multi-column relations can only be applied to clustering columns but was applied to: a",
+            "SELECT * FROM %s WHERE (a, b) >= (1, 1) and a = 1",
+        )
+
 
 def testInvalidColumnNames(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c map<int, int>, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c map<int, int>, PRIMARY KEY (a, b))"
+    ) as table:
         # Slightly different error messages in Scylla and Cassandra. Both
         # include the string "name d".
         assert_invalid_message(cql, table, "name d", "SELECT * FROM %s WHERE d = 0")
-        assert_invalid_message(cql, table, "name d", "SELECT * FROM %s WHERE d IN (0, 1)")
-        assert_invalid_message(cql, table, "name d", "SELECT * FROM %s WHERE d > 0 and d <= 2")
-        assert_invalid_message(cql, table, "name d", "SELECT * FROM %s WHERE d CONTAINS 0")
-        assert_invalid_message(cql, table, "name d", "SELECT * FROM %s WHERE d CONTAINS KEY 0")
+        assert_invalid_message(
+            cql, table, "name d", "SELECT * FROM %s WHERE d IN (0, 1)"
+        )
+        assert_invalid_message(
+            cql, table, "name d", "SELECT * FROM %s WHERE d > 0 and d <= 2"
+        )
+        assert_invalid_message(
+            cql, table, "name d", "SELECT * FROM %s WHERE d CONTAINS 0"
+        )
+        assert_invalid_message(
+            cql, table, "name d", "SELECT * FROM %s WHERE d CONTAINS KEY 0"
+        )
         # Here, Cassandra says "Undefined column name d" but Scylla gives
         # a clearer error message about the real cause: "Aliases aren't
         # allowed in the where clause ('d = 0')".
@@ -576,33 +1639,51 @@ def testInvalidColumnNames(cql, test_keyspace):
         assert_invalid(cql, table, "SELECT c AS d FROM %s WHERE d CONTAINS KEY 0")
         assert_invalid_message(cql, table, "name d", "SELECT d FROM %s WHERE a = 0")
 
+
 def testInvalidNonFrozenUDTRelation(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as type:
-        with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b {type})") as table:
+        with create_table(
+            cql, test_keyspace, f"(a int PRIMARY KEY, b {type})"
+        ) as table:
             udt = user_type("a", 1)
-            ks, t = type.split('.')
+            ks, t = type.split(".")
 
             # All operators
             # As decided https://issues.apache.org/jira/browse/CASSANDRA-13247,
-            # Cassandra does not allow restrictions on non-frozen UDTs. 
+            # Cassandra does not allow restrictions on non-frozen UDTs.
             # Scylla does implement them, so the commented out tests below
             # are not relevant (Scylla will complain that ALLOW FILTERING
             # is missing, not about the non-frozen UDT).
-            msg = "Non-frozen UDT column 'b' (" + t + ") cannot be restricted by any relation"
-            #assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b = ?", udt)
-            #assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b > ?", udt)
-            #assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b < ?", udt)
-            #assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b >= ?", udt)
-            #assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b <= ?", udt)
-            #assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b IN (?)", udt)
+            msg = (
+                "Non-frozen UDT column 'b' ("
+                + t
+                + ") cannot be restricted by any relation"
+            )
+            # assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b = ?", udt)
+            # assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b > ?", udt)
+            # assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b < ?", udt)
+            # assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b >= ?", udt)
+            # assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b <= ?", udt)
+            # assert_invalid_message(cql, table, msg, "SELECT * FROM %s WHERE b IN (?)", udt)
             # Scylla and Cassandra print different errors here - Scylla
             # says that b is not a string, Cassandra says it is a non-frozen
             # UDT.
             assert_invalid(cql, table, "SELECT * FROM %s WHERE b LIKE ?", udt)
-            assert_invalid_message(cql, table, "Unsupported \"!=\" relation",
-                             "SELECT * FROM %s WHERE b != {a: 0}", udt)
+            assert_invalid_message(
+                cql,
+                table,
+                'Unsupported "!=" relation',
+                "SELECT * FROM %s WHERE b != {a: 0}",
+                udt,
+            )
             # Reproduces #10632:
-            assert_invalid_message(cql, table, "b IS NOT",
-                             "SELECT * FROM %s WHERE b IS NOT NULL", udt)
-            assert_invalid_message(cql, table, "Cannot use CONTAINS on non-collection column",
-                             "SELECT * FROM %s WHERE b CONTAINS ?", udt)
+            assert_invalid_message(
+                cql, table, "b IS NOT", "SELECT * FROM %s WHERE b IS NOT NULL", udt
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                "Cannot use CONTAINS on non-collection column",
+                "SELECT * FROM %s WHERE b CONTAINS ?",
+                udt,
+            )

--- a/test/cqlpy/cassandra_tests/validation/operations/select_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_test.py
@@ -15,446 +15,1294 @@ from cassandra.util import Duration
 
 REQUIRES_ALLOW_FILTERING_MESSAGE = "Cannot execute this query as it might involve data filtering and thus may have unpredictable performance. If you want to execute this query despite the performance unpredictability, use ALLOW FILTERING"
 
+
 def testSingleClustering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(p text, c text, v text, s text static, PRIMARY KEY (p, c))") as table:
-        execute(cql, table, "INSERT INTO %s(p, c, v, s) values (?, ?, ?, ?)", "p1", "k1", "v1", "sv1")
-        execute(cql, table, "INSERT INTO %s(p, c, v) values (?, ?, ?)", "p1", "k2", "v2")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(p text, c text, v text, s text static, PRIMARY KEY (p, c))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(p, c, v, s) values (?, ?, ?, ?)",
+            "p1",
+            "k1",
+            "v1",
+            "sv1",
+        )
+        execute(
+            cql, table, "INSERT INTO %s(p, c, v) values (?, ?, ?)", "p1", "k2", "v2"
+        )
         execute(cql, table, "INSERT INTO %s(p, s) values (?, ?)", "p2", "sv2")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=?", "p1"),
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=?", "p1"),
             ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=?", "p2"),
-            ["p2", None, "sv2", None])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=?", "p2"),
+            ["p2", None, "sv2", None],
+        )
 
         # Ascending order
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c ASC", "p1"),
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c ASC", "p1"),
             ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c ASC", "p2"),
-            ["p2", None, "sv2", None])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c ASC", "p2"),
+            ["p2", None, "sv2", None],
+        )
 
         # Descending order
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c DESC", "p1"),
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c DESC", "p1"),
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c DESC", "p2"),
-            ["p2", None, "sv2", None])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c DESC", "p2"),
+            ["p2", None, "sv2", None],
+        )
 
         # No order with one relation
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k1"),
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k1"),
             ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k2"),
-            ["p1", "k2", "sv1", "v2"])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k2"),
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k3"))
+        assert_empty(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k3")
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c =?", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c =?", "p1", "k1"),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=?", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=?", "p1", "k1"),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=?", "p1", "k0"))
+        assert_empty(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=?", "p1", "k0")
+        )
 
         # Ascending with one relation
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC", "p1", "k1"),
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC",
+                "p1",
+                "k1",
+            ),
             ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC", "p1", "k2"),
-            ["p1", "k2", "sv1", "v2"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC",
+                "p1",
+                "k2",
+            ),
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC", "p1", "k3"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC",
+                "p1",
+                "k3",
+            )
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c =? ORDER BY c ASC", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c =? ORDER BY c ASC",
+                "p1",
+                "k1",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c ASC", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c ASC",
+                "p1",
+                "k1",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c ASC", "p1", "k0"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c ASC",
+                "p1",
+                "k0",
+            )
+        )
 
         # Descending with one relation
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC", "p1", "k1"),
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC",
+                "p1",
+                "k1",
+            ),
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC", "p1", "k2"),
-            ["p1", "k2", "sv1", "v2"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC",
+                "p1",
+                "k2",
+            ),
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC", "p1", "k3"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC",
+                "p1",
+                "k3",
+            )
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c =? ORDER BY c DESC", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c =? ORDER BY c DESC",
+                "p1",
+                "k1",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c DESC", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c DESC",
+                "p1",
+                "k1",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c DESC", "p1", "k0"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c DESC",
+                "p1",
+                "k0",
+            )
+        )
 
         # IN
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c IN (?, ?)", "p1", "k1", "k2"),
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c IN (?, ?)",
+                "p1",
+                "k1",
+                "k2",
+            ),
             ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c IN (?, ?) ORDER BY c ASC", "p1", "k1", "k2"),
-            ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c IN (?, ?) ORDER BY c DESC", "p1", "k1", "k2"),
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
+        )
+
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c IN (?, ?) ORDER BY c ASC",
+                "p1",
+                "k1",
+                "k2",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+            ["p1", "k2", "sv1", "v2"],
+        )
+
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c IN (?, ?) ORDER BY c DESC",
+                "p1",
+                "k1",
+                "k2",
+            ),
+            ["p1", "k2", "sv1", "v2"],
+            ["p1", "k1", "sv1", "v1"],
+        )
+
 
 def testSingleClusteringReversed(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(p text, c text, v text, s text static, PRIMARY KEY (p, c)) WITH CLUSTERING ORDER BY (c DESC)") as table:
-        execute(cql, table, "INSERT INTO %s(p, c, v, s) values (?, ?, ?, ?)", "p1", "k1", "v1", "sv1")
-        execute(cql, table, "INSERT INTO %s(p, c, v) values (?, ?, ?)", "p1", "k2", "v2")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(p text, c text, v text, s text static, PRIMARY KEY (p, c)) WITH CLUSTERING ORDER BY (c DESC)",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(p, c, v, s) values (?, ?, ?, ?)",
+            "p1",
+            "k1",
+            "v1",
+            "sv1",
+        )
+        execute(
+            cql, table, "INSERT INTO %s(p, c, v) values (?, ?, ?)", "p1", "k2", "v2"
+        )
         execute(cql, table, "INSERT INTO %s(p, s) values (?, ?)", "p2", "sv2")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=?", "p1"),
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=?", "p1"),
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=?", "p2"),
-            ["p2", None, "sv2", None])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=?", "p2"),
+            ["p2", None, "sv2", None],
+        )
 
         # Ascending order
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c ASC", "p1"),
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c ASC", "p1"),
             ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c ASC", "p2"),
-            ["p2", None, "sv2", None])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c ASC", "p2"),
+            ["p2", None, "sv2", None],
+        )
 
         # Descending order
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c DESC", "p1"),
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c DESC", "p1"),
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c DESC", "p2"),
-            ["p2", None, "sv2", None])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? ORDER BY c DESC", "p2"),
+            ["p2", None, "sv2", None],
+        )
 
         # No order with one relation
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k1"),
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k1"),
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k2"),
-            ["p1", "k2", "sv1", "v2"])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k2"),
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k3"))
+        assert_empty(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=?", "p1", "k3")
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c=?", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c=?", "p1", "k1"),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=?", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=?", "p1", "k1"),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=?", "p1", "k0"))
+        assert_empty(
+            execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=?", "p1", "k0")
+        )
 
         # Ascending with one relation
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC", "p1", "k1"),
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC",
+                "p1",
+                "k1",
+            ),
             ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC", "p1", "k2"),
-            ["p1", "k2", "sv1", "v2"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC",
+                "p1",
+                "k2",
+            ),
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC", "p1", "k3"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c ASC",
+                "p1",
+                "k3",
+            )
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c=? ORDER BY c ASC", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c=? ORDER BY c ASC",
+                "p1",
+                "k1",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c ASC", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c ASC",
+                "p1",
+                "k1",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c ASC", "p1", "k0"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c ASC",
+                "p1",
+                "k0",
+            )
+        )
 
         # Descending with one relation
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC", "p1", "k1"),
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC",
+                "p1",
+                "k1",
+            ),
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC", "p1", "k2"),
-            ["p1", "k2", "sv1", "v2"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC",
+                "p1",
+                "k2",
+            ),
+            ["p1", "k2", "sv1", "v2"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC", "p1", "k3"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c>=? ORDER BY c DESC",
+                "p1",
+                "k3",
+            )
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c=? ORDER BY c DESC", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c=? ORDER BY c DESC",
+                "p1",
+                "k1",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c DESC", "p1", "k1"),
-            ["p1", "k1", "sv1", "v1"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c DESC",
+                "p1",
+                "k1",
+            ),
+            ["p1", "k1", "sv1", "v1"],
+        )
 
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c DESC", "p1", "k0"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c<=? ORDER BY c DESC",
+                "p1",
+                "k0",
+            )
+        )
 
         # IN
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c IN (?, ?)", "p1", "k1", "k2"),
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c IN (?, ?)",
+                "p1",
+                "k1",
+                "k2",
+            ),
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
-
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c IN (?, ?) ORDER BY c ASC", "p1", "k1", "k2"),
             ["p1", "k1", "sv1", "v1"],
-            ["p1", "k2", "sv1", "v2"])
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p=? AND c IN (?, ?) ORDER BY c DESC", "p1", "k1", "k2"),
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c IN (?, ?) ORDER BY c ASC",
+                "p1",
+                "k1",
+                "k2",
+            ),
+            ["p1", "k1", "sv1", "v1"],
             ["p1", "k2", "sv1", "v2"],
-            ["p1", "k1", "sv1", "v1"])
+        )
+
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE p=? AND c IN (?, ?) ORDER BY c DESC",
+                "p1",
+                "k1",
+                "k2",
+            ),
+            ["p1", "k2", "sv1", "v2"],
+            ["p1", "k1", "sv1", "v1"],
+        )
+
 
 # Check query with KEY IN clause
 # migrated from cql_tests.py:TestCQL.select_key_in_test()
 def testSelectKeyIn(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(userid uuid PRIMARY KEY, firstname text, lastname text, age int)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(userid uuid PRIMARY KEY, firstname text, lastname text, age int)",
+    ) as table:
         id1 = UUID("550e8400-e29b-41d4-a716-446655440000")
         id2 = UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
 
-        execute(cql, table, "INSERT INTO %s (userid, firstname, lastname, age) VALUES (?, 'Frodo', 'Baggins', 32)", id1)
-        execute(cql, table, "INSERT INTO %s (userid, firstname, lastname, age) VALUES (?, 'Samwise', 'Gamgee', 33)", id2)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, firstname, lastname, age) VALUES (?, 'Frodo', 'Baggins', 32)",
+            id1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (userid, firstname, lastname, age) VALUES (?, 'Samwise', 'Gamgee', 33)",
+            id2,
+        )
 
-        assert_row_count(execute(cql, table, "SELECT firstname, lastname FROM %s WHERE userid IN (?, ?)", id1, id2), 2)
+        assert_row_count(
+            execute(
+                cql,
+                table,
+                "SELECT firstname, lastname FROM %s WHERE userid IN (?, ?)",
+                id1,
+                id2,
+            ),
+            2,
+        )
+
 
 def testSetContainsWithIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(account text, id int, categories set<text>, PRIMARY KEY (account, id))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(account text, id int, categories set<text>, PRIMARY KEY (account, id))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
 
-        execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 5, {"lmn"})
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+            "test",
+            5,
+            {"lmn"},
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?", "xyz", "lmn"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?",
+                    "xyz",
+                    "lmn",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE categories CONTAINS ?", "lmn"),
-                       ["test", 5, {"lmn"}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE categories CONTAINS ?", "lmn"
+                ),
+                ["test", 5, {"lmn"}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?", "test", "lmn"),
-                       ["test", 5, {"lmn"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?",
+                    "test",
+                    "lmn",
+                ),
+                ["test", 5, {"lmn"}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, "lmn"),
-                       ["test", 5, {"lmn"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?",
+                    "test",
+                    5,
+                    "lmn",
+                ),
+                ["test", 5, {"lmn"}],
+            )
 
             # Scylla does not consider "= null" an error, it just matches nothing.
             # See issue #4776.
-            #assert_invalid_message(cql, table, "Unsupported null value for column categories",
+            # assert_invalid_message(cql, table, "Unsupported null value for column categories",
             #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
-            assert_invalid_message(cql, table, "unset value",
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)
+            assert_invalid_message(
+                cql,
+                table,
+                "unset value",
+                "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?",
+                "test",
+                5,
+                UNSET_VALUE,
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS ?", "xyz", "lmn", "notPresent")
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING", "xyz", "lmn", "notPresent"))
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS ?",
+                "xyz",
+                "lmn",
+                "notPresent",
+            )
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING",
+                    "xyz",
+                    "lmn",
+                    "notPresent",
+                )
+            )
+
 
 def testListContainsWithIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(account text, id int, categories list<text>, PRIMARY KEY (account, id))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(account text, id int, categories list<text>, PRIMARY KEY (account, id))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
 
-        execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 5, ["lmn"])
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+            "test",
+            5,
+            ["lmn"],
+        )
         for _ in before_and_after_flush(cql, table):
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?", "xyz", "lmn"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?",
+                    "xyz",
+                    "lmn",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?;", "test", "lmn"),
-                       ["test", 5, ["lmn"]])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?;",
+                    "test",
+                    "lmn",
+                ),
+                ["test", 5, ["lmn"]],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE categories CONTAINS ?", "lmn"),
-                       ["test", 5, ["lmn"]])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE categories CONTAINS ?", "lmn"
+                ),
+                ["test", 5, ["lmn"]],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?;", "test", 5, "lmn"),
-                       ["test", 5, ["lmn"]])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?;",
+                    "test",
+                    5,
+                    "lmn",
+                ),
+                ["test", 5, ["lmn"]],
+            )
 
             # Scylla does not consider "= null" an error, it just matches nothing.
             # See issue #4776.
-            #assert_invalid_message(cql, table, "Unsupported null value for column categories",
+            # assert_invalid_message(cql, table, "Unsupported null value for column categories",
             #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
-            assert_invalid_message(cql, table, "unset value",
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)
+            assert_invalid_message(
+                cql,
+                table,
+                "unset value",
+                "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?",
+                "test",
+                5,
+                UNSET_VALUE,
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ?",
-                                 "test", 5, "lmn", "notPresent")
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING",
-                                "test", 5, "lmn", "notPresent"))
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ?",
+                "test",
+                5,
+                "lmn",
+                "notPresent",
+            )
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING",
+                    "test",
+                    5,
+                    "lmn",
+                    "notPresent",
+                )
+            )
+
 
 def testListContainsWithIndexAndFiltering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(e int PRIMARY KEY, f list<text>, s int)") as table:
+    with create_table(
+        cql, test_keyspace, "(e int PRIMARY KEY, f list<text>, s int)"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(f)")
         for i in range(3):
-            execute(cql, table, "INSERT INTO %s (e, f, s) VALUES (?, ?, ?)", i, ["Dubai"], 4)
+            execute(
+                cql, table, "INSERT INTO %s (e, f, s) VALUES (?, ?, ?)", i, ["Dubai"], 4
+            )
         for i in range(3, 5):
-            execute(cql, table, "INSERT INTO %s (e, f, s) VALUES (?, ?, ?)", i, ["Dubai"], 3)
+            execute(
+                cql, table, "INSERT INTO %s (e, f, s) VALUES (?, ?, ?)", i, ["Dubai"], 3
+            )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE f CONTAINS ? AND s=? allow filtering", "Dubai", 3),
-                       [4, ["Dubai"], 3],
-                       [3, ["Dubai"], 3])
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE f CONTAINS ? AND s=? allow filtering",
+                    "Dubai",
+                    3,
+                ),
+                [4, ["Dubai"], 3],
+                [3, ["Dubai"], 3],
+            )
+
 
 def testMapKeyContainsWithIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(keys(categories))")
 
-        execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 5, {"lmn": "foo"})
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+            "test",
+            5,
+            {"lmn": "foo"},
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ?", "xyz", "lmn"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ?",
+                    "xyz",
+                    "lmn",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ?", "test", "lmn"),
-                       ["test", 5, {"lmn": "foo"}])
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE categories CONTAINS KEY ?", "lmn"),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ?",
+                    "test",
+                    "lmn",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE categories CONTAINS KEY ?",
+                    "lmn",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, "lmn"),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?",
+                    "test",
+                    5,
+                    "lmn",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
 
             # Scylla does not consider "= null" an error, it just matches nothing.
             # See issue #4776.
-            #assert_invalid_message(cql, table, "Unsupported null value for column categories",
+            # assert_invalid_message(cql, table, "Unsupported null value for column categories",
             #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, None)
 
-            assert_invalid_message(cql, table, "unset value",
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?", "test", 5, UNSET_VALUE)
+            assert_invalid_message(
+                cql,
+                table,
+                "unset value",
+                "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ?",
+                "test",
+                5,
+                UNSET_VALUE,
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ? AND categories CONTAINS KEY ?",
-                                 "test", 5, "lmn", "notPresent")
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ? AND categories CONTAINS KEY ? ALLOW FILTERING",
-                                "test", 5, "lmn", "notPresent"))
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ? AND categories CONTAINS KEY ?",
+                "test",
+                5,
+                "lmn",
+                "notPresent",
+            )
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ? AND categories CONTAINS KEY ? ALLOW FILTERING",
+                    "test",
+                    5,
+                    "lmn",
+                    "notPresent",
+                )
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ? AND categories CONTAINS ?",
-                                 "test", 5, "lmn", "foo")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS KEY ? AND categories CONTAINS ?",
+                "test",
+                5,
+                "lmn",
+                "foo",
+            )
+
 
 def testMapValueContainsWithIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
 
-        execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 5, {"lmn": "foo"})
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+            "test",
+            5,
+            {"lmn": "foo"},
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?", "xyz", "foo"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?",
+                    "xyz",
+                    "foo",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?", "test", "foo"),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?",
+                    "test",
+                    "foo",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE categories CONTAINS ?", "foo"),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE categories CONTAINS ?", "foo"
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, "foo"),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?",
+                    "test",
+                    5,
+                    "foo",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
 
             # Scylla does not consider "= null" an error, it just matches nothing.
             # See issue #4776.
-            #assert_invalid_message(cql, table, "Unsupported null value for column categories",
+            # assert_invalid_message(cql, table, "Unsupported null value for column categories",
             #                     "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, None)
 
-            assert_invalid_message(cql, table, "unset value",
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?", "test", 5, UNSET_VALUE)
+            assert_invalid_message(
+                cql,
+                table,
+                "unset value",
+                "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ?",
+                "test",
+                5,
+                UNSET_VALUE,
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ?",
-                                 "test", 5, "foo", "notPresent")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ?",
+                "test",
+                5,
+                "foo",
+                "notPresent",
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING",
-                                "test", 5, "foo", "notPresent"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND id = ? AND categories CONTAINS ? AND categories CONTAINS ? ALLOW FILTERING",
+                    "test",
+                    5,
+                    "foo",
+                    "notPresent",
+                )
+            )
+
 
 # See CASSANDRA-7525
 def testQueryMultipleIndexTypes(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))",
+    ) as table:
         # create an index on
         execute(cql, table, "CREATE INDEX ON %s(id)")
         execute(cql, table, "CREATE INDEX ON %s(categories)")
 
         for _ in before_and_after_flush(cql, table):
-            execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 5, {"lmn": "foo"})
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+                "test",
+                5,
+                {"lmn": "foo"},
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE categories CONTAINS ? AND id = ? ALLOW FILTERING", "foo", 5),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE categories CONTAINS ? AND id = ? ALLOW FILTERING",
+                    "foo",
+                    5,
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND id = ? ALLOW FILTERING", "test", "foo", 5),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND id = ? ALLOW FILTERING",
+                    "test",
+                    "foo",
+                    5,
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
+
 
 # See CASSANDRA-8033
 def testFilterWithIndexForContains(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k1 int, k2 int, v set<int>, PRIMARY KEY ((k1, k2)))") as table:
+    with create_table(
+        cql, test_keyspace, "(k1 int, k2 int, v set<int>, PRIMARY KEY ((k1, k2)))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(k2)")
-        execute(cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", 0, 0, {1, 2, 3})
-        execute(cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", 0, 1, {2, 3, 4})
-        execute(cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", 1, 0, {3, 4, 5})
-        execute(cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", 1, 1, {4, 5, 6})
+        execute(
+            cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", 0, 0, {1, 2, 3}
+        )
+        execute(
+            cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", 0, 1, {2, 3, 4}
+        )
+        execute(
+            cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", 1, 0, {3, 4, 5}
+        )
+        execute(
+            cql, table, "INSERT INTO %s (k1, k2, v) VALUES (?, ?, ?)", 1, 1, {4, 5, 6}
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k2 = ?", 1),
-                       [0, 1, {2, 3, 4}],
-                       [1, 1, {4, 5, 6}])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE k2 = ?", 1),
+                [0, 1, {2, 3, 4}],
+                [1, 1, {4, 5, 6}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k2 = ? AND v CONTAINS ? ALLOW FILTERING", 1, 6),
-                       [1, 1, {4, 5, 6}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE k2 = ? AND v CONTAINS ? ALLOW FILTERING",
+                    1,
+                    6,
+                ),
+                [1, 1, {4, 5, 6}],
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE k2 = ? AND v CONTAINS ? ALLOW FILTERING", 1, 7))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE k2 = ? AND v CONTAINS ? ALLOW FILTERING",
+                    1,
+                    7,
+                )
+            )
+
 
 # See CASSANDRA-8073
 def testIndexLookupWithClusteringPrefix(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d set<int>, PRIMARY KEY (a, b, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d set<int>, PRIMARY KEY (a, b, c))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(d)")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, {1, 2, 3})
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 1, {3, 4, 5})
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 0, {1, 2, 3})
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 1, 1, {3, 4, 5})
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            {1, 2, 3},
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            0,
+            1,
+            {3, 4, 5},
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            1,
+            0,
+            {1, 2, 3},
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            0,
+            1,
+            1,
+            {3, 4, 5},
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND d CONTAINS ?", 0, 1, 3),
-                       [0, 1, 0, {1, 2, 3}],
-                       [0, 1, 1, {3, 4, 5}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a=? AND b=? AND d CONTAINS ?",
+                    0,
+                    1,
+                    3,
+                ),
+                [0, 1, 0, {1, 2, 3}],
+                [0, 1, 1, {3, 4, 5}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=? AND b=? AND d CONTAINS ?", 0, 1, 2),
-                       [0, 1, 0, {1, 2, 3}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a=? AND b=? AND d CONTAINS ?",
+                    0,
+                    1,
+                    2,
+                ),
+                [0, 1, 0, {1, 2, 3}],
+            )
 
-            assert_rows(execute(cql, table,"SELECT * FROM %s WHERE a=? AND b=? AND d CONTAINS ?", 0, 1, 5),
-                       [0, 1, 1, {3, 4, 5}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a=? AND b=? AND d CONTAINS ?",
+                    0,
+                    1,
+                    5,
+                ),
+                [0, 1, 1, {3, 4, 5}],
+            )
+
 
 def testContainsKeyAndContainsWithIndexOnMapKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(keys(categories))")
-        execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 5, {"lmn": "foo"})
-        execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 6, {"lmn": "foo2"})
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+            "test",
+            5,
+            {"lmn": "foo"},
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+            "test",
+            6,
+            {"lmn": "foo2"},
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?", "test", "foo")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?",
+                "test",
+                "foo",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ?", "test", "lmn"),
-                       ["test", 5, {"lmn": "foo"}],
-                       ["test", 6, {"lmn": "foo2"}])
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ? AND categories CONTAINS ? ALLOW FILTERING",
-                               "test", "lmn", "foo"),
-                       ["test", 5, {"lmn": "foo"}])
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS KEY ? ALLOW FILTERING",
-                               "test", "foo", "lmn"),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ?",
+                    "test",
+                    "lmn",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+                ["test", 6, {"lmn": "foo2"}],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ? AND categories CONTAINS ? ALLOW FILTERING",
+                    "test",
+                    "lmn",
+                    "foo",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS KEY ? ALLOW FILTERING",
+                    "test",
+                    "foo",
+                    "lmn",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
+
 
 def testContainsKeyAndContainsWithIndexOnMapValue(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(account text, id int, categories map<text, text>, PRIMARY KEY (account, id))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(categories)")
-        execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 5, {"lmn": "foo"})
-        execute(cql, table, "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)", "test", 6, {"lmn2": "foo"})
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+            "test",
+            5,
+            {"lmn": "foo"},
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (account, id , categories) VALUES (?, ?, ?)",
+            "test",
+            6,
+            {"lmn2": "foo"},
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ?", "test", "lmn")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ?",
+                "test",
+                "lmn",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?", "test", "foo"),
-                       ["test", 5, {"lmn": "foo"}],
-                       ["test", 6, {"lmn2": "foo"}])
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ? AND categories CONTAINS ? ALLOW FILTERING",
-                               "test", "lmn", "foo"),
-                       ["test", 5, {"lmn": "foo"}])
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS KEY ? ALLOW FILTERING",
-                               "test", "foo", "lmn"),
-                       ["test", 5, {"lmn": "foo"}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ?",
+                    "test",
+                    "foo",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+                ["test", 6, {"lmn2": "foo"}],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS KEY ? AND categories CONTAINS ? ALLOW FILTERING",
+                    "test",
+                    "lmn",
+                    "foo",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE account = ? AND categories CONTAINS ? AND categories CONTAINS KEY ? ALLOW FILTERING",
+                    "test",
+                    "foo",
+                    "lmn",
+                ),
+                ["test", 5, {"lmn": "foo"}],
+            )
+
 
 # Test token ranges
 # migrated from cql_tests.py:TestCQL.token_range_test()
@@ -470,118 +1318,258 @@ def testTokenRange(cql, test_keyspace):
         inOrder = [r[0] for r in res]
 
         min_token = -9223372036854775808
-        res = list(execute(cql, table, f"SELECT k FROM %s WHERE token(k) >= {min_token}"))
+        res = list(
+            execute(cql, table, f"SELECT k FROM %s WHERE token(k) >= {min_token}")
+        )
         assert c == len(res)
 
-        res = list(execute(cql, table, f"SELECT k FROM %s WHERE token(k) >= token({inOrder[32]}) AND token(k) < token({inOrder[65]})"))
+        res = list(
+            execute(
+                cql,
+                table,
+                f"SELECT k FROM %s WHERE token(k) >= token({inOrder[32]}) AND token(k) < token({inOrder[65]})",
+            )
+        )
         for i in range(32, 65):
             assert inOrder[i] == res[i - 32][0]
+
 
 # Test select count
 # migrated from cql_tests.py:TestCQL.count_test()
 def testSelectCount(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(kind text, time int, value1 int, value2 int, PRIMARY KEY (kind, time))") as table:
-        execute(cql, table, "INSERT INTO %s (kind, time, value1, value2) VALUES ('ev1', ?, ?, ?)", 0, 0, 0)
-        execute(cql, table, "INSERT INTO %s (kind, time, value1, value2) VALUES ('ev1', ?, ?, ?)", 1, 1, 1)
-        execute(cql, table, "INSERT INTO %s (kind, time, value1) VALUES ('ev1', ?, ?)", 2, 2)
-        execute(cql, table, "INSERT INTO %s (kind, time, value1, value2) VALUES ('ev1', ?, ?, ?)", 3, 3, 3)
-        execute(cql, table, "INSERT INTO %s (kind, time, value1) VALUES ('ev1', ?, ?)", 4, 4)
-        execute(cql, table, "INSERT INTO %s (kind, time, value1, value2) VALUES ('ev2', 0, 0, 0)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(kind text, time int, value1 int, value2 int, PRIMARY KEY (kind, time))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (kind, time, value1, value2) VALUES ('ev1', ?, ?, ?)",
+            0,
+            0,
+            0,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (kind, time, value1, value2) VALUES ('ev1', ?, ?, ?)",
+            1,
+            1,
+            1,
+        )
+        execute(
+            cql, table, "INSERT INTO %s (kind, time, value1) VALUES ('ev1', ?, ?)", 2, 2
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (kind, time, value1, value2) VALUES ('ev1', ?, ?, ?)",
+            3,
+            3,
+            3,
+        )
+        execute(
+            cql, table, "INSERT INTO %s (kind, time, value1) VALUES ('ev1', ?, ?)", 4, 4
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (kind, time, value1, value2) VALUES ('ev2', 0, 0, 0)",
+        )
 
-        assert_rows(execute(cql, table, "SELECT COUNT(*) FROM %s WHERE kind = 'ev1'"),
-                   [5])
+        assert_rows(
+            execute(cql, table, "SELECT COUNT(*) FROM %s WHERE kind = 'ev1'"), [5]
+        )
 
-        assert_rows(execute(cql, table, "SELECT COUNT(1) FROM %s WHERE kind IN ('ev1', 'ev2') AND time=0"),
-                   [2])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT COUNT(1) FROM %s WHERE kind IN ('ev1', 'ev2') AND time=0",
+            ),
+            [2],
+        )
+
 
 # Range test query from CASSANDRA-4372
 # migrated from cql_tests.py:TestCQL.range_query_test()
 def testRangeQuery(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, f text, PRIMARY KEY (a, b, c, d, e))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 1, 2, '2')")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 1, 1, '1')")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 2, 1, '1')")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 1, 3, '3')")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 1, 5, '5')")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, f text, PRIMARY KEY (a, b, c, d, e))",
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 1, 2, '2')"
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 1, 1, '1')"
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 2, 1, '1')"
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 1, 3, '3')"
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, e, f) VALUES (1, 1, 1, 1, 5, '5')"
+        )
 
-        assert_rows(execute(cql, table, "SELECT a, b, c, d, e, f FROM %s WHERE a = 1 AND b = 1 AND c = 1 AND d = 1 AND e >= 2"),
-                   [1, 1, 1, 1, 2, "2"],
-                   [1, 1, 1, 1, 3, "3"],
-                   [1, 1, 1, 1, 5, "5"])
+        assert_rows(
+            execute(
+                cql,
+                table,
+                "SELECT a, b, c, d, e, f FROM %s WHERE a = 1 AND b = 1 AND c = 1 AND d = 1 AND e >= 2",
+            ),
+            [1, 1, 1, 1, 2, "2"],
+            [1, 1, 1, 1, 3, "3"],
+            [1, 1, 1, 1, 5, "5"],
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.composite_row_key_test()
 def testCompositeRowKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k1 int, k2 int, c int, v int, PRIMARY KEY ((k1, k2), c))") as table:
+    with create_table(
+        cql, test_keyspace, "(k1 int, k2 int, c int, v int, PRIMARY KEY ((k1, k2), c))"
+    ) as table:
         for i in range(4):
-            execute(cql, table, "INSERT INTO %s (k1, k2, c, v) VALUES (?, ?, ?, ?)", 0, i, i, i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k1, k2, c, v) VALUES (?, ?, ?, ?)",
+                0,
+                i,
+                i,
+                i,
+            )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s"),
-                   [0, 2, 2, 2],
-                   [0, 3, 3, 3],
-                   [0, 0, 0, 0],
-                   [0, 1, 1, 1])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s"),
+            [0, 2, 2, 2],
+            [0, 3, 3, 3],
+            [0, 0, 0, 0],
+            [0, 1, 1, 1],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k1 = 0 and k2 IN (1, 3)"),
-                   [0, 1, 1, 1],
-                   [0, 3, 3, 3])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE k1 = 0 and k2 IN (1, 3)"),
+            [0, 1, 1, 1],
+            [0, 3, 3, 3],
+        )
 
         assert_invalid(cql, table, "SELECT * FROM %s WHERE k2 = 3")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE token(k1, k2) = token(0, 1)"),
-                   [0, 1, 1, 1])
-
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE token(k1, k2) = token(0, 1)"),
+            [0, 1, 1, 1],
+        )
 
         MIN_VALUE = -9223372036854775808
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE token(k1, k2) > ?", MIN_VALUE),
-                   [0, 2, 2, 2],
-                   [0, 3, 3, 3],
-                   [0, 0, 0, 0],
-                   [0, 1, 1, 1])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE token(k1, k2) > ?", MIN_VALUE),
+            [0, 2, 2, 2],
+            [0, 3, 3, 3],
+            [0, 0, 0, 0],
+            [0, 1, 1, 1],
+        )
+
 
 # Test for Cassandra-4532, NPE when trying to select a slice from a composite table
 # migrated from cql_tests.py:TestCQL.bug_4532_test()
 def testSelectSliceFromComposite(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(status ascii, ctime bigint, key ascii, nil ascii, PRIMARY KEY (status, ctime, key))") as table:
-        execute(cql, table, "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345678,'key1','')")
-        execute(cql, table, "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345678,'key2','')")
-        execute(cql, table, "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345679,'key3','')")
-        execute(cql, table, "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345679,'key4','')")
-        execute(cql, table, "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345679,'key5','')")
-        execute(cql, table, "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345680,'key6','')")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(status ascii, ctime bigint, key ascii, nil ascii, PRIMARY KEY (status, ctime, key))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345678,'key1','')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345678,'key2','')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345679,'key3','')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345679,'key4','')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345679,'key5','')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (status,ctime,key,nil) VALUES ('C',12345680,'key6','')",
+        )
 
-        assert_invalid(cql, table,"SELECT * FROM %s WHERE ctime>=12345679 AND key='key3' AND ctime<=12345680 LIMIT 3;")
-        assert_invalid(cql, table,"SELECT * FROM %s WHERE ctime=12345679  AND key='key3' AND ctime<=12345680 LIMIT 3")
+        assert_invalid(
+            cql,
+            table,
+            "SELECT * FROM %s WHERE ctime>=12345679 AND key='key3' AND ctime<=12345680 LIMIT 3;",
+        )
+        assert_invalid(
+            cql,
+            table,
+            "SELECT * FROM %s WHERE ctime=12345679  AND key='key3' AND ctime<=12345680 LIMIT 3",
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.bug_4882_test()
 def testDifferentOrdering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2)) WITH CLUSTERING ORDER BY (c1 ASC, c2 DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, c1 int, c2 int, v int, PRIMARY KEY (k, c1, c2)) WITH CLUSTERING ORDER BY (c1 ASC, c2 DESC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, c1, c2, v) VALUES (0, 0, 0, 0)")
         execute(cql, table, "INSERT INTO %s (k, c1, c2, v) VALUES (0, 1, 1, 1)")
         execute(cql, table, "INSERT INTO %s (k, c1, c2, v) VALUES (0, 0, 2, 2)")
         execute(cql, table, "INSERT INTO %s (k, c1, c2, v) VALUES (0, 1, 3, 3)")
 
-        assert_rows(execute(cql, table, "select * from %s where k = 0 limit 1"),
-                   [0, 0, 2, 2])
+        assert_rows(
+            execute(cql, table, "select * from %s where k = 0 limit 1"), [0, 0, 2, 2]
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.allow_filtering_test()
 def testAllowFiltering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))"
+    ) as table:
         for i in range(3):
             for j in range(3):
-                execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (?, ?, ?)", i, j, j)
+                execute(
+                    cql, table, "INSERT INTO %s (k, c, v) VALUES (?, ?, ?)", i, j, j
+                )
 
         # Don't require filtering, always allowed
-        queries = [ "SELECT * FROM %s WHERE k = 1",
-                    "SELECT * FROM %s WHERE k = 1 AND c > 2",
-                    "SELECT * FROM %s WHERE k = 1 AND c = 2"]
+        queries = [
+            "SELECT * FROM %s WHERE k = 1",
+            "SELECT * FROM %s WHERE k = 1 AND c > 2",
+            "SELECT * FROM %s WHERE k = 1 AND c = 2",
+        ]
 
         for q in queries:
             execute(cql, table, q)
             execute(cql, table, q + " ALLOW FILTERING")
 
         # Require filtering, allowed only with ALLOW FILTERING
-        queries = [ "SELECT * FROM %s WHERE c = 2",
-                     "SELECT * FROM %s WHERE c > 2 AND c <= 4"]
+        queries = [
+            "SELECT * FROM %s WHERE c = 2",
+            "SELECT * FROM %s WHERE c > 2 AND c <= 4",
+        ]
 
         for q in queries:
             assert_invalid(cql, table, q)
@@ -591,37 +1579,63 @@ def testAllowFiltering(cql, test_keyspace):
         execute(cql, table, "CREATE INDEX ON %s (a)")
 
         for i in range(5):
-            execute(cql, table, "INSERT INTO %s (k, a, b) VALUES (?, ?, ?)", i, i * 10, i * 100)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b) VALUES (?, ?, ?)",
+                i,
+                i * 10,
+                i * 100,
+            )
 
         # Don't require filtering, always allowed
-        queries = [ "SELECT * FROM %s WHERE k = 1",
-                    "SELECT * FROM %s WHERE a = 20"]
+        queries = ["SELECT * FROM %s WHERE k = 1", "SELECT * FROM %s WHERE a = 20"]
 
         for q in queries:
             execute(cql, table, q)
             execute(cql, table, q + " ALLOW FILTERING")
 
         # Require filtering, allowed only with ALLOW FILTERING
-        queries = [ "SELECT * FROM %s WHERE a = 20 AND b = 200" ]
+        queries = ["SELECT * FROM %s WHERE a = 20 AND b = 200"]
 
         for q in queries:
             assert_invalid(cql, table, q)
             execute(cql, table, q + " ALLOW FILTERING")
 
+
 # Test for bug from CASSANDRA-5122,
 # migrated from cql_tests.py:TestCQL.composite_partition_key_validation_test()
 def testSelectOnCompositeInvalid(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b text, c uuid, PRIMARY KEY ((a,b)))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b , c ) VALUES (1, 'aze', 4d481800-4c5f-11e1-82e0-3f484de45426)")
-        execute(cql, table, "INSERT INTO %s (a, b , c ) VALUES (1, 'ert', 693f5800-8acb-11e3-82e0-3f484de45426)")
-        execute(cql, table, "INSERT INTO %s (a, b , c ) VALUES (1, 'opl', d4815800-2d8d-11e0-82e0-3f484de45426)")
+    with create_table(
+        cql, test_keyspace, "(a int, b text, c uuid, PRIMARY KEY ((a,b)))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b , c ) VALUES (1, 'aze', 4d481800-4c5f-11e1-82e0-3f484de45426)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b , c ) VALUES (1, 'ert', 693f5800-8acb-11e3-82e0-3f484de45426)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b , c ) VALUES (1, 'opl', d4815800-2d8d-11e0-82e0-3f484de45426)",
+        )
 
         assert_row_count(execute(cql, table, "SELECT * FROM %s"), 3)
         assert_invalid(cql, table, "SELECT * FROM %s WHERE a=1")
 
+
 # Migrated from cql_tests.py:TestCQL.multi_in_test()
 def testMultiSelects(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(group text, zipcode text, state text, fips_regions int, city text, PRIMARY KEY (group, zipcode, state, fips_regions))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(group text, zipcode text, state text, fips_regions int, city text, PRIMARY KEY (group, zipcode, state, fips_regions))",
+    ) as table:
         str = "INSERT INTO %s (group, zipcode, state, fips_regions, city) VALUES (?, ?, ?, ?, ?)"
         execute(cql, table, str, "test", "06029", "CT", 9, "Ellington")
         execute(cql, table, str, "test", "06031", "CT", 9, "Falls Village")
@@ -642,44 +1656,126 @@ def testMultiSelects(cql, test_keyspace):
         execute(cql, table, str, "test2", "94102", "CA", 6, "San Francisco")
 
         assert_row_count(execute(cql, table, "select zipcode from %s"), 16)
-        assert_row_count(execute(cql, table, "select zipcode from %s where group='test'"), 8)
+        assert_row_count(
+            execute(cql, table, "select zipcode from %s where group='test'"), 8
+        )
         assert_invalid(cql, table, "select zipcode from %s where zipcode='06902'")
-        assert_row_count(execute(cql, table, "select zipcode from %s where zipcode='06902' ALLOW FILTERING"), 2)
-        assert_row_count(execute(cql, table, "select zipcode from %s where group='test' and zipcode='06902'"), 1)
-        assert_row_count(execute(cql, table, "select zipcode from %s where group='test' and zipcode IN ('06902','73301','94102')"), 3)
-        assert_row_count(execute(cql, table, "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA')"), 2)
-        assert_row_count(execute(cql, table, "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA') and fips_regions = 9"), 1)
-        assert_row_count(execute(cql, table, "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA') ORDER BY zipcode DESC"), 2)
-        assert_row_count(execute(cql, table, "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA') and fips_regions > 0"), 2)
-        assert_empty(execute(cql, table, "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA') and fips_regions < 0"))
+        assert_row_count(
+            execute(
+                cql,
+                table,
+                "select zipcode from %s where zipcode='06902' ALLOW FILTERING",
+            ),
+            2,
+        )
+        assert_row_count(
+            execute(
+                cql,
+                table,
+                "select zipcode from %s where group='test' and zipcode='06902'",
+            ),
+            1,
+        )
+        assert_row_count(
+            execute(
+                cql,
+                table,
+                "select zipcode from %s where group='test' and zipcode IN ('06902','73301','94102')",
+            ),
+            3,
+        )
+        assert_row_count(
+            execute(
+                cql,
+                table,
+                "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA')",
+            ),
+            2,
+        )
+        assert_row_count(
+            execute(
+                cql,
+                table,
+                "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA') and fips_regions = 9",
+            ),
+            1,
+        )
+        assert_row_count(
+            execute(
+                cql,
+                table,
+                "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA') ORDER BY zipcode DESC",
+            ),
+            2,
+        )
+        assert_row_count(
+            execute(
+                cql,
+                table,
+                "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA') and fips_regions > 0",
+            ),
+            2,
+        )
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "select zipcode from %s where group='test' AND zipcode IN ('06902','73301','94102') and state IN ('CT','CA') and fips_regions < 0",
+            )
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.ticket_5230_test()
 def testMultipleClausesOnPrimaryKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(key text, c text, v text, PRIMARY KEY (key, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(key text, c text, v text, PRIMARY KEY (key, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (key, c, v) VALUES ('foo', '1', '1')")
         execute(cql, table, "INSERT INTO %s(key, c, v) VALUES ('foo', '2', '2')")
         execute(cql, table, "INSERT INTO %s(key, c, v) VALUES ('foo', '3', '3')")
-        assert_rows(execute(cql, table, "SELECT c FROM %s WHERE key = 'foo' AND c IN ('1', '2')"),
-                   ["1"], ["2"])
+        assert_rows(
+            execute(
+                cql, table, "SELECT c FROM %s WHERE key = 'foo' AND c IN ('1', '2')"
+            ),
+            ["1"],
+            ["2"],
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.bug_5404()
 def testSelectWithToken(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(key text PRIMARY KEY)") as table:
         # We just want to make sure this doesn 't NPE server side
-        assert_invalid(cql, table, "select * from %s where token(key) > token(int(3030343330393233)) limit 1")
+        assert_invalid(
+            cql,
+            table,
+            "select * from %s where token(key) > token(int(3030343330393233)) limit 1",
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.clustering_order_and_functions_test()
 def testFunctionsWithClusteringDesc(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, t timeuuid, PRIMARY KEY (k, t) ) WITH CLUSTERING ORDER BY (t DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, t timeuuid, PRIMARY KEY (k, t) ) WITH CLUSTERING ORDER BY (t DESC)",
+    ) as table:
         for i in range(5):
             execute(cql, table, "INSERT INTO %s (k, t) VALUES (?, now())", i)
         execute(cql, table, "SELECT dateOf(t) FROM %s")
+
 
 # Migrated from cql_tests.py:TestCQL.select_with_alias_test()
 def testSelectWithAlias(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int PRIMARY KEY, name text)") as table:
         for id in range(5):
-            execute(cql, table, "INSERT INTO %s (id, name) VALUES (?, ?) USING TTL 1000 AND TIMESTAMP 0", id, "name" + str(id))
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (id, name) VALUES (?, ?) USING TTL 1000 AND TIMESTAMP 0",
+                id,
+                "name" + str(id),
+            )
 
         # test aliasing count( *)
         rs = execute(cql, table, "SELECT count(*) AS user_count FROM %s")
@@ -690,7 +1786,9 @@ def testSelectWithAlias(cql, test_keyspace):
         assert rs.one()._asdict() == {"user_name": "name0"}
 
         # test aliasing writetime
-        rs = execute(cql, table, "SELECT writeTime(name) AS name_writetime FROM %s WHERE id = 0")
+        rs = execute(
+            cql, table, "SELECT writeTime(name) AS name_writetime FROM %s WHERE id = 0"
+        )
         assert rs.one()._asdict() == {"name_writetime": 0}
 
         # test aliasing ttl
@@ -699,34 +1797,73 @@ def testSelectWithAlias(cql, test_keyspace):
 
         # test aliasing a regular function
         rs = execute(cql, table, "SELECT intAsBlob(id) AS id_blob FROM %s WHERE id = 0")
-        assert rs.one()._asdict() == {"id_blob": bytearray([0,0,0,0])}
+        assert rs.one()._asdict() == {"id_blob": bytearray([0, 0, 0, 0])}
 
         # test that select throws a meaningful exception for aliases in where clause
-        assert_invalid_message(cql, table, "user_id",
-                             "SELECT id AS user_id, name AS user_name FROM %s WHERE user_id = 0")
+        assert_invalid_message(
+            cql,
+            table,
+            "user_id",
+            "SELECT id AS user_id, name AS user_name FROM %s WHERE user_id = 0",
+        )
 
         # test that select throws a meaningful exception for aliases in order by clause
-        assert_invalid_message(cql, table, "user_name",
-                             "SELECT id AS user_id, name AS user_name FROM %s WHERE id IN (0) ORDER BY user_name")
+        assert_invalid_message(
+            cql,
+            table,
+            "user_name",
+            "SELECT id AS user_id, name AS user_name FROM %s WHERE id IN (0) ORDER BY user_name",
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.select_distinct_test()
 def testSelectDistinct(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk0 int, pk1 int, ck0 int, val int, PRIMARY KEY ((pk0, pk1), ck0))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk0 int, pk1 int, ck0 int, val int, PRIMARY KEY ((pk0, pk1), ck0))",
+    ) as table:
         for i in range(3):
-            execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 0, 0)", i, i)
-            execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 1, 1)", i, i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 0, 0)",
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 1, 1)",
+                i,
+                i,
+            )
 
-        assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 1"),
-                   [0, 0])
+        assert_rows(
+            execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 1"), [0, 0]
+        )
 
-        assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 3"),
-                   [0, 0],
-                   [2, 2],
-                   [1, 1])
+        assert_rows(
+            execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s LIMIT 3"),
+            [0, 0],
+            [2, 2],
+            [1, 1],
+        )
 
         # Test selection validation.
-        assert_invalid_message(cql, table, "queries must request all the partition key columns", "SELECT DISTINCT pk0 FROM %s")
-        assert_invalid_message(cql, table, "queries must only request partition key columns", "SELECT DISTINCT pk0, pk1, ck0 FROM %s")
+        assert_invalid_message(
+            cql,
+            table,
+            "queries must request all the partition key columns",
+            "SELECT DISTINCT pk0 FROM %s",
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "queries must only request partition key columns",
+            "SELECT DISTINCT pk0, pk1, ck0 FROM %s",
+        )
+
 
 # Migrated from cql_tests.py:TestCQL.select_distinct_with_deletions_test()
 def testSelectDistinctWithDeletions(cql, test_keyspace):
@@ -749,177 +1886,378 @@ def testSelectDistinctWithDeletions(cql, test_keyspace):
         rows = list(execute(cql, table, "SELECT DISTINCT k FROM %s"))
         assert len(rows) == 9
 
+
 def testSelectDistinctWithWhereClause(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, a int, b int, PRIMARY KEY (k, a))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, a int, b int, PRIMARY KEY (k, a))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
 
         for i in range(10):
             execute(cql, table, "INSERT INTO %s (k, a, b) VALUES (?, ?, ?)", i, i, i)
-            execute(cql, table, "INSERT INTO %s (k, a, b) VALUES (?, ?, ?)", i, i * 10, i * 10)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b) VALUES (?, ?, ?)",
+                i,
+                i * 10,
+                i * 10,
+            )
 
         # Cassandra's message is "SELECT DISTINCT with WHERE clause only
         # supports restriction by partition key and/or static columns."
         # Scylla's message was a bit different when we didn't support
         # static columns, but that's not the goal of this test (see next one).
         distinctQueryErrorMsg = "SELECT DISTINCT with WHERE"
-        assert_invalid_message(cql, table, distinctQueryErrorMsg,
-                             "SELECT DISTINCT k FROM %s WHERE a >= 80 ALLOW FILTERING")
+        assert_invalid_message(
+            cql,
+            table,
+            distinctQueryErrorMsg,
+            "SELECT DISTINCT k FROM %s WHERE a >= 80 ALLOW FILTERING",
+        )
 
-        assert_invalid_message(cql, table, distinctQueryErrorMsg,
-                             "SELECT DISTINCT k FROM %s WHERE k IN (1, 2, 3) AND a = 10")
+        assert_invalid_message(
+            cql,
+            table,
+            distinctQueryErrorMsg,
+            "SELECT DISTINCT k FROM %s WHERE k IN (1, 2, 3) AND a = 10",
+        )
 
-        assert_invalid_message(cql, table, distinctQueryErrorMsg,
-                             "SELECT DISTINCT k FROM %s WHERE b = 5")
+        assert_invalid_message(
+            cql, table, distinctQueryErrorMsg, "SELECT DISTINCT k FROM %s WHERE b = 5"
+        )
 
-        assert_rows(execute(cql, table, "SELECT DISTINCT k FROM %s WHERE k = 1"),
-                   [1])
-        assert_rows(execute(cql, table, "SELECT DISTINCT k FROM %s WHERE k IN (5, 6, 7)"),
-                   [5],
-                   [6],
-                   [7])
+        assert_rows(execute(cql, table, "SELECT DISTINCT k FROM %s WHERE k = 1"), [1])
+        assert_rows(
+            execute(cql, table, "SELECT DISTINCT k FROM %s WHERE k IN (5, 6, 7)"),
+            [5],
+            [6],
+            [7],
+        )
 
     # With static columns
-    with create_table(cql, test_keyspace, "(k int, a int, s int static, b int, PRIMARY KEY (k, a))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, a int, s int static, b int, PRIMARY KEY (k, a))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
         for i in range(10):
-            execute(cql, table, "INSERT INTO %s (k, a, b, s) VALUES (?, ?, ?, ?)", i, i, i, i)
-            execute(cql, table, "INSERT INTO %s (k, a, b, s) VALUES (?, ?, ?, ?)", i, i * 10, i * 10, i * 10)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b, s) VALUES (?, ?, ?, ?)",
+                i,
+                i,
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b, s) VALUES (?, ?, ?, ?)",
+                i,
+                i * 10,
+                i * 10,
+                i * 10,
+            )
 
-        assert_rows(execute(cql, table, "SELECT DISTINCT s FROM %s WHERE k = 5"),
-                   [50])
-        assert_rows(execute(cql, table, "SELECT DISTINCT s FROM %s WHERE k IN (5, 6, 7)"),
-                   [50],
-                   [60],
-                   [70])
+        assert_rows(execute(cql, table, "SELECT DISTINCT s FROM %s WHERE k = 5"), [50])
+        assert_rows(
+            execute(cql, table, "SELECT DISTINCT s FROM %s WHERE k IN (5, 6, 7)"),
+            [50],
+            [60],
+            [70],
+        )
+
 
 # Reproduces issue #10354
-@pytest.mark.xfail(reason="#10354 - we forgot to allow SELECT DISTINCT filtering on static column")
+@pytest.mark.xfail(
+    reason="SELECT DISTINCT should allow filter on static columns, not just partition keys #10354"
+)
 def testSelectDistinctWithWhereClauseOnStaticColumn(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, a int, s int static, s1 int static, b int, PRIMARY KEY (k, a))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, a int, s int static, s1 int static, b int, PRIMARY KEY (k, a))",
+    ) as table:
         for i in range(10):
-            execute(cql, table, "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)", i, i, i, i, i)
-            execute(cql, table, "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)", i, i * 10, i * 10, i * 10, i * 10)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)",
+                i,
+                i,
+                i,
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)",
+                i,
+                i * 10,
+                i * 10,
+                i * 10,
+                i * 10,
+            )
 
-        execute(cql, table, "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)", 2, 10, 10, 10, 10)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, a, b, s, s1) VALUES (?, ?, ?, ?, ?)",
+            2,
+            10,
+            10,
+            10,
+            10,
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 90 AND s1 = 90 ALLOW FILTERING"),
-                       [9, 90, 90])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 90 AND s1 = 90 ALLOW FILTERING",
+                ),
+                [9, 90, 90],
+            )
 
-            assert_rows(execute(cql, table, "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 90 AND s1 = 90 ALLOW FILTERING"),
-                       [9, 90, 90])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 90 AND s1 = 90 ALLOW FILTERING",
+                ),
+                [9, 90, 90],
+            )
 
-            assert_rows(execute(cql, table, "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 10 AND s1 = 10 ALLOW FILTERING"),
-                       [1, 10, 10],
-                       [2, 10, 10])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT k, s, s1 FROM %s WHERE s = 10 AND s1 = 10 ALLOW FILTERING",
+                ),
+                [1, 10, 10],
+                [2, 10, 10],
+            )
 
-            assert_rows(execute(cql, table, "SELECT DISTINCT k, s, s1 FROM %s WHERE k = 1 AND s = 10 AND s1 = 10 ALLOW FILTERING"),
-                       [1, 10, 10])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT k, s, s1 FROM %s WHERE k = 1 AND s = 10 AND s1 = 10 ALLOW FILTERING",
+                ),
+                [1, 10, 10],
+            )
+
 
 # Migrated from cql_tests.py:TestCQL.bug_6327_test()
 def testSelectInClauseAtOne(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, v int, PRIMARY KEY (k, v))") as table:
+    with create_table(
+        cql, test_keyspace, "(k int, v int, PRIMARY KEY (k, v))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, v) VALUES (0, 0)")
 
         flush(cql, table)
 
-        assert_rows(execute(cql, table, "SELECT v FROM %s WHERE k=0 AND v IN (1, 0)"),
-                   [0])
+        assert_rows(
+            execute(cql, table, "SELECT v FROM %s WHERE k=0 AND v IN (1, 0)"), [0]
+        )
+
 
 # Test for the CASSANDRA-6579 'select count' paging bug,
 # migrated from cql_tests.py:TestCQL.select_count_paging_test()
 def testSelectCountPaging(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(field1 text, field2 timeuuid, field3 boolean, PRIMARY KEY (field1, field2))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(field1 text, field2 timeuuid, field3 boolean, PRIMARY KEY (field1, field2))",
+    ) as table:
         execute(cql, table, "create index on %s (field3)")
 
-        execute(cql, table, "insert into %s (field1, field2, field3) values ('hola', now(), false)")
-        execute(cql, table, "insert into %s (field1, field2, field3) values ('hola', now(), false)")
+        execute(
+            cql,
+            table,
+            "insert into %s (field1, field2, field3) values ('hola', now(), false)",
+        )
+        execute(
+            cql,
+            table,
+            "insert into %s (field1, field2, field3) values ('hola', now(), false)",
+        )
 
-        assert_rows(execute(cql, table, "select count(*) from %s where field3 = false limit 1"),
-                   [2])
+        assert_rows(
+            execute(cql, table, "select count(*) from %s where field3 = false limit 1"),
+            [2],
+        )
+
 
 # Test for CASSANDRA-7105 bug,
 # migrated from cql_tests.py:TestCQL.clustering_order_in_test()
 def testClusteringOrder(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY ((a, b), c)) with clustering order by (c desc)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, PRIMARY KEY ((a, b), c)) with clustering order by (c desc)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (1, 2, 3)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (4, 5, 6)")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b=2 AND c IN (3)"),
-                   [1, 2, 3])
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b=2 AND c IN (3, 4)"),
-                   [1, 2, 3])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b=2 AND c IN (3)"),
+            [1, 2, 3],
+        )
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b=2 AND c IN (3, 4)"),
+            [1, 2, 3],
+        )
+
 
 # Test for CASSANDRA-7105 bug,
 # SELECT with IN on final column of composite and compound primary key fails
 # migrated from cql_tests.py:TestCQL.bug7105_test()
 def testSelectInFinalColumn(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 2, 3, 3)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 4, 6, 5)")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b=2 ORDER BY b DESC"),
-                   [1, 2, 3, 3])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b=2 ORDER BY b DESC"),
+            [1, 2, 3, 3],
+        )
+
 
 def testAlias(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int PRIMARY KEY, name text)") as table:
         for i in range(5):
-            execute(cql, table, "INSERT INTO %s (id, name) VALUES (?, ?) USING TTL 10 AND TIMESTAMP 0", i, str(i))
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (id, name) VALUES (?, ?) USING TTL 10 AND TIMESTAMP 0",
+                i,
+                str(i),
+            )
 
         # The error message in Cassandra and Scylla are different: Cassandra
         # Says "Undefined column name user_id", Scylla says "Aliases aren't
         # allowed in the where clause ('user_id = 0')
-        assert_invalid_message(cql, table, "user_id",
-                             "SELECT id AS user_id, name AS user_name FROM %s WHERE user_id = 0")
+        assert_invalid_message(
+            cql,
+            table,
+            "user_id",
+            "SELECT id AS user_id, name AS user_name FROM %s WHERE user_id = 0",
+        )
 
         # test that select throws a meaningful exception for aliases in order by clause
         # The error message in Cassandra and Scylla are different: Cassandra
         # Says "Undefined column name user_name", Scylla says "Aliases aren't
         # allowed in the order by clause (user_name)
-        assert_invalid_message(cql, table, "user_name",
-                             "SELECT id AS user_id, name AS user_name FROM %s WHERE id IN (0) ORDER BY user_name")
+        assert_invalid_message(
+            cql,
+            table,
+            "user_name",
+            "SELECT id AS user_id, name AS user_name FROM %s WHERE id IN (0) ORDER BY user_name",
+        )
 
 
 # Reproduces issue #10357
-def testAllowFilteringOnPartitionKeyOnStaticColumnsWithRowsWithOnlyStaticValues(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))") as table:
+def testAllowFilteringOnPartitionKeyOnStaticColumnsWithRowsWithOnlyStaticValues(
+    cql, test_keyspace
+):
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))",
+    ) as table:
         for i in range(5):
             execute(cql, table, "INSERT INTO %s (a, s) VALUES (?, ?)", i, i)
             if i != 2:
                 for j in range(4):
-                    execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", i, j, j, i + j)
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+                        i,
+                        j,
+                        j,
+                        i + j,
+                    )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c = 2 AND s >= 1 ALLOW FILTERING"),
-                                    [1, 2, 1, 2, 3],
-                                    [3, 2, 3, 2, 5],
-                                    [4, 2, 4, 2, 6])
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c = 2 AND s >= 1 ALLOW FILTERING",
+                ),
+                [1, 2, 1, 2, 3],
+                [3, 2, 3, 2, 5],
+                [4, 2, 4, 2, 6],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND c = 2 AND s >= 1 LIMIT 2 ALLOW FILTERING"),
-                       [1, 2, 1, 2, 3],
-                       [4, 2, 4, 2, 6])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND c = 2 AND s >= 1 LIMIT 2 ALLOW FILTERING",
+                ),
+                [1, 2, 1, 2, 3],
+                [4, 2, 4, 2, 6],
+            )
 
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a >= 3 AND c = 2 AND s >= 1 LIMIT 2 ALLOW FILTERING"),
-                                    [4, 2, 4, 2, 6],
-                                    [3, 2, 3, 2, 5])
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 3 AND c = 2 AND s >= 1 LIMIT 2 ALLOW FILTERING",
+                ),
+                [4, 2, 4, 2, 6],
+                [3, 2, 3, 2, 5],
+            )
+
 
 # Reproduces issue #10357
 def testFilteringOnStaticColumnsWithRowsWithOnlyStaticValues(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))",
+    ) as table:
         for i in range(5):
             execute(cql, table, "INSERT INTO %s (a, s) VALUES (?, ?)", i, i)
             if i != 2:
                 for j in range(4):
-                    execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", i, j, j, i + j)
+                    execute(
+                        cql,
+                        table,
+                        "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+                        i,
+                        j,
+                        j,
+                        i + j,
+                    )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c = 2 AND s >= 1 LIMIT 2 ALLOW FILTERING"),
-                       [1, 2, 1, 2, 3],
-                       [4, 2, 4, 2, 6])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c = 2 AND s >= 1 LIMIT 2 ALLOW FILTERING",
+                ),
+                [1, 2, 1, 2, 3],
+                [4, 2, 4, 2, 6],
+            )
+
 
 # Reproduces #10357, #10358
 def testFilteringWithoutIndices(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, s int static, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, s int static, PRIMARY KEY (a, b))",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 2, 4, 8)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 3, 6, 12)")
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 4, 4, 8)")
@@ -936,414 +2274,884 @@ def testFilteringWithoutIndices(cql, test_keyspace):
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c = 4 AND d = 8")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c = 4 AND d = 8",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c = 4 AND d = 8 ALLOW FILTERING"),
-                       [1, 2, 1, 4, 8],
-                       [1, 4, 1, 4, 8])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c = 4 AND d = 8 ALLOW FILTERING"
+                ),
+                [1, 2, 1, 4, 8],
+                [1, 4, 1, 4, 8],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE a = 1 AND b = 4 AND d = 8")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND b = 4 AND d = 8",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND b = 4 AND d = 8 ALLOW FILTERING"),
-                       [1, 4, 1, 4, 8])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND b = 4 AND d = 8 ALLOW FILTERING",
+                ),
+                [1, 4, 1, 4, 8],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE s = 1 AND d = 12")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE s = 1 AND d = 12",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE s = 1 AND d = 12 ALLOW FILTERING"),
-                       [1, 3, 1, 6, 12])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE s = 1 AND d = 12 ALLOW FILTERING",
+                ),
+                [1, 3, 1, 6, 12],
+            )
 
             # The first call fails differently in Scylla and Cassandra, and
             # the second call passes on Scylla - see discussion why, and why
             # we don't consider this a bug, in #5545.
-            #assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
+            # assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
             #                     "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7)")
-            #assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
+            # assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (c) is not yet supported",
             #                     "SELECT * FROM %s WHERE a IN (1, 2) AND c IN (6, 7) ALLOW FILTERING")
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > 4")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > 4 ALLOW FILTERING"),
-                       [1, 3, 1, 6, 12],
-                       [2, 3, 2, 7, 12])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE c > 4 ALLOW FILTERING"),
+                [1, 3, 1, 6, 12],
+                [2, 3, 2, 7, 12],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE s > 1")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE s > 1",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE s > 1 ALLOW FILTERING"),
-                       [2, 3, 2, 7, 12],
-                       [3, None, 3, None, None])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE s > 1 ALLOW FILTERING"),
+                [2, 3, 2, 7, 12],
+                [3, None, 3, None, None],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b < 3 AND c <= 4")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b < 3 AND c <= 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b < 3 AND c <= 4 ALLOW FILTERING"),
-                       [1, 2, 1, 4, 8])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b < 3 AND c <= 4 ALLOW FILTERING",
+                ),
+                [1, 2, 1, 4, 8],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c >= 3 AND c <= 6")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c >= 3 AND c <= 6",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= 3 AND c <= 6 ALLOW FILTERING"),
-                       [1, 2, 1, 4, 8],
-                       [1, 3, 1, 6, 12],
-                       [1, 4, 1, 4, 8])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= 3 AND c <= 6 ALLOW FILTERING",
+                ),
+                [1, 2, 1, 4, 8],
+                [1, 3, 1, 6, 12],
+                [1, 4, 1, 4, 8],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE s >= 1 LIMIT 2 ALLOW FILTERING"),
-                       [1, 2, 1, 4, 8],
-                       [1, 3, 1, 6, 12])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE s >= 1 LIMIT 2 ALLOW FILTERING"
+                ),
+                [1, 2, 1, 4, 8],
+                [1, 3, 1, 6, 12],
+            )
 
         # Checks filtering with null
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c = null")
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c = null",
+        )
         # Scylla does not consider "= null" an error, rather it just matches
         # nothing. See discussion in test_null.py::test_filtering_eq_null
-        #assert_invalid_message(cql, table, "Unsupported null value for column c",
+        # assert_invalid_message(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE c > null")
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c > null",
+        )
         # Scylla does not consider "> null" an error, rather it just matches
         # nothing. See discussion in test_null.py::test_filtering_inequality_null
-        #assert_invalid_message(cql, table, "Unsupported null value for column c",
+        # assert_invalid_message(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c > null ALLOW FILTERING")
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE s > null")
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE s > null",
+        )
         # Scylla does not consider "> null" an error, rather it just matches
         # nothing. See discussion in test_null.py::test_filtering_inequality_null
-        #assert_invalid_message(cql, table, "Unsupported null value for column s",
+        # assert_invalid_message(cql, table, "Unsupported null value for column s",
         #                     "SELECT * FROM %s WHERE s > null ALLOW FILTERING")
 
         # Checks filtering with unset
         # Reproduces #10358
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE s = ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
-                             UNSET_VALUE)
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE s = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+
 
 # Reproduces #10358, #10361
 def testFilteringWithoutIndicesWithCollections(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c list<int>, d set<int>, e map<int, int>, PRIMARY KEY (a, b))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 3, [3, 2], {6, 4}, {3: 2})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 4, [1, 2], {2, 4}, {1: 2})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (2, 3, [3, 6], {6, 12}, {3: 6})")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c list<int>, d set<int>, e map<int, int>, PRIMARY KEY (a, b))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 3, [3, 2], {6, 4}, {3: 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 4, [1, 2], {2, 4}, {1: 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (2, 3, [3, 6], {6, 12}, {3: 6})",
+        )
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering for lists
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c CONTAINS 2")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
             # Checks filtering for sets
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE d CONTAINS 4")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE d CONTAINS 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
             # Checks filtering for maps
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE e CONTAINS 2")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE e CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e CONTAINS 2 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE e CONTAINS 2 ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e CONTAINS KEY 1 ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE e CONTAINS KEY 1 ALLOW FILTERING",
+                ),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e[1] = 6 ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE e[1] = 6 ALLOW FILTERING"),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING"),
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING",
+                ),
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
         # Checks filtering with null
         # Scylla does not consider "CONTAINS null" an error, rather should
         # just matches nothing. See issue #10359.
-        #assert_invalid_message(cql, table, "Unsupported null value for column c",
+        # assert_invalid_message(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column d",
+        # assert_invalid_message(cql, table, "Unsupported null value for column d",
         #                     "SELECT * FROM %s WHERE d CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null value for column e",
         #                     "SELECT * FROM %s WHERE e CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null value for column e",
         #                     "SELECT * FROM %s WHERE e CONTAINS KEY null ALLOW FILTERING")
         # Scylla does not consider "e[null]" an error, it just returns NULL.
         # See issue #10361.
-        #assert_invalid_message(cql, table, "Unsupported null map key for column e",
+        # assert_invalid_message(cql, table, "Unsupported null map key for column e",
         #                     "SELECT * FROM %s WHERE e[null] = 2 ALLOW FILTERING")
         # Scylla does not consider "= null" an error, it just matches nothing.
         # See issue #4776.
-        #assert_invalid_message(cql, table, "Unsupported null map value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null map value for column e",
         #                     "SELECT * FROM %s WHERE e[1] = null ALLOW FILTERING")
 
         # Checks filtering with unset
         # Reproduces #10358:
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE d CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE e CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE e CONTAINS KEY ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset",
-                             "SELECT * FROM %s WHERE e[?] = 2 ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset",
-                             "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
-                             UNSET_VALUE)
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE d CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE e CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE e CONTAINS KEY ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset",
+            "SELECT * FROM %s WHERE e[?] = 2 ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset",
+            "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+
 
 def testFilteringWithoutIndicesWithFrozenCollections(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, d frozen<set<int>>, e frozen<map<int, int>>, PRIMARY KEY (a, b))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 3, [3, 2], {6, 4}, {3: 2})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 4, [1, 2], {2, 4}, {1: 2})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (2, 3, [3, 6], {6, 12}, {3: 6})")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<list<int>>, d frozen<set<int>>, e frozen<map<int, int>>, PRIMARY KEY (a, b))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 3, [3, 2], {6, 4}, {3: 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 4, [1, 2], {2, 4}, {1: 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (2, 3, [3, 6], {6, 12}, {3: 6})",
+        )
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering for lists
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c = [3, 2]")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c = [3, 2]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c = [3, 2] ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c = [3, 2] ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c > [1, 5] AND c < [3, 6]")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c > [1, 5] AND c < [3, 6]",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > [1, 5] AND c < [3, 6] ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}],
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c > [1, 5] AND c < [3, 6] ALLOW FILTERING",
+                ),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c >= [1, 6] AND c < [3, 3] ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}],
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c >= [1, 6] AND c < [3, 3] ALLOW FILTERING",
+                ),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE c CONTAINS 2")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
             # Checks filtering for sets
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE d = {6, 4}")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE d = {6, 4}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d = {6, 4} ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE d = {6, 4} ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE d > {4, 5} AND d < {6}")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE d > {4, 5} AND d < {6}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d > {4, 5} AND d < {6} ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE d > {4, 5} AND d < {6} ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d >= {2, 12} AND d <= {4, 6} ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}],
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE d >= {2, 12} AND d <= {4, 6} ALLOW FILTERING",
+                ),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE d CONTAINS 4")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE d CONTAINS 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4},{3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
             # Checks filtering for maps
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE e = {1 : 2}")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE e = {1 : 2}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e = {1 : 2} ALLOW FILTERING"),
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE e = {1 : 2} ALLOW FILTERING"
+                ),
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE e > {1 : 4} AND e < {3 : 6}")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE e > {1 : 4} AND e < {3 : 6}",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e > {1 : 4} AND e < {3 : 6} ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}],
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE e > {1 : 4} AND e < {3 : 6} ALLOW FILTERING",
+                ),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e >= {1 : 6} AND e <= {3 : 2} ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}],
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE e >= {1 : 6} AND e <= {3 : 2} ALLOW FILTERING",
+                ),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE e CONTAINS 2")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE e CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e CONTAINS 2 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE e CONTAINS 2 ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e CONTAINS KEY 1 ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE e CONTAINS KEY 1 ALLOW FILTERING",
+                ),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_invalid_message(cql, table, "Map-entry equality predicates on frozen map column e are not supported",
-                                 "SELECT * FROM %s WHERE e[1] = 6 ALLOW FILTERING")
+            assert_invalid_message(
+                cql,
+                table,
+                "Map-entry equality predicates on frozen map column e are not supported",
+                "SELECT * FROM %s WHERE e[1] = 6 ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING"),
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING",
+                ),
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
         # Checks filtering with null
         # Scylla does not consider "= null" an error, rather it just matches
         # nothing. See discussion in test_null.py::test_filtering_eq_null
-        #assert_invalid_message(cql, table, "Unsupported null value for column c",
+        # assert_invalid_message(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c = null ALLOW FILTERING")
         # Scylla does not consider "CONTAINS null" an error, rather should
         # just matches nothing. See issue #10359.
-        #assert_invalid_message(cql, table, "Unsupported null value for column c",
+        # assert_invalid_message(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE c CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column d",
+        # assert_invalid_message(cql, table, "Unsupported null value for column d",
         #                     "SELECT * FROM %s WHERE d = null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column d",
+        # assert_invalid_message(cql, table, "Unsupported null value for column d",
         #                     "SELECT * FROM %s WHERE d CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null value for column e",
         #                     "SELECT * FROM %s WHERE e = null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null value for column e",
         #                     "SELECT * FROM %s WHERE e CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null value for column e",
         #                     "SELECT * FROM %s WHERE e CONTAINS KEY null ALLOW FILTERING")
         # Scylla does not consider "e[null]" an error, it just returns NULL.
         # See issue #10361.
-        #assert_invalid_message(cql, table, "Map-entry equality predicates on frozen map column e are not supported",
+        # assert_invalid_message(cql, table, "Map-entry equality predicates on frozen map column e are not supported",
         #                     "SELECT * FROM %s WHERE e[null] = 2 ALLOW FILTERING")
         # Scylla does not consider "= null" an error, it just matches nothing.
         # See issue #4776.
-        #assert_invalid_message(cql, table, "Map-entry equality predicates on frozen map column e are not supported",
+        # assert_invalid_message(cql, table, "Map-entry equality predicates on frozen map column e are not supported",
         #                     "SELECT * FROM %s WHERE e[1] = null ALLOW FILTERING")
 
         # Checks filtering with unset
         # Reproduces #10358:
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE d = ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE d CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE e = ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE e CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE e CONTAINS KEY ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "Map-entry equality predicates on frozen map column e are not supported",
-                             "SELECT * FROM %s WHERE e[?] = 2 ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "Map-entry equality predicates on frozen map column e are not supported",
-                             "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
-                             UNSET_VALUE)
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE c = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE d = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE d CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE e = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE e CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE e CONTAINS KEY ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Map-entry equality predicates on frozen map column e are not supported",
+            "SELECT * FROM %s WHERE e[?] = 2 ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Map-entry equality predicates on frozen map column e are not supported",
+            "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+
+
 # Reproduces #8627
-@pytest.mark.xfail(reason="#8627")
+@pytest.mark.xfail(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627"
+)
 def testIndexQueryWithValueOver64K(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c blob, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c blob, PRIMARY KEY (a, b))"
+    ) as table:
         TOO_BIG = 1024 * 65
-        too_big = bytearray([1])*TOO_BIG
+        too_big = bytearray([1]) * TOO_BIG
         execute(cql, table, "CREATE INDEX ON %s (c)")
 
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 0, bytearray([1]))
-        execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 1, bytearray([1, 1]))
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+            0,
+            0,
+            bytearray([1]),
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)",
+            0,
+            1,
+            bytearray([1, 1]),
+        )
 
-        assert_invalid_message(cql, table, "Index expression values may not be larger than 64K",
-                             "SELECT * FROM %s WHERE c = ?  ALLOW FILTERING", too_big)
+        assert_invalid_message(
+            cql,
+            table,
+            "Index expression values may not be larger than 64K",
+            "SELECT * FROM %s WHERE c = ?  ALLOW FILTERING",
+            too_big,
+        )
 
-        ks_name = table.split('.')[0]
-        index_name = table.split('.')[1] + "_c_idx"
+        ks_name = table.split(".")[0]
+        index_name = table.split(".")[1] + "_c_idx"
         execute(cql, table, f"DROP INDEX {ks_name}.{index_name}")
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE c = ?  ALLOW FILTERING", too_big))
+        assert_empty(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE c = ?  ALLOW FILTERING", too_big
+            )
+        )
+
 
 # Reproduces #10366
-@pytest.mark.xfail(reason="#10366 - server error instead of InvalidRequest")
+@pytest.mark.xfail(
+    reason="Enforce Key-length limits during SELECT #10366 - server error instead of InvalidRequest"
+)
 def testPKQueryWithValueOver64K(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b text, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a text, b text, PRIMARY KEY (a, b))"
+    ) as table:
         TOO_BIG = 1024 * 65
-        too_big = 'x'*TOO_BIG
-        assert_invalid_throw(cql, table, InvalidRequest,
-                           "SELECT * FROM %s WHERE a = ?", too_big)
+        too_big = "x" * TOO_BIG
+        assert_invalid_throw(
+            cql, table, InvalidRequest, "SELECT * FROM %s WHERE a = ?", too_big
+        )
+
 
 # Reproduces #10366
-@pytest.mark.xfail(reason="#10366 - server error instead of silent return")
+@pytest.mark.xfail(
+    reason="Enforce Key-length limits during SELECT #10366 - server error instead of silent return"
+)
 def testCKQueryWithValueOver64K(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b text, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql, test_keyspace, "(a text, b text, PRIMARY KEY (a, b))"
+    ) as table:
         TOO_BIG = 1024 * 65
-        too_big = 'x'*TOO_BIG
+        too_big = "x" * TOO_BIG
         execute(cql, table, "SELECT * FROM %s WHERE a = 'foo' AND b = ?", too_big)
+
 
 def testAllowFilteringOnPartitionKeyWithDistinct(cql, test_keyspace):
     # Test a regular(CQL3) table.
-    with create_table(cql, test_keyspace, "(pk0 int, pk1 int, ck0 int, val int, PRIMARY KEY ((pk0, pk1), ck0))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk0 int, pk1 int, ck0 int, val int, PRIMARY KEY ((pk0, pk1), ck0))",
+    ) as table:
         for i in range(3):
-            execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 0, 0)", i, i)
-            execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 1, 1)", i, i)
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 0, 0)",
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 1, 1)",
+                i,
+                i,
+            )
 
         for _ in before_and_after_flush(cql, table):
-            assert_invalid_message(cql, table, 'FILTERING',
-                    "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 = 1 LIMIT 3")
+            assert_invalid_message(
+                cql,
+                table,
+                "FILTERING",
+                "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 = 1 LIMIT 3",
+            )
 
-            assert_invalid_message(cql, table, 'FILTERING',
-                    "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 > 0 AND pk1 = 1 LIMIT 3")
+            assert_invalid_message(
+                cql,
+                table,
+                "FILTERING",
+                "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 > 0 AND pk1 = 1 LIMIT 3",
+            )
 
-            assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 = 1 LIMIT 1 ALLOW FILTERING"),
-                    [1, 1])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 = 1 LIMIT 1 ALLOW FILTERING",
+                ),
+                [1, 1],
+            )
 
-            assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 = 1 LIMIT 3 ALLOW FILTERING"),
-                    [1, 1])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 = 1 LIMIT 3 ALLOW FILTERING",
+                ),
+                [1, 1],
+            )
 
-            assert_empty(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 < 0 AND pk1 = 1 LIMIT 3 ALLOW FILTERING"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 < 0 AND pk1 = 1 LIMIT 3 ALLOW FILTERING",
+                )
+            )
 
             # Test selection validation.
-            assert_invalid_message(cql, table, "queries must request all the partition key columns",
-                    "SELECT DISTINCT pk0 FROM %s ALLOW FILTERING")
-            assert_invalid_message(cql, table, "queries must only request partition key columns",
-                    "SELECT DISTINCT pk0, pk1, ck0 FROM %s ALLOW FILTERING")
+            assert_invalid_message(
+                cql,
+                table,
+                "queries must request all the partition key columns",
+                "SELECT DISTINCT pk0 FROM %s ALLOW FILTERING",
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                "queries must only request partition key columns",
+                "SELECT DISTINCT pk0, pk1, ck0 FROM %s ALLOW FILTERING",
+            )
+
 
 def testAllowFilteringOnPartitionKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY ((a, b), c))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY ((a, b), c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 12, 13, 14)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 15, 16, 17)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (21, 22, 23, 24)")
@@ -1352,72 +3160,124 @@ def testAllowFilteringOnPartitionKey(cql, test_keyspace):
         for _ in before_and_after_flush(cql, table):
             # IN restrictions *are* allowed in Scylla (the correctness of them
             # is tested in test_filtering.py::test_filtering_with_in_relation
-            #assert_invalid_message(cql, table, "IN restrictions are not supported when the query involves filtering",
+            # assert_invalid_message(cql, table, "IN restrictions are not supported when the query involves filtering",
             #        "SELECT * FROM %s WHERE b in (11,12) ALLOW FILTERING")
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                    "SELECT * FROM %s WHERE a = 11")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 11",
+            )
 
             # different error messages in Scylla and Cassandra
-            assert_invalid(cql, table,
-                    "SELECT * FROM %s WHERE a > 11")
-            assert_invalid(cql, table,
-                    "SELECT * FROM %s WHERE a > 11 and b = 1")
+            assert_invalid(cql, table, "SELECT * FROM %s WHERE a > 11")
+            assert_invalid(cql, table, "SELECT * FROM %s WHERE a > 11 and b = 1")
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 11 ALLOW FILTERING"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a = 11 ALLOW FILTERING"),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a in (11) and b in (12,15,22)"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE a in (11) and b in (12,15,22)"
+                ),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+            )
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE b in (12,15,22)")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE b in (12,15,22)",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a in (11) and b in (12,15,22) ALLOW FILTERING"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a in (11) and b in (12,15,22) ALLOW FILTERING",
+                ),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a in (11) ALLOW FILTERING"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a in (11) ALLOW FILTERING"),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b = 15 ALLOW FILTERING"),
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE b = 15 ALLOW FILTERING"),
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b >= 15 ALLOW FILTERING"),
-                    [11, 15, 16, 17],
-                    [31, 32, 33, 34],
-                    [21, 22, 23, 24])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE b >= 15 ALLOW FILTERING"),
+                [11, 15, 16, 17],
+                [31, 32, 33, 34],
+                [21, 22, 23, 24],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 11 ALLOW FILTERING"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17],
-                    [31, 32, 33, 34],
-                    [21, 22, 23, 24])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a >= 11 ALLOW FILTERING"),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+                [31, 32, 33, 34],
+                [21, 22, 23, 24],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 11 AND b <= 15 ALLOW FILTERING"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 11 AND b <= 15 ALLOW FILTERING",
+                ),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 11 AND b >= 14 ALLOW FILTERING"),
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 11 AND b >= 14 ALLOW FILTERING",
+                ),
+                [11, 15, 16, 17],
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE a < 11 ALLOW FILTERING"))
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE b > 32 ALLOW FILTERING"))
+            assert_empty(
+                execute(cql, table, "SELECT * FROM %s WHERE a < 11 ALLOW FILTERING")
+            )
+            assert_empty(
+                execute(cql, table, "SELECT * FROM %s WHERE b > 32 ALLOW FILTERING")
+            )
 
         # Checks filtering with unset
         # Reproduces #10358
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE a = ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE a > ? ALLOW FILTERING",
-                             UNSET_VALUE)
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE a = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE a > ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
 
     # No clustering key
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY ((a, b)))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY ((a, b)))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 12, 13, 14)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 15, 16, 17)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (21, 22, 23, 24)")
@@ -1426,34 +3286,52 @@ def testAllowFilteringOnPartitionKey(cql, test_keyspace):
         for _ in before_and_after_flush(cql, table):
             # IN restrictions *are* allowed in Scylla (the correctness of them
             # is tested in test_filtering.py::test_filtering_with_in_relation
-            #assert_invalid_message(cql, table, "IN restrictions are not supported when the query involves filtering",
+            # assert_invalid_message(cql, table, "IN restrictions are not supported when the query involves filtering",
             #        "SELECT * FROM %s WHERE b in (11,12) ALLOW FILTERING")
 
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                    "SELECT * FROM %s WHERE a = 11")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 11",
+            )
 
             # different error messages in Scylla and Cassandra
-            assert_invalid(cql, table,
-                    "SELECT * FROM %s WHERE a > 11")
-            assert_invalid(cql, table,
-                    "SELECT * FROM %s WHERE a > 11 and b = 1")
+            assert_invalid(cql, table, "SELECT * FROM %s WHERE a > 11")
+            assert_invalid(cql, table, "SELECT * FROM %s WHERE a > 11 and b = 1")
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 11 ALLOW FILTERING"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a = 11 ALLOW FILTERING"),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 11 ALLOW FILTERING"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17],
-                    [31, 32, 33, 34],
-                    [21, 22, 23, 24])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a >= 11 ALLOW FILTERING"),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+                [31, 32, 33, 34],
+                [21, 22, 23, 24],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 11 AND b <= 15 ALLOW FILTERING"),
-                    [11, 12, 13, 14],
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 11 AND b <= 15 ALLOW FILTERING",
+                ),
+                [11, 12, 13, 14],
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 11 AND b >= 14 ALLOW FILTERING"),
-                    [11, 15, 16, 17])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 11 AND b >= 14 ALLOW FILTERING",
+                ),
+                [11, 15, 16, 17],
+            )
 
     # one partition key
     with create_table(cql, test_keyspace, "(a int primary key, b int, c int)") as table:
@@ -1469,58 +3347,125 @@ def testAllowFilteringOnPartitionKey(cql, test_keyspace):
         execute(cql, table, "DELETE FROM %s WHERE a = 5")
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 ALLOW FILTERING"),
-                    [1, 2, 4])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a = 1 ALLOW FILTERING"),
+                [1, 2, 4],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 ALLOW FILTERING"),
-                    [1, 2, 4],
-                    [2, 1, 6],
-                    [4, 1, 7],
-                    [3, 2, 4])
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a >= 1 ALLOW FILTERING"),
+                [1, 2, 4],
+                [2, 1, 6],
+                [4, 1, 7],
+                [3, 2, 4],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b >= 2  ALLOW FILTERING"),
-                    [1, 2, 4],
-                    [3, 2, 4])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b >= 2  ALLOW FILTERING",
+                ),
+                [1, 2, 4],
+                [3, 2, 4],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b >= 2 AND c <= 4 ALLOW FILTERING"),
-                    [1, 2, 4],
-                    [3, 2, 4])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b >= 2 AND c <= 4 ALLOW FILTERING",
+                ),
+                [1, 2, 4],
+                [3, 2, 4],
+            )
+
 
 def testAllowFilteringOnPartitionAndClusteringKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY ((a, b), c, d))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY ((a, b), c, d))",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (11, 12, 13, 14, 15)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (11, 15, 16, 17, 18)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (21, 22, 23, 24, 25)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (31, 32, 33, 34, 35)")
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 11 AND b = 15 AND c = 16"),
-                    [11, 15, 16, 17, 18])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE a = 11 AND b = 15 AND c = 16"
+                ),
+                [11, 15, 16, 17, 18],
+            )
 
-            assert_invalid_message(cql, table,
-                    "Clustering column \"d\" cannot be restricted (preceding column \"c\" is restricted by a non-EQ relation)",
-                    "SELECT * FROM %s WHERE a = 11 AND b = 12 AND c > 13 AND d = 14")
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 11 AND b = 15 AND c = 16 AND d > 16"),
-                    [11, 15, 16, 17, 18])
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "d" cannot be restricted (preceding column "c" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE a = 11 AND b = 12 AND c > 13 AND d = 14",
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 11 AND b = 15 AND c = 16 AND d > 16",
+                ),
+                [11, 15, 16, 17, 18],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 11 AND b = 15 AND c > 13 AND d >= 17 ALLOW FILTERING"),
-                    [11, 15, 16, 17, 18])
-            assert_invalid_message(cql, table,
-                    "Clustering column \"d\" cannot be restricted (preceding column \"c\" is restricted by a non-EQ relation)",
-                    "SELECT * FROM %s WHERE a = 11 AND b = 12 AND c > 13 AND d > 17")
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c > 30 AND d >= 34 ALLOW FILTERING"),
-                    [31, 32, 33, 34, 35])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 11 AND b = 15 AND c > 13 AND d >= 17 ALLOW FILTERING",
+                ),
+                [11, 15, 16, 17, 18],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "d" cannot be restricted (preceding column "c" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE a = 11 AND b = 12 AND c > 13 AND d > 17",
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE c > 30 AND d >= 34 ALLOW FILTERING",
+                ),
+                [31, 32, 33, 34, 35],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 11 AND c > 15 AND d >= 16 ALLOW FILTERING"),
-                    [11, 15, 16, 17, 18])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 11 AND c > 15 AND d >= 16 ALLOW FILTERING",
+                ),
+                [11, 15, 16, 17, 18],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 11 AND b >= 15 AND c > 15 AND d >= 16 ALLOW FILTERING"),
-                    [11, 15, 16, 17, 18])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 11 AND b >= 15 AND c > 15 AND d >= 16 ALLOW FILTERING",
+                ),
+                [11, 15, 16, 17, 18],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a <= 100 AND b >= 15 AND c > 0 AND d <= 100 ALLOW FILTERING"),
-                    [11, 15, 16, 17, 18],
-                    [31, 32, 33, 34, 35],
-                    [21, 22, 23, 24, 25])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a <= 100 AND b >= 15 AND c > 0 AND d <= 100 ALLOW FILTERING",
+                ),
+                [11, 15, 16, 17, 18],
+                [31, 32, 33, 34, 35],
+                [21, 22, 23, 24, 25],
+            )
 
             # Scylla's and Cassandra's error messages differ here because there
             # are multiple errors in the request... Cassandra says
@@ -1528,11 +3473,16 @@ def testAllowFilteringOnPartitionAndClusteringKey(cql, test_keyspace):
             # \"c\" is restricted by a non-EQ relation)", while Scylla says:
             # "Only EQ and IN relation are supported on the partition key
             # (unless you use the token() function or ALLOW FILTERING)
-            assert_invalid(cql, table,
-                    "SELECT * FROM %s WHERE a <= 11 AND c > 15 AND d >= 16")
+            assert_invalid(
+                cql, table, "SELECT * FROM %s WHERE a <= 11 AND c > 15 AND d >= 16"
+            )
 
     # test clutering order
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY ((a, b), c, d)) WITH CLUSTERING ORDER BY (c DESC, d ASC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY ((a, b), c, d)) WITH CLUSTERING ORDER BY (c DESC, d ASC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (11, 11, 13, 14, 15)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (11, 11, 14, 17, 18)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (11, 12, 15, 14, 15)")
@@ -1543,19 +3493,42 @@ def testAllowFilteringOnPartitionAndClusteringKey(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (21, 12, 26, 34, 35)")
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE b >= 12 ALLOW FILTERING"),
-                                    [11, 12, 15, 14, 15],
-                                    [11, 12, 16, 17, 18],
-                                    [21, 12, 25, 24, 25],
-                                    [21, 12, 26, 34, 35])
+            assert_rows_ignoring_order(
+                execute(cql, table, "SELECT * FROM %s WHERE b >= 12 ALLOW FILTERING"),
+                [11, 12, 15, 14, 15],
+                [11, 12, 16, 17, 18],
+                [21, 12, 25, 24, 25],
+                [21, 12, 26, 34, 35],
+            )
 
-@pytest.mark.xfail(reason="#10358")
+
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #10358")
 def testAllowFilteringOnPartitionKeyWithoutIndicesWithCollections(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c list<int>, d set<int>, e map<int, int>, PRIMARY KEY ((a, b)))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 3, [3, 2], {6, 4}, {3: 2})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 4, [1, 2], {2, 4}, {1: 2})")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (2, 3, [3, 6], {6, 12}, {3: 6})")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c list<int>, d set<int>, e map<int, int>, PRIMARY KEY ((a, b)))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 3, [3, 2], {6, 4}, {3: 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (1, 4, [1, 2], {2, 4}, {1: 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d, e) VALUES (2, 3, [3, 6], {6, 12}, {3: 6})",
+        )
 
         for _ in before_and_after_flush(cql, table):
             # Checks filtering for lists
@@ -1564,173 +3537,389 @@ def testAllowFilteringOnPartitionKeyWithoutIndicesWithCollections(cql, test_keys
             # prints the more specific "Only EQ and IN relation are supported
             # on the partition key (unless you use the token() function or allow
             # filtering)".
-            assert_invalid_message(cql, table, "filtering",
-                    "SELECT * FROM %s WHERE b < 0 AND c CONTAINS 2")
-
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b >= 4 AND c CONTAINS 2 ALLOW FILTERING"),
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_invalid_message(
+                cql, table, "filtering", "SELECT * FROM %s WHERE b < 0 AND c CONTAINS 2"
+            )
 
             assert_rows(
-                    execute(cql, table, "SELECT * FROM %s WHERE a > 0 AND b <= 3 AND c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b >= 4 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
+
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a > 0 AND b <= 3 AND c CONTAINS 2 AND c CONTAINS 3 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
             # Checks filtering for sets
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                    "SELECT * FROM %s WHERE a = 1 AND d CONTAINS 4")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE a = 1 AND d CONTAINS 4",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 ALLOW FILTERING"
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE d CONTAINS 4 AND d CONTAINS 6 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
             # Checks filtering for maps
-            assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                                 "SELECT * FROM %s WHERE e CONTAINS 2")
+            assert_invalid_message(
+                cql,
+                table,
+                REQUIRES_ALLOW_FILTERING_MESSAGE,
+                "SELECT * FROM %s WHERE e CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a < 2 AND b >= 3 AND e CONTAINS 2 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}],
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a < 2 AND b >= 3 AND e CONTAINS 2 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND e CONTAINS KEY 1 ALLOW FILTERING"),
-                       [1, 4, [1, 2], {2, 4}, {1: 2}],
-                       [1, 2, [1, 6], {2, 12}, {1: 6}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND e CONTAINS KEY 1 ALLOW FILTERING",
+                ),
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a in (1) AND b in (2) AND e[1] = 6 ALLOW FILTERING"),
-                       [1, 2, [1, 6], {2, 12}, {1: 6}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a in (1) AND b in (2) AND e[1] = 6 ALLOW FILTERING",
+                ),
+                [1, 2, [1, 6], {2, 12}, {1: 6}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 1 AND e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING"),
-                       [1, 4, [1, 2], {2, 4}, {1: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 1 AND e CONTAINS KEY 1 AND e CONTAINS 2 ALLOW FILTERING",
+                ),
+                [1, 4, [1, 2], {2, 4}, {1: 2}],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a >= 1 AND b in (3) AND c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING"),
-                       [1, 3, [3, 2], {6, 4}, {3: 2}])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a >= 1 AND b in (3) AND c CONTAINS 2 AND d CONTAINS 4 AND e CONTAINS KEY 3 ALLOW FILTERING",
+                ),
+                [1, 3, [3, 2], {6, 4}, {3: 2}],
+            )
 
         # Checks filtering with null
         # Scylla does not consider "CONTAINS null" an error, rather should
         # just matches nothing. See issue #10359.
-        #assert_invalid_message(cql, table, "Unsupported null value for column c",
+        # assert_invalid_message(cql, table, "Unsupported null value for column c",
         #                     "SELECT * FROM %s WHERE a > 1 AND c CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column d",
+        # assert_invalid_message(cql, table, "Unsupported null value for column d",
         #                     "SELECT * FROM %s WHERE b < 1 AND d CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null value for column e",
         #                     "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e CONTAINS null ALLOW FILTERING")
-        #assert_invalid_message(cql, table, "Unsupported null value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null value for column e",
         #                     "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e CONTAINS KEY null ALLOW FILTERING")
         # Scylla does not consider "e[null]" an error, it just returns NULL.
         # See issue #10361.
-        #assert_invalid_message(cql, table, "Unsupported null map key for column e",
+        # assert_invalid_message(cql, table, "Unsupported null map key for column e",
         #                     "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[null] = 2 ALLOW FILTERING")
         # Scylla does not consider "= null" an error, it just matches nothing.
         # See issue #4776.
-        #assert_invalid_message(cql, table, "Unsupported null map value for column e",
+        # assert_invalid_message(cql, table, "Unsupported null map value for column e",
         #                     "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[1] = null ALLOW FILTERING")
 
         # Checks filtering with unset
         # Reproduces #10358
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND c CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND d CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e CONTAINS ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "unset value",
-                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e CONTAINS KEY ? ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset map key for column e",
-                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[?] = 2 ALLOW FILTERING",
-                             UNSET_VALUE)
-        assert_invalid_message(cql, table, "Unsupported unset map value for column e",
-                             "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[1] = ? ALLOW FILTERING",
-                             UNSET_VALUE)
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND c CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND d CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e CONTAINS ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "unset value",
+            "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e CONTAINS KEY ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Unsupported unset map key for column e",
+            "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[?] = 2 ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+        assert_invalid_message(
+            cql,
+            table,
+            "Unsupported unset map value for column e",
+            "SELECT * FROM %s WHERE a >= 1 AND b < 1 AND e[1] = ? ALLOW FILTERING",
+            UNSET_VALUE,
+        )
+
 
 def executeFilteringOnly(cql, table, statement):
     assert_invalid(cql, table, statement)
     return execute_without_paging(cql, table, statement + " ALLOW FILTERING")
 
+
 def testAllowFilteringOnPartitionKeyWithCounters(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY ((a, b), c))") as table:
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 14, 11, 12, 13)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 24, 21, 22, 23)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 27, 21, 22, 26)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 34, 31, 32, 33)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 24, 41, 42, 43)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, cnt counter, PRIMARY KEY ((a, b), c))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            14,
+            11,
+            12,
+            13,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            24,
+            21,
+            22,
+            23,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            27,
+            21,
+            22,
+            26,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            34,
+            31,
+            32,
+            33,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            24,
+            41,
+            42,
+            43,
+        )
 
         for _ in before_and_after_flush(cql, table):
+            assert_rows(
+                executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt = 24"),
+                [41, 42, 43, 24],
+                [21, 22, 23, 24],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 22 AND cnt = 24"
+                ),
+                [41, 42, 43, 24],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 10 AND b < 25 AND cnt = 24"
+                ),
+                [21, 22, 23, 24],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 10 AND c < 25 AND cnt = 24"
+                ),
+                [21, 22, 23, 24],
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt = 24"),
-                       [41, 42, 43, 24],
-                       [21, 22, 23, 24])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 22 AND cnt = 24"),
-                       [41, 42, 43, 24])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 10 AND b < 25 AND cnt = 24"),
-                       [21, 22, 23, 24])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 10 AND c < 25 AND cnt = 24"),
-                       [21, 22, 23, 24])
+            assert_invalid_message(
+                cql,
+                table,
+                "ORDER BY is only supported when the partition key is restricted by an EQ or an IN.",
+                "SELECT * FROM %s WHERE a = 21 AND b > 10 AND cnt > 23 ORDER BY c DESC ALLOW FILTERING",
+            )
 
-            assert_invalid_message(cql, table,
-            "ORDER BY is only supported when the partition key is restricted by an EQ or an IN.",
-            "SELECT * FROM %s WHERE a = 21 AND b > 10 AND cnt > 23 ORDER BY c DESC ALLOW FILTERING")
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 21 AND b = 22 AND cnt > 23 ORDER BY c DESC",
+                ),
+                [21, 22, 26, 27],
+                [21, 22, 23, 24],
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a = 21 AND b = 22 AND cnt > 23 ORDER BY c DESC"),
-                       [21, 22, 26, 27],
-                       [21, 22, 23, 24])
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE cnt > 20 AND cnt < 30"
+                ),
+                [41, 42, 43, 24],
+                [21, 22, 23, 24],
+                [21, 22, 26, 27],
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt > 20 AND cnt < 30"),
-                       [41, 42, 43, 24],
-                       [21, 22, 23, 24],
-                       [21, 22, 26, 27])
 
 def testFilteringOnClusteringColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 12, 13, 14)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 15, 16, 17)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (21, 22, 23, 24)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (31, 32, 33, 34)")
 
         for _ in before_and_after_flush(cql, table):
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE a = 11 AND b = 15"),
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 11 AND b = 15"),
-                       [11, 15, 16, 17])
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE a = 11 AND b > 12 AND c = 15",
+            )
 
-            assert_invalid_message(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                                 "SELECT * FROM %s WHERE a = 11 AND b > 12 AND c = 15")
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE a = 11 AND b = 15 AND c > 15"
+                ),
+                [11, 15, 16, 17],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 11 AND b = 15 AND c > 15"),
-                       [11, 15, 16, 17])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 11 AND b > 12 AND c > 13 AND d = 17 ALLOW FILTERING",
+                ),
+                [11, 15, 16, 17],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE a = 11 AND b > 12 AND c > 13 and d = 17",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 11 AND b > 12 AND c > 13 AND d = 17 ALLOW FILTERING"),
-                       [11, 15, 16, 17])
-            assert_invalid_message(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                                 "SELECT * FROM %s WHERE a = 11 AND b > 12 AND c > 13 and d = 17")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b > 20 AND c > 30 ALLOW FILTERING",
+                ),
+                [31, 32, 33, 34],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE b > 20 AND c > 30",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b > 20 AND c > 30 ALLOW FILTERING"),
-                       [31, 32, 33, 34])
-            assert_invalid_message(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                                 "SELECT * FROM %s WHERE b > 20 AND c > 30")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b > 20 AND c < 30 ALLOW FILTERING",
+                ),
+                [21, 22, 23, 24],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE b > 20 AND c < 30",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b > 20 AND c < 30 ALLOW FILTERING"),
-                       [21, 22, 23, 24])
-            assert_invalid_message(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                                 "SELECT * FROM %s WHERE b > 20 AND c < 30")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b > 20 AND c = 33 ALLOW FILTERING",
+                ),
+                [31, 32, 33, 34],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE b > 20 AND c = 33",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b > 20 AND c = 33 ALLOW FILTERING"),
-                       [31, 32, 33, 34])
-            assert_invalid_message(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                                 "SELECT * FROM %s WHERE b > 20 AND c = 33")
-
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c = 33 ALLOW FILTERING"),
-                       [31, 32, 33, 34])
-            assert_invalid_message(cql, table, "PRIMARY KEY column \"c\" cannot be restricted as preceding column \"b\" is not restricted",
-                                 "SELECT * FROM %s WHERE c = 33")
+            assert_rows(
+                execute(cql, table, "SELECT * FROM %s WHERE c = 33 ALLOW FILTERING"),
+                [31, 32, 33, 34],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'PRIMARY KEY column "c" cannot be restricted as preceding column "b" is not restricted',
+                "SELECT * FROM %s WHERE c = 33",
+            )
 
     # --------------------------------------------------
     # Clustering column within and across partition keys
     # --------------------------------------------------
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 12, 13, 14)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 15, 16, 17)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (11, 18, 19, 20)")
@@ -1744,345 +3933,945 @@ def testFilteringOnClusteringColumns(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (31, 38, 39, 40)")
 
         for _ in before_and_after_flush(cql, table):
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE a = 21 AND c > 23"
+                ),
+                [21, 25, 26, 27],
+                [21, 28, 29, 30],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 21 AND c > 23 ORDER BY b DESC",
+                ),
+                [21, 28, 29, 30],
+                [21, 25, 26, 27],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE c > 16 and c < 36"
+                ),
+                [11, 18, 19, 20],
+                [21, 22, 23, 24],
+                [21, 25, 26, 27],
+                [21, 28, 29, 30],
+                [31, 32, 33, 34],
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a = 21 AND c > 23"),
-                       [21, 25, 26, 27],
-                       [21, 28, 29, 30])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a = 21 AND c > 23 ORDER BY b DESC"),
-                       [21, 28, 29, 30],
-                       [21, 25, 26, 27])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c > 16 and c < 36"),
-                       [11, 18, 19, 20],
-                       [21, 22, 23, 24],
-                       [21, 25, 26, 27],
-                       [21, 28, 29, 30],
-                       [31, 32, 33, 34])
 
-@pytest.mark.xfail(reason="#4244")
+@pytest.mark.xfail(
+    reason="Add support for mixing token, multi- and single-column restrictions #4244"
+)
 def testFilteringWithMultiColumnSlices(cql, test_keyspace):
-    #/----------------------------------------
-    #/ Multi-column slices for clustering keys
-    #/----------------------------------------
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d))") as table:
+    # /----------------------------------------
+    # / Multi-column slices for clustering keys
+    # /----------------------------------------
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d))",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (11, 12, 13, 14, 15)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (21, 22, 23, 24, 25)")
         execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (31, 32, 33, 34, 35)")
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b = 22 AND d = 24 ALLOW FILTERING"),
-                       [21, 22, 23, 24, 25])
-            assert_invalid_message(cql, table, "PRIMARY KEY column \"d\" cannot be restricted as preceding column \"c\" is not restricted",
-                                 "SELECT * FROM %s WHERE b = 22 AND d = 24")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b = 22 AND d = 24 ALLOW FILTERING",
+                ),
+                [21, 22, 23, 24, 25],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'PRIMARY KEY column "d" cannot be restricted as preceding column "c" is not restricted',
+                "SELECT * FROM %s WHERE b = 22 AND d = 24",
+            )
 
             # As of issue #4244 in Scylla, "Mixing single column relations and
             # multi column relations on clustering columns is not allowed".
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE (b, c) > (20, 30) AND d = 34 ALLOW FILTERING"),
-                       [31, 32, 33, 34, 35])
-            assert_invalid_message(cql, table, "Clustering column \"d\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                                 "SELECT * FROM %s WHERE (b, c) > (20, 30) AND d = 34")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE (b, c) > (20, 30) AND d = 34 ALLOW FILTERING",
+                ),
+                [31, 32, 33, 34, 35],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "d" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE (b, c) > (20, 30) AND d = 34",
+            )
+
 
 def testContainsFilteringForClusteringKeys(cql, test_keyspace):
-    #/-------------------------------------------------
-    #/ Frozen collections filtering for clustering keys
-    #/-------------------------------------------------
+    # /-------------------------------------------------
+    # / Frozen collections filtering for clustering keys
+    # /-------------------------------------------------
     # first clustering column
-    with create_table(cql, test_keyspace, "(a int, b frozen<list<int>>, c int, PRIMARY KEY (a, b, c))") as table:
-
+    with create_table(
+        cql, test_keyspace, "(a int, b frozen<list<int>>, c int, PRIMARY KEY (a, b, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?, ?, ?)", 11, [1, 3], 14)
         execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?, ?, ?)", 21, [2, 3], 24)
         execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?, ?, ?)", 21, [3, 3], 34)
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 21 AND b CONTAINS 2 ALLOW FILTERING"),
-                       [21, [2, 3], 24])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 21 AND b CONTAINS 2 ALLOW FILTERING",
+                ),
+                [21, [2, 3], 24],
+            )
             # The wording of the error message in Cassandra and Scylla is a
             # bit different.
-            assert_invalid_message(cql, table, "CONTAINS",
-                                 "SELECT * FROM %s WHERE a = 21 AND b CONTAINS 2")
+            assert_invalid_message(
+                cql, table, "CONTAINS", "SELECT * FROM %s WHERE a = 21 AND b CONTAINS 2"
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b CONTAINS 2 ALLOW FILTERING"),
-                       [21, [2, 3], 24])
-            assert_invalid_message(cql, table, "CONTAINS",
-                                 "SELECT * FROM %s WHERE b CONTAINS 2")
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE b CONTAINS 2 ALLOW FILTERING"
+                ),
+                [21, [2, 3], 24],
+            )
+            assert_invalid_message(
+                cql, table, "CONTAINS", "SELECT * FROM %s WHERE b CONTAINS 2"
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b CONTAINS 3 ALLOW FILTERING"),
-                       [11, [1, 3], 14],
-                       [21, [2, 3], 24],
-                       [21, [3, 3], 34])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE b CONTAINS 3 ALLOW FILTERING"
+                ),
+                [11, [1, 3], 14],
+                [21, [2, 3], 24],
+                [21, [3, 3], 34],
+            )
 
     # non-first clustering column
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, d int, PRIMARY KEY (a, b, c))") as table:
-
-        execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)", 11, 12, [1, 3], 14)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)", 21, 22, [2, 3], 24)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)", 21, 22, [3, 3], 34)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<list<int>>, d int, PRIMARY KEY (a, b, c))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)",
+            11,
+            12,
+            [1, 3],
+            14,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            [2, 3],
+            24,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            [3, 3],
+            34,
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 21 AND c CONTAINS 2 ALLOW FILTERING"),
-                       [21, 22, [2, 3], 24])
-            assert_invalid_message(cql, table, "CONTAINS",
-                                 "SELECT * FROM %s WHERE a = 21 AND c CONTAINS 2")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 21 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                [21, 22, [2, 3], 24],
+            )
+            assert_invalid_message(
+                cql, table, "CONTAINS", "SELECT * FROM %s WHERE a = 21 AND c CONTAINS 2"
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b > 20 AND c CONTAINS 2 ALLOW FILTERING"),
-                       [21, 22, [2, 3], 24])
-            assert_invalid_message(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                                 "SELECT * FROM %s WHERE b > 20 AND c CONTAINS 2")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b > 20 AND c CONTAINS 2 ALLOW FILTERING",
+                ),
+                [21, 22, [2, 3], 24],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE b > 20 AND c CONTAINS 2",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE c CONTAINS 3 ALLOW FILTERING"),
-                       [11, 12, [1, 3], 14],
-                       [21, 22, [2, 3], 24],
-                       [21, 22, [3, 3], 34])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE c CONTAINS 3 ALLOW FILTERING"
+                ),
+                [11, 12, [1, 3], 14],
+                [21, 22, [2, 3], 24],
+                [21, 22, [3, 3], 34],
+            )
 
-    with create_table(cql, test_keyspace, "(a int, b int, c frozen<map<text, text>>, d int, PRIMARY KEY (a, b, c))") as table:
-
-        execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)", 11, 12, {"1": "3"}, 14)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)", 21, 22, {"2": "3"}, 24)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)", 21, 22, {"3": "3"}, 34)
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c frozen<map<text, text>>, d int, PRIMARY KEY (a, b, c))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)",
+            11,
+            12,
+            {"1": "3"},
+            14,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            {"2": "3"},
+            24,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a,b,c,d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            {"3": "3"},
+            34,
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b > 20 AND c CONTAINS KEY '2' ALLOW FILTERING"),
-                       [21, 22, {"2": "3"}, 24])
-            assert_invalid_message(cql, table, "Clustering column \"c\" cannot be restricted (preceding column \"b\" is restricted by a non-EQ relation)",
-                                 "SELECT * FROM %s WHERE b > 20 AND c CONTAINS KEY '2'")
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE b > 20 AND c CONTAINS KEY '2' ALLOW FILTERING",
+                ),
+                [21, 22, {"2": "3"}, 24],
+            )
+            assert_invalid_message(
+                cql,
+                table,
+                'Clustering column "c" cannot be restricted (preceding column "b" is restricted by a non-EQ relation)',
+                "SELECT * FROM %s WHERE b > 20 AND c CONTAINS KEY '2'",
+            )
+
 
 def dotestContainsOnPartitionKey(cql, test_keyspace, schema):
     with create_table(cql, test_keyspace, schema) as table:
         execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {1: 2}, 1, 1)
         execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {1: 2}, 2, 2)
 
-        execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {1: 2, 3: 4}, 1, 3)
-        execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {1: 2, 3: 4}, 2, 3)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)",
+            {1: 2, 3: 4},
+            1,
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)",
+            {1: 2, 3: 4},
+            2,
+            3,
+        )
 
         execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {5: 6}, 5, 5)
         execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {7: 8}, 6, 6)
 
-        assert_invalid_message(cql, table, 'ALLOW FILTERING',
-                             "SELECT * FROM %s WHERE pk CONTAINS KEY 1")
+        assert_invalid_message(
+            cql, table, "ALLOW FILTERING", "SELECT * FROM %s WHERE pk CONTAINS KEY 1"
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE pk CONTAINS KEY 1 ALLOW FILTERING"),
-                                    [{1: 2}, 1, 1],
-                                    [{1: 2}, 2, 2],
-                                    [{1: 2, 3: 4}, 1, 3],
-                                    [{1: 2, 3: 4}, 2, 3])
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk CONTAINS KEY 1 ALLOW FILTERING",
+                ),
+                [{1: 2}, 1, 1],
+                [{1: 2}, 2, 2],
+                [{1: 2, 3: 4}, 1, 3],
+                [{1: 2, 3: 4}, 2, 3],
+            )
 
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND pk CONTAINS 4 ALLOW FILTERING"),
-                                    [{1: 2, 3: 4}, 1, 3],
-                                    [{1: 2, 3: 4}, 2, 3])
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND pk CONTAINS 4 ALLOW FILTERING",
+                ),
+                [{1: 2, 3: 4}, 1, 3],
+                [{1: 2, 3: 4}, 2, 3],
+            )
 
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND pk CONTAINS KEY 3 ALLOW FILTERING"),
-                                    [{1: 2, 3: 4}, 1, 3],
-                                    [{1: 2, 3: 4}, 2, 3])
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND pk CONTAINS KEY 3 ALLOW FILTERING",
+                ),
+                [{1: 2, 3: 4}, 1, 3],
+                [{1: 2, 3: 4}, 2, 3],
+            )
 
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND v = 3 ALLOW FILTERING"),
-                                    [{1: 2, 3: 4}, 1, 3],
-                                    [{1: 2, 3: 4}, 2, 3])
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND v = 3 ALLOW FILTERING",
+                ),
+                [{1: 2, 3: 4}, 1, 3],
+                [{1: 2, 3: 4}, 2, 3],
+            )
 
-            assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND ck = 1 AND v = 3 ALLOW FILTERING"),
-                                    [{1: 2, 3: 4}, 1, 3])
+            assert_rows_ignoring_order(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk CONTAINS KEY 1 AND ck = 1 AND v = 3 ALLOW FILTERING",
+                ),
+                [{1: 2, 3: 4}, 1, 3],
+            )
 
 
 def testContainsOnPartitionKey(cql, test_keyspace):
-    dotestContainsOnPartitionKey(cql, test_keyspace, "(pk frozen<map<int, int>>, ck int, v int, PRIMARY KEY (pk, ck))")
+    dotestContainsOnPartitionKey(
+        cql,
+        test_keyspace,
+        "(pk frozen<map<int, int>>, ck int, v int, PRIMARY KEY (pk, ck))",
+    )
+
 
 def testContainsOnPartitionKeyPart(cql, test_keyspace):
-    dotestContainsOnPartitionKey(cql, test_keyspace, "(pk frozen<map<int, int>>, ck int, v int, PRIMARY KEY ((pk, ck)))")
+    dotestContainsOnPartitionKey(
+        cql,
+        test_keyspace,
+        "(pk frozen<map<int, int>>, ck int, v int, PRIMARY KEY ((pk, ck)))",
+    )
 
-@pytest.mark.xfail(reason="#10443")
+
+@pytest.mark.xfail(
+    reason="SELECT with IN and ORDER BY orders rows per partition instead of for the entire response #10443"
+)
 def testFilteringWithOrderClause(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d list<int>, PRIMARY KEY (a, b, c))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, 13, [1,4])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 22, 23, [2,4])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 25, 26, [2,7])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 31, 32, 33, [3,4])
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d list<int>, PRIMARY KEY (a, b, c))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            11,
+            12,
+            13,
+            [1, 4],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            23,
+            [2, 4],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            25,
+            26,
+            [2, 7],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            31,
+            32,
+            33,
+            [3, 4],
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d FROM %s WHERE a = 21 AND c > 20 ORDER BY b DESC"),
-                       [21, 25, 26, [2, 7]],
-                       [21, 22, 23, [2, 4]])
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d FROM %s WHERE a = 21 AND c > 20 ORDER BY b DESC",
+                ),
+                [21, 25, 26, [2, 7]],
+                [21, 22, 23, [2, 4]],
+            )
 
             # reproduces #10443
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d FROM %s WHERE a IN(21, 31) AND c > 20 ORDER BY b DESC"),
-                       [31, 32, 33, [3, 4]],
-                       [21, 25, 26, [2, 7]],
-                       [21, 22, 23, [2, 4]])
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d FROM %s WHERE a IN(21, 31) AND c > 20 ORDER BY b DESC",
+                ),
+                [31, 32, 33, [3, 4]],
+                [21, 25, 26, [2, 7]],
+                [21, 22, 23, [2, 4]],
+            )
+
 
 def testfilteringOnStaticColumnTest(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d int, s int static, PRIMARY KEY (a, b))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (11, 12, 13, 14, 15)")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (21, 22, 23, 24, 25)")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (21, 26, 27, 28, 29)")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (31, 32, 33, 34, 35)")
-        execute(cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (11, 42, 43, 44, 45)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b int, c int, d int, s int static, PRIMARY KEY (a, b))",
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (11, 12, 13, 14, 15)"
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (21, 22, 23, 24, 25)"
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (21, 26, 27, 28, 29)"
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (31, 32, 33, 34, 35)"
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a, b, c, d, s) VALUES (11, 42, 43, 44, 45)"
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d, s FROM %s WHERE s = 29"),
-                       [21, 22, 23, 24, 29],
-                       [21, 26, 27, 28, 29])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d, s FROM %s WHERE b > 22 AND s = 29"),
-                       [21, 26, 27, 28, 29])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d, s FROM %s WHERE b > 10 and b < 26 AND s = 29"),
-                       [21, 22, 23, 24, 29])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d, s FROM %s WHERE c > 10 and c < 27 AND s = 29"),
-                       [21, 22, 23, 24, 29])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d, s FROM %s WHERE c > 10 and c < 43 AND s = 29"),
-                       [21, 22, 23, 24, 29],
-                       [21, 26, 27, 28, 29])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d, s FROM %s WHERE c > 10 AND s > 15 AND s < 45"),
-                       [21, 22, 23, 24, 29],
-                       [21, 26, 27, 28, 29],
-                       [31, 32, 33, 34, 35])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d, s FROM %s WHERE a = 21 AND s > 15 AND s < 45 ORDER BY b DESC"),
-                       [21, 26, 27, 28, 29],
-                       [21, 22, 23, 24, 29])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d, s FROM %s WHERE c > 13 and d < 44"),
-                       [21, 22, 23, 24, 29],
-                       [21, 26, 27, 28, 29],
-                       [31, 32, 33, 34, 35])
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT a, b, c, d, s FROM %s WHERE s = 29"
+                ),
+                [21, 22, 23, 24, 29],
+                [21, 26, 27, 28, 29],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT a, b, c, d, s FROM %s WHERE b > 22 AND s = 29"
+                ),
+                [21, 26, 27, 28, 29],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d, s FROM %s WHERE b > 10 and b < 26 AND s = 29",
+                ),
+                [21, 22, 23, 24, 29],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d, s FROM %s WHERE c > 10 and c < 27 AND s = 29",
+                ),
+                [21, 22, 23, 24, 29],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d, s FROM %s WHERE c > 10 and c < 43 AND s = 29",
+                ),
+                [21, 22, 23, 24, 29],
+                [21, 26, 27, 28, 29],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d, s FROM %s WHERE c > 10 AND s > 15 AND s < 45",
+                ),
+                [21, 22, 23, 24, 29],
+                [21, 26, 27, 28, 29],
+                [31, 32, 33, 34, 35],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d, s FROM %s WHERE a = 21 AND s > 15 AND s < 45 ORDER BY b DESC",
+                ),
+                [21, 26, 27, 28, 29],
+                [21, 22, 23, 24, 29],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT a, b, c, d, s FROM %s WHERE c > 13 and d < 44"
+                ),
+                [21, 22, 23, 24, 29],
+                [21, 26, 27, 28, 29],
+                [31, 32, 33, 34, 35],
+            )
+
 
 def testcontainsFilteringOnNonClusteringColumn(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, d list<int>, PRIMARY KEY (a, b, c))") as table:
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, 13, [1,4])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 22, 23, [2,4])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 21, 25, 26, [2,7])
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 31, 32, 33, [3,4])
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, d list<int>, PRIMARY KEY (a, b, c))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            11,
+            12,
+            13,
+            [1, 4],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            22,
+            23,
+            [2, 4],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            21,
+            25,
+            26,
+            [2, 7],
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            31,
+            32,
+            33,
+            [3, 4],
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d FROM %s WHERE b > 20 AND d CONTAINS 2"),
-                       [21, 22, 23, [2, 4]],
-                       [21, 25, 26, [2, 7]])
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d FROM %s WHERE b > 20 AND d CONTAINS 2",
+                ),
+                [21, 22, 23, [2, 4]],
+                [21, 25, 26, [2, 7]],
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT a, b, c, d FROM %s WHERE b > 20 AND d CONTAINS 2 AND d contains 4"),
-                       [21, 22, 23, [2, 4]])
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT a, b, c, d FROM %s WHERE b > 20 AND d CONTAINS 2 AND d contains 4",
+                ),
+                [21, 22, 23, [2, 4]],
+            )
+
 
 # Test for CASSANDRA-11310 compatibility with 2i
 def testCustomIndexWithFiltering(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a text, b int, c text, d int, PRIMARY KEY (a, b, c))") as table:
+    with create_table(
+        cql, test_keyspace, "(a text, b int, c text, d int, PRIMARY KEY (a, b, c))"
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s(c)")
 
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", "a", 0, "b", 1)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", "a", 1, "b", 2)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", "a", 2, "b", 3)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", "c", 3, "b", 4)
-        execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", "d", 4, "d", 5)
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            "a",
+            0,
+            "b",
+            1,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            "a",
+            1,
+            "b",
+            2,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            "a",
+            2,
+            "b",
+            3,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            "c",
+            3,
+            "b",
+            4,
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)",
+            "d",
+            4,
+            "d",
+            5,
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a='a' AND b > 0 AND c = 'b'"),
-                       ["a", 1, "b", 2],
-                       ["a", 2, "b", 3])
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE a='a' AND b > 0 AND c = 'b'"
+                ),
+                ["a", 1, "b", 2],
+                ["a", 2, "b", 3],
+            )
 
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c = 'b' AND d = 4"),
-                       ["c", 3, "b", 4])
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE c = 'b' AND d = 4"
+                ),
+                ["c", 3, "b", 4],
+            )
+
 
 def testFilteringWithCounters(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY (a, b, c))") as table:
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 14, 11, 12, 13)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 24, 21, 22, 23)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 27, 21, 25, 26)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 34, 31, 32, 33)
-        execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 24, 41, 42, 43)
+    with create_table(
+        cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY (a, b, c))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            14,
+            11,
+            12,
+            13,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            24,
+            21,
+            22,
+            23,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            27,
+            21,
+            25,
+            26,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            34,
+            31,
+            32,
+            33,
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?",
+            24,
+            41,
+            42,
+            43,
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt = 24"),
-                       [21, 22, 23, 24],
-                       [41, 42, 43, 24])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 22 AND cnt = 24"),
-                       [41, 42, 43, 24])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 10 AND b < 25 AND cnt = 24"),
-                       [21, 22, 23, 24])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 10 AND c < 25 AND cnt = 24"),
-                       [21, 22, 23, 24])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE a = 21 AND b > 10 AND cnt > 23 ORDER BY b DESC"),
-                       [21, 25, 26, 27],
-                       [21, 22, 23, 24])
-            assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt > 20 AND cnt < 30"),
-                       [21, 22, 23, 24],
-                       [21, 25, 26, 27],
-                       [41, 42, 43, 24])
+            assert_rows(
+                executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE cnt = 24"),
+                [21, 22, 23, 24],
+                [41, 42, 43, 24],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 22 AND cnt = 24"
+                ),
+                [41, 42, 43, 24],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 10 AND b < 25 AND cnt = 24"
+                ),
+                [21, 22, 23, 24],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE b > 10 AND c < 25 AND cnt = 24"
+                ),
+                [21, 22, 23, 24],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE a = 21 AND b > 10 AND cnt > 23 ORDER BY b DESC",
+                ),
+                [21, 25, 26, 27],
+                [21, 22, 23, 24],
+            )
+            assert_rows(
+                executeFilteringOnly(
+                    cql, table, "SELECT * FROM %s WHERE cnt > 20 AND cnt < 30"
+                ),
+                [21, 22, 23, 24],
+                [21, 25, 26, 27],
+                [41, 42, 43, 24],
+            )
+
 
 # Check select with ith different column order. See CASSANDRA-10988
 def testClusteringOrderWithSlice(cql, test_keyspace):
     # non-compound, ASC order
-    with create_table(cql, test_keyspace, "(a text, b int, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b ASC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b ASC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES ('a', 2)")
         execute(cql, table, "INSERT INTO %s (a, b) VALUES ('a', 3)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
-                   ["a", 2],
-                   ["a", 3])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
+            ["a", 2],
+            ["a", 3],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b DESC"),
-                   ["a", 3],
-                   ["a", 2])
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b DESC"
+            ),
+            ["a", 3],
+            ["a", 2],
+        )
 
     # non-compound, DESC order
-    with create_table(cql, test_keyspace, "(a text, b int, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES ('a', 2)")
         execute(cql, table, "INSERT INTO %s (a, b) VALUES ('a', 3)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
-                   ["a", 3],
-                   ["a", 2])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
+            ["a", 3],
+            ["a", 2],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"),
-                   ["a", 2],
-                   ["a", 3])
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"
+            ),
+            ["a", 2],
+            ["a", 3],
+        )
 
     # compound, first column DESC order
-    with create_table(cql, test_keyspace, "(a text, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b DESC, c ASC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('a', 2, 4)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('a', 3, 5)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
-                   ["a", 3, 5],
-                   ["a", 2, 4])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
+            ["a", 3, 5],
+            ["a", 2, 4],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"),
-                   ["a", 2, 4],
-                   ["a", 3, 5])
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"
+            ),
+            ["a", 2, 4],
+            ["a", 3, 5],
+        )
 
     # compound, mixed order
-    with create_table(cql, test_keyspace, "(a text, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b ASC, c DESC)") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a text, b int, c int, PRIMARY KEY (a, b, c)) WITH CLUSTERING ORDER BY (b ASC, c DESC)",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('a', 2, 4)")
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('a', 3, 5)")
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
-                   ["a", 2, 4],
-                   ["a", 3, 5])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0"),
+            ["a", 2, 4],
+            ["a", 3, 5],
+        )
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"),
-                   ["a", 2, 4],
-                   ["a", 3, 5])
+        assert_rows(
+            execute(
+                cql, table, "SELECT * FROM %s WHERE a = 'a' AND b > 0 ORDER BY b ASC"
+            ),
+            ["a", 2, 4],
+            ["a", 3, 5],
+        )
+
 
 def testFilteringWithSecondaryIndex(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk int, c1 int, c2 int, c3 int, v int, PRIMARY KEY (pk, c1, c2, c3))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk int, c1 int, c2 int, c3 int, v int, PRIMARY KEY (pk, c1, c2, c3))",
+    ) as table:
         execute(cql, table, "CREATE INDEX v_idx_1 ON %s (v);")
-        for i in range(1, 5+1):
-            execute(cql, table, "INSERT INTO %s (pk, c1, c2, c3, v) VALUES (?, ?, ?, ?, ?)", 1, 1, 1, 1, i)
-            execute(cql, table, "INSERT INTO %s (pk, c1, c2, c3, v) VALUES (?, ?, ?, ?, ?)", 1, 1, 1, i, i)
-            execute(cql, table, "INSERT INTO %s (pk, c1, c2, c3, v) VALUES (?, ?, ?, ?, ?)", 1, 1, i, i, i)
-            execute(cql, table, "INSERT INTO %s (pk, c1, c2, c3, v) VALUES (?, ?, ?, ?, ?)", 1, i, i, i, i)
+        for i in range(1, 5 + 1):
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c1, c2, c3, v) VALUES (?, ?, ?, ?, ?)",
+                1,
+                1,
+                1,
+                1,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c1, c2, c3, v) VALUES (?, ?, ?, ?, ?)",
+                1,
+                1,
+                1,
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c1, c2, c3, v) VALUES (?, ?, ?, ?, ?)",
+                1,
+                1,
+                i,
+                i,
+                i,
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c1, c2, c3, v) VALUES (?, ?, ?, ?, ?)",
+                1,
+                i,
+                i,
+                i,
+                i,
+            )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND  c1 > 0 AND c1 < 5 AND c2 = 1 AND v = 3 ALLOW FILTERING;"),
-                       [1, 1, 1, 3, 3])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = 1 AND  c1 > 0 AND c1 < 5 AND c2 = 1 AND v = 3 ALLOW FILTERING;",
+                ),
+                [1, 1, 1, 3, 3],
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND  c1 > 1 AND c1 < 5 AND c2 = 1 AND v = 3 ALLOW FILTERING;"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = 1 AND  c1 > 1 AND c1 < 5 AND c2 = 1 AND v = 3 ALLOW FILTERING;",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND  c1 > 1 AND c2 > 2 AND c3 > 2 AND v = 3 ALLOW FILTERING;"),
-                       [1, 3, 3, 3, 3])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = 1 AND  c1 > 1 AND c2 > 2 AND c3 > 2 AND v = 3 ALLOW FILTERING;",
+                ),
+                [1, 3, 3, 3, 3],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND  c1 > 1 AND c2 > 2 AND c3 = 3 AND v = 3 ALLOW FILTERING;"),
-                       [1, 3, 3, 3, 3])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = 1 AND  c1 > 1 AND c2 > 2 AND c3 = 3 AND v = 3 ALLOW FILTERING;",
+                ),
+                [1, 3, 3, 3, 3],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND  c1 IN(0,1,2) AND c2 > 1 AND c2 < 1 AND v = 3 ALLOW FILTERING;"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = 1 AND  c1 IN(0,1,2) AND c2 > 1 AND c2 < 1 AND v = 3 ALLOW FILTERING;",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND  c1 IN(0,1,2) AND c2 = 1 AND v = 3 ALLOW FILTERING;"),
-                       [1, 1, 1, 3, 3])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = 1 AND  c1 IN(0,1,2) AND c2 = 1 AND v = 3 ALLOW FILTERING;",
+                ),
+                [1, 1, 1, 3, 3],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = 1 AND  c1 IN(0,1,2) AND c2 = 1 AND v = 3"),
-                       [1, 1, 1, 3, 3])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = 1 AND  c1 IN(0,1,2) AND c2 = 1 AND v = 3",
+                ),
+                [1, 1, 1, 3, 3],
+            )
+
 
 def testIndexQueryWithCompositePartitionKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(p1 int, p2 int, v int, PRIMARY KEY ((p1, p2)))") as table:
-        assert_invalid_message(cql, table, REQUIRES_ALLOW_FILTERING_MESSAGE,
-                             "SELECT * FROM %s WHERE p1 = 1 AND v = 3")
+    with create_table(
+        cql, test_keyspace, "(p1 int, p2 int, v int, PRIMARY KEY ((p1, p2)))"
+    ) as table:
+        assert_invalid_message(
+            cql,
+            table,
+            REQUIRES_ALLOW_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE p1 = 1 AND v = 3",
+        )
         execute(cql, table, "CREATE INDEX ON %s(v)")
 
         execute(cql, table, "INSERT INTO %s(p1, p2, v) values (?, ?, ?)", 1, 1, 3)
@@ -2090,307 +4879,832 @@ def testIndexQueryWithCompositePartitionKey(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s(p1, p2, v) values (?, ?, ?)", 2, 1, 3)
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE p1 = 1 AND v = 3 ALLOW FILTERING"),
-                       [1, 2, 3],
-                       [1, 1, 3])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE p1 = 1 AND v = 3 ALLOW FILTERING",
+                ),
+                [1, 2, 3],
+                [1, 1, 3],
+            )
+
 
 def testEmptyRestrictionValue(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))") as table:
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123", b"2", b"2")
+    with create_table(
+        cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))"
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"2",
+            b"2",
+        )
 
         for _ in before_and_after_flush(cql, table):
             # Cassandra does not allow looking for an empty-string partition
             # key. Scylla considers this a bug, because such partition keys are
             # allowed in views. See full explanation in test_materialized_view.py
             # test_mv_empty_string_partition_key_individual
-            #assert_invalid_message(cql, table, "Key may not be empty", "SELECT * FROM %s WHERE pk = textAsBlob('');")
-            #assert_invalid_message(cql, table, "Key may not be empty", "SELECT * FROM %s WHERE pk IN (textAsBlob(''), textAsBlob('1'));")
+            # assert_invalid_message(cql, table, "Key may not be empty", "SELECT * FROM %s WHERE pk = textAsBlob('');")
+            # assert_invalid_message(cql, table, "Key may not be empty", "SELECT * FROM %s WHERE pk IN (textAsBlob(''), textAsBlob('1'));")
 
-            #assert_invalid_message(cql, table, "Key may not be empty",
+            # assert_invalid_message(cql, table, "Key may not be empty",
             #                     "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
             #                     b"", b"2", b"2")
 
             # Test clustering columns restrictions
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) = (textAsBlob(''));"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) = (textAsBlob(''));",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));"),
-                       [b"foo123", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));",
+                ),
+                [b"foo123", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) IN ((textAsBlob('')), (textAsBlob('1')));"),
-                       [b"foo123", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) IN ((textAsBlob('')), (textAsBlob('1')));",
+                ),
+                [b"foo123", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('');"),
-                       [b"foo123", b"1", b"1"],
-                       [b"foo123", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('');",
+                ),
+                [b"foo123", b"1", b"1"],
+                [b"foo123", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) > (textAsBlob(''));"),
-                       [b"foo123", b"1", b"1"],
-                       [b"foo123", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) > (textAsBlob(''));",
+                ),
+                [b"foo123", b"1", b"1"],
+                [b"foo123", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('');"),
-                       [b"foo123", b"1", b"1"],
-                       [b"foo123", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('');",
+                ),
+                [b"foo123", b"1", b"1"],
+                [b"foo123", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) >= (textAsBlob(''));"),
-                       [b"foo123", b"1", b"1"],
-                       [b"foo123", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) >= (textAsBlob(''));",
+                ),
+                [b"foo123", b"1", b"1"],
+                [b"foo123", b"2", b"2"],
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('');",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) <= (textAsBlob(''));"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) <= (textAsBlob(''));",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('');",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) < (textAsBlob(''));"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) < (textAsBlob(''));",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('') AND c < textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('') AND c < textAsBlob('');",
+                )
+            )
 
-
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123", b"", b"4")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"",
+            b"4",
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');"),
-                       [b"foo123", b"", b"4"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c = textAsBlob('');",
+                ),
+                [b"foo123", b"", b"4"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) = (textAsBlob(''));"),
-                       [b"foo123", b"", b"4"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) = (textAsBlob(''));",
+                ),
+                [b"foo123", b"", b"4"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));"),
-                       [b"foo123", b"", b"4"],
-                       [b"foo123", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'));",
+                ),
+                [b"foo123", b"", b"4"],
+                [b"foo123", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) IN ((textAsBlob('')), (textAsBlob('1')));"),
-                       [b"foo123", b"", b"4"],
-                       [b"foo123", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) IN ((textAsBlob('')), (textAsBlob('1')));",
+                ),
+                [b"foo123", b"", b"4"],
+                [b"foo123", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('');"),
-                       [b"foo123", b"1", b"1"],
-                       [b"foo123", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('');",
+                ),
+                [b"foo123", b"1", b"1"],
+                [b"foo123", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) > (textAsBlob(''));"),
-                       [b"foo123", b"1", b"1"],
-                       [b"foo123", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) > (textAsBlob(''));",
+                ),
+                [b"foo123", b"1", b"1"],
+                [b"foo123", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('');"),
-                       [b"foo123", b"", b"4"],
-                       [b"foo123", b"1", b"1"],
-                       [b"foo123", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('');",
+                ),
+                [b"foo123", b"", b"4"],
+                [b"foo123", b"1", b"1"],
+                [b"foo123", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) >= (textAsBlob(''));"),
-                       [b"foo123", b"", b"4"],
-                       [b"foo123", b"1", b"1"],
-                       [b"foo123", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) >= (textAsBlob(''));",
+                ),
+                [b"foo123", b"", b"4"],
+                [b"foo123", b"1", b"1"],
+                [b"foo123", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('');"),
-                       [b"foo123", b"", b"4"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('');",
+                ),
+                [b"foo123", b"", b"4"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) <= (textAsBlob(''));"),
-                       [b"foo123", b"", b"4"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) <= (textAsBlob(''));",
+                ),
+                [b"foo123", b"", b"4"],
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('');",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) < (textAsBlob(''));"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c) < (textAsBlob(''));",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('') AND c < textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('') AND c < textAsBlob('');",
+                )
+            )
 
         # Test restrictions on non-primary key value
-        assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;"))
+        assert_empty(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;",
+            )
+        )
 
-        execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                b"foo123", b"3", b"")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+            b"foo123",
+            b"3",
+            b"",
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;"),
-                       [b"foo123", b"3", b""])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;",
+                ),
+                [b"foo123", b"3", b""],
+            )
+
 
 def testEmptyRestrictionValueWithMultipleClusteringColumns(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2))") as table:
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"2", b"2")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"1",
+            b"1",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"1",
+            b"2",
+            b"2",
+        )
 
         for _ in before_and_after_flush(cql, table):
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 = textAsBlob('');",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 = textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) = (textAsBlob('1'), textAsBlob(''));",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) = (textAsBlob('1'), textAsBlob(''));"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');",
+                ),
+                [b"foo123", b"1", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');"),
-                       [b"foo123", b"1", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 IN (textAsBlob(''), textAsBlob('1'));",
+                ),
+                [b"foo123", b"1", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 IN (textAsBlob(''), textAsBlob('1'));"),
-                       [b"foo123", b"1", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')));",
+                ),
+                [b"foo123", b"1", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')));"),
-                       [b"foo123", b"1", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('');",
+                ),
+                [b"foo123", b"1", b"1", b"1"],
+                [b"foo123", b"1", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('');"),
-                       [b"foo123", b"1", b"1", b"1"],
-                       [b"foo123", b"1", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 > textAsBlob('');",
+                ),
+                [b"foo123", b"1", b"1", b"1"],
+                [b"foo123", b"1", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 > textAsBlob('');"),
-                       [b"foo123", b"1", b"1", b"1"],
-                       [b"foo123", b"1", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'));",
+                ),
+                [b"foo123", b"1", b"1", b"1"],
+                [b"foo123", b"1", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'));"),
-                       [b"foo123", b"1", b"1", b"1"],
-                       [b"foo123", b"1", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 >= textAsBlob('');",
+                ),
+                [b"foo123", b"1", b"1", b"1"],
+                [b"foo123", b"1", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 >= textAsBlob('');"),
-                       [b"foo123", b"1", b"1", b"1"],
-                       [b"foo123", b"1", b"2", b"2"])
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 <= textAsBlob('');",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 <= textAsBlob('');"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) <= (textAsBlob('1'), textAsBlob(''));",
+                )
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) <= (textAsBlob('1'), textAsBlob(''));"))
-
-        execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
-                b"foo123", b"", b"1", b"4")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+            b"foo123",
+            b"",
+            b"1",
+            b"4",
+        )
 
         for _ in before_and_after_flush(cql, table):
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');"),
-                       [b"foo123", b"", b"1", b"4"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('');",
+                ),
+                [b"foo123", b"", b"1", b"4"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('') AND c2 = textAsBlob('1');"),
-                       [b"foo123", b"", b"1", b"4"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('') AND c2 = textAsBlob('1');",
+                ),
+                [b"foo123", b"", b"1", b"4"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) = (textAsBlob(''), textAsBlob('1'));"),
-                       [b"foo123", b"", b"1", b"4"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) = (textAsBlob(''), textAsBlob('1'));",
+                ),
+                [b"foo123", b"", b"1", b"4"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');"),
-                       [b"foo123", b"", b"1", b"4"],
-                       [b"foo123", b"1", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1');",
+                ),
+                [b"foo123", b"", b"1", b"4"],
+                [b"foo123", b"1", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')));"),
-                       [b"foo123", b"", b"1", b"4"],
-                       [b"foo123", b"1", b"1", b"1"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')));",
+                ),
+                [b"foo123", b"", b"1", b"4"],
+                [b"foo123", b"1", b"1", b"1"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'));"),
-                       [b"foo123", b"1", b"1", b"1"],
-                       [b"foo123", b"1", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'));",
+                ),
+                [b"foo123", b"1", b"1", b"1"],
+                [b"foo123", b"1", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) >= (textAsBlob(''), textAsBlob('1'));"),
-                       [b"foo123", b"", b"1", b"4"],
-                       [b"foo123", b"1", b"1", b"1"],
-                       [b"foo123", b"1", b"2", b"2"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) >= (textAsBlob(''), textAsBlob('1'));",
+                ),
+                [b"foo123", b"", b"1", b"4"],
+                [b"foo123", b"1", b"1", b"1"],
+                [b"foo123", b"1", b"2", b"2"],
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) <= (textAsBlob(''), textAsBlob('1'));"),
-                       [b"foo123", b"", b"1", b"4"])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) <= (textAsBlob(''), textAsBlob('1'));",
+                ),
+                [b"foo123", b"", b"1", b"4"],
+            )
 
-            assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) < (textAsBlob(''), textAsBlob('1'));"))
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) < (textAsBlob(''), textAsBlob('1'));",
+                )
+            )
+
 
 def testEmptyRestrictionValueWithOrderBy(cql, test_keyspace):
-    for options in ["", " WITH CLUSTERING ORDER BY (c DESC)" ]:
+    for options in ["", " WITH CLUSTERING ORDER BY (c DESC)"]:
         orderingClause = ""
         if not "ORDER" in options:
             orderingClause = "ORDER BY c DESC"
-        with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))" + options) as table:
-            execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                    b"foo123",
-                    b"1",
-                    b"1")
-            execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                    b"foo123",
-                    b"2",
-                    b"2")
+        with create_table(
+            cql,
+            test_keyspace,
+            "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))" + options,
+        ) as table:
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+                b"foo123",
+                b"1",
+                b"1",
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+                b"foo123",
+                b"2",
+                b"2",
+            )
 
             for _ in before_and_after_flush(cql, table):
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')" + orderingClause),
-                           [b"foo123", b"2", b"2"],
-                           [b"foo123", b"1", b"1"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"2", b"2"],
+                    [b"foo123", b"1", b"1"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('')" + orderingClause),
-                           [b"foo123", b"2", b"2"],
-                           [b"foo123", b"1", b"1"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"2", b"2"],
+                    [b"foo123", b"1", b"1"],
+                )
 
-                assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('')" + orderingClause))
+                assert_empty(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('')"
+                        + orderingClause,
+                    )
+                )
 
-                assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('')" + orderingClause))
+                assert_empty(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('')"
+                        + orderingClause,
+                    )
+                )
 
-            execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
-                    b"foo123", b"", b"4")
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
+                b"foo123",
+                b"",
+                b"4",
+            )
 
             for _ in before_and_after_flush(cql, table):
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'))" + orderingClause),
-                           [b"foo123", b"1", b"1"],
-                           [b"foo123", b"", b"4"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c IN (textAsBlob(''), textAsBlob('1'))"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"1"],
+                    [b"foo123", b"", b"4"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')" + orderingClause),
-                           [b"foo123", b"2", b"2"],
-                           [b"foo123", b"1", b"1"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c > textAsBlob('')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"2", b"2"],
+                    [b"foo123", b"1", b"1"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('')" + orderingClause),
-                           [b"foo123", b"2", b"2"],
-                           [b"foo123", b"1", b"1"],
-                           [b"foo123", b"", b"4"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c >= textAsBlob('')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"2", b"2"],
+                    [b"foo123", b"1", b"1"],
+                    [b"foo123", b"", b"4"],
+                )
 
-                assert_empty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('')" + orderingClause))
+                assert_empty(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c < textAsBlob('')"
+                        + orderingClause,
+                    )
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('')" + orderingClause),
-                           [b"foo123", b"", b"4"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c <= textAsBlob('')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"", b"4"],
+                )
 
-def testEmptyRestrictionValueWithMultipleClusteringColumnsAndOrderBy(cql, test_keyspace):
-    for options in ["", " WITH CLUSTERING ORDER BY (c1 DESC, c2 DESC)" ]:
+
+def testEmptyRestrictionValueWithMultipleClusteringColumnsAndOrderBy(
+    cql, test_keyspace
+):
+    for options in ["", " WITH CLUSTERING ORDER BY (c1 DESC, c2 DESC)"]:
         orderingClause = ""
         if not "ORDER" in options:
             orderingClause = "ORDER BY c1 DESC, c2 DESC"
-        with create_table(cql, test_keyspace, "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2))" + options) as table:
-            execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
-            execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"2", b"2")
+        with create_table(
+            cql,
+            test_keyspace,
+            "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2))" + options,
+        ) as table:
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+                b"foo123",
+                b"1",
+                b"1",
+                b"1",
+            )
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+                b"foo123",
+                b"1",
+                b"2",
+                b"2",
+            )
 
             for _ in before_and_after_flush(cql, table):
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"2", b"2"],
+                    [b"foo123", b"1", b"1", b"1"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 > textAsBlob('')" + orderingClause),
-                           [b"foo123", b"1", b"2", b"2"],
-                           [b"foo123", b"1", b"1", b"1"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 > textAsBlob('')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"2", b"2"],
+                    [b"foo123", b"1", b"1", b"1"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 > textAsBlob('')" + orderingClause),
-                           [b"foo123", b"1", b"2", b"2"],
-                           [b"foo123", b"1", b"1", b"1"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'))"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"2", b"2"],
+                    [b"foo123", b"1", b"1", b"1"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'))" + orderingClause),
-                           [b"foo123", b"1", b"2", b"2"],
-                           [b"foo123", b"1", b"1", b"1"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 >= textAsBlob('')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"2", b"2"],
+                    [b"foo123", b"1", b"1", b"1"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 = textAsBlob('1') AND c2 >= textAsBlob('')" + orderingClause),
-                           [b"foo123", b"1", b"2", b"2"],
-                           [b"foo123", b"1", b"1", b"1"])
-
-            execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
-                    b"foo123", b"", b"1", b"4")
+            execute(
+                cql,
+                table,
+                "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)",
+                b"foo123",
+                b"",
+                b"1",
+                b"4",
+            )
 
             for _ in before_and_after_flush(cql, table):
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1')"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"1", b"1"],
+                    [b"foo123", b"", b"1", b"4"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND c1 IN (textAsBlob(''), textAsBlob('1')) AND c2 = textAsBlob('1')" + orderingClause),
-                           [b"foo123", b"1", b"1", b"1"],
-                           [b"foo123", b"", b"1", b"4"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')))"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"1", b"1"],
+                    [b"foo123", b"", b"1", b"4"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) IN ((textAsBlob(''), textAsBlob('1')), (textAsBlob('1'), textAsBlob('1')))" + orderingClause),
-                           [b"foo123", b"1", b"1", b"1"],
-                           [b"foo123", b"", b"1", b"4"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'))"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"2", b"2"],
+                    [b"foo123", b"1", b"1", b"1"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) > (textAsBlob(''), textAsBlob('1'))" + orderingClause),
-                           [b"foo123", b"1", b"2", b"2"],
-                           [b"foo123", b"1", b"1", b"1"])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) >= (textAsBlob(''), textAsBlob('1'))"
+                        + orderingClause,
+                    ),
+                    [b"foo123", b"1", b"2", b"2"],
+                    [b"foo123", b"1", b"1", b"1"],
+                    [b"foo123", b"", b"1", b"4"],
+                )
 
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) >= (textAsBlob(''), textAsBlob('1'))" + orderingClause),
-                           [b"foo123", b"1", b"2", b"2"],
-                           [b"foo123", b"1", b"1", b"1"],
-                           [b"foo123", b"", b"1", b"4"])
 
 def testWithDistinctAndJsonAsColumnName(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(distinct int, json int, value int, PRIMARY KEY (distinct, json))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(distinct int, json int, value int, PRIMARY KEY (distinct, json))",
+    ) as table:
         execute(cql, table, "INSERT INTO %s (distinct, json, value) VALUES (0, 0, 0)")
 
         assert_rows(execute(cql, table, "SELECT distinct, json FROM %s"), [0, 0])
         assert_rows(execute(cql, table, "SELECT distinct distinct FROM %s"), [0])
+
 
 def testFilteringOnDurationColumn(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, d duration)") as table:
@@ -2398,286 +5712,599 @@ def testFilteringOnDurationColumn(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (k, d) VALUES (1, 2s)")
         execute(cql, table, "INSERT INTO %s (k, d) VALUES (2, 1s)")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE d=1s ALLOW FILTERING"),
-                   [0, Duration(0, 0, 1000000000)],
-                   [2, Duration(0, 0, 1000000000)])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE d=1s ALLOW FILTERING"),
+            [0, Duration(0, 0, 1000000000)],
+            [2, Duration(0, 0, 1000000000)],
+        )
 
         # Scylla does support this case - see
         #  test_filtering.py::test_filtering_with_in_relation
-        #assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (d) is not yet supported",
+        # assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (d) is not yet supported",
         #                     "SELECT * FROM %s WHERE d IN (1s, 2s) ALLOW FILTERING")
 
-        assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                             "SELECT * FROM %s WHERE d > 1s ALLOW FILTERING")
+        assert_invalid_message_re(
+            cql,
+            table,
+            ".*[dD]uration.*",
+            "SELECT * FROM %s WHERE d > 1s ALLOW FILTERING",
+        )
 
-        assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                             "SELECT * FROM %s WHERE d >= 1s ALLOW FILTERING")
+        assert_invalid_message_re(
+            cql,
+            table,
+            ".*[dD]uration.*",
+            "SELECT * FROM %s WHERE d >= 1s ALLOW FILTERING",
+        )
 
-        assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                             "SELECT * FROM %s WHERE d <= 1s ALLOW FILTERING")
+        assert_invalid_message_re(
+            cql,
+            table,
+            ".*[dD]uration.*",
+            "SELECT * FROM %s WHERE d <= 1s ALLOW FILTERING",
+        )
 
-        assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                             "SELECT * FROM %s WHERE d < 1s ALLOW FILTERING")
+        assert_invalid_message_re(
+            cql,
+            table,
+            ".*[dD]uration.*",
+            "SELECT * FROM %s WHERE d < 1s ALLOW FILTERING",
+        )
+
 
 def testFilteringOnListContainingDurations(cql, test_keyspace):
     for frozen in [False, True]:
         listType = "frozen<list<duration>>" if frozen else "list<duration>"
-        with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, l {listType})") as table:
+        with create_table(
+            cql, test_keyspace, f"(k int PRIMARY KEY, l {listType})"
+        ) as table:
             execute(cql, table, "INSERT INTO %s (k, l) VALUES (0, [1s, 2s])")
             execute(cql, table, "INSERT INTO %s (k, l) VALUES (1, [2s, 3s])")
             execute(cql, table, "INSERT INTO %s (k, l) VALUES (2, [1s, 3s])")
             if frozen:
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE l = [1s, 2s] ALLOW FILTERING"),
-                           [0, [Duration(0, 0, 1000000000), Duration(0, 0, 2000000000)]])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE l = [1s, 2s] ALLOW FILTERING",
+                    ),
+                    [0, [Duration(0, 0, 1000000000), Duration(0, 0, 2000000000)]],
+                )
 
             # Scylla does support this case - see
             #  test_filtering.py::test_filtering_with_in_relation
-            #assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (l) is not yet supported",
+            # assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (l) is not yet supported",
             #                     "SELECT * FROM %s WHERE l IN ([1s, 2s], [2s, 3s]) ALLOW FILTERING")
 
-            assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                                 "SELECT * FROM %s WHERE l > [2s, 3s] ALLOW FILTERING")
+            assert_invalid_message_re(
+                cql,
+                table,
+                ".*[dD]uration.*",
+                "SELECT * FROM %s WHERE l > [2s, 3s] ALLOW FILTERING",
+            )
 
-            assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                                 "SELECT * FROM %s WHERE l >= [2s, 3s] ALLOW FILTERING")
+            assert_invalid_message_re(
+                cql,
+                table,
+                ".*[dD]uration.*",
+                "SELECT * FROM %s WHERE l >= [2s, 3s] ALLOW FILTERING",
+            )
 
-            assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                                 "SELECT * FROM %s WHERE l <= [2s, 3s] ALLOW FILTERING")
+            assert_invalid_message_re(
+                cql,
+                table,
+                ".*[dD]uration.*",
+                "SELECT * FROM %s WHERE l <= [2s, 3s] ALLOW FILTERING",
+            )
 
-            assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                                 "SELECT * FROM %s WHERE l < [2s, 3s] ALLOW FILTERING")
+            assert_invalid_message_re(
+                cql,
+                table,
+                ".*[dD]uration.*",
+                "SELECT * FROM %s WHERE l < [2s, 3s] ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE l CONTAINS 1s ALLOW FILTERING"),
-                       [0, [Duration(0, 0, 1000000000), Duration(0, 0, 2000000000)]],
-                       [2, [Duration(0, 0, 1000000000), Duration(0, 0, 3000000000)]])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE l CONTAINS 1s ALLOW FILTERING"
+                ),
+                [0, [Duration(0, 0, 1000000000), Duration(0, 0, 2000000000)]],
+                [2, [Duration(0, 0, 1000000000), Duration(0, 0, 3000000000)]],
+            )
+
 
 def testFilteringOnMapContainingDurations(cql, test_keyspace):
     for frozen in [False, True]:
         mapType = "frozen<map<int, duration>>" if frozen else "map<int, duration>"
-        with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, m {mapType})") as table:
+        with create_table(
+            cql, test_keyspace, f"(k int PRIMARY KEY, m {mapType})"
+        ) as table:
             execute(cql, table, "INSERT INTO %s (k, m) VALUES (0, {1:1s, 2:2s})")
             execute(cql, table, "INSERT INTO %s (k, m) VALUES (1, {2:2s, 3:3s})")
             execute(cql, table, "INSERT INTO %s (k, m) VALUES (2, {1:1s, 3:3s})")
 
             if frozen:
-                assert_rows(execute(cql, table, "SELECT * FROM %s WHERE m = {1:1s, 2:2s} ALLOW FILTERING"),
-                           [0, {1: Duration(0, 0, 1000000000), 2: Duration(0, 0, 2000000000)}])
+                assert_rows(
+                    execute(
+                        cql,
+                        table,
+                        "SELECT * FROM %s WHERE m = {1:1s, 2:2s} ALLOW FILTERING",
+                    ),
+                    [0, {1: Duration(0, 0, 1000000000), 2: Duration(0, 0, 2000000000)}],
+                )
 
             # Scylla does support this case - see
             #  test_filtering.py::test_filtering_with_in_relation
-            #assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (m) is not yet supported",
+            # assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (m) is not yet supported",
             #        "SELECT * FROM %s WHERE m IN ({1:1s, 2:2s}, {1:1s, 3:3s}) ALLOW FILTERING")
 
-            assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                    "SELECT * FROM %s WHERE m > {1:1s, 3:3s} ALLOW FILTERING")
+            assert_invalid_message_re(
+                cql,
+                table,
+                ".*[dD]uration.*",
+                "SELECT * FROM %s WHERE m > {1:1s, 3:3s} ALLOW FILTERING",
+            )
 
-            assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                    "SELECT * FROM %s WHERE m >= {1:1s, 3:3s} ALLOW FILTERING")
+            assert_invalid_message_re(
+                cql,
+                table,
+                ".*[dD]uration.*",
+                "SELECT * FROM %s WHERE m >= {1:1s, 3:3s} ALLOW FILTERING",
+            )
 
-            assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                    "SELECT * FROM %s WHERE m <= {1:1s, 3:3s} ALLOW FILTERING")
+            assert_invalid_message_re(
+                cql,
+                table,
+                ".*[dD]uration.*",
+                "SELECT * FROM %s WHERE m <= {1:1s, 3:3s} ALLOW FILTERING",
+            )
 
-            assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                    "SELECT * FROM %s WHERE m < {1:1s, 3:3s} ALLOW FILTERING")
+            assert_invalid_message_re(
+                cql,
+                table,
+                ".*[dD]uration.*",
+                "SELECT * FROM %s WHERE m < {1:1s, 3:3s} ALLOW FILTERING",
+            )
 
-            assert_rows(execute(cql, table, "SELECT * FROM %s WHERE m CONTAINS 1s ALLOW FILTERING"),
-                       [0, {1: Duration(0, 0, 1000000000), 2: Duration(0, 0, 2000000000)}],
-                       [2, {1: Duration(0, 0, 1000000000), 3: Duration(0, 0, 3000000000)}])
+            assert_rows(
+                execute(
+                    cql, table, "SELECT * FROM %s WHERE m CONTAINS 1s ALLOW FILTERING"
+                ),
+                [0, {1: Duration(0, 0, 1000000000), 2: Duration(0, 0, 2000000000)}],
+                [2, {1: Duration(0, 0, 1000000000), 3: Duration(0, 0, 3000000000)}],
+            )
+
 
 def testFilteringOnTupleContainingDurations(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, t tuple<int, duration>)") as table:
+    with create_table(
+        cql, test_keyspace, f"(k int PRIMARY KEY, t tuple<int, duration>)"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, t) VALUES (0, (1, 2s))")
         execute(cql, table, "INSERT INTO %s (k, t) VALUES (1, (2, 3s))")
         execute(cql, table, "INSERT INTO %s (k, t) VALUES (2, (1, 3s))")
 
-        assert_rows(execute(cql, table, "SELECT * FROM %s WHERE t = (1, 2s) ALLOW FILTERING"),
-                   [0, (1, Duration(0, 0, 2000000000))])
+        assert_rows(
+            execute(cql, table, "SELECT * FROM %s WHERE t = (1, 2s) ALLOW FILTERING"),
+            [0, (1, Duration(0, 0, 2000000000))],
+        )
 
         # Scylla does support this case - see
         #  test_filtering.py::test_filtering_with_in_relation
-        #assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (t) is not yet supported",
+        # assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (t) is not yet supported",
         #        "SELECT * FROM %s WHERE t IN ((1, 2s), (1, 3s)) ALLOW FILTERING")
 
-        assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                "SELECT * FROM %s WHERE t > (1, 2s) ALLOW FILTERING")
+        assert_invalid_message_re(
+            cql,
+            table,
+            ".*[dD]uration.*",
+            "SELECT * FROM %s WHERE t > (1, 2s) ALLOW FILTERING",
+        )
 
-        assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                "SELECT * FROM %s WHERE t >= (1, 2s) ALLOW FILTERING")
+        assert_invalid_message_re(
+            cql,
+            table,
+            ".*[dD]uration.*",
+            "SELECT * FROM %s WHERE t >= (1, 2s) ALLOW FILTERING",
+        )
 
-        assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                "SELECT * FROM %s WHERE t <= (1, 2s) ALLOW FILTERING")
+        assert_invalid_message_re(
+            cql,
+            table,
+            ".*[dD]uration.*",
+            "SELECT * FROM %s WHERE t <= (1, 2s) ALLOW FILTERING",
+        )
 
-        assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                "SELECT * FROM %s WHERE t < (1, 2s) ALLOW FILTERING")
+        assert_invalid_message_re(
+            cql,
+            table,
+            ".*[dD]uration.*",
+            "SELECT * FROM %s WHERE t < (1, 2s) ALLOW FILTERING",
+        )
+
 
 def testFilteringOnUdtContainingDurations(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(i int, d duration)") as oudt:
         for frozen in [False, True]:
             udt = f"frozen<{oudt}>" if frozen else oudt
-            with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, u {udt})") as table:
+            with create_table(
+                cql, test_keyspace, f"(k int PRIMARY KEY, u {udt})"
+            ) as table:
                 execute(cql, table, "INSERT INTO %s (k, u) VALUES (0, {i: 1, d:2s})")
                 execute(cql, table, "INSERT INTO %s (k, u) VALUES (1, {i: 2, d:3s})")
                 execute(cql, table, "INSERT INTO %s (k, u) VALUES (2, {i: 1, d:3s})")
 
                 if frozen:
-                    assert_rows(execute(cql, table, "SELECT * FROM %s WHERE u = {i: 1, d:2s} ALLOW FILTERING"),
-                           [0, user_type("i", 1, "d", Duration(0, 0, 2000000000))])
+                    assert_rows(
+                        execute(
+                            cql,
+                            table,
+                            "SELECT * FROM %s WHERE u = {i: 1, d:2s} ALLOW FILTERING",
+                        ),
+                        [0, user_type("i", 1, "d", Duration(0, 0, 2000000000))],
+                    )
 
                 # Scylla does support this case - see
                 #  test_filtering.py::test_filtering_with_in_relation
-                #assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (u) is not yet supported",
+                # assert_invalid_message(cql, table, "IN predicates on non-primary-key columns (u) is not yet supported",
                 #    "SELECT * FROM %s WHERE u IN ({i: 2, d:3s}, {i: 1, d:3s}) ALLOW FILTERING")
 
-                assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                    "SELECT * FROM %s WHERE u > {i: 1, d:3s} ALLOW FILTERING")
+                assert_invalid_message_re(
+                    cql,
+                    table,
+                    ".*[dD]uration.*",
+                    "SELECT * FROM %s WHERE u > {i: 1, d:3s} ALLOW FILTERING",
+                )
 
-                assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                    "SELECT * FROM %s WHERE u >= {i: 1, d:3s} ALLOW FILTERING")
+                assert_invalid_message_re(
+                    cql,
+                    table,
+                    ".*[dD]uration.*",
+                    "SELECT * FROM %s WHERE u >= {i: 1, d:3s} ALLOW FILTERING",
+                )
 
-                assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                    "SELECT * FROM %s WHERE u <= {i: 1, d:3s} ALLOW FILTERING")
+                assert_invalid_message_re(
+                    cql,
+                    table,
+                    ".*[dD]uration.*",
+                    "SELECT * FROM %s WHERE u <= {i: 1, d:3s} ALLOW FILTERING",
+                )
 
-                assert_invalid_message_re(cql, table, ".*[dD]uration.*",
-                    "SELECT * FROM %s WHERE u < {i: 1, d:3s} ALLOW FILTERING")
+                assert_invalid_message_re(
+                    cql,
+                    table,
+                    ".*[dD]uration.*",
+                    "SELECT * FROM %s WHERE u < {i: 1, d:3s} ALLOW FILTERING",
+                )
+
 
 def testFilteringOnCollectionsWithNull(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k int, v int, l list<int>, s set<text>, m map<text, int>, PRIMARY KEY (k, v))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(k int, v int, l list<int>, s set<text>, m map<text, int>, PRIMARY KEY (k, v))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (v)")
         execute(cql, table, "CREATE INDEX ON %s (s)")
         execute(cql, table, "CREATE INDEX ON %s (m)")
 
-        execute(cql, table, "INSERT INTO %s (k, v, l, s, m) VALUES (0, 0, [1, 2],    {'a'},      {'a' : 1})")
-        execute(cql, table, "INSERT INTO %s (k, v, l, s, m) VALUES (0, 1, [3, 4],    {'b', 'c'}, {'a' : 1, 'b' : 2})")
-        execute(cql, table, "INSERT INTO %s (k, v, l, s, m) VALUES (0, 2, [1],       {'a', 'c'}, {'c' : 3})")
-        execute(cql, table, "INSERT INTO %s (k, v, l, s, m) VALUES (1, 0, [1, 2, 4], {},         {'b' : 1})")
-        execute(cql, table, "INSERT INTO %s (k, v, l, s, m) VALUES (1, 1, [4, 5],    {'d'},      {'a' : 1, 'b' : 3})")
-        execute(cql, table, "INSERT INTO %s (k, v, l, s, m) VALUES (1, 2, null,      null,       null)")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v, l, s, m) VALUES (0, 0, [1, 2],    {'a'},      {'a' : 1})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v, l, s, m) VALUES (0, 1, [3, 4],    {'b', 'c'}, {'a' : 1, 'b' : 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v, l, s, m) VALUES (0, 2, [1],       {'a', 'c'}, {'c' : 3})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v, l, s, m) VALUES (1, 0, [1, 2, 4], {},         {'b' : 1})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v, l, s, m) VALUES (1, 1, [4, 5],    {'d'},      {'a' : 1, 'b' : 3})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (k, v, l, s, m) VALUES (1, 2, null,      null,       null)",
+        )
 
         for _ in before_and_after_flush(cql, table):
             # lists
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE l CONTAINS 1 ALLOW FILTERING"), [1, 0], [0, 0], [0, 2])
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE k = 0 AND l CONTAINS 1 ALLOW FILTERING"), [0, 0], [0, 2])
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE l CONTAINS 2 ALLOW FILTERING"), [1, 0], [0, 0])
-            assert_empty(execute(cql, table, "SELECT k, v FROM %s WHERE l CONTAINS 6 ALLOW FILTERING"))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, v FROM %s WHERE l CONTAINS 1 ALLOW FILTERING"
+                ),
+                [1, 0],
+                [0, 0],
+                [0, 2],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s WHERE k = 0 AND l CONTAINS 1 ALLOW FILTERING",
+                ),
+                [0, 0],
+                [0, 2],
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, v FROM %s WHERE l CONTAINS 2 ALLOW FILTERING"
+                ),
+                [1, 0],
+                [0, 0],
+            )
+            assert_empty(
+                execute(
+                    cql, table, "SELECT k, v FROM %s WHERE l CONTAINS 6 ALLOW FILTERING"
+                )
+            )
 
             # sets
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE s CONTAINS 'a' ALLOW FILTERING" ), [0, 0], [0, 2])
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE k = 0 AND s CONTAINS 'a' ALLOW FILTERING"), [0, 0], [0, 2])
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE s CONTAINS 'd' ALLOW FILTERING"), [1, 1])
-            assert_empty(execute(cql, table, "SELECT k, v FROM %s  WHERE s CONTAINS 'e' ALLOW FILTERING"))
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s WHERE s CONTAINS 'a' ALLOW FILTERING",
+                ),
+                [0, 0],
+                [0, 2],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s WHERE k = 0 AND s CONTAINS 'a' ALLOW FILTERING",
+                ),
+                [0, 0],
+                [0, 2],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s WHERE s CONTAINS 'd' ALLOW FILTERING",
+                ),
+                [1, 1],
+            )
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s  WHERE s CONTAINS 'e' ALLOW FILTERING",
+                )
+            )
 
             # maps
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE m CONTAINS 1 ALLOW FILTERING"), [1, 0], [1, 1], [0, 0], [0, 1])
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS 1 ALLOW FILTERING"), [0, 0], [0, 1])
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE m CONTAINS 2 ALLOW FILTERING"), [0, 1])
-            assert_empty(execute(cql, table, "SELECT k, v FROM %s  WHERE m CONTAINS 4 ALLOW FILTERING"))
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, v FROM %s WHERE m CONTAINS 1 ALLOW FILTERING"
+                ),
+                [1, 0],
+                [1, 1],
+                [0, 0],
+                [0, 1],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS 1 ALLOW FILTERING",
+                ),
+                [0, 0],
+                [0, 1],
+            )
+            assert_rows(
+                execute(
+                    cql, table, "SELECT k, v FROM %s WHERE m CONTAINS 2 ALLOW FILTERING"
+                ),
+                [0, 1],
+            )
+            assert_empty(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s  WHERE m CONTAINS 4 ALLOW FILTERING",
+                )
+            )
 
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE m CONTAINS KEY 'a' ALLOW FILTERING"), [1, 1], [0, 0], [0, 1])
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS KEY 'a' ALLOW FILTERING"), [0, 0], [0, 1])
-            assert_rows(execute(cql, table, "SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS KEY 'c' ALLOW FILTERING"), [0, 2])
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s WHERE m CONTAINS KEY 'a' ALLOW FILTERING",
+                ),
+                [1, 1],
+                [0, 0],
+                [0, 1],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS KEY 'a' ALLOW FILTERING",
+                ),
+                [0, 0],
+                [0, 1],
+            )
+            assert_rows(
+                execute(
+                    cql,
+                    table,
+                    "SELECT k, v FROM %s WHERE k = 0 AND m CONTAINS KEY 'c' ALLOW FILTERING",
+                ),
+                [0, 2],
+            )
+
 
 def testMixedTTLOnColumns(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, i int)") as table:
         execute(cql, table, "INSERT INTO %s (k) VALUES (2);")
         execute(cql, table, "INSERT INTO %s (k, i) VALUES (1, 1) USING TTL 100;")
         execute(cql, table, "INSERT INTO %s (k, i) VALUES (3, 3) USING TTL 100;")
-        assert_rows(execute(cql, table, "SELECT k, i FROM %s "),
-                   [1, 1],
-                   [2, None],
-                   [3, 3])
+        assert_rows(
+            execute(cql, table, "SELECT k, i FROM %s "), [1, 1], [2, None], [3, 3]
+        )
 
         rs = execute(cql, table, "SELECT k, i, ttl(i) AS name_ttl FROM %s")
         i = 0
         for row in rs:
-            if i % 2 == 0: # Every odd row has a null i/ttl
+            if i % 2 == 0:  # Every odd row has a null i/ttl
                 assert row.name_ttl >= 70 and row.name_ttl <= 100
             else:
                 assert row.name_ttl is None
             i += 1
 
+
 def testMixedTTLOnColumnsWide(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k int, c int, i int, PRIMARY KEY (k, c))") as table:
+    with create_table(
+        cql, test_keyspace, f"(k int, c int, i int, PRIMARY KEY (k, c))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k, c) VALUES (2, 2);")
         execute(cql, table, "INSERT INTO %s (k, c, i) VALUES (1, 1, 1) USING TTL 100;")
         execute(cql, table, "INSERT INTO %s (k, c) VALUES (1, 2) ;")
         execute(cql, table, "INSERT INTO %s (k, c, i) VALUES (1, 3, 3) USING TTL 100;")
         execute(cql, table, "INSERT INTO %s (k, c, i) VALUES (3, 3, 3) USING TTL 100;")
-        assert_rows(execute(cql, table, "SELECT k, c, i FROM %s "),
-                   [1, 1, 1],
-                   [1, 2, None],
-                   [1, 3, 3],
-                   [2, 2, None],
-                   [3, 3, 3])
+        assert_rows(
+            execute(cql, table, "SELECT k, c, i FROM %s "),
+            [1, 1, 1],
+            [1, 2, None],
+            [1, 3, 3],
+            [2, 2, None],
+            [3, 3, 3],
+        )
 
         rs = execute(cql, table, "SELECT k, c, i, ttl(i) AS name_ttl FROM %s")
         i = 0
         for row in rs:
-            if i % 2 == 0: # Every odd row has a null i/ttl
+            if i % 2 == 0:  # Every odd row has a null i/ttl
                 assert row.name_ttl >= 70 and row.name_ttl <= 100
             else:
                 assert row.name_ttl is None
             i += 1
 
+
 # CASSANDRA-14989 (Scylla issue #10448)
 def testTokenFctAcceptsValidArguments(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
+    with create_table(
+        cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
         assert_row_count(execute(cql, table, "SELECT token(k1, k2) FROM %s"), 1)
 
+
 def testTokenFctRejectsInvalidColumnName(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
+    with create_table(
+        cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
         # Slightly different error messages in Scylla and Cassandra
         assert_invalid_message(cql, table, "name s1", "SELECT token(s1, k1) FROM %s")
 
+
 def testTokenFctRejectsInvalidColumnType(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
+    with create_table(
+        cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
-        assert_invalid_message(cql, table, "Type error: k2 cannot be passed as argument 0 of function system.token of type uuid",
-                             "SELECT token(k2, k1) FROM %s")
+        assert_invalid_message(
+            cql,
+            table,
+            "Type error: k2 cannot be passed as argument 0 of function system.token of type uuid",
+            "SELECT token(k2, k1) FROM %s",
+        )
+
 
 def testTokenFctRejectsInvalidColumnCount(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
+    with create_table(
+        cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))"
+    ) as table:
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
-        assert_invalid_message(cql, table, "Invalid number of arguments in call to function system.token: 2 required but 1 provided",
-                             "SELECT token(k1) FROM %s")
+        assert_invalid_message(
+            cql,
+            table,
+            "Invalid number of arguments in call to function system.token: 2 required but 1 provided",
+            "SELECT token(k1) FROM %s",
+        )
+
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
 @pytest.mark.skip("UDF tests not yet translated")
-def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs_SameKeyspace(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
-        createFunctionOverload(KEYSPACE + ".token", "double",
-                               "CREATE FUNCTION %s (val double) RETURNS null ON null INPUT RETURNS double LANGUAGE java AS 'return 10.0d;'")
+def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs_SameKeyspace(
+    cql, test_keyspace
+):
+    with create_table(
+        cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))"
+    ) as table:
+        createFunctionOverload(
+            KEYSPACE + ".token",
+            "double",
+            "CREATE FUNCTION %s (val double) RETURNS null ON null INPUT RETURNS double LANGUAGE java AS 'return 10.0d;'",
+        )
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
         assert_rows(execute(cql, table, "SELECT token(10) FROM %s"), row(10.0))
 
+
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
 @pytest.mark.skip("UDF tests not yet translated")
-def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
-        createFunctionOverload(KEYSPACE + ".token", "double",
-                               "CREATE FUNCTION %s (val double) RETURNS null ON null INPUT RETURNS double LANGUAGE java AS 'return 10.0d;'")
+def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks(
+    cql, test_keyspace
+):
+    with create_table(
+        cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))"
+    ) as table:
+        createFunctionOverload(
+            KEYSPACE + ".token",
+            "double",
+            "CREATE FUNCTION %s (val double) RETURNS null ON null INPUT RETURNS double LANGUAGE java AS 'return 10.0d;'",
+        )
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
-        assert_rows(execute(cql, table, "SELECT " + KEYSPACE + ".token(10) FROM %s"), row(10.0))
+        assert_rows(
+            execute(cql, table, "SELECT " + KEYSPACE + ".token(10) FROM %s"), row(10.0)
+        )
+
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
 @pytest.mark.skip("UDF tests not yet translated")
 def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
-        createFunctionOverload(KEYSPACE + ".token", "double",
-                               "CREATE FUNCTION %s (val double) RETURNS null ON null INPUT RETURNS double LANGUAGE java AS 'return 10.0d;'")
+    with create_table(
+        cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))"
+    ) as table:
+        createFunctionOverload(
+            KEYSPACE + ".token",
+            "double",
+            "CREATE FUNCTION %s (val double) RETURNS null ON null INPUT RETURNS double LANGUAGE java AS 'return 10.0d;'",
+        )
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
         assertRowCount(execute(cql, table, "SELECT token(k1, k2) FROM %s"), 1)
+
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
 @pytest.mark.skip("UDF tests not yet translated")
-def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks_SystemKeyspace(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
-        createFunctionOverload(KEYSPACE + ".token", "double",
-                               "CREATE FUNCTION %s (val double) RETURNS null ON null INPUT RETURNS double LANGUAGE java AS 'return 10.0d;'")
+def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks_SystemKeyspace(
+    cql, test_keyspace
+):
+    with create_table(
+        cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))"
+    ) as table:
+        createFunctionOverload(
+            KEYSPACE + ".token",
+            "double",
+            "CREATE FUNCTION %s (val double) RETURNS null ON null INPUT RETURNS double LANGUAGE java AS 'return 10.0d;'",
+        )
         execute(cql, table, "INSERT INTO %s (k1, k2) VALUES (uuid(), 'k2')")
         assertRowCount(execute(cql, table, "SELECT system.token(k1, k2) FROM %s"), 1)

--- a/test/cqlpy/cassandra_tests/validation/operations/update_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/update_test.py
@@ -11,8 +11,11 @@
 from ...porting import *
 import re
 
+
 def testTypeCasts(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, t text, a ascii, d double, i int)") as table:
+    with create_table(
+        cql, test_keyspace, "(k int PRIMARY KEY, t text, a ascii, d double, i int)"
+    ) as table:
         # The following is fine
         execute(cql, table, "UPDATE %s SET t = 'foo' WHERE k = ?", 0)
         execute(cql, table, "UPDATE %s SET t = (ascii)'foo' WHERE k = ?", 0)
@@ -34,132 +37,347 @@ def testTypeCasts(cql, test_keyspace):
         assertInvalid(cql, table, "UPDATE %s SET d = (int)3 WHERE k = ?", 0)
         assertInvalid(cql, table, "UPDATE %s SET i = (double)3 WHERE k = ?", 0)
 
+
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testUpdate(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, value int, PRIMARY KEY (partitionKey, clustering_1))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 2, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 3, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (1, 0, 4)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, value int, PRIMARY KEY (partitionKey, clustering_1))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 2, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (0, 3, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value) VALUES (1, 0, 4)",
+        )
 
         if forceFlush:
             flush(cql, table)
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?", 7, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
-                           0, 1),
-                   row(7))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
+                0,
+                1,
+            ),
+            row(7),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1) = (?)", 8, 0, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1) = (?)",
+            8,
+            0,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
-                           0, 2),
-                   row(8))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ?",
+                0,
+                2,
+            ),
+            row(8),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey IN (?, ?) AND clustering_1 = ?", 9, 0, 1, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey IN (?, ?) AND clustering_1 = ?",
+            9,
+            0,
+            1,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ?",
-                           0, 1, 0),
-                   row(0, 0, 9),
-                   row(1, 0, 9))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ?",
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 9),
+            row(1, 0, 9),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey IN ? AND clustering_1 = ?", 19, [0, 1], 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey IN ? AND clustering_1 = ?",
+            19,
+            [0, 1],
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN ? AND clustering_1 = ?",
-                           [0, 1], 0),
-                   row(0, 0, 19),
-                   row(1, 0, 19))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey IN ? AND clustering_1 = ?",
+                [0, 1],
+                0,
+            ),
+            row(0, 0, 19),
+            row(1, 0, 19),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 IN (?, ?)", 10, 0, 1, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
+            10,
+            0,
+            1,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
-                           0, 1, 0),
-                   row(0, 0, 10),
-                   row(0, 1, 10))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?)",
+                0,
+                1,
+                0,
+            ),
+            row(0, 0, 10),
+            row(0, 1, 10),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))", 20, 0, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
+            20,
+            0,
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
-                           0, 0, 1),
-                   row(0, 0, 20),
-                   row(0, 1, 20))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
+                0,
+                0,
+                1,
+            ),
+            row(0, 0, 20),
+            row(0, 1, 20),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?", null, 0, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            null,
+            0,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
-                           0, 0, 1),
-                   row(0, 0, null),
-                   row(0, 1, 20))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1) IN ((?), (?))",
+                0,
+                0,
+                1,
+            ),
+            row(0, 0, null),
+            row(0, 1, 20),
+        )
 
         # test invalid queries
 
         # missing primary key element
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "UPDATE %s SET value = ? WHERE clustering_1 = ? ", 7, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "UPDATE %s SET value = ? WHERE clustering_1 = ? ",
+            7,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_1",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ?", 7, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_1",
+            "UPDATE %s SET value = ? WHERE partitionKey = ?",
+            7,
+            0,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_1",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ?", 7, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_1",
+            "UPDATE %s SET value = ? WHERE partitionKey = ?",
+            7,
+            0,
+        )
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses for UPDATE",
-                             "UPDATE %s SET value = ? WHERE token(partitionKey) = token(?) AND clustering_1 = ?",
-                             7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses for UPDATE",
+            "UPDATE %s SET value = ? WHERE token(partitionKey) = token(?) AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
         # multiple time the same value
         # Cassandra throws syntax error here, Scylla throws the more
         # reasonable invalid request error.
-        assertInvalidThrow(cql, table, (SyntaxException, InvalidRequest), "UPDATE %s SET value = ?, value = ? WHERE partitionKey = ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidThrow(
+            cql,
+            table,
+            (SyntaxException, InvalidRequest),
+            "UPDATE %s SET value = ?, value = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
         # multiple time same primary key element in WHERE clause
         # This *is* accepted by Scylla - see issue #12472
-        #assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
         #                     "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_1 = ?", 7, 0, 1, 1)
 
         # unknown identifiers
-        assertInvalidMessage(cql, table, "value1",
-                             "UPDATE %s SET value1 = ? WHERE partitionKey = ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "UPDATE %s SET value1 = ? WHERE partitionKey = ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "UPDATE %s SET value = ? WHERE partitionKey1 = ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey1",
+            "UPDATE %s SET value = ? WHERE partitionKey1 = ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_3",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_3 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_3",
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_3 = ?",
+            7,
+            0,
+            1,
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key",
-                             "UPDATE %s SET value = ? WHERE partitionKey > ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key",
+            "UPDATE %s SET value = ? WHERE partitionKey > ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
         # Cassandra complains about "Cannot use UPDATE with CONTAINS, but
         # Scylla complains about "Cannot use CONTAINS on non-collection".
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey CONTAINS ? AND clustering_1 = ?", 7, 0, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey CONTAINS ? AND clustering_1 = ?",
+            7,
+            0,
+            1,
+        )
 
         # Reproduces #12474:
-        assertInvalidMessage(cql, table, "where clause",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND value = ?", 7, 0, 1, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "where clause",
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND value = ?",
+            7,
+            0,
+            1,
+            3,
+        )
 
         # Scylla and Cassandra print different error messages in this case:
         # Cassandra says "Slice restrictions are not supported on the
         # clustering columns in UPDATE statements", and Scylla says
         # "Invalid operator in where clause (clustering_1 > ?)"
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 > ?", 7, 0, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 > ?",
+            7,
+            0,
+            1,
+        )
+
 
 def testUpdateWithContainsAndContainsKey(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(a int, b frozen<map<int, int>>, c int, PRIMARY KEY (a, b))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(a int, b frozen<map<int, int>>, c int, PRIMARY KEY (a, b))",
+    ) as table:
         row = [1, {1: 1, 2: 2}, 3]
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", *row)
 
@@ -169,268 +387,753 @@ def testUpdateWithContainsAndContainsKey(cql, test_keyspace):
         # Cassandra says "Cannot use UPDATE with CONTAINS", Scylla says
         # "Cannot restrict clustering columns by a CONTAINS relation without
         # a secondary index or filtering"'.
-        assertInvalid(cql, table,
-                             "UPDATE %s SET c=3 WHERE a=1 AND b CONTAINS 1")
+        assertInvalid(cql, table, "UPDATE %s SET c=3 WHERE a=1 AND b CONTAINS 1")
 
         assertRows(execute(cql, table, "SELECT * FROM %s"), row)
 
-        assertInvalid(cql, table,
-                             "UPDATE %s SET c=3 WHERE a=1 AND b CONTAINS KEY 1")
+        assertInvalid(cql, table, "UPDATE %s SET c=3 WHERE a=1 AND b CONTAINS KEY 1")
 
         assertRows(execute(cql, table, "SELECT * FROM %s"), row)
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testUpdateWithSecondaryIndices(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, value int, values set<int>, PRIMARY KEY (partitionKey, clustering_1))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, value int, values set<int>, PRIMARY KEY (partitionKey, clustering_1))",
+    ) as table:
         execute(cql, table, "CREATE INDEX ON %s (value)")
         execute(cql, table, "CREATE INDEX ON %s (clustering_1)")
         execute(cql, table, "CREATE INDEX ON %s (values)")
 
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 0, 0, {0})")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 1, 1, {0, 1})")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 2, 2, {0, 1, 2})")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 3, 3, {0, 1, 2, 3})")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (1, 0, 4, {0, 1, 2, 3, 4})")
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 0, 0, {0})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 1, 1, {0, 1})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 2, 2, {0, 1, 2})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (0, 3, 3, {0, 1, 2, 3})",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, value, values) VALUES (1, 0, 4, {0, 1, 2, 3, 4})",
+        )
 
         if forceFlush:
             flush(cql, table)
 
         # In most errors below, the error message from Scylla and Cassandra
         # are different:
-        assertInvalidMessage(cql, table, "PRIMARY KEY column",
-                             "UPDATE %s SET values= {6} WHERE partitionKey = ? AND clustering_1 = ? AND value = ?", 3, 3, 3)
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value= ? WHERE partitionKey = ? AND clustering_1 = ? AND values CONTAINS ?", 6, 3, 3, 3)
-        assertInvalid(cql, table,
-                             "UPDATE %s SET values= {6} WHERE partitionKey = ? AND value = ?", 3, 3)
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value= ? WHERE partitionKey = ? AND values CONTAINS ?", 6, 3, 3)
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "UPDATE %s SET values= {6} WHERE clustering_1 = ?", 3)
-        assertInvalid(cql, table,
-                             "UPDATE %s SET values= {6} WHERE value = ?", 3)
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value= ? WHERE values CONTAINS ?", 6, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "PRIMARY KEY column",
+            "UPDATE %s SET values= {6} WHERE partitionKey = ? AND clustering_1 = ? AND value = ?",
+            3,
+            3,
+            3,
+        )
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value= ? WHERE partitionKey = ? AND clustering_1 = ? AND values CONTAINS ?",
+            6,
+            3,
+            3,
+            3,
+        )
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET values= {6} WHERE partitionKey = ? AND value = ?",
+            3,
+            3,
+        )
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value= ? WHERE partitionKey = ? AND values CONTAINS ?",
+            6,
+            3,
+            3,
+        )
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "UPDATE %s SET values= {6} WHERE clustering_1 = ?",
+            3,
+        )
+        assertInvalid(cql, table, "UPDATE %s SET values= {6} WHERE value = ?", 3)
+        assertInvalid(
+            cql, table, "UPDATE %s SET value= ? WHERE values CONTAINS ?", 6, 3
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testUpdateWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 2, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 3, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 1, 4)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 2, 5)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 6)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 2, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 3, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 1, 4)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 1, 2, 5)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (1, 0, 0, 6)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 1),
-                   row(7))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                1,
+            ),
+            row(7),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) = (?, ?)", 8, 0, 1, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) = (?, ?)",
+            8,
+            0,
+            1,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 2),
-                   row(8))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                2,
+            ),
+            row(8),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?", 9, 0, 1, 0, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
+            9,
+            0,
+            1,
+            0,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 0, 0),
-                   row(0, 0, 0, 9),
-                   row(1, 0, 0, 9))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                0,
+                0,
+            ),
+            row(0, 0, 0, 9),
+            row(1, 0, 0, 9),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey IN ? AND clustering_1 = ? AND clustering_2 = ?", 9, [0, 1], 0, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey IN ? AND clustering_1 = ? AND clustering_2 = ?",
+            9,
+            [0, 1],
+            0,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey IN ? AND clustering_1 = ? AND clustering_2 = ?",
-                           [0, 1], 0, 0),
-                   row(0, 0, 0, 9),
-                   row(1, 0, 0, 9))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey IN ? AND clustering_1 = ? AND clustering_2 = ?",
+                [0, 1],
+                0,
+                0,
+            ),
+            row(0, 0, 0, 9),
+            row(1, 0, 0, 9),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)", 12, 0, 1, 1, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)",
+            12,
+            0,
+            1,
+            1,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)",
-                           0, 1, 1, 2),
-                   row(0, 1, 1, 12),
-                   row(0, 1, 2, 12))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 IN (?, ?)",
+                0,
+                1,
+                1,
+                2,
+            ),
+            row(0, 1, 1, 12),
+            row(0, 1, 2, 12),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND clustering_2 IN (?, ?)", 10, 0, 1, 0, 1, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND clustering_2 IN (?, ?)",
+            10,
+            0,
+            1,
+            0,
+            1,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND clustering_2 IN (?, ?)",
-                           0, 1, 0, 1, 2),
-                   row(0, 0, 1, 10),
-                   row(0, 0, 2, 10),
-                   row(0, 1, 1, 10),
-                   row(0, 1, 2, 10))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 IN (?, ?) AND clustering_2 IN (?, ?)",
+                0,
+                1,
+                0,
+                1,
+                2,
+            ),
+            row(0, 0, 1, 10),
+            row(0, 0, 2, 10),
+            row(0, 1, 1, 10),
+            row(0, 1, 2, 10),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))", 20, 0, 0, 2, 1, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
+            20,
+            0,
+            0,
+            2,
+            1,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
-                           0, 0, 2, 1, 2),
-                   row(0, 0, 2, 20),
-                   row(0, 1, 2, 20))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
+                0,
+                0,
+                2,
+                1,
+                2,
+            ),
+            row(0, 0, 2, 20),
+            row(0, 1, 2, 20),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", null, 0, 0, 2)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            null,
+            0,
+            0,
+            2,
+        )
         if forceFlush:
             flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
-                           0, 0, 2, 1, 2),
-                   row(0, 0, 2, null),
-                   row(0, 1, 2, 20))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND (clustering_1, clustering_2) IN ((?, ?), (?, ?))",
+                0,
+                0,
+                2,
+                1,
+                2,
+            ),
+            row(0, 0, 2, null),
+            row(0, 1, 2, 20),
+        )
 
         # test invalid queries
 
         # missing primary key element
-        assertInvalidMessage(cql, table, "partitionkey",
-                             "UPDATE %s SET value = ? WHERE clustering_1 = ? AND clustering_2 = ?", 7, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey",
+            "UPDATE %s SET value = ? WHERE clustering_1 = ? AND clustering_2 = ?",
+            7,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_1",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_2 = ?", 7, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_1",
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_1",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ?", 7, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_1",
+            "UPDATE %s SET value = ? WHERE partitionKey = ?",
+            7,
+            0,
+        )
 
         # token function
-        assertInvalidMessage(cql, table, "The token function cannot be used in WHERE clauses for UPDATE",
-                             "UPDATE %s SET value = ? WHERE token(partitionKey) = token(?) AND clustering_1 = ? AND clustering_2 = ?",
-                             7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "The token function cannot be used in WHERE clauses for UPDATE",
+            "UPDATE %s SET value = ? WHERE token(partitionKey) = token(?) AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
         # multiple time the same value
         # Cassandra throws syntax error here, Scylla throws the more
         # reasonable invalid request error.
-        assertInvalidThrow(cql, table, (SyntaxException, InvalidRequest), "UPDATE %s SET value = ?, value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidThrow(
+            cql,
+            table,
+            (SyntaxException, InvalidRequest),
+            "UPDATE %s SET value = ?, value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
         # multiple time same primary key element in WHERE clause
         # This *is* accepted by Scylla - see issue #12472
-        #assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
+        # assertInvalidMessage(cql, table, "clustering_1 cannot be restricted by more than one relation if it includes an Equal",
         #                     "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND clustering_1 = ?", 7, 0, 1, 1, 1)
 
         # unknown identifiers
-        assertInvalidMessage(cql, table, "value1",
-                             "UPDATE %s SET value1 = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "value1",
+            "UPDATE %s SET value1 = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "partitionkey1",
-                             "UPDATE %s SET value = ? WHERE partitionKey1 = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "partitionkey1",
+            "UPDATE %s SET value = ? WHERE partitionKey1 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "clustering_3",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_3 = ?", 7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_3",
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_3 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
         # Invalid operator in the where clause
-        assertInvalidMessage(cql, table, "Only EQ and IN relation are supported on the partition key",
-                             "UPDATE %s SET value = ? WHERE partitionKey > ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Only EQ and IN relation are supported on the partition key",
+            "UPDATE %s SET value = ? WHERE partitionKey > ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
 
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey CONTAINS ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 1, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey CONTAINS ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            1,
+            1,
+        )
         # Reproduces #12474:
-        assertInvalidMessage(cql, table, "where clause",
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND value = ?", 7, 0, 1, 1, 3)
+        assertInvalidMessage(
+            cql,
+            table,
+            "where clause",
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ? AND value = ?",
+            7,
+            0,
+            1,
+            1,
+            3,
+        )
 
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 > ?", 7, 0, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND clustering_1 > ?",
+            7,
+            0,
+            1,
+        )
 
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) > (?, ?)", 7, 0, 1, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey = ? AND (clustering_1, clustering_2) > (?, ?)",
+            7,
+            0,
+            1,
+            1,
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testUpdateWithMultiplePartitionKeyComponents(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey_1 int, partitionKey_2 int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY ((partitionKey_1, partitionKey_2), clustering_1, clustering_2))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 0)")
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 1, 0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 1, 1, 1, 2)")
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (1, 0, 0, 1, 3)")
-        execute(cql, table, "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (1, 1, 0, 1, 3)")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey_1 int, partitionKey_2 int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY ((partitionKey_1, partitionKey_2), clustering_1, clustering_2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 0, 0, 0, 0)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 1, 0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (0, 1, 1, 1, 2)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (1, 0, 0, 1, 3)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey_1, partitionKey_2, clustering_1, clustering_2, value) VALUES (1, 1, 0, 1, 3)",
+        )
         if forceFlush:
             flush(cql, table)
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey_1 = ? AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 0, 0, 0, 0)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey_1 = ? AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            0,
+            0,
+            0,
+            0,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT value FROM %s WHERE partitionKey_1 = ? AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 0, 0, 0),
-                   row(7))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT value FROM %s WHERE partitionKey_1 = ? AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                0,
+                0,
+                0,
+            ),
+            row(7),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?", 9, 0, 1, 1, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            9,
+            0,
+            1,
+            1,
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 1, 1, 0, 1),
-                   row(0, 1, 0, 1, 9),
-                   row(1, 1, 0, 1, 9))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                1,
+                1,
+                0,
+                1,
+            ),
+            row(0, 1, 0, 1, 9),
+            row(1, 1, 0, 1, 9),
+        )
 
-        execute(cql, table, "UPDATE %s SET value = ? WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?", 10, 0, 1, 0, 1, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey_1 IN (?, ?) AND partitionKey_2 IN (?, ?) AND clustering_1 = ? AND clustering_2 = ?",
+            10,
+            0,
+            1,
+            0,
+            1,
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(0, 0, 0, 0, 7),
-                   row(0, 0, 0, 1, 10),
-                   row(0, 1, 0, 1, 10),
-                   row(0, 1, 1, 1, 2),
-                   row(1, 0, 0, 1, 10),
-                   row(1, 1, 0, 1, 10))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(0, 0, 0, 0, 7),
+            row(0, 0, 0, 1, 10),
+            row(0, 1, 0, 1, 10),
+            row(0, 1, 1, 1, 2),
+            row(1, 0, 0, 1, 10),
+            row(1, 1, 0, 1, 10),
+        )
 
         # missing primary key element
         # Reproduces #12474:
         # Different error message returned, changed to assertInvalid instead of assertInvalidMessage
-        assertInvalid(cql, table,
-                             "UPDATE %s SET value = ? WHERE partitionKey_1 = ? AND clustering_1 = ? AND clustering_2 = ?", 7, 1, 1)
+        assertInvalid(
+            cql,
+            table,
+            "UPDATE %s SET value = ? WHERE partitionKey_1 = ? AND clustering_1 = ? AND clustering_2 = ?",
+            7,
+            1,
+            1,
+        )
+
 
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testUpdateWithAStaticColumn(cql, test_keyspace, forceFlush):
-    with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, staticValue text static, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value, staticValue) VALUES (0, 0, 0, 0, 'A')")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)")
-        execute(cql, table, "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value, staticValue) VALUES (1, 0, 0, 6, 'B')")
+    with create_table(
+        cql,
+        test_keyspace,
+        "(partitionKey int, clustering_1 int, clustering_2 int, value int, staticValue text static, PRIMARY KEY (partitionKey, clustering_1, clustering_2))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value, staticValue) VALUES (0, 0, 0, 0, 'A')",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value) VALUES (0, 0, 1, 1)",
+        )
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s (partitionKey, clustering_1, clustering_2, value, staticValue) VALUES (1, 0, 0, 6, 'B')",
+        )
         if forceFlush:
             flush(cql, table)
 
-        execute(cql, table, "UPDATE %s SET staticValue = ? WHERE partitionKey = ?", "A2", 0)
+        execute(
+            cql, table, "UPDATE %s SET staticValue = ? WHERE partitionKey = ?", "A2", 0
+        )
         if forceFlush:
             flush(cql, table)
 
-        assertRows(execute(cql, table, "SELECT DISTINCT staticValue FROM %s WHERE partitionKey = ?", 0),
-                   row("A2"))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT DISTINCT staticValue FROM %s WHERE partitionKey = ?",
+                0,
+            ),
+            row("A2"),
+        )
 
-        assertInvalidMessage(cql, table, "clustering_1",
-                             "UPDATE %s SET staticValue = ?, value = ? WHERE partitionKey = ?", "A2", 7, 0)
+        assertInvalidMessage(
+            cql,
+            table,
+            "clustering_1",
+            "UPDATE %s SET staticValue = ?, value = ? WHERE partitionKey = ?",
+            "A2",
+            7,
+            0,
+        )
 
-        execute(cql, table, "UPDATE %s SET staticValue = ?, value = ?  WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                "A3", 7, 0, 0, 1)
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET staticValue = ?, value = ?  WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            "A3",
+            7,
+            0,
+            0,
+            1,
+        )
         if forceFlush:
             flush(cql, table)
-        assertRows(execute(cql, table, "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                           0, 0, 1),
-                   row(0, 0, 1, "A3", 7))
+        assertRows(
+            execute(
+                cql,
+                table,
+                "SELECT * FROM %s WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+                0,
+                0,
+                1,
+            ),
+            row(0, 0, 1, "A3", 7),
+        )
 
-        assertInvalidMessage(cql, table, "Invalid restrictions on clustering columns since the UPDATE statement modifies only static columns",
-                             "UPDATE %s SET staticValue = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
-                             "A3", 0, 0, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "Invalid restrictions on clustering columns since the UPDATE statement modifies only static columns",
+            "UPDATE %s SET staticValue = ? WHERE partitionKey = ? AND clustering_1 = ? AND clustering_2 = ?",
+            "A3",
+            0,
+            0,
+            1,
+        )
+
 
 def testUpdateWithStaticList(cql, test_keyspace):
-    with create_table(cql, test_keyspace, "(k int, clustering int, value int, l list<text> static, PRIMARY KEY (k, clustering))") as table:
-        execute(cql, table, "INSERT INTO %s(k, clustering, value, l) VALUES (?, ?, ?, ?)", 0, 0, 0 ,["v1", "v2", "v3"])
+    with create_table(
+        cql,
+        test_keyspace,
+        "(k int, clustering int, value int, l list<text> static, PRIMARY KEY (k, clustering))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "INSERT INTO %s(k, clustering, value, l) VALUES (?, ?, ?, ?)",
+            0,
+            0,
+            0,
+            ["v1", "v2", "v3"],
+        )
 
-        assertRows(execute(cql, table, "SELECT l FROM %s WHERE k = 0"), row(["v1", "v2", "v3"]))
+        assertRows(
+            execute(cql, table, "SELECT l FROM %s WHERE k = 0"), row(["v1", "v2", "v3"])
+        )
 
         execute(cql, table, "UPDATE %s SET l[?] = ? WHERE k = ?", 1, "v4", 0)
 
-        assertRows(execute(cql, table, "SELECT l FROM %s WHERE k = 0"), row(["v1", "v4", "v3"]))
+        assertRows(
+            execute(cql, table, "SELECT l FROM %s WHERE k = 0"), row(["v1", "v4", "v3"])
+        )
 
-@pytest.mark.xfail(reason="#12243")
+
+@pytest.mark.xfail(reason='Setting USING TTL of "null" should be allowed #12243')
 def testUpdateWithDefaultTtl(cql, test_keyspace):
     secondsPerMinute = 60
-    with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10 * secondsPerMinute}") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10 * secondsPerMinute}",
+    ) as table:
         execute(cql, table, "UPDATE %s SET b = 1 WHERE a = 1")
         resultSet = list(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 1"))
         assert 1 == len(resultSet)
@@ -453,9 +1156,11 @@ def testUpdateWithDefaultTtl(cql, test_keyspace):
         execute(cql, table, "UPDATE %s USING TTL ? SET b = ? WHERE a = ?", None, 3, 3)
         assertRows(execute(cql, table, "SELECT ttl(b) FROM %s WHERE a = 3"), row(None))
 
+
 # Both Scylla and Cassandra define MAX_TTL or max_ttl with the same formula,
 # 20 years in seconds. In both systems, it is not configurable.
 MAX_TTL = 20 * 365 * 24 * 60 * 60
+
 
 def testUpdateWithTtl(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, v int)") as table:
@@ -463,118 +1168,261 @@ def testUpdateWithTtl(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (k, v) VALUES (2, 2) USING TTL ?", 3600)
 
         # test with unset
-        execute(cql, table, "UPDATE %s USING TTL ? SET v = ? WHERE k = ?", unset(), 1, 1); # treat as 'unlimited'
+        execute(
+            cql, table, "UPDATE %s USING TTL ? SET v = ? WHERE k = ?", unset(), 1, 1
+        )  # treat as 'unlimited'
         assertRows(execute(cql, table, "SELECT ttl(v) FROM %s WHERE k = 1"), row(None))
 
         # test with null
-        execute(cql, table, "UPDATE %s USING TTL ? SET v = ? WHERE k = ?", unset(), 2, 2)
-        assertRows(execute(cql, table, "SELECT k, v, TTL(v) FROM %s WHERE k = 2"), row(2, 2, None))
+        execute(
+            cql, table, "UPDATE %s USING TTL ? SET v = ? WHERE k = ?", unset(), 2, 2
+        )
+        assertRows(
+            execute(cql, table, "SELECT k, v, TTL(v) FROM %s WHERE k = 2"),
+            row(2, 2, None),
+        )
 
         # test error handling
-        assertInvalidMessage(cql, table, "A TTL must be greater or equal to 0",
-                             "UPDATE %s USING TTL ? SET v = ? WHERE k = ?", -5, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "A TTL must be greater or equal to 0",
+            "UPDATE %s USING TTL ? SET v = ? WHERE k = ?",
+            -5,
+            1,
+            1,
+        )
 
-        assertInvalidMessage(cql, table, "ttl is too large.",
-                             "UPDATE %s USING TTL ? SET v = ? WHERE k = ?",
-                             MAX_TTL + 1, 1, 1)
+        assertInvalidMessage(
+            cql,
+            table,
+            "ttl is too large.",
+            "UPDATE %s USING TTL ? SET v = ? WHERE k = ?",
+            MAX_TTL + 1,
+            1,
+            1,
+        )
+
 
 # Test for CASSANDRA-12829
 def testUpdateWithEmptyInRestriction(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(a int, b int, c int, PRIMARY KEY (a,b))") as table:
-        execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)",1,1,1)
-        execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)",1,2,2)
-        execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)",1,3,3)
+    with create_table(
+        cql, test_keyspace, f"(a int, b int, c int, PRIMARY KEY (a,b))"
+    ) as table:
+        execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)", 1, 1, 1)
+        execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)", 1, 2, 2)
+        execute(cql, table, "INSERT INTO %s (a,b,c) VALUES (?,?,?)", 1, 3, 3)
 
-        assertInvalidMessage(cql, table, " b",
-                             "UPDATE %s SET c = 100 WHERE a IN ();")
+        assertInvalidMessage(cql, table, " b", "UPDATE %s SET c = 100 WHERE a IN ();")
         execute(cql, table, "UPDATE %s SET c = 100 WHERE a IN () AND b IN ();")
         execute(cql, table, "UPDATE %s SET c = 100 WHERE a IN () AND b = 1;")
         execute(cql, table, "UPDATE %s SET c = 100 WHERE a = 1 AND b IN ();")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1,1,1),
-                   row(1,2,2),
-                   row(1,3,3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 1, 1),
+            row(1, 2, 2),
+            row(1, 3, 3),
+        )
 
-    with create_table(cql, test_keyspace, f"(a int, b int, c int, d int, s int static, PRIMARY KEY ((a,b), c))") as table:
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)",1,1,1,1,1)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)",1,1,2,2,1)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)",1,1,3,3,1)
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int, b int, c int, d int, s int static, PRIMARY KEY ((a,b), c))",
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 1, 1, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 2, 2, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,s) VALUES (?,?,?,?,?)", 1, 1, 3, 3, 1
+        )
 
         execute(cql, table, "UPDATE %s SET d = 100 WHERE a = 1 AND b = 1 AND c IN ();")
-        execute(cql, table, "UPDATE %s SET d = 100 WHERE a = 1 AND b IN () AND c IN ();")
-        execute(cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b IN () AND c IN ();")
-        execute(cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b IN () AND c = 1;")
-        execute(cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b = 1 AND c IN ();")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1,1,1,1,1),
-                   row(1,1,2,1,2),
-                   row(1,1,3,1,3))
+        execute(
+            cql, table, "UPDATE %s SET d = 100 WHERE a = 1 AND b IN () AND c IN ();"
+        )
+        execute(
+            cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b IN () AND c IN ();"
+        )
+        execute(
+            cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b IN () AND c = 1;"
+        )
+        execute(
+            cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b = 1 AND c IN ();"
+        )
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 1, 1, 1, 1),
+            row(1, 1, 2, 1, 2),
+            row(1, 1, 3, 1, 3),
+        )
 
         # No clustering keys restricted, update whole partition
         execute(cql, table, "UPDATE %s set s = 100 where a = 1 AND b = 1;")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1,1,1,100,1),
-                   row(1,1,2,100,2),
-                   row(1,1,3,100,3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 1, 1, 100, 1),
+            row(1, 1, 2, 100, 2),
+            row(1, 1, 3, 100, 3),
+        )
 
         execute(cql, table, "UPDATE %s set s = 200 where a = 1 AND b IN ();")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1,1,1,100,1),
-                   row(1,1,2,100,2),
-                   row(1,1,3,100,3))
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 1, 1, 100, 1),
+            row(1, 1, 2, 100, 2),
+            row(1, 1, 3, 100, 3),
+        )
 
-    with create_table(cql, test_keyspace, f"(a int, b int, c int, d int, e int, PRIMARY KEY ((a,b), c, d))") as table:
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)",1,1,1,1,1)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)",1,1,1,2,2)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)",1,1,1,3,3)
-        execute(cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)",1,1,1,4,4)
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int, b int, c int, d int, e int, PRIMARY KEY ((a,b), c, d))",
+    ) as table:
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 1, 1
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 2, 2
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 3, 3
+        )
+        execute(
+            cql, table, "INSERT INTO %s (a,b,c,d,e) VALUES (?,?,?,?,?)", 1, 1, 1, 4, 4
+        )
 
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a = 1 AND b = 1 AND c = 1 AND d IN ();")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a = 1 AND b = 1 AND c IN () AND d IN ();")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a = 1 AND b IN () AND c IN () AND d IN ();")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c IN () AND d IN ();")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c IN () AND d = 1;")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c = 1 AND d = 1;")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c = 1 AND d IN ();")
-        assertRows(execute(cql, table, "SELECT * FROM %s"),
-                   row(1,1,1,1,1),
-                   row(1,1,1,2,2),
-                   row(1,1,1,3,3),
-                   row(1,1,1,4,4))
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a = 1 AND b = 1 AND c = 1 AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a = 1 AND b = 1 AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a = 1 AND b IN () AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c IN () AND d = 1;",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c = 1 AND d = 1;",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c = 1 AND d IN ();",
+        )
+        assertRows(
+            execute(cql, table, "SELECT * FROM %s"),
+            row(1, 1, 1, 1, 1),
+            row(1, 1, 1, 2, 2),
+            row(1, 1, 1, 3, 3),
+            row(1, 1, 1, 4, 4),
+        )
+
 
 # Test for CASSANDRA-13152
 def testThatUpdatesWithEmptyInRestrictionDoNotCreateMutations(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(a int, b int, c int, PRIMARY KEY (a,b))") as table:
+    with create_table(
+        cql, test_keyspace, f"(a int, b int, c int, PRIMARY KEY (a,b))"
+    ) as table:
         execute(cql, table, "UPDATE %s SET c = 100 WHERE a IN () AND b = 1;")
         execute(cql, table, "UPDATE %s SET c = 100 WHERE a = 1 AND b IN ();")
 
         # I don't know how to check this with CQL...
-        #assertTrue("The memtable should be empty but is not", isMemtableEmpty())
+        # assertTrue("The memtable should be empty but is not", isMemtableEmpty())
 
-    with create_table(cql, test_keyspace, f"(a int, b int, c int, d int, s int static, PRIMARY KEY ((a,b), c))") as table:
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int, b int, c int, d int, s int static, PRIMARY KEY ((a,b), c))",
+    ) as table:
         execute(cql, table, "UPDATE %s SET d = 100 WHERE a = 1 AND b = 1 AND c IN ();")
-        execute(cql, table, "UPDATE %s SET d = 100 WHERE a = 1 AND b IN () AND c IN ();")
-        execute(cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b IN () AND c IN ();")
-        execute(cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b IN () AND c = 1;")
-        execute(cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b = 1 AND c IN ();")
+        execute(
+            cql, table, "UPDATE %s SET d = 100 WHERE a = 1 AND b IN () AND c IN ();"
+        )
+        execute(
+            cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b IN () AND c IN ();"
+        )
+        execute(
+            cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b IN () AND c = 1;"
+        )
+        execute(
+            cql, table, "UPDATE %s SET d = 100 WHERE a IN () AND b = 1 AND c IN ();"
+        )
 
         # I don't know how to check this with CQL...
-        #assertTrue("The memtable should be empty but is not", isMemtableEmpty())
+        # assertTrue("The memtable should be empty but is not", isMemtableEmpty())
 
-    with create_table(cql, test_keyspace, f"(a int, b int, c int, d int, e int, PRIMARY KEY ((a,b), c, d))") as table:
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a = 1 AND b = 1 AND c = 1 AND d IN ();")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a = 1 AND b = 1 AND c IN () AND d IN ();")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a = 1 AND b IN () AND c IN () AND d IN ();")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c IN () AND d IN ();")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c IN () AND d = 1;")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c = 1 AND d = 1;")
-        execute(cql, table, "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c = 1 AND d IN ();")
+    with create_table(
+        cql,
+        test_keyspace,
+        f"(a int, b int, c int, d int, e int, PRIMARY KEY ((a,b), c, d))",
+    ) as table:
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a = 1 AND b = 1 AND c = 1 AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a = 1 AND b = 1 AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a = 1 AND b IN () AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c IN () AND d IN ();",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c IN () AND d = 1;",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c = 1 AND d = 1;",
+        )
+        execute(
+            cql,
+            table,
+            "UPDATE %s SET e = 100 WHERE a IN () AND b IN () AND c = 1 AND d IN ();",
+        )
 
         # I don't know how to check this with CQL...
-        #assertTrue("The memtable should be empty but is not", isMemtableEmpty())
+        # assertTrue("The memtable should be empty but is not", isMemtableEmpty())
+
 
 def testAdderNonCounter(cql, test_keyspace):
-    with create_table(cql, test_keyspace, f"(pk int PRIMARY KEY, a int, b text)") as table:
+    with create_table(
+        cql, test_keyspace, f"(pk int PRIMARY KEY, a int, b text)"
+    ) as table:
         # if error ever includes "b" its safe to update this test
-        with pytest.raises(InvalidRequest, match=re.escape('Invalid operation (a = a + 1) for non counter column a')):
+        with pytest.raises(
+            InvalidRequest,
+            match=re.escape("Invalid operation (a = a + 1) for non counter column a"),
+        ):
             execute(cql, table, "UPDATE %s SET a = a + 1, b = b + 'fail' WHERE pk = 1")

--- a/test/cqlpy/test_aggregate.py
+++ b/test/cqlpy/test_aggregate.py
@@ -14,15 +14,26 @@ from cassandra.util import Date
 from cassandra.protocol import SyntaxException
 from .cassandra_tests.porting import assert_invalid_message
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int, c int, v int, d double, dc decimal, PRIMARY KEY (p, c)") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int, c int, v int, d double, dc decimal, PRIMARY KEY (p, c)",
+    ) as table:
         yield table
+
 
 @pytest.fixture(scope="module")
 def table2(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, somecolumn int, "SomeColumn" int, "OtherColumn" int, PRIMARY KEY (p, c)') as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        'p int, c int, somecolumn int, "SomeColumn" int, "OtherColumn" int, PRIMARY KEY (p, c)',
+    ) as table:
         yield table
+
 
 # When there is no row matching the selection, the count should be 0.
 # First check a "=" expression matching no row:
@@ -36,6 +47,7 @@ def test_count_empty_eq(cql, table1):
     assert [(0,)] == list(cql.execute(f"select sum(v) from {table1} where p = {p}"))
     assert [(0,)] == list(cql.execute(f"select avg(v) from {table1} where p = {p}"))
 
+
 # Above in test_count_empty_eq() we tested that aggregates return some value -
 # sometimes 0 and sometimes null - when aggregating no data. If we select
 # not just the aggregate but also something else like p, the result is even
@@ -47,9 +59,16 @@ def test_count_empty_eq(cql, table1):
 # See issue #13027.
 def test_count_and_p_empty_eq(cql, table1):
     p = unique_key_int()
-    assert [(None,0)] == list(cql.execute(f"select p, count(*) from {table1} where p = {p}"))
-    assert [(None,None)] == list(cql.execute(f"select p, min(v) from {table1} where p = {p}"))
-    assert [(None,0)] == list(cql.execute(f"select p, sum(v) from {table1} where p = {p}"))
+    assert [(None, 0)] == list(
+        cql.execute(f"select p, count(*) from {table1} where p = {p}")
+    )
+    assert [(None, None)] == list(
+        cql.execute(f"select p, min(v) from {table1} where p = {p}")
+    )
+    assert [(None, 0)] == list(
+        cql.execute(f"select p, sum(v) from {table1} where p = {p}")
+    )
+
 
 # The query "p = null" also matches no row so should have a count 0, but
 # it's a special case where no partition belongs to the query range so the
@@ -62,13 +81,23 @@ def test_count_empty_eq_null(cql, table1, scylla_only):
     assert [(0,)] == list(cql.execute(f"select count(*) from {table1} where p = null"))
     # A more complex list of aggregators, some return zero and some null
     # for an empty result set:
-    assert [(0,0,None,0)] == list(cql.execute(f"select count(*), count(v), min(v), sum(v) from {table1} where p = null"))
+    assert [(0, 0, None, 0)] == list(
+        cql.execute(
+            f"select count(*), count(v), min(v), sum(v) from {table1} where p = null"
+        )
+    )
+
 
 # Another special case of a query which matches no partition - an IN with
 # an empty list. Reproduces #12475.
 def test_count_empty_in(cql, table1):
     assert [(0,)] == list(cql.execute(f"select count(*) from {table1} where p in ()"))
-    assert [(0,0,None,0)] == list(cql.execute(f"select count(*), count(v), min(v), sum(v) from {table1} where p in ()"))
+    assert [(0, 0, None, 0)] == list(
+        cql.execute(
+            f"select count(*), count(v), min(v), sum(v) from {table1} where p in ()"
+        )
+    )
+
 
 # Simple test of counting the number of rows in a single partition
 def test_count_in_partition(cql, table1):
@@ -78,6 +107,7 @@ def test_count_in_partition(cql, table1):
     cql.execute(stmt, [p, 2, 2])
     cql.execute(stmt, [p, 3, 3])
     assert [(3,)] == list(cql.execute(f"select count(*) from {table1} where p = {p}"))
+
 
 # Using count(v) instead of count(*) allows counting only rows with a non-NULL
 # value in v
@@ -91,15 +121,30 @@ def test_count_specific_column(cql, test_keyspace, table1):
     assert [(4,)] == list(cql.execute(f"select count(*) from {table1} where p = {p}"))
     assert [(3,)] == list(cql.execute(f"select count(v) from {table1} where p = {p}"))
     # Check with non-scalar types too, reproduces #14198
-    with new_type(cql, test_keyspace, '(i int, t text)') as udt:
-        with new_test_table(cql, test_keyspace, f'p int, c int, fli frozen<list<int>>, tup tuple<int, bigint>, udt {udt}, PRIMARY KEY (p, c)') as table2:
-            cql.execute(f'INSERT INTO {table2}(p, c, fli, tup, udt) VALUES({p}, 5, [1, 2], (3, 4), {{i: 3, t: \'text\'}})')
-            cql.execute(f'INSERT INTO {table2}(p, c) VALUES({p}, 6)')
+    with new_type(cql, test_keyspace, "(i int, t text)") as udt:
+        with new_test_table(
+            cql,
+            test_keyspace,
+            f"p int, c int, fli frozen<list<int>>, tup tuple<int, bigint>, udt {udt}, PRIMARY KEY (p, c)",
+        ) as table2:
+            cql.execute(
+                f"INSERT INTO {table2}(p, c, fli, tup, udt) VALUES({p}, 5, [1, 2], (3, 4), {{i: 3, t: 'text'}})"
+            )
+            cql.execute(f"INSERT INTO {table2}(p, c) VALUES({p}, 6)")
 
-            assert [(1,)] == list(cql.execute(f"select count(fli) from {table2} where p = {p}"))
-            assert [(1,)] == list(cql.execute(f"select count(tup) from {table2} where p = {p}"))
-            assert [(1,)] == list(cql.execute(f"select count(udt) from {table2} where p = {p}"))
-            assert [(2,)] == list(cql.execute(f"select count(*) from {table2} where p = {p}"))
+            assert [(1,)] == list(
+                cql.execute(f"select count(fli) from {table2} where p = {p}")
+            )
+            assert [(1,)] == list(
+                cql.execute(f"select count(tup) from {table2} where p = {p}")
+            )
+            assert [(1,)] == list(
+                cql.execute(f"select count(udt) from {table2} where p = {p}")
+            )
+            assert [(2,)] == list(
+                cql.execute(f"select count(*) from {table2} where p = {p}")
+            )
+
 
 # COUNT can be combined with GROUP BY to count separately for each partition
 # or row.
@@ -110,7 +155,10 @@ def test_count_and_group_by_row(cql, table1):
     cql.execute(stmt, [p, 2, 2])
     cql.execute(stmt, [p, 3, 3])
     cql.execute(stmt, [p, 4, None])
-    assert [(p, 1, 1), (p, 2, 1), (p, 3, 1), (p, 4, 0)] == list(cql.execute(f"select p, c, count(v) from {table1} where p = {p} group by p,c"))
+    assert [(p, 1, 1), (p, 2, 1), (p, 3, 1), (p, 4, 0)] == list(
+        cql.execute(f"select p, c, count(v) from {table1} where p = {p} group by p,c")
+    )
+
 
 def test_count_and_group_by_partition(cql, table1):
     p1 = unique_key_int()
@@ -120,7 +168,12 @@ def test_count_and_group_by_partition(cql, table1):
     cql.execute(stmt, [p1, 2, 2])
     cql.execute(stmt, [p2, 3, 3])
     cql.execute(stmt, [p2, 4, None])
-    assert [(p1, 2), (p2, 1)] == list(cql.execute(f"select p, count(v) from {table1} where p in ({p1},{p2}) group by p"))
+    assert [(p1, 2), (p2, 1)] == list(
+        cql.execute(
+            f"select p, count(v) from {table1} where p in ({p1},{p2}) group by p"
+        )
+    )
+
 
 # In the above tests we looked for per-row or per-partition counts and got
 # back more than one count. But if our query matches no row, we should get
@@ -129,22 +182,37 @@ def test_count_and_group_by_partition(cql, table1):
 # Reproduces #12477
 def test_count_and_group_by_row_none(cql, table1):
     p = unique_key_int()
-    assert [] == list(cql.execute(f"select p, c, count(v) from {table1} where p = {p} group by p,c"))
+    assert [] == list(
+        cql.execute(f"select p, c, count(v) from {table1} where p = {p} group by p,c")
+    )
+
 
 def test_count_and_group_by_partition_none(cql, table1):
     p = unique_key_int()
-    assert [] == list(cql.execute(f"select p, count(v) from {table1} where p = {p} group by p"))
+    assert [] == list(
+        cql.execute(f"select p, count(v) from {table1} where p = {p} group by p")
+    )
+
 
 # Regression-test for #7729.
 def test_timeuuid(cql, test_keyspace):
     schema = "a int, b timeuuid, primary key (a,b)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'insert into {table} (a, b) values (0, 13814000-1dd2-11ff-8080-808080808080)')
-        cql.execute(f'insert into {table} (a, b) values (0, 6b1b3620-33fd-11eb-8080-808080808080)')
-        assert project('system_todate_system_min_b',
-                       cql.execute(f'select todate(min(b)) from {table} where a = 0')) == [Date('2020-12-01')]
-        assert project('system_todate_system_max_b',
-                       cql.execute(f'select todate(max(b)) from {table} where a = 0')) == [Date('2038-09-06')]
+        cql.execute(
+            f"insert into {table} (a, b) values (0, 13814000-1dd2-11ff-8080-808080808080)"
+        )
+        cql.execute(
+            f"insert into {table} (a, b) values (0, 6b1b3620-33fd-11eb-8080-808080808080)"
+        )
+        assert project(
+            "system_todate_system_min_b",
+            cql.execute(f"select todate(min(b)) from {table} where a = 0"),
+        ) == [Date("2020-12-01")]
+        assert project(
+            "system_todate_system_max_b",
+            cql.execute(f"select todate(max(b)) from {table} where a = 0"),
+        ) == [Date("2038-09-06")]
+
 
 # Check floating-point aggregations with non-finite results - inf and nan.
 # Reproduces issue #13551: sum of +inf and -inf produced an error instead
@@ -154,15 +222,24 @@ def test_aggregation_inf_nan(cql, table1):
     # Add a single infinity value, see we can read it back as infinity,
     # and its sum() is also infinity of course.
     cql.execute(f"insert into {table1} (p, c, d) values ({p}, 1, infinity)")
-    assert [(math.inf,)] == list(cql.execute(f"select d from {table1} where p = {p} and c = 1"))
-    assert [(math.inf,)] == list(cql.execute(f"select sum(d) from {table1} where p = {p}"))
+    assert [(math.inf,)] == list(
+        cql.execute(f"select d from {table1} where p = {p} and c = 1")
+    )
+    assert [(math.inf,)] == list(
+        cql.execute(f"select sum(d) from {table1} where p = {p}")
+    )
     # Add a second value, a negative infinity. See we can read it back, and
     # now the sum of +Inf and -Inf should be a NaN.
     # Note that we have to use isnan() to check that the result is a NaN,
     # because equality check doesn't work on NaN:
     cql.execute(f"insert into {table1} (p, c, d) values ({p}, 2, -infinity)")
-    assert [(-math.inf,)] == list(cql.execute(f"select d from {table1} where p = {p} and c = 2"))
-    assert math.isnan(list(cql.execute(f"select sum(d) from {table1} where p = {p}"))[0][0])
+    assert [(-math.inf,)] == list(
+        cql.execute(f"select d from {table1} where p = {p} and c = 2")
+    )
+    assert math.isnan(
+        list(cql.execute(f"select sum(d) from {table1} where p = {p}"))[0][0]
+    )
+
 
 # When averaging "decimal" (arbitrary-precision floating point) values,
 # which precision should the output use? The average of 0, 0, 1 is
@@ -179,32 +256,45 @@ def test_aggregation_inf_nan(cql, table1):
 # scenarios tested in this test - averaging 1 and 2 or 1.1 and 1.2 -
 # don't do something that any reasonable user might expect, and will need
 # to be fixed.
-@pytest.mark.xfail(reason="issue #13601")
+@pytest.mark.xfail(
+    reason='Average of "decimal" values rounds the average if all inputs are integers #13601'
+)
 def test_avg_decimal(cql, table1, cassandra_bug):
     p = unique_key_int()
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 1, 1.0)")
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 2, 2.0)")
-    assert [(Decimal('1.5'),)] == list(cql.execute(f"select avg(dc) from {table1} where p = {p}"))
+    assert [(Decimal("1.5"),)] == list(
+        cql.execute(f"select avg(dc) from {table1} where p = {p}")
+    )
     p = unique_key_int()
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 1, 1)")
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 2, 2.0)")
-    assert [(Decimal('1.5'),)] == list(cql.execute(f"select avg(dc) from {table1} where p = {p}"))
+    assert [(Decimal("1.5"),)] == list(
+        cql.execute(f"select avg(dc) from {table1} where p = {p}")
+    )
     p = unique_key_int()
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 1, 1.0)")
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 2, 2)")
-    assert [(Decimal('1.5'),)] == list(cql.execute(f"select avg(dc) from {table1} where p = {p}"))
+    assert [(Decimal("1.5"),)] == list(
+        cql.execute(f"select avg(dc) from {table1} where p = {p}")
+    )
     p = unique_key_int()
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 1, 1)")
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 2, 2)")
     # Reproduces #13601: the average of 1 and 2 was rounded up to the
     # integer 2 instead of returning 1.5:
-    assert [(Decimal('1.5'),)] == list(cql.execute(f"select avg(dc) from {table1} where p = {p}"))
+    assert [(Decimal("1.5"),)] == list(
+        cql.execute(f"select avg(dc) from {table1} where p = {p}")
+    )
     # Similarly, average of 1.1 and 1.2 was rounded up to 1.2 instead of
     # returning 1.15.
     p = unique_key_int()
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 1, 1.1)")
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 2, 1.2)")
-    assert [(Decimal('1.15'),)] == list(cql.execute(f"select avg(dc) from {table1} where p = {p}"))
+    assert [(Decimal("1.15"),)] == list(
+        cql.execute(f"select avg(dc) from {table1} where p = {p}")
+    )
+
 
 # Another test for average of "decimal" values: the average of 1, 2, 2, 3.
 # In this case the average is an integer, 2, but Cassandra doesn't even
@@ -218,30 +308,63 @@ def test_avg_decimal_2(cql, table1, cassandra_bug):
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 3, 2)")
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 4, 3)")
     # Reproduces CASSANDRA-18470:
-    assert [(Decimal('2'),)] == list(cql.execute(f"select avg(dc) from {table1} where p = {p}"))
+    assert [(Decimal("2"),)] == list(
+        cql.execute(f"select avg(dc) from {table1} where p = {p}")
+    )
+
 
 def test_reject_aggregates_in_where_clause(cql, table1):
-    assert_invalid_message(cql, table1, 'Aggregation',
-                           f'SELECT * FROM {table1} WHERE p = sum((int)4)')
+    assert_invalid_message(
+        cql, table1, "Aggregation", f"SELECT * FROM {table1} WHERE p = sum((int)4)"
+    )
+
 
 # Reproduces #13265
 # Aggregates must handle case-sensitive column names correctly.
 def test_sum_case_sensitive_column(cql, table2):
     p = unique_key_int()
-    cql.execute(f'insert into {table2} (p, c, somecolumn, "SomeColumn", "OtherColumn") VALUES ({p}, 1, 1, 10, 100)')
-    cql.execute(f'insert into {table2} (p, c, somecolumn, "SomeColumn", "OtherColumn") VALUES ({p}, 2, 2, 20, 200)')
-    cql.execute(f'insert into {table2} (p, c, somecolumn, "SomeColumn", "OtherColumn") VALUES ({p}, 3, 3, 30, 300)')
+    cql.execute(
+        f'insert into {table2} (p, c, somecolumn, "SomeColumn", "OtherColumn") VALUES ({p}, 1, 1, 10, 100)'
+    )
+    cql.execute(
+        f'insert into {table2} (p, c, somecolumn, "SomeColumn", "OtherColumn") VALUES ({p}, 2, 2, 20, 200)'
+    )
+    cql.execute(
+        f'insert into {table2} (p, c, somecolumn, "SomeColumn", "OtherColumn") VALUES ({p}, 3, 3, 30, 300)'
+    )
 
-    assert cql.execute(f'select sum(somecolumn) from {table2} where p = {p}').one()[0] == 6
-    assert cql.execute(f'select sum("somecolumn") from {table2} where p = {p}').one()[0] == 6
-    assert cql.execute(f'select sum("SomeColumn") from {table2} where p = {p}').one()[0] == 60
-    assert cql.execute(f'select sum(SomeColumn) from {table2} where p = {p}').one()[0] == 6
-    assert cql.execute(f'select sum("OtherColumn") from {table2} where p = {p}').one()[0] == 600
+    assert (
+        cql.execute(f"select sum(somecolumn) from {table2} where p = {p}").one()[0] == 6
+    )
+    assert (
+        cql.execute(f'select sum("somecolumn") from {table2} where p = {p}').one()[0]
+        == 6
+    )
+    assert (
+        cql.execute(f'select sum("SomeColumn") from {table2} where p = {p}').one()[0]
+        == 60
+    )
+    assert (
+        cql.execute(f"select sum(SomeColumn) from {table2} where p = {p}").one()[0] == 6
+    )
+    assert (
+        cql.execute(f'select sum("OtherColumn") from {table2} where p = {p}').one()[0]
+        == 600
+    )
 
-    assert_invalid_message(cql, table2, 'someColumn',
-                           f'select sum("someColumn") from {table2} where p = {p}')
-    assert_invalid_message(cql, table2, 'othercolumn',
-                           f'select sum(OtherColumn) from {table2} where p = {p}')
+    assert_invalid_message(
+        cql,
+        table2,
+        "someColumn",
+        f'select sum("someColumn") from {table2} where p = {p}',
+    )
+    assert_invalid_message(
+        cql,
+        table2,
+        "othercolumn",
+        f"select sum(OtherColumn) from {table2} where p = {p}",
+    )
+
 
 # Check that a simple case of summing up a specific int column in a partition
 # works correctly
@@ -252,6 +375,7 @@ def test_sum_in_partition(cql, table1):
     cql.execute(stmt, [p, 2, 5])
     cql.execute(stmt, [p, 3, 6])
     assert [(15,)] == list(cql.execute(f"select sum(v) from {table1} where p = {p}"))
+
 
 # Check that you *can't* do "sum(*)" expecting (perhaps) sums of all the
 # columns. It's a syntax error: The grammar allows "count(*)" because it has

--- a/test/cqlpy/test_allow_filtering.py
+++ b/test/cqlpy/test_allow_filtering.py
@@ -40,18 +40,20 @@ from .util import unique_name, new_test_table
 # the request with what we will get by filtering in Python the entire
 # contents of the table ('everything') with the given 'filt' function.
 
+
 def check_af_optional(cql, table_and_everything, where, filt):
     (table, everything) = table_and_everything
     # Check that the query is allowed even without ALLOW FILTERING
     # (and returns the correct results):
-    results = list(cql.execute(f'SELECT * FROM {table} WHERE {where}'))
+    results = list(cql.execute(f"SELECT * FROM {table} WHERE {where}"))
     if filt:
         expected_results = list(filter(filt, everything))
         assert results == expected_results
     # Check that adding ALLOW FILTERING is unnecessary, but allowed:
-    results = list(cql.execute(f'SELECT * FROM {table} WHERE {where} ALLOW FILTERING'))
+    results = list(cql.execute(f"SELECT * FROM {table} WHERE {where} ALLOW FILTERING"))
     if filt:
         assert results == expected_results
+
 
 def check_af_mandatory(cql, table_and_everything, where, filt):
     (table, everything) = table_and_everything
@@ -65,36 +67,46 @@ def check_af_mandatory(cql, table_and_everything, where, filt):
     # clustering key - unfortunately this message doesn't mention "ALLOW
     # FILTERING" at all, although it should because the error goes away
     # when ALLOW FILTERING is specified.
-    with pytest.raises(InvalidRequest, match=re.compile('allow filtering|cannot be restricted', re.IGNORECASE)):
-        cql.execute(f'SELECT * FROM {table} WHERE {where}')
+    with pytest.raises(
+        InvalidRequest,
+        match=re.compile("allow filtering|cannot be restricted", re.IGNORECASE),
+    ):
+        cql.execute(f"SELECT * FROM {table} WHERE {where}")
     # Check that with ALLOW FILTERING, the query is allowed, and returns
     # the correct results:
-    results = list(cql.execute(f'SELECT * FROM {table} WHERE {where} ALLOW FILTERING'))
+    results = list(cql.execute(f"SELECT * FROM {table} WHERE {where} ALLOW FILTERING"))
     if filt:
         expected_results = list(filter(filt, everything))
         assert results == expected_results
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
-    cql.execute("CREATE TABLE " + table +
-        "(k int, c int, v int, PRIMARY KEY (k,c))")
+    cql.execute("CREATE TABLE " + table + "(k int, c int, v int, PRIMARY KEY (k,c))")
     for i in range(0, 3):
         for j in range(0, 3):
-            cql.execute(f'INSERT INTO {table} (k, c, v) VALUES ({i}, {j}, {j})')
-    everything = list(cql.execute('SELECT * FROM ' + table))
+            cql.execute(f"INSERT INTO {table} (k, c, v) VALUES ({i}, {j}, {j})")
+    everything = list(cql.execute("SELECT * FROM " + table))
     yield (table, everything)
     cql.execute("DROP TABLE " + table)
+
 
 # Reading an entire partition, or a contiguous "slice" of a partition, is
 # allowed without ALLOW FILTERING. Adding an unnecessary ALLOW FILTERING
 # is also allowed.
 def test_allow_filtering_partition_slice(cql, table1):
-    check_af_optional(cql, table1, 'k=1', lambda row: row.k==1)
-    check_af_optional(cql, table1, 'k=1 AND c>2', lambda row: row.k==1 and row.c>2)
-    check_af_optional(cql, table1, 'k=1 AND c<2', lambda row: row.k==1 and row.c<2)
-    check_af_optional(cql, table1, 'k=1 AND c=2', lambda row: row.k==1 and row.c==2)
-    check_af_optional(cql, table1, 'k=1 AND c>=2 AND c<=4', lambda row: row.k==1 and row.c>=2 and row.c<=4)
+    check_af_optional(cql, table1, "k=1", lambda row: row.k == 1)
+    check_af_optional(cql, table1, "k=1 AND c>2", lambda row: row.k == 1 and row.c > 2)
+    check_af_optional(cql, table1, "k=1 AND c<2", lambda row: row.k == 1 and row.c < 2)
+    check_af_optional(cql, table1, "k=1 AND c=2", lambda row: row.k == 1 and row.c == 2)
+    check_af_optional(
+        cql,
+        table1,
+        "k=1 AND c>=2 AND c<=4",
+        lambda row: row.k == 1 and row.c >= 2 and row.c <= 4,
+    )
+
 
 # Although as the above test showed that a partition slice does not require
 # filtering, if we add another restriction like 'v=2' the filtering *is*
@@ -104,27 +116,56 @@ def test_allow_filtering_partition_slice(cql, table1):
 # 'k=1 and c=2' is different, and will be tested in the following test
 # test_allow_filtering_single_row().
 def test_allow_filtering_partition_slice_and_restriction(cql, table1):
-    check_af_mandatory(cql, table1, 'k=1 AND v=2', lambda row: row.k==1 and row.v==2)
-    check_af_mandatory(cql, table1, 'k=1 AND c>2 AND v=2', lambda row: row.k==1 and row.c>2 and row.v==2)
-    check_af_mandatory(cql, table1, 'k=1 AND c<2 AND v=2', lambda row: row.k==1 and row.c<2 and row.v==2)
-    check_af_mandatory(cql, table1, 'k=1 AND c>=2 AND c<=4 AND v=2', lambda row: row.k==1 and row.c>=2 and row.c<=4 and row.v==2)
+    check_af_mandatory(
+        cql, table1, "k=1 AND v=2", lambda row: row.k == 1 and row.v == 2
+    )
+    check_af_mandatory(
+        cql,
+        table1,
+        "k=1 AND c>2 AND v=2",
+        lambda row: row.k == 1 and row.c > 2 and row.v == 2,
+    )
+    check_af_mandatory(
+        cql,
+        table1,
+        "k=1 AND c<2 AND v=2",
+        lambda row: row.k == 1 and row.c < 2 and row.v == 2,
+    )
+    check_af_mandatory(
+        cql,
+        table1,
+        "k=1 AND c>=2 AND c<=4 AND v=2",
+        lambda row: row.k == 1 and row.c >= 2 and row.c <= 4 and row.v == 2,
+    )
+
 
 # Reading a clustering single row 'k=1 AND c=2' always takes a O(1) amount
 # of work and returns one or zero results. Adding another restriction
 # like 'v=2' doesn't change any of the above, so doesn't require filtering.
 # Reproduces #7964 on Scylla, and also wrong on Cassandra so marked
 # cassandra_bug.
-@pytest.mark.xfail(reason="#7964")
+@pytest.mark.xfail(
+    reason="Further restricting a query already limited to a single row should not require ALLOW FILTERING #7964"
+)
 def test_allow_filtering_single_row(cql, table1, cassandra_bug):
-    check_af_optional(cql, table1, 'k=1 AND c=2', lambda row: row.k==1 and row.c==2)
+    check_af_optional(cql, table1, "k=1 AND c=2", lambda row: row.k == 1 and row.c == 2)
     # Reproduces #7964, as ALLOW FILTERING is considered mandatory, not optional
-    check_af_optional(cql, table1, 'k=1 AND c=2 AND v=2', lambda row: row.k==1 and row.c==2 and row.v==2)
+    check_af_optional(
+        cql,
+        table1,
+        "k=1 AND c=2 AND v=2",
+        lambda row: row.k == 1 and row.c == 2 and row.v == 2,
+    )
+
 
 # A scan of the whole table or of a whole partition looking for one particular
 # regular column value requires filtering.
 def test_allow_filtering_regular_column(cql, table1):
-    check_af_mandatory(cql, table1, 'v=2', lambda row: row.v==2)
-    check_af_mandatory(cql, table1, 'k=1 AND v=2', lambda row: row.k==1 and row.v==2)
+    check_af_mandatory(cql, table1, "v=2", lambda row: row.v == 2)
+    check_af_mandatory(
+        cql, table1, "k=1 AND v=2", lambda row: row.k == 1 and row.v == 2
+    )
+
 
 # A scan of the whole table looking for one particular *clustering* column
 # value requires filtering: Such a query may return just a few or even no
@@ -133,11 +174,14 @@ def test_allow_filtering_regular_column(cql, table1):
 # also read a chunk of rows to look for the matching clustering-column value.
 # Reproduces issue #7608.
 def test_allow_filtering_clustering_key(cql, table1):
-    check_af_mandatory(cql, table1, 'c=2', lambda row: row.c==2)
-    check_af_mandatory(cql, table1, 'c>2', lambda row: row.c>2)
+    check_af_mandatory(cql, table1, "c=2", lambda row: row.c == 2)
+    check_af_mandatory(cql, table1, "c>2", lambda row: row.c > 2)
     # But looking for a particular clustering column value inside a specific
     # partition does not require filtering.
-    check_af_optional(cql, table1, 'c=2 AND k = 1', lambda row: row.c==2 and row.k==1)
+    check_af_optional(
+        cql, table1, "c=2 AND k = 1", lambda row: row.c == 2 and row.k == 1
+    )
+
 
 # Same as the above test_allow_filtering_clustering_key, except that instead
 # of scanning all the partitions, we limit the scan half of them using a
@@ -150,8 +194,9 @@ def test_allow_filtering_clustering_key_token_range(cql, table1):
     # TODO: the current implementation of check_af_mandatory() doesn't know
     # how to request or compare results with the token, so we pass None to
     # so it only checks that ALLOW FILTERING is mandatory.
-    check_af_mandatory(cql, table1, 'c=2 AND token(k) > 123', None)
-    check_af_mandatory(cql, table1, 'c=2 AND token(k) > 123 AND token(k) < 200', None)
+    check_af_mandatory(cql, table1, "c=2 AND token(k) > 123", None)
+    check_af_mandatory(cql, table1, "c=2 AND token(k) > 123 AND token(k) < 200", None)
+
 
 # In the above test we noted that filtering by clustering key in a
 # potentially large subset of the partitions (a token range) also needs
@@ -163,13 +208,15 @@ def test_allow_filtering_clustering_key_token_range(cql, table1):
 # is guaranteed to match just one partition, doesn't need ALLOW FILTERING.
 # Reproduces issue #7608.
 def test_allow_filtering_clustering_key_token_specific(cql, table1):
-    check_af_mandatory(cql, table1, 'c=2 AND token(k) = 123', None)
-    check_af_optional(cql, table1, 'c=2 AND k = 123', None)
+    check_af_mandatory(cql, table1, "c=2 AND token(k) = 123", None)
+    check_af_optional(cql, table1, "c=2 AND k = 123", None)
+
 
 # A restriction on the partition key other than equality requires filtering.
 def test_allow_filtering_partition_key(cql, table1):
-    check_af_optional(cql, table1, 'k=2', lambda row: row.k==2)
-    check_af_mandatory(cql, table1, 'k>2', lambda row: row.k>2)
+    check_af_optional(cql, table1, "k=2", lambda row: row.k == 2)
+    check_af_mandatory(cql, table1, "k>2", lambda row: row.k > 2)
+
 
 # A utility function for waiting for a secondary index to become up-
 # up-to-date (this may not be immediate).
@@ -182,14 +229,17 @@ def wait_for_index(cql, table, column, everything):
         column_values = {getattr(row, column) for row in everything}
         results = []
         for v in column_values:
-            results.extend(list(cql.execute(f'SELECT * FROM {table} WHERE {column}={v}')))
+            results.extend(
+                list(cql.execute(f"SELECT * FROM {table} WHERE {column}={v}"))
+            )
 
         if sorted(results) == sorted(everything):
             return
-        
+
         time.sleep(0.1)
 
-    pytest.fail('Timeout waiting for index to become up to date.')
+    pytest.fail("Timeout waiting for index to become up to date.")
+
 
 # Similar to wait_for_index(), just for a local secondary index
 def wait_for_local_index(cql, table, pk, column, everything):
@@ -198,45 +248,61 @@ def wait_for_local_index(cql, table, pk, column, everything):
         column_values = {(getattr(row, pk), getattr(row, column)) for row in everything}
         results = []
         for p, v in column_values:
-            results.extend(list(cql.execute(f'SELECT * FROM {table} WHERE {pk}={p} AND {column}={v}')))
+            results.extend(
+                list(
+                    cql.execute(
+                        f"SELECT * FROM {table} WHERE {pk}={p} AND {column}={v}"
+                    )
+                )
+            )
         if sorted(results) == sorted(everything):
             return
         time.sleep(0.1)
-    pytest.fail('Timeout waiting for index to become up to date.')
+    pytest.fail("Timeout waiting for index to become up to date.")
+
 
 @pytest.fixture(scope="module")
 def table2(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
-    cql.execute("CREATE TABLE " + table +
-        "(k int, a int, b int, PRIMARY KEY (k))")
+    cql.execute("CREATE TABLE " + table + "(k int, a int, b int, PRIMARY KEY (k))")
     cql.execute("CREATE INDEX ON " + table + "(a)")
     for i in range(0, 5):
-        cql.execute("INSERT INTO {} (k, a, b) VALUES ({}, {}, {})".format(
-                table, i, i*10, i*100))
-    everything = list(cql.execute('SELECT * FROM ' + table))
-    wait_for_index(cql, table, 'a', everything)
+        cql.execute(
+            "INSERT INTO {} (k, a, b) VALUES ({}, {}, {})".format(
+                table, i, i * 10, i * 100
+            )
+        )
+    everything = list(cql.execute("SELECT * FROM " + table))
+    wait_for_index(cql, table, "a", everything)
     yield (table, everything)
     cql.execute("DROP TABLE " + table)
+
 
 # When an index is available, beyond the normal ability to efficiently
 # (without ALLOW FILTERING) retrieve a partition or a partition slice,
 # we can retrieve a particular value of the indexed column "a" without
 # filtering.
 def test_allow_filtering_indexed_no_filtering(cql, table2):
-    check_af_optional(cql, table2, 'k=1', lambda row: row.k==1)
-    check_af_optional(cql, table2, 'a=20', lambda row: row.a==20)
+    check_af_optional(cql, table2, "k=1", lambda row: row.k == 1)
+    check_af_optional(cql, table2, "a=20", lambda row: row.a == 20)
+
 
 # When an index is available, we still need ALLOW FILTERING to filter
 # on an additional regular column.
 def test_allow_filtering_indexed_filtering_required(cql, table2):
-    check_af_mandatory(cql, table2, 'a=20 AND b=200', lambda row: row.a==20 and row.b==200)
+    check_af_mandatory(
+        cql, table2, "a=20 AND b=200", lambda row: row.a == 20 and row.b == 200
+    )
+
 
 # Searching for the intersection of indexed value *and* a partition key
 # (a=20 and k=1) can be done without filtering: The search for a=20 results
 # in a partition, whose first clustering key is the partition key, so we
 # can skip to it without filtering.
 def test_allow_filtering_indexed_a_and_k(cql, table2):
-    check_af_optional(cql, table2, 'a=20 AND k=1', lambda row: row.a==20 and row.k==1)
+    check_af_optional(
+        cql, table2, "a=20 AND k=1", lambda row: row.a == 20 and row.k == 1
+    )
 
 
 # table3 is an even more elaborate table with several partition key columns,
@@ -245,27 +311,41 @@ def test_allow_filtering_indexed_a_and_k(cql, table2):
 @pytest.fixture(scope="module")
 def table3(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
-    cql.execute("CREATE TABLE " + table +
-        "(k1 int, k2 int, c1 int, c2 int, a int, b int, s int static, PRIMARY KEY ((k1,k2),c1,c2))")
+    cql.execute(
+        "CREATE TABLE "
+        + table
+        + "(k1 int, k2 int, c1 int, c2 int, a int, b int, s int static, PRIMARY KEY ((k1,k2),c1,c2))"
+    )
     cql.execute("CREATE INDEX ON " + table + "(s)")
     cql.execute("CREATE INDEX ON " + table + "(a)")
     cql.execute("CREATE INDEX ON " + table + "(b)")
     for i in range(0, 5):
         for j in range(0, 5):
-            cql.execute("INSERT INTO {} (k1, k2, c1, c2, a, b, s) VALUES ({}, {}, {}, {}, {}, {}, {})".format(
-                table, i, j, i*10, j*10, i*100, j*100, i+j))
-    everything = list(cql.execute('SELECT * FROM ' + table))
-    wait_for_index(cql, table, 'a', everything)
-    wait_for_index(cql, table, 'b', everything)
-    wait_for_index(cql, table, 's', everything)
+            cql.execute(
+                "INSERT INTO {} (k1, k2, c1, c2, a, b, s) VALUES ({}, {}, {}, {}, {}, {}, {})".format(
+                    table, i, j, i * 10, j * 10, i * 100, j * 100, i + j
+                )
+            )
+    everything = list(cql.execute("SELECT * FROM " + table))
+    wait_for_index(cql, table, "a", everything)
+    wait_for_index(cql, table, "b", everything)
+    wait_for_index(cql, table, "s", everything)
     yield (table, everything)
     cql.execute("DROP TABLE " + table)
 
+
 def test_allow_filtering_multi_column(cql, table3):
     """Multi-column restrictions are just like other clustering restrictions"""
-    check_af_mandatory(cql, table3, '(c1,c2)=(10,10)', lambda row: row.c1==10 and row.c2==10)
-    check_af_optional(cql, table3, '(c1,c2)=(10,10) and k1=1 and k2=1',
-            lambda row: row.c1==10 and row.c2==10 and row.k1==1 and row.k2==1)
+    check_af_mandatory(
+        cql, table3, "(c1,c2)=(10,10)", lambda row: row.c1 == 10 and row.c2 == 10
+    )
+    check_af_optional(
+        cql,
+        table3,
+        "(c1,c2)=(10,10) and k1=1 and k2=1",
+        lambda row: row.c1 == 10 and row.c2 == 10 and row.k1 == 1 and row.k2 == 1,
+    )
+
 
 # In test_allow_filtering_indexed_a_and_k() above we noted that the
 # combination of an indexed column and the partition key can be searched
@@ -274,29 +354,56 @@ def test_allow_filtering_multi_column(cql, table3):
 # many results matching the indexed column, and finding the ones matching
 # the given clustering key value requires filtering.
 def test_allow_filtering_indexed_a_and_c(cql, table3):
-    check_af_mandatory(cql, table3, 'a=100 AND c1=10', lambda row: row.a==100 and row.c1==10)
+    check_af_mandatory(
+        cql, table3, "a=100 AND c1=10", lambda row: row.a == 100 and row.c1 == 10
+    )
+
 
 # Exactly the same for an indexed static column: s=5 may match many rows,
 # and c1=10 may restrict the returned list to much fewer.
 # (See also discussion in #12828)
 def test_allow_filtering_indexed_s_and_c(cql, table3):
-    check_af_mandatory(cql, table3, 's=5 AND c1=10', lambda row: row.s==5 and row.c1==10)
+    check_af_mandatory(
+        cql, table3, "s=5 AND c1=10", lambda row: row.s == 5 and row.c1 == 10
+    )
+
 
 # Similarly, trying two combine two different indexes requires filtering.
 # Scylla does not have efficient intersections of two indexes.
 def test_allow_filtering_indexed_two_indexes(cql, table3):
-    check_af_mandatory(cql, table3, 'a=100 AND b=100', lambda row: row.a==100 and row.b==100)
+    check_af_mandatory(
+        cql, table3, "a=100 AND b=100", lambda row: row.a == 100 and row.b == 100
+    )
+
 
 # Test that queries involving key columns still requires filtering if
 # the searched columns are not a full partition key, or not a prefix
 # of the clustering key.
 def test_allow_filtering_prefix(cql, table3):
-    check_af_mandatory(cql, table3, 'k1=1', lambda row: row.k1==1)
-    check_af_mandatory(cql, table3, 'k2=1', lambda row: row.k2==1)
-    check_af_optional(cql, table3, 'k1=1 AND k2=1', lambda row: row.k1==1 and row.k2 ==1)
-    check_af_optional(cql, table3, 'k1=1 AND k2=1 AND c1=10', lambda row: row.k1==1 and row.k2==1 and row.c1==10)
-    check_af_mandatory(cql, table3, 'k1=1 AND k2=1 AND c2=10', lambda row: row.k1==1 and row.k2==1 and row.c2==10)
-    check_af_optional(cql, table3, 'k1=1 AND k2=1 AND c1=10 AND c2=10', lambda row: row.k1==1 and row.k2==1 and row.c1==10 and row.c2==10)
+    check_af_mandatory(cql, table3, "k1=1", lambda row: row.k1 == 1)
+    check_af_mandatory(cql, table3, "k2=1", lambda row: row.k2 == 1)
+    check_af_optional(
+        cql, table3, "k1=1 AND k2=1", lambda row: row.k1 == 1 and row.k2 == 1
+    )
+    check_af_optional(
+        cql,
+        table3,
+        "k1=1 AND k2=1 AND c1=10",
+        lambda row: row.k1 == 1 and row.k2 == 1 and row.c1 == 10,
+    )
+    check_af_mandatory(
+        cql,
+        table3,
+        "k1=1 AND k2=1 AND c2=10",
+        lambda row: row.k1 == 1 and row.k2 == 1 and row.c2 == 10,
+    )
+    check_af_optional(
+        cql,
+        table3,
+        "k1=1 AND k2=1 AND c1=10 AND c2=10",
+        lambda row: row.k1 == 1 and row.k2 == 1 and row.c1 == 10 and row.c2 == 10,
+    )
+
 
 # Just like "k=1" (for partition key) and "a=1" (for indexed column) does
 # not require filtering, neither should "k in (1,2)" or "a in (1,2)" -
@@ -309,10 +416,15 @@ def test_allow_filtering_prefix(cql, table3):
 # without ALLOW FILTERING. The test test_allow_filtering_index_in()
 # reproduces issue #5545 / #13533
 def test_allow_filtering_pk_in(cql, table1):
-    check_af_optional(cql, table1, 'k IN (1,2)', lambda row: row.k in {1,2})
-@pytest.mark.xfail(reason="issue #5545, #13533: Scylla supports IN on indexed column, but only with ALLOW FILTERING")
+    check_af_optional(cql, table1, "k IN (1,2)", lambda row: row.k in {1, 2})
+
+
+@pytest.mark.xfail(
+    reason="WHERE IN secondary_index requires ALLOW FILTERING unlike in Cassandra #5545, WHERE IN is much slower than individual selects #13533"
+)
 def test_allow_filtering_index_in(cql, table2):
-    check_af_optional(cql, table2, 'a IN (1,2)', lambda row: row.a in {1,2})
+    check_af_optional(cql, table2, "a IN (1,2)", lambda row: row.a in {1, 2})
+
 
 # Exactly the same bug #13533 as tested above in
 # test_allow_filtering_index_in, also exists for *local* secondary
@@ -321,19 +433,26 @@ def test_allow_filtering_index_in(cql, table2):
 @pytest.fixture(scope="module")
 def table2local(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
-    cql.execute("CREATE TABLE " + table +
-        "(k int, a int, b int, PRIMARY KEY (k))")
+    cql.execute("CREATE TABLE " + table + "(k int, a int, b int, PRIMARY KEY (k))")
     cql.execute("CREATE INDEX ON " + table + "((k), a)")
     for i in range(0, 5):
-        cql.execute("INSERT INTO {} (k, a, b) VALUES ({}, {}, {})".format(
-                table, i//2, i*10, i*100))
-    everything = list(cql.execute('SELECT * FROM ' + table))
-    wait_for_local_index(cql, table, 'k', 'a', everything)
+        cql.execute(
+            "INSERT INTO {} (k, a, b) VALUES ({}, {}, {})".format(
+                table, i // 2, i * 10, i * 100
+            )
+        )
+    everything = list(cql.execute("SELECT * FROM " + table))
+    wait_for_local_index(cql, table, "k", "a", everything)
     yield (table, everything)
     cql.execute("DROP TABLE " + table)
-@pytest.mark.xfail(reason="issue #13533: Scylla supports IN on indexed column, but only with ALLOW FILTERING")
+
+
+@pytest.mark.xfail(reason="WHERE IN is much slower than individual selects #13533")
 def test_allow_filtering_local_index_in(cql, table2local, scylla_only):
-    check_af_optional(cql, table2local, 'k = 0 AND a IN (1,2)', lambda row: row.a in {1,2})
+    check_af_optional(
+        cql, table2local, "k = 0 AND a IN (1,2)", lambda row: row.a in {1, 2}
+    )
+
 
 # The following test Reproduces bug #7888 in CONTAINS/CONTAINS KEY relations
 # on frozen collection clustering columns when the query is restricted to a
@@ -341,16 +460,33 @@ def test_allow_filtering_local_index_in(cql, table2local, scylla_only):
 # Cassandra's more elaborate test for this issue,
 # cassandra_tests/validation/entities/frozen_collections_test.py::testClusteringColumnFiltering
 def test_contains_frozen_collection_ck(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "a int, b frozen<map<int, int>>, c int, PRIMARY KEY (a,b,c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "a int, b frozen<map<int, int>>, c int, PRIMARY KEY (a,b,c)"
+    ) as table:
         # The CREATE INDEX for c is necessary to reproduce this bug.
         # Everything works without it.
         cql.execute(f"CREATE INDEX ON {table} (c)")
         cql.execute("INSERT INTO " + table + " (a, b, c) VALUES (0, {0: 0, 1: 1}, 0)")
         # The "a=0" below is necessary to reproduce this bug.
-        assert 1 == len(list(cql.execute(
-            "SELECT * FROM " + table + " WHERE a=0 AND c=0 AND b CONTAINS 0 ALLOW FILTERING")))
-        assert 1 == len(list(cql.execute(
-            "SELECT * FROM " + table + " WHERE a=0 AND c=0 AND b CONTAINS KEY 0 ALLOW FILTERING")))
+        assert 1 == len(
+            list(
+                cql.execute(
+                    "SELECT * FROM "
+                    + table
+                    + " WHERE a=0 AND c=0 AND b CONTAINS 0 ALLOW FILTERING"
+                )
+            )
+        )
+        assert 1 == len(
+            list(
+                cql.execute(
+                    "SELECT * FROM "
+                    + table
+                    + " WHERE a=0 AND c=0 AND b CONTAINS KEY 0 ALLOW FILTERING"
+                )
+            )
+        )
+
 
 # table4 contains example table from issue #8991
 @pytest.fixture(scope="module")
@@ -362,21 +498,27 @@ def table4(cql, test_keyspace):
     cql.execute(f"INSERT INTO {table} (k, c1, c2) VALUES (0, 1, 1)")
 
     everything = list(cql.execute(f"SELECT * FROM {table}"))
-    wait_for_index(cql, table, 'c2', everything)
+    wait_for_index(cql, table, "c2", everything)
     yield (table, everything)
     cql.execute(f"DROP TABLE {table}")
+
 
 # Selecting from indexed table using only clustering key should require filtering
 # Variation of #7608 found in #8991
 def test_select_indexed_cluster(cql, table4):
-    check_af_mandatory(cql, table4, 'c1 = 1 AND c2 = 1', lambda row: row.c1 == 1 and row.c2 == 1)
+    check_af_mandatory(
+        cql, table4, "c1 = 1 AND c2 = 1", lambda row: row.c1 == 1 and row.c2 == 1
+    )
+
 
 # table5 contains an indexed table with 3 clustering columns.
 # used to test correct filtering of rows fetched from an index table.
 @pytest.fixture(scope="module")
 def table5(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
-    cql.execute(f"CREATE TABLE {table} (p int, c1 frozen<list<int>>, c2 frozen<list<int>>, c3 int, PRIMARY KEY (p,c1,c2,c3))")
+    cql.execute(
+        f"CREATE TABLE {table} (p int, c1 frozen<list<int>>, c2 frozen<list<int>>, c3 int, PRIMARY KEY (p,c1,c2,c3))"
+    )
     cql.execute(f"CREATE INDEX ON {table} (c3)")
     cql.execute(f"INSERT INTO {table} (p, c1, c2, c3) VALUES (0, [1], [2], 0)")
     cql.execute(f"INSERT INTO {table} (p, c1, c2, c3) VALUES (0, [2], [2], 0)")
@@ -384,9 +526,10 @@ def table5(cql, test_keyspace):
     cql.execute(f"INSERT INTO {table} (p, c1, c2, c3) VALUES (0, [1], [2], 1)")
 
     everything = list(cql.execute(f"SELECT * FROM {table}"))
-    wait_for_index(cql, table, 'c3', everything)
+    wait_for_index(cql, table, "c3", everything)
     yield (table, everything)
     cql.execute(f"DROP TABLE {table}")
+
 
 # Test that implementation of filtering for indexes works ok.
 # Current implementation is a bit conservative - it might sometimes state
@@ -394,14 +537,24 @@ def table5(cql, test_keyspace):
 def test_select_indexed_cluster_three_keys(cql, table5):
     def check_good_row(row):
         return row.p == 0 and row.c1 == [1] and row.c2 == [2] and row.c3 == 0
-    
-    check_af_optional(cql, table5, "c3 = 0", lambda r : r.c3 == 0)
+
+    check_af_optional(cql, table5, "c3 = 0", lambda r: r.c3 == 0)
     check_af_mandatory(cql, table5, "c1 = [1] AND c2 = [2] AND c3 = 0", check_good_row)
-    check_af_mandatory(cql, table5, "p = 0 AND c1 CONTAINS 1 AND c3 = 0", lambda r : r.p == 0 and r.c1 == [1] and r.c3 == 0)
-    check_af_mandatory(cql, table5, "p = 0 AND c1 = [1] AND c2 CONTAINS 2 AND c3 = 0", check_good_row)
+    check_af_mandatory(
+        cql,
+        table5,
+        "p = 0 AND c1 CONTAINS 1 AND c3 = 0",
+        lambda r: r.p == 0 and r.c1 == [1] and r.c3 == 0,
+    )
+    check_af_mandatory(
+        cql, table5, "p = 0 AND c1 = [1] AND c2 CONTAINS 2 AND c3 = 0", check_good_row
+    )
 
     # Doesn't use an index - shouldn't be affected
-    check_af_optional(cql, table5, "p = 0 AND c1 = [1] AND c2 = [2] AND c3 = 0", check_good_row)
+    check_af_optional(
+        cql, table5, "p = 0 AND c1 = [1] AND c2 = [2] AND c3 = 0", check_good_row
+    )
+
 
 # Here are the cases where current implementation of need_filtering() fails
 # By coincidence they also fail on cassandra, it looks like cassandra is buggy
@@ -412,7 +565,13 @@ def test_select_indexed_cluster_three_keys_conservative(cql, table5, cassandra_b
 
     # Don't require filtering, but for now we report they do
     check_af_optional(cql, table5, "p = 0 AND c1 = [1] AND c3 = 0", check_good_row)
-    check_af_optional(cql, table5, "p = 0 AND c1 = [1] AND c2 < [3] AND c3 = 0", lambda r : check_good_row(r) and r.c2 < [3])
+    check_af_optional(
+        cql,
+        table5,
+        "p = 0 AND c1 = [1] AND c2 < [3] AND c3 = 0",
+        lambda r: check_good_row(r) and r.c2 < [3],
+    )
+
 
 # This test demonstrates a loose end after issue #9085 was fixed by PR #9122.
 # The fix ensured correct results - but not correct ALLOW FILTERING need.
@@ -430,28 +589,37 @@ def test_select_indexed_cluster_three_keys_conservative(cql, table5, cassandra_b
 # FILTERING requirement, not just on the correctness of the results.
 @pytest.mark.xfail(reason="PR #9122 loose end")
 def test_allow_filtering_multi_column_and_index(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c1 int, c2 int, r int, primary key(p,c1,c2)') as table:
-        cql.execute(f'CREATE INDEX ON {table}(r)')
-        cql.execute(f'INSERT INTO {table}(p, c1, c2, r) VALUES (1, 1, 1, 0)')
-        cql.execute(f'INSERT INTO {table}(p, c1, c2, r) VALUES (1, 1, 2, 1)')
-        cql.execute(f'INSERT INTO {table}(p, c1, c2, r) VALUES (1, 2, 1, 0)')
-        cql.execute(f'INSERT INTO {table}(p, c1, c2, r) VALUES (2, 2, -1, 0)')
+    with new_test_table(
+        cql, test_keyspace, "p int, c1 int, c2 int, r int, primary key(p,c1,c2)"
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}(r)")
+        cql.execute(f"INSERT INTO {table}(p, c1, c2, r) VALUES (1, 1, 1, 0)")
+        cql.execute(f"INSERT INTO {table}(p, c1, c2, r) VALUES (1, 1, 2, 1)")
+        cql.execute(f"INSERT INTO {table}(p, c1, c2, r) VALUES (1, 2, 1, 0)")
+        cql.execute(f"INSERT INTO {table}(p, c1, c2, r) VALUES (2, 2, -1, 0)")
         everything = list(cql.execute(f"SELECT * FROM {table}"))
-        wait_for_index(cql, table, 'r', everything)
+        wait_for_index(cql, table, "r", everything)
         # If the base table's partition key (p) is missing in the query, it's
         # not a full prefix of the index table's clustering key, so filtering
         # *is* needed:
-        check_af_mandatory(cql, (table, everything),
+        check_af_mandatory(
+            cql,
+            (table, everything),
             "(c1,c2)<(2,0) AND r = 0",
-            lambda r : r.r == 0 and (r.c1 < 2 or (r.c1 == 2 and r.c2 < 0)))
+            lambda r: r.r == 0 and (r.c1 < 2 or (r.c1 == 2 and r.c2 < 0)),
+        )
         # But if the base table's partition key is in the query, along with
         # the clustering key, then it's a full prefix of the index's
         # clustering key - so filtering is not needed. PR #9122 fixed the
         # correctness of this query, but left ALLOW FILTERING mandatory so
         # the following test failed:
-        check_af_optional(cql, (table, everything),
+        check_af_optional(
+            cql,
+            (table, everything),
             "p=1 AND (c1,c2)<(2,0) AND r = 0",
-            lambda r : r.p == 1 and r.r == 0 and (r.c1 < 2 or (r.c1 == 2 and r.c2 < 0)))
+            lambda r: r.p == 1 and r.r == 0 and (r.c1 < 2 or (r.c1 == 2 and r.c2 < 0)),
+        )
+
 
 # In test_allow_filtering_clustering_key above we checked that a scan of the
 # whole table looking for one particular *clustering* column value requires
@@ -460,18 +628,22 @@ def test_allow_filtering_multi_column_and_index(cql, test_keyspace):
 # instead of the restriction c=2 we use multi-column syntax (c)=(2) - which
 # should be the same (see discussion in issue #13250).
 def test_allow_filtering_clustering_key_multicolumn_syntax(cql, table1):
-    check_af_mandatory(cql, table1, '(c)=(2)', lambda row: row.c==2)
+    check_af_mandatory(cql, table1, "(c)=(2)", lambda row: row.c == 2)
+
 
 # Moreover, if we have multiple clustering key columns, c1 and c2,
 # (c2)=(10) should be allowed just like c2=10 (and require filtering
 # just like it) - we shouldn't complain that c1 is missing. Reproduces #13250.
-@pytest.mark.xfail(reason="issue #13250")
+@pytest.mark.xfail(
+    reason="one-element multi-column restriction should be handled like a single-column restriction #13250"
+)
 def test_allow_filtering_compound_clustering_key_multicolumn_syntax(cql, table3):
-    check_af_mandatory(cql, table3, 'c1=10', lambda row: row.c1==10)
-    check_af_mandatory(cql, table3, '(c1)=(10)', lambda row: row.c1==10)
-    check_af_mandatory(cql, table3, 'c2=10', lambda row: row.c2==10)
+    check_af_mandatory(cql, table3, "c1=10", lambda row: row.c1 == 10)
+    check_af_mandatory(cql, table3, "(c1)=(10)", lambda row: row.c1 == 10)
+    check_af_mandatory(cql, table3, "c2=10", lambda row: row.c2 == 10)
     # Reproduces #13250:
-    check_af_mandatory(cql, table3, '(c2)=(10)', lambda row: row.c2==10)
+    check_af_mandatory(cql, table3, "(c2)=(10)", lambda row: row.c2 == 10)
+
 
 # Intersecting two indexes requires ALLOW FILTERING, because no matter how
 # efficient we implement index intersection (and Scylla doesn't...), there
@@ -482,27 +654,26 @@ def test_allow_filtering_compound_clustering_key_multicolumn_syntax(cql, table3)
 # This query needs to process at least half a million rows before returning
 # no matches. This is ALLOW FILTERING par excellence.
 def test_allow_filtering_index_intersection(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, x int, y int, primary key(p)') as table:
-        cql.execute(f'CREATE INDEX ON {table}(x)')
-        cql.execute(f'CREATE INDEX ON {table}(y)')
-        cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (0, 0, 0)')
-        cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (1, 0, 1)')
-        cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (2, 1, 0)')
-        cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (3, 1, 1)')
+    with new_test_table(
+        cql, test_keyspace, "p int, x int, y int, primary key(p)"
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}(x)")
+        cql.execute(f"CREATE INDEX ON {table}(y)")
+        cql.execute(f"INSERT INTO {table}(p, x, y) VALUES (0, 0, 0)")
+        cql.execute(f"INSERT INTO {table}(p, x, y) VALUES (1, 0, 1)")
+        cql.execute(f"INSERT INTO {table}(p, x, y) VALUES (2, 1, 0)")
+        cql.execute(f"INSERT INTO {table}(p, x, y) VALUES (3, 1, 1)")
         everything = list(cql.execute(f"SELECT * FROM {table}"))
-        wait_for_index(cql, table, 'x', everything)
-        wait_for_index(cql, table, 'y', everything)
+        wait_for_index(cql, table, "x", everything)
+        wait_for_index(cql, table, "y", everything)
         # If we search on just one index, ALLOW FILTERING is not needed:
-        check_af_optional(cql, (table, everything),
-            "x = 1",
-            lambda r : r.x == 1)
-        check_af_optional(cql, (table, everything),
-            "y = 1",
-            lambda r : r.y == 1)
+        check_af_optional(cql, (table, everything), "x = 1", lambda r: r.x == 1)
+        check_af_optional(cql, (table, everything), "y = 1", lambda r: r.y == 1)
         # But intersecting two indexes, ALLOW FILTERING is required:
-        check_af_mandatory(cql, (table, everything),
-            "x = 1 AND y = 1",
-            lambda r : r.x == 1 and r.y == 1)
+        check_af_mandatory(
+            cql, (table, everything), "x = 1 AND y = 1", lambda r: r.x == 1 and r.y == 1
+        )
+
 
 # Exactly the same test as the above, but using the "SAI" indexer, which
 # reproduces a regression in Cassandra 5's SAI compared to their classic
@@ -510,25 +681,23 @@ def test_allow_filtering_index_intersection(cql, test_keyspace):
 # Since Scylla doesn't support SAI, we skip the test on Scylla (and also
 # on older Cassandra).
 def test_allow_filtering_index_intersection_sai(cql, test_keyspace, cassandra_bug):
-    with new_test_table(cql, test_keyspace, 'p int, x int, y int, primary key(p)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, x int, y int, primary key(p)"
+    ) as table:
         try:
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(x) USING 'SAI'")
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(y) USING 'SAI'")
         except (InvalidRequest, ConfigurationException):
-            pytest.skip('SAI test skipped, SAI not supported')
-        cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (0, 0, 0)')
-        cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (1, 0, 1)')
-        cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (2, 1, 0)')
-        cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (3, 1, 1)')
+            pytest.skip("SAI test skipped, SAI not supported")
+        cql.execute(f"INSERT INTO {table}(p, x, y) VALUES (0, 0, 0)")
+        cql.execute(f"INSERT INTO {table}(p, x, y) VALUES (1, 0, 1)")
+        cql.execute(f"INSERT INTO {table}(p, x, y) VALUES (2, 1, 0)")
+        cql.execute(f"INSERT INTO {table}(p, x, y) VALUES (3, 1, 1)")
         everything = list(cql.execute(f"SELECT * FROM {table}"))
-        wait_for_index(cql, table, 'x', everything)
-        wait_for_index(cql, table, 'y', everything)
-        check_af_optional(cql, (table, everything),
-            "x = 1",
-            lambda r : r.x == 1)
-        check_af_optional(cql, (table, everything),
-            "y = 1",
-            lambda r : r.y == 1)
-        check_af_mandatory(cql, (table, everything),
-            "x = 1 AND y = 1",
-            lambda r : r.x == 1 and r.y == 1)
+        wait_for_index(cql, table, "x", everything)
+        wait_for_index(cql, table, "y", everything)
+        check_af_optional(cql, (table, everything), "x = 1", lambda r: r.x == 1)
+        check_af_optional(cql, (table, everything), "y = 1", lambda r: r.y == 1)
+        check_af_mandatory(
+            cql, (table, everything), "x = 1 AND y = 1", lambda r: r.x == 1 and r.y == 1
+        )

--- a/test/cqlpy/test_counter.py
+++ b/test/cqlpy/test_counter.py
@@ -12,46 +12,63 @@ from .util import new_test_table, unique_key_int
 from cassandra.protocol import InvalidRequest
 from .rest_api import scylla_inject_error
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, i bigint, v int") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int PRIMARY KEY, i bigint, v int"
+    ) as table:
         yield table
+
 
 @pytest.fixture(scope="module")
 def table2(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, c counter") as table:
         yield table
 
+
 # Test that the function counterasblob() exists and works as expected -
 # same as bigintasblob on the same number (a counter is a 64-bit number).
 # Reproduces #14742
 def test_counter_to_blob(cql, table1, table2):
     p = unique_key_int()
-    cql.execute(f'UPDATE {table1} SET i = 1000 WHERE p = {p}')
-    cql.execute(f'UPDATE {table2} SET c = c + 1000 WHERE p = {p}')
-    expected = b'\x00\x00\x00\x00\x00\x00\x03\xe8'
-    assert [(expected,)] == list(cql.execute(f"SELECT bigintasblob(i) FROM {table1} WHERE p={p}"))
-    assert [(expected,)] == list(cql.execute(f"SELECT counterasblob(c) FROM {table2} WHERE p={p}"))
+    cql.execute(f"UPDATE {table1} SET i = 1000 WHERE p = {p}")
+    cql.execute(f"UPDATE {table2} SET c = c + 1000 WHERE p = {p}")
+    expected = b"\x00\x00\x00\x00\x00\x00\x03\xe8"
+    assert [(expected,)] == list(
+        cql.execute(f"SELECT bigintasblob(i) FROM {table1} WHERE p={p}")
+    )
+    assert [(expected,)] == list(
+        cql.execute(f"SELECT counterasblob(c) FROM {table2} WHERE p={p}")
+    )
     # Although the representation of the counter and bigint types are the
     # same (64-bit), you can't use the wrong "*asblob()" function:
-    with pytest.raises(InvalidRequest, match='counterasblob'):
+    with pytest.raises(InvalidRequest, match="counterasblob"):
         cql.execute(f"SELECT counterasblob(i) FROM {table1} WHERE p={p}")
     # The opposite order is allowed in Scylla because of #14319, so let's
     # split it into a second test test_counter_to_blob2:
-@pytest.mark.xfail(reason="issue #14319")
+
+
+@pytest.mark.xfail(
+    reason="Maybe inconsistent handling of implicit timestamp<->bigint conversion #14319"
+)
 def test_counter_to_blob2(cql, table1, table2):
     p = unique_key_int()
-    cql.execute(f'UPDATE {table2} SET c = c + 1000 WHERE p = {p}')
+    cql.execute(f"UPDATE {table2} SET c = c + 1000 WHERE p = {p}")
     # Reproduces #14319:
-    with pytest.raises(InvalidRequest, match='bigintasblob'):
+    with pytest.raises(InvalidRequest, match="bigintasblob"):
         cql.execute(f"SELECT bigintasblob(c) FROM {table2} WHERE p={p}")
+
 
 # Test that the function blobascounter() exists and works as expected.
 # Reproduces #14742
 def test_counter_from_blob(cql, table1):
     p = unique_key_int()
-    cql.execute(f'UPDATE {table1} SET i = 1000 WHERE p = {p}')
-    assert [(1000,)] == list(cql.execute(f"SELECT blobascounter(bigintasblob(i)) FROM {table1} WHERE p={p}"))
+    cql.execute(f"UPDATE {table1} SET i = 1000 WHERE p = {p}")
+    assert [(1000,)] == list(
+        cql.execute(f"SELECT blobascounter(bigintasblob(i)) FROM {table1} WHERE p={p}")
+    )
+
 
 # blobascounter() must insist to receive a properly-sized (8-byte) blob.
 # If it accepts a shorter blob (e.g., 4 bytes) and returns that to the driver,
@@ -62,14 +79,17 @@ def test_counter_from_blob(cql, table1):
 # needs to be separately enforced for the counter type.
 def test_blobascounter_wrong_size(cql, table1):
     p = unique_key_int()
-    cql.execute(f'UPDATE {table1} SET v = 1000 WHERE p = {p}')
-    with pytest.raises(InvalidRequest, match='blobascounter'):
+    cql.execute(f"UPDATE {table1} SET v = 1000 WHERE p = {p}")
+    with pytest.raises(InvalidRequest, match="blobascounter"):
         cql.execute(f"SELECT blobascounter(intasblob(v)) FROM {table1} WHERE p={p}")
+
 
 # Drop a table while there is a counter update operation in progress.
 # Verify the table waits for the operation to complete before it's destroyed.
 # Reproduces scylladb/scylla-enterprise#4475
 def test_counter_update_while_table_dropped(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, c counter") as table, \
-         scylla_inject_error(cql, "apply_counter_update_delay_5s", one_shot=True):
-        cql.execute_async(f'UPDATE {table} SET c = c + 1 WHERE p = 0')
+    with (
+        new_test_table(cql, test_keyspace, "p int PRIMARY KEY, c counter") as table,
+        scylla_inject_error(cql, "apply_counter_update_delay_5s", one_shot=True),
+    ):
+        cql.execute_async(f"UPDATE {table} SET c = c + 1 WHERE p = 0")

--- a/test/cqlpy/test_empty.py
+++ b/test/cqlpy/test_empty.py
@@ -12,12 +12,14 @@ from .util import unique_name, unique_key_string, unique_key_int, new_test_table
 
 from . import nodetool
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (p text, c text, v text, primary key (p, c))")
     yield table
     cql.execute("DROP TABLE " + table)
+
 
 # In test_insert_null_key in test_null.py we verified that a null value is not
 # allowed as a key column - neither as a partition key nor clustering key.
@@ -31,11 +33,14 @@ def test_insert_empty_string_key(cql, table1):
     s = unique_key_string()
     # An empty-string clustering *is* allowed:
     cql.execute(f"INSERT INTO {table1} (p,c,v) VALUES ('{s}', '', 'cat')")
-    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' AND c=''")) == [('cat',)]
+    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' AND c=''")) == [
+        ("cat",)
+    ]
     # But an empty-string partition key is *not* allowed, with a specific
     # error that a "Key may not be empty":
-    with pytest.raises(InvalidRequest, match='Key may not be empty'):
+    with pytest.raises(InvalidRequest, match="Key may not be empty"):
         cql.execute(f"INSERT INTO {table1} (p,c,v) VALUES ('', '{s}', 'dog')")
+
 
 # Test an empty-string clustering key again, but this time doing a flush
 # bypassing the cache - checking that empty-string clustering keys can
@@ -45,36 +50,53 @@ def test_insert_empty_string_key_with_flush(cql, table1, scylla_only):
     s = unique_key_string()
     cql.execute(f"INSERT INTO {table1} (p,c,v) VALUES ('{s}', '', 'cat')")
     nodetool.flush(cql, table1)
-    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' AND c='' BYPASS CACHE")) == [('cat',)]
-    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' BYPASS CACHE")) == [('cat',)]
+    assert list(
+        cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' AND c='' BYPASS CACHE")
+    ) == [("cat",)]
+    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' BYPASS CACHE")) == [
+        ("cat",)
+    ]
+
 
 # In contrast with normal tables where an empty clustering key is allowed,
 # in a WITH COMPACT STORAGE table, an empty clustering key is not allowed.
 # As usual, an empty partition key is not allowed either.
-@pytest.mark.xfail(reason="issue #12749, misleading error message")
+@pytest.mark.xfail(
+    reason="Unsupported empty clustering key in COMPACT table #12749, misleading error message"
+)
 def test_insert_empty_string_key_compact(compact_storage, cql, test_keyspace):
-    schema = 'p text, c text, v text, primary key (p, c)'
-    with new_test_table(cql, test_keyspace, schema, 'WITH COMPACT STORAGE') as table:
+    schema = "p text, c text, v text, primary key (p, c)"
+    with new_test_table(cql, test_keyspace, schema, "WITH COMPACT STORAGE") as table:
         s = unique_key_string()
-        with pytest.raises(InvalidRequest, match='empty'):
+        with pytest.raises(InvalidRequest, match="empty"):
             cql.execute(f"INSERT INTO {table} (p,c,v) VALUES ('{s}', '', 'cat')")
-        with pytest.raises(InvalidRequest, match='Key may not be empty'):
+        with pytest.raises(InvalidRequest, match="Key may not be empty"):
             cql.execute(f"INSERT INTO {table} (p,c,v) VALUES ('', '{s}', 'dog')")
+
 
 # However, in a COMPACT STORAGE table with a *compound* clustering key (more
 # than one clustering key column), setting one of them to empty *is* allowed.
-@pytest.mark.xfail(reason="issue #12749")
-def test_insert_empty_string_compound_clustering_key_compact(compact_storage, cql, test_keyspace):
-    schema = 'p text, c1 text, c2 text, v text, primary key (p, c1, c2)'
-    with new_test_table(cql, test_keyspace, schema, 'WITH COMPACT STORAGE') as table:
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749")
+def test_insert_empty_string_compound_clustering_key_compact(
+    compact_storage, cql, test_keyspace
+):
+    schema = "p text, c1 text, c2 text, v text, primary key (p, c1, c2)"
+    with new_test_table(cql, test_keyspace, schema, "WITH COMPACT STORAGE") as table:
         s = unique_key_string()
         # Setting just one of the clustering key components, or both, to
         # an empty string, is allowed. This is in contrast with a single-
         # component clustering key which we saw above is cannot be set empty.
         cql.execute(f"INSERT INTO {table} (p,c1,c2,v) VALUES ('{s}', '', 'dog', 'cat')")
-        cql.execute(f"INSERT INTO {table} (p,c1,c2,v) VALUES ('{s}', 'hello', '', 'mouse')")
+        cql.execute(
+            f"INSERT INTO {table} (p,c1,c2,v) VALUES ('{s}', 'hello', '', 'mouse')"
+        )
         cql.execute(f"INSERT INTO {table} (p,c1,c2,v) VALUES ('{s}', '', '', 'horse')")
-        assert list(cql.execute(f"SELECT v FROM {table} WHERE p='{s}'")) == [('horse',),('cat',),('mouse',)]
+        assert list(cql.execute(f"SELECT v FROM {table} WHERE p='{s}'")) == [
+            ("horse",),
+            ("cat",),
+            ("mouse",),
+        ]
+
 
 # test_update_empty_string_key() is the same as test_insert_empty_string_key()
 # just uses an UPDATE instead of INSERT. It turns out that exactly the cases
@@ -83,11 +105,14 @@ def test_update_empty_string_key(cql, table1):
     s = unique_key_string()
     # An empty-string clustering *is* allowed:
     cql.execute(f"UPDATE {table1} SET v = 'cat' WHERE p='{s}' AND c=''")
-    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' AND c=''")) == [('cat',)]
+    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' AND c=''")) == [
+        ("cat",)
+    ]
     # But an empty-string partition key is *not* allowed, with a specific
     # error that a "Key may not be empty":
-    with pytest.raises(InvalidRequest, match='Key may not be empty'):
+    with pytest.raises(InvalidRequest, match="Key may not be empty"):
         cql.execute(f"UPDATE {table1} SET v = 'dog' WHERE p='' AND c='{s}'")
+
 
 # ... and same for DELETE
 def test_delete_empty_string_key(cql, table1):
@@ -96,8 +121,9 @@ def test_delete_empty_string_key(cql, table1):
     cql.execute(f"DELETE FROM {table1} WHERE p='{s}' AND c=''")
     # But an empty-string partition key is *not* allowed, with a specific
     # error that a "Key may not be empty":
-    with pytest.raises(InvalidRequest, match='Key may not be empty'):
+    with pytest.raises(InvalidRequest, match="Key may not be empty"):
         cql.execute(f"DELETE FROM {table1} WHERE p='' AND c='{s}'")
+
 
 # Another test like test_insert_empty_string_key() just using an INSERT JSON
 # instead of a regular INSERT. Because INSERT JSON takes a different code path
@@ -107,12 +133,19 @@ def test_delete_empty_string_key(cql, table1):
 def test_insert_json_empty_string_key(cql, table1):
     s = unique_key_string()
     # An empty-string clustering *is* allowed:
-    cql.execute("""INSERT INTO %s JSON '{"p": "%s", "c": "", "v": "cat"}'""" % (table1, s))
-    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' AND c=''")) == [('cat',)]
+    cql.execute(
+        """INSERT INTO %s JSON '{"p": "%s", "c": "", "v": "cat"}'""" % (table1, s)
+    )
+    assert list(cql.execute(f"SELECT v FROM {table1} WHERE p='{s}' AND c=''")) == [
+        ("cat",)
+    ]
     # But an empty-string partition key is *not* allowed, with a specific
     # error that a "Key may not be empty":
-    with pytest.raises(InvalidRequest, match='Key may not be empty'):
-        cql.execute("""INSERT INTO %s JSON '{"p": "", "c": "%s", "v": "cat"}'""" % (table1, s))
+    with pytest.raises(InvalidRequest, match="Key may not be empty"):
+        cql.execute(
+            """INSERT INTO %s JSON '{"p": "", "c": "%s", "v": "cat"}'""" % (table1, s)
+        )
+
 
 # Although an empty string is not allowed as a partition key (as tested
 # above by test_empty_string_key()), it turns out that in a *compound*
@@ -121,11 +154,14 @@ def test_insert_json_empty_string_key(cql, table1):
 # deemed unworthy to fix - see:
 #    https://issues.apache.org/jira/browse/CASSANDRA-11487
 def test_empty_string_key2(cql, test_keyspace):
-    schema = 'p1 text, p2 text, c text, v text, primary key ((p1, p2), c)'
+    schema = "p1 text, p2 text, c text, v text, primary key ((p1, p2), c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"INSERT INTO {table} (p1,p2,c,v) VALUES ('', '', '', 'cat')")
         cql.execute(f"INSERT INTO {table} (p1,p2,c,v) VALUES ('x', 'y', 'z', 'dog')")
-        assert list(cql.execute(f"SELECT v FROM {table} WHERE p1='' AND p2='' AND c=''")) == [('cat',)]
+        assert list(
+            cql.execute(f"SELECT v FROM {table} WHERE p1='' AND p2='' AND c=''")
+        ) == [("cat",)]
+
 
 # For historical reasons, CQL allows any type to be empty, not just strings.
 # An "empty" int value is a value with size 0 - and is distinct from a null
@@ -134,7 +170,7 @@ def test_empty_string_key2(cql, test_keyspace):
 # probably be aware if we ever break it, so it's good to have a regression
 # test for it.
 def test_empty_int(cql, test_keyspace):
-    schema = 'p text, v int, primary key (p)'
+    schema = "p text, v int, primary key (p)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # blobAsInt(0x) is the way to generate an empty int in CQL:
         cql.execute(f"INSERT INTO {table} (p,v) VALUES ('hi', blobAsInt(0x))")
@@ -143,6 +179,7 @@ def test_empty_int(cql, test_keyspace):
         # with an empty integer being returned - e.g., see
         # https://github.com/scylladb/scylla-rust-driver/issues/278
         assert list(cql.execute(f"SELECT v FROM {table} WHERE p='hi'")) == [(None,)]
+
 
 # Above in test_empty_int() we noted a bizarre and archaic (not used by
 # modern CQL users) feature where any type can be set to "empty".
@@ -154,14 +191,37 @@ def test_empty_int(cql, test_keyspace):
 # repeated with regular INSERT and with INSERT JSON.
 # The bugs uncovered by these tests were reported in issue #10625 and #7944.
 
+
 # Create a test table with an integer partition key, and many regular
 # columns of all scalar types. The column of type int is called "vint".
 @pytest.fixture(scope="module")
 def table_all_scalar(cql, test_keyspace):
-    types = ['ascii', 'bigint', 'blob', 'boolean', 'date', 'decimal', 'double', 'duration', 'float', 'inet', 'int', 'smallint', 'text', 'time', 'timestamp', 'timeuuid', 'tinyint', 'uuid', 'varchar', 'varint']
-    vars = ', '.join(['v'+x+' '+x for x in types])
-    with new_test_table(cql, test_keyspace, f'p int primary key, {vars}') as table:
+    types = [
+        "ascii",
+        "bigint",
+        "blob",
+        "boolean",
+        "date",
+        "decimal",
+        "double",
+        "duration",
+        "float",
+        "inet",
+        "int",
+        "smallint",
+        "text",
+        "time",
+        "timestamp",
+        "timeuuid",
+        "tinyint",
+        "uuid",
+        "varchar",
+        "varint",
+    ]
+    vars = ", ".join(["v" + x + " " + x for x in types])
+    with new_test_table(cql, test_keyspace, f"p int primary key, {vars}") as table:
         yield table
+
 
 # The following types can be assigned any string, and in particular it
 # is perfectly fine to assign to them an empty string.
@@ -169,89 +229,144 @@ def table_all_scalar(cql, test_keyspace):
 def test_empty_string_for_string_types(cql, table_all_scalar, t):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table_all_scalar} (p,v{t}) VALUES ({p}, '')")
-    assert list(cql.execute(f"SELECT v{t} FROM {table_all_scalar} WHERE p={p}")) == [('',)]
+    assert list(cql.execute(f"SELECT v{t} FROM {table_all_scalar} WHERE p={p}")) == [
+        ("",)
+    ]
+
 
 @pytest.mark.parametrize("t", ["ascii", "text", "varchar"])
 def test_empty_string_for_string_types_json(cql, table_all_scalar, t):
     p = unique_key_int()
-    cql.execute(f"INSERT INTO {table_all_scalar} JSON '{{\"p\": {p}, \"v{t}\": \"\"}}'")
-    assert list(cql.execute(f"SELECT v{t} FROM {table_all_scalar} WHERE p={p}")) == [('',)]
+    cql.execute(f'INSERT INTO {table_all_scalar} JSON \'{{"p": {p}, "v{t}": ""}}\'')
+    assert list(cql.execute(f"SELECT v{t} FROM {table_all_scalar} WHERE p={p}")) == [
+        ("",)
+    ]
+
 
 # "fussy" string types are types that in CQL can be assigned a string
 # constant, but the string needs to follow a particular format and in
 # particular the empty string should not be allowed.
 # Reproduces #10625.
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Empty composite partition keys are allowed in Scylla #10625")
 @pytest.mark.parametrize("t", ["date", "time"])
 def test_empty_string_for_fussy_string_types(cql, table_all_scalar, t):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
         cql.execute(f"INSERT INTO {table_all_scalar} (p,v{t}) VALUES ({p}, '')")
 
-@pytest.mark.xfail(reason="issue #10625")
+
+@pytest.mark.xfail(reason="Empty composite partition keys are allowed in Scylla #10625")
 @pytest.mark.parametrize("t", ["date", "time"])
 def test_empty_string_for_fussy_string_types_json(cql, table_all_scalar, t):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
-        cql.execute(f"INSERT INTO {table_all_scalar} JSON '{{\"p\": {p}, \"v{t}\": \"\"}}'")
+        cql.execute(f'INSERT INTO {table_all_scalar} JSON \'{{"p": {p}, "v{t}": ""}}\'')
+
 
 # Same as test_empty_string_for_fussy_string_types, but for some reason
 # Cassandra allows the empty string for these two types, even though an
 # empty string doesn't make sense as an IP address or a timestamp.
 # We consider this a Cassandra bug, hence the tag "cassandra_bug" below.
 # Reproduces #10625.
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Empty composite partition keys are allowed in Scylla #10625")
 @pytest.mark.parametrize("t", ["inet", "timestamp"])
 def test_empty_string_for_fussy_string_types2(cql, table_all_scalar, t, cassandra_bug):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
         cql.execute(f"INSERT INTO {table_all_scalar} (p,v{t}) VALUES ({p}, '')")
 
-@pytest.mark.xfail(reason="issue #10625")
+
+@pytest.mark.xfail(reason="Empty composite partition keys are allowed in Scylla #10625")
 @pytest.mark.parametrize("t", ["inet", "timestamp"])
-def test_empty_string_for_fussy_string_types2_json(cql, table_all_scalar, t, cassandra_bug):
+def test_empty_string_for_fussy_string_types2_json(
+    cql, table_all_scalar, t, cassandra_bug
+):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
-        cql.execute(f"INSERT INTO {table_all_scalar} JSON '{{\"p\": {p}, \"v{t}\": \"\"}}'")
+        cql.execute(f'INSERT INTO {table_all_scalar} JSON \'{{"p": {p}, "v{t}": ""}}\'')
+
 
 # All other types cannot be assigned a string constant at all (the error
 # is not specific to the empty string)
-@pytest.mark.parametrize("t", ["bigint", "blob", "boolean", "decimal", "double", "duration", "float", "int", "smallint", "timeuuid", "tinyint", "uuid", "varint"])
+@pytest.mark.parametrize(
+    "t",
+    [
+        "bigint",
+        "blob",
+        "boolean",
+        "decimal",
+        "double",
+        "duration",
+        "float",
+        "int",
+        "smallint",
+        "timeuuid",
+        "tinyint",
+        "uuid",
+        "varint",
+    ],
+)
 def test_empty_string_for_other_types(cql, table_all_scalar, t):
     p = unique_key_int()
-    with pytest.raises(InvalidRequest, match='Invalid STRING constant'):
+    with pytest.raises(InvalidRequest, match="Invalid STRING constant"):
         cql.execute(f"INSERT INTO {table_all_scalar} (p,v{t}) VALUES ({p}, '')")
+
 
 # Although INSERT JSON can convert strings to numbers, it shouldn't allow
 # an *empty* string.
 # Reproduces #7944 and #10625.
 # See also test_json.py::test_fromjson_{varint,int}_empty_string*
 # which reproduces the same bug but just for two specific types.
-@pytest.mark.xfail(reason="issue #7944")
-@pytest.mark.parametrize("t", ["bigint", "blob", "boolean", "decimal", "double", "duration", "float", "int", "smallint", "timeuuid", "tinyint", "uuid", "varint"])
+@pytest.mark.xfail(
+    reason='fromJson() should not accept the empty string "" as a number #7944'
+)
+@pytest.mark.parametrize(
+    "t",
+    [
+        "bigint",
+        "blob",
+        "boolean",
+        "decimal",
+        "double",
+        "duration",
+        "float",
+        "int",
+        "smallint",
+        "timeuuid",
+        "tinyint",
+        "uuid",
+        "varint",
+    ],
+)
 def test_empty_string_for_other_types_json(cql, table_all_scalar, t, cassandra_bug):
     p = unique_key_int()
-    with pytest.raises(InvalidRequest, match='Error decoding JSON'):
-        cql.execute(f"INSERT INTO {table_all_scalar} JSON '{{\"p\": {p}, \"v{t}\": \"\"}}'")
-        assert list(cql.execute(f"SELECT v{t} FROM {table_all_scalar} WHERE p={p}")) == [('',)]
+    with pytest.raises(InvalidRequest, match="Error decoding JSON"):
+        cql.execute(f'INSERT INTO {table_all_scalar} JSON \'{{"p": {p}, "v{t}": ""}}\'')
+        assert list(
+            cql.execute(f"SELECT v{t} FROM {table_all_scalar} WHERE p={p}")
+        ) == [("",)]
+
 
 # Some of the tests that failed above allowed inserting a empty value
 # in an "unofficial" way by assigning an empty string to it. This is not
 # a big problem for regular columns, but for key columns it is bad -
 # namely, because the partition key cannot be empty.
 # See #10625, #7944
-@pytest.mark.xfail(reason="issue #7944, Scylla returns internal server error")
+@pytest.mark.xfail(
+    reason="fromJson() should not accept the empty string as a number #7944, Scylla returns internal server error"
+)
 def test_empty_string_for_nonstring_partition_key1(cql, test_keyspace):
-    schema = 'p int primary key, v int'
+    schema = "p int primary key, v int"
     with new_test_table(cql, test_keyspace, schema) as table:
         # Cassandra returns a "Key may not be empty" but even better would
         # be to report earlier that an empty string cannot be converted to
         # a number.
         with pytest.raises(InvalidRequest):
-            cql.execute(f"INSERT INTO {table} JSON '{{\"p\": \"\", \"v\": 3}}'")
+            cql.execute(f'INSERT INTO {table} JSON \'{{"p": "", "v": 3}}\'')
+
 
 def test_empty_string_for_nonstring_partition_key2(cql, test_keyspace):
-    schema = 'p inet primary key, v int'
+    schema = "p inet primary key, v int"
     with new_test_table(cql, test_keyspace, schema) as table:
         # Cassandra returns a "Key may not be empty" but even better would
         # be to report earlier that an empty string cannot be converted to

--- a/test/cqlpy/test_filtering.py
+++ b/test/cqlpy/test_filtering.py
@@ -16,6 +16,7 @@ from .util import new_test_table, new_type, user_type
 from cassandra.protocol import InvalidRequest
 from cassandra.query import UNSET_VALUE
 
+
 # When filtering for "x > 0" or "x < 0", rows with an unset value for x
 # should not match the filter.
 # Reproduces issue #6295 and its duplicate #8122.
@@ -24,12 +25,21 @@ def test_filter_on_unset(cql, test_keyspace):
         cql.execute(f"INSERT INTO {table} (a) VALUES (1)")
         cql.execute(f"INSERT INTO {table} (a, b) VALUES (2, 2)")
         cql.execute(f"INSERT INTO {table} (a, b) VALUES (3, -1)")
-        assert list(cql.execute(f"SELECT a FROM {table} WHERE b>0 ALLOW FILTERING")) == [(2,)]
-        assert list(cql.execute(f"SELECT a FROM {table} WHERE b<0 ALLOW FILTERING")) == [(3,)]
+        assert list(
+            cql.execute(f"SELECT a FROM {table} WHERE b>0 ALLOW FILTERING")
+        ) == [(2,)]
+        assert list(
+            cql.execute(f"SELECT a FROM {table} WHERE b<0 ALLOW FILTERING")
+        ) == [(3,)]
         cql.execute(f"ALTER TABLE {table} ADD c int")
         cql.execute(f"INSERT INTO {table} (a, b,c ) VALUES (4, 5, 6)")
-        assert list(cql.execute(f"SELECT a FROM {table} WHERE c<0 ALLOW FILTERING")) == []
-        assert list(cql.execute(f"SELECT a FROM {table} WHERE c>0 ALLOW FILTERING")) == [(4,)]
+        assert (
+            list(cql.execute(f"SELECT a FROM {table} WHERE c<0 ALLOW FILTERING")) == []
+        )
+        assert list(
+            cql.execute(f"SELECT a FROM {table} WHERE c>0 ALLOW FILTERING")
+        ) == [(4,)]
+
 
 # Reproducers for issue #8203, which test a scan (whole-table or single-
 # partition) with filtering which keeps just the last row, after a long list
@@ -47,16 +57,20 @@ def test_filter_on_unset(cql, test_keyspace):
 # and Scylla versions have different version numbers), and if not, we skip
 # this test.
 
+
 # Reproducer for issue #8203, partition-range (whole-table) scan case
-def test_filtering_contiguous_nonmatching_partition_range(cql, test_keyspace, driver_bug_1):
+def test_filtering_contiguous_nonmatching_partition_range(
+    cql, test_keyspace, driver_bug_1
+):
     # The bug depends on the amount of data being scanned passing some
     # page size limit, so it doesn't matter if the reproducer has a lot of
     # small rows or fewer long rows - and inserting fewer long rows is
     # significantly faster.
     count = 100
-    long='x'*60000
-    with new_test_table(cql, test_keyspace,
-            "p int, c text, v int, PRIMARY KEY (p, c)") as table:
+    long = "x" * 60000
+    with new_test_table(
+        cql, test_keyspace, "p int, c text, v int, PRIMARY KEY (p, c)"
+    ) as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c, v) VALUES (?, '{long}', ?)")
         for i in range(count):
             cql.execute(stmt, [i, i])
@@ -64,27 +78,45 @@ def test_filtering_contiguous_nonmatching_partition_range(cql, test_keyspace, dr
         # know the partition order (we don't want the test to depend on the
         # partitioner). So we first figure out a partition near the end (at
         # some high token), and use that in the filter.
-        p, v = list(cql.execute(f"SELECT p, v FROM {table} WHERE TOKEN(p) > 8000000000000000000 LIMIT 1"))[0]
-        assert list(cql.execute(f"SELECT p FROM {table} WHERE v={v} ALLOW FILTERING")) == [(p,)]
+        p, v = list(
+            cql.execute(
+                f"SELECT p, v FROM {table} WHERE TOKEN(p) > 8000000000000000000 LIMIT 1"
+            )
+        )[0]
+        assert list(
+            cql.execute(f"SELECT p FROM {table} WHERE v={v} ALLOW FILTERING")
+        ) == [(p,)]
+
 
 # Reproducer for issue #8203, single-partition scan case
-def test_filtering_contiguous_nonmatching_single_partition(cql, test_keyspace, driver_bug_1):
+def test_filtering_contiguous_nonmatching_single_partition(
+    cql, test_keyspace, driver_bug_1
+):
     count = 100
-    long='x'*60000
-    with new_test_table(cql, test_keyspace,
-            "p int, c int, s text, v int, PRIMARY KEY (p, c)") as table:
-        stmt = cql.prepare(f"INSERT INTO {table} (p, c, v, s) VALUES (1, ?, ?, '{long}')")
+    long = "x" * 60000
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, s text, v int, PRIMARY KEY (p, c)"
+    ) as table:
+        stmt = cql.prepare(
+            f"INSERT INTO {table} (p, c, v, s) VALUES (1, ?, ?, '{long}')"
+        )
         for i in range(count):
             cql.execute(stmt, [i, i])
         # To fail this test, we must select s here. If s is not selected,
         # Scylla won't count its size as part of the 1MB limit, and will not
         # return empty pages - the first page will contain the result.
-        assert list(cql.execute(f"SELECT c, s FROM {table} WHERE p=1 AND v={count-1} ALLOW FILTERING")) == [(count-1, long)]
+        assert list(
+            cql.execute(
+                f"SELECT c, s FROM {table} WHERE p=1 AND v={count - 1} ALLOW FILTERING"
+            )
+        ) == [(count - 1, long)]
+
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "a int, b int, PRIMARY KEY (a)") as table:
         yield table
+
 
 # Although the "!=" operator exists in the parser and might be allowed in
 # other places (e.g., LWT), it is *NOT* supported in WHERE clauses - not
@@ -93,12 +125,13 @@ def table1(cql, test_keyspace):
 # Scylla, and there are no plans to add this support, so for now the test
 # verifies that at least we get the expected error.
 def test_operator_ne_not_supported(cql, table1):
-    with pytest.raises(InvalidRequest, match='Unsupported.*!='):
-        cql.execute(f'SELECT a FROM {table1} WHERE b != 0 ALLOW FILTERING')
-    with pytest.raises(InvalidRequest, match='Unsupported.*!='):
-        cql.execute(f'SELECT a FROM {table1} WHERE a != 0')
-    with pytest.raises(InvalidRequest, match='Unsupported.*!='):
-        cql.execute(f'SELECT a FROM {table1} WHERE token(a) != 0')
+    with pytest.raises(InvalidRequest, match="Unsupported.*!="):
+        cql.execute(f"SELECT a FROM {table1} WHERE b != 0 ALLOW FILTERING")
+    with pytest.raises(InvalidRequest, match="Unsupported.*!="):
+        cql.execute(f"SELECT a FROM {table1} WHERE a != 0")
+    with pytest.raises(InvalidRequest, match="Unsupported.*!="):
+        cql.execute(f"SELECT a FROM {table1} WHERE token(a) != 0")
+
 
 # Test that LIKE operator works fine as a filter when the filtered column
 # has descending order. Regression test for issue #10183, when it was
@@ -109,24 +142,45 @@ def test_operator_ne_not_supported(cql, table1):
 # "cassandra_bug" because they have an open issue to fix it (CASSANDRA-17198).
 # When Cassandra fixes this issue, this mark should be removed.
 def test_filter_like_on_desc_column(cql, test_keyspace, cassandra_bug):
-    with new_test_table(cql, test_keyspace, "a int, b text, primary key(a, b)",
-            extra="with clustering order by (b desc)") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "a int, b text, primary key(a, b)",
+        extra="with clustering order by (b desc)",
+    ) as table:
         cql.execute(f"INSERT INTO {table} (a, b) VALUES (1, 'one')")
         res = cql.execute(f"SELECT b FROM {table} WHERE b LIKE '%%%' ALLOW FILTERING")
         assert res.one().b == "one"
 
+
 # Test that the fact that a column is indexed does not cause us to fetch
 # incorrect results from a filtering query (issue #10300).
 def test_index_with_in_relation(scylla_only, cql, test_keyspace):
-    schema = 'p int, c int, v boolean, primary key (p,c)'
+    schema = "p int, c int, v boolean, primary key (p,c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"create index on {table}(v)")
-        for p, c, v in [(0,0,True),(0,1,False),(0,2,True),(0,3,False),
-                (1,0,True),(1,1,False),(1,2,True),(1,3,False),
-                (2,0,True),(2,1,False),(2,2,True),(2,3,False)]:
+        for p, c, v in [
+            (0, 0, True),
+            (0, 1, False),
+            (0, 2, True),
+            (0, 3, False),
+            (1, 0, True),
+            (1, 1, False),
+            (1, 2, True),
+            (1, 3, False),
+            (2, 0, True),
+            (2, 1, False),
+            (2, 2, True),
+            (2, 3, False),
+        ]:
             cql.execute(f"insert into {table} (p,c,v) values ({p}, {c}, {v})")
-        res = cql.execute(f"select * from {table} where p in (0,1) and v = False ALLOW FILTERING")
-        assert set(res) == set([(0,1,False),(0,3,False),(1,1,False), (1,3,False)])
+        res = cql.execute(
+            f"select * from {table} where p in (0,1) and v = False ALLOW FILTERING"
+        )
+        assert set(res) == set(
+            [(0, 1, False), (0, 3, False), (1, 1, False), (1, 3, False)]
+        )
+
 
 # Test that IN restrictions are supported with filtering and return the
 # correct results.
@@ -137,43 +191,50 @@ def test_index_with_in_relation(scylla_only, cql, test_keyspace):
 # partition-key columns p1 or p2. By the way, it does support IN restrictions
 # on a clustering-key column.
 def test_filtering_with_in_relation(cql, test_keyspace, cassandra_bug):
-    schema = 'p1 int, p2 int, c int, v int, primary key ((p1, p2),c)'
+    schema = "p1 int, p2 int, c int, v int, primary key ((p1, p2),c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 3, 4)")
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (2, 3, 4, 5)")
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (3, 4, 5, 6)")
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (4, 5, 6, 7)")
         res = cql.execute(f"select * from {table} where p1 in (2,4) ALLOW FILTERING")
-        assert set(res) == set([(2,3,4,5), (4,5,6,7)])
+        assert set(res) == set([(2, 3, 4, 5), (4, 5, 6, 7)])
         res = cql.execute(f"select * from {table} where p2 in (2,4) ALLOW FILTERING")
-        assert set(res) == set([(1,2,3,4), (3,4,5,6)])
+        assert set(res) == set([(1, 2, 3, 4), (3, 4, 5, 6)])
         res = cql.execute(f"select * from {table} where c in (3,5) ALLOW FILTERING")
-        assert set(res) == set([(1,2,3,4), (3,4,5,6)])
+        assert set(res) == set([(1, 2, 3, 4), (3, 4, 5, 6)])
         res = cql.execute(f"select * from {table} where v in (5,7) ALLOW FILTERING")
-        assert set(res) == set([(2,3,4,5), (4,5,6,7)])
+        assert set(res) == set([(2, 3, 4, 5), (4, 5, 6, 7)])
+
 
 # Test that NOT IN restrictions are supported with filtering and return the
 # correct results.
 def test_filtering_with_not_in_relation(cql, test_keyspace):
-    schema = 'p1 int, p2 int, c int, v int, primary key ((p1, p2),c)'
+    schema = "p1 int, p2 int, c int, v int, primary key ((p1, p2),c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 3, 4)")
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (2, 3, 4, 5)")
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (3, 4, 5, 6)")
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (4, 5, 6, 7)")
         cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (5, 6, 7, NULL)")
-        res = cql.execute(f"select * from {table} where p1 NOT IN (2,4) ALLOW FILTERING")
-        assert set(res) == set([(1,2,3,4), (3,4,5,6), (5,6,7,None)])
-        res = cql.execute(f"select * from {table} where p2 NOT IN (2,4) ALLOW FILTERING")
-        assert set(res) == set([(2,3,4,5), (4,5,6,7), (5,6,7,None)])
+        res = cql.execute(
+            f"select * from {table} where p1 NOT IN (2,4) ALLOW FILTERING"
+        )
+        assert set(res) == set([(1, 2, 3, 4), (3, 4, 5, 6), (5, 6, 7, None)])
+        res = cql.execute(
+            f"select * from {table} where p2 NOT IN (2,4) ALLOW FILTERING"
+        )
+        assert set(res) == set([(2, 3, 4, 5), (4, 5, 6, 7), (5, 6, 7, None)])
         res = cql.execute(f"select * from {table} where c NOT IN (3,5) ALLOW FILTERING")
-        assert set(res) == set([(2,3,4,5), (4,5,6,7), (5,6,7,None)])
+        assert set(res) == set([(2, 3, 4, 5), (4, 5, 6, 7), (5, 6, 7, None)])
         res = cql.execute(f"select * from {table} where v NOT IN (5,7) ALLOW FILTERING")
-        assert set(res) == set([(1,2,3,4), (3,4,5,6)])
-        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        assert set(res) == set([(1, 2, 3, 4), (3, 4, 5, 6)])
+        with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
             cql.execute(f"select * from {table} where p1 NOT IN (2,4)")
         # Since NULL is unknown, it could have matched p1, so NOT IN returns NULL too.
-        res = cql.execute(f"select * from {table} where v NOT IN (5,NULL) ALLOW FILTERING")
+        res = cql.execute(
+            f"select * from {table} where v NOT IN (5,NULL) ALLOW FILTERING"
+        )
         assert set(res) == set()
 
 
@@ -195,26 +256,41 @@ def test_filtering_with_not_in_relation(cql, test_keyspace):
 #
 # Also test list subscripts. These also don't work in Cassandra.
 def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
-    with new_test_table(cql, test_keyspace,
-            "p int, m1 map<int, int>, m2 map<text, text>, s set<int>, l list<text>, PRIMARY KEY (p)") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int, m1 map<int, int>, m2 map<text, text>, s set<int>, l list<text>, PRIMARY KEY (p)",
+    ) as table:
         # Check for *errors* in subscript expressions - such as wrong type or
         # null - with an empty table. This will force the implementation to
         # check for these errors before actually evaluating the filter
         # expression - because there will be no rows to filter.
 
         # A subscript is not allowed on a non-map column (in this case, a set)
-        with pytest.raises(InvalidRequest, match='cannot be subscripted'):
+        with pytest.raises(InvalidRequest, match="cannot be subscripted"):
             cql.execute(f"SELECT p FROM {table} WHERE s[2] = 3 ALLOW FILTERING")
         # A wrong type is passed for the subscript is not allowed
-        with pytest.raises(InvalidRequest, match=re.escape('key(m1)')):
+        with pytest.raises(InvalidRequest, match=re.escape("key(m1)")):
             cql.execute(f"select p from {table} where m1['black'] = 2 ALLOW FILTERING")
-        with pytest.raises(InvalidRequest, match=re.escape('key(m2)')):
+        with pytest.raises(InvalidRequest, match=re.escape("key(m2)")):
             cql.execute(f"select p from {table} where m2[1] = 2 ALLOW FILTERING")
         # See discussion of m1[null] above. Reproduces #10361, and fails
         # on Cassandra (Cassandra deliberately returns an error here -
         # an InvalidRequest with "Unsupported null map key for column m1"
-        assert list(cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")) == []
-        assert list(cql.execute(f"select p from {table} where m2[null] = 'hi' ALLOW FILTERING")) == []
+        assert (
+            list(
+                cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")
+            )
+            == []
+        )
+        assert (
+            list(
+                cql.execute(
+                    f"select p from {table} where m2[null] = 'hi' ALLOW FILTERING"
+                )
+            )
+            == []
+        )
         # Similar to above checks, but using a prepared statement. We can't
         # cause the driver to send the wrong type to a bound variable, so we
         # can't check that case unfortunately, but we have a new UNSET_VALUE
@@ -226,16 +302,26 @@ def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
         # and the error might might not be caught. So this test is commented
         # out. We'll do it below, after we add some data to ensure that the
         # expression does need to be evaluated.
-        #with pytest.raises(InvalidRequest, match='Unsupported unset map key for column m1'):
+        # with pytest.raises(InvalidRequest, match='Unsupported unset map key for column m1'):
         #    cql.execute(stmt, [UNSET_VALUE])
 
         # Finally, check for successful filtering with subscripts. For that we
         # need to add some data:
-        cql.execute("INSERT INTO "+table+" (p, m1, m2) VALUES (1, {1:2, 3:4}, {'dog':'cat', 'hi':'hello'})")
-        cql.execute("INSERT INTO "+table+" (p, m1, m2) VALUES (2, {2:3, 4:5}, {'man':'woman', 'black':'white'})")
+        cql.execute(
+            "INSERT INTO "
+            + table
+            + " (p, m1, m2) VALUES (1, {1:2, 3:4}, {'dog':'cat', 'hi':'hello'})"
+        )
+        cql.execute(
+            "INSERT INTO "
+            + table
+            + " (p, m1, m2) VALUES (2, {2:3, 4:5}, {'man':'woman', 'black':'white'})"
+        )
         res = cql.execute(f"select p from {table} where m1[1] = 2 ALLOW FILTERING")
         assert list(res) == [(1,)]
-        res = cql.execute(f"select p from {table} where m2['black'] = 'white' ALLOW FILTERING")
+        res = cql.execute(
+            f"select p from {table} where m2['black'] = 'white' ALLOW FILTERING"
+        )
         assert list(res) == [(2,)]
         res = cql.execute(stmt, [1])
         assert list(res) == [(1,)]
@@ -244,8 +330,13 @@ def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
         # earlier when there was no data in the table. Now there is, and
         # the scan brings up several rows, it may exercise different code
         # paths.
-        assert list(cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")) == []
-        with pytest.raises(InvalidRequest, match='unset'):
+        assert (
+            list(
+                cql.execute(f"select p from {table} where m1[null] = 2 ALLOW FILTERING")
+            )
+            == []
+        )
+        with pytest.raises(InvalidRequest, match="unset"):
             cql.execute(stmt, [UNSET_VALUE])
 
         # check subscripted list filtering
@@ -254,23 +345,28 @@ def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
         assert list(res) == [(11,)]
         res = cql.execute(f"SELECT p FROM {table} WHERE l[1] = 'eight' ALLOW FILTERING")
         assert list(res) == []
-        res = cql.execute(f"SELECT p FROM {table} WHERE l[-5] = 'minus five' ALLOW FILTERING")
+        res = cql.execute(
+            f"SELECT p FROM {table} WHERE l[-5] = 'minus five' ALLOW FILTERING"
+        )
         assert list(res) == []
         res = cql.execute(f"SELECT p FROM {table} WHERE l[3] = 'three' ALLOW FILTERING")
         assert list(res) == []
 
         # check list filtering type checking
-        with pytest.raises(InvalidRequest, match=re.escape('Invalid STRING constant')):
+        with pytest.raises(InvalidRequest, match=re.escape("Invalid STRING constant")):
             cql.execute(f"select * from {table} where l['hi'] = 'hi' ALLOW FILTERING")
-        with pytest.raises(InvalidRequest, match=re.escape('Invalid INTEGER constant')):
+        with pytest.raises(InvalidRequest, match=re.escape("Invalid INTEGER constant")):
             cql.execute(f"select * from {table} where l[3] = 3 ALLOW FILTERING")
 
         # check that NULL lists or NULL indexes don't confuse the system
         cql.execute(f"INSERT INTO {table} (p) VALUES (12)")
         res = cql.execute(f"SELECT p FROM {table} WHERE l[1] = 'one' ALLOW FILTERING")
         assert list(res) == [(11,)]
-        res = cql.execute(f"SELECT p FROM {table} WHERE l[NULL] = 'one' ALLOW FILTERING")
+        res = cql.execute(
+            f"SELECT p FROM {table} WHERE l[NULL] = 'one' ALLOW FILTERING"
+        )
         assert list(res) == []
+
 
 # Beyond the tests of map subscript expressions above, also test what happens
 # when the expression is fine (e.g., m[2] = 3) but the *data* itself is null.
@@ -279,10 +375,14 @@ def test_filtering_with_subscript(cql, test_keyspace, cassandra_bug):
 # This test reproduces #10417, but not always - run with "--count" to
 # reproduce failures.
 def test_filtering_null_map_with_subscript(cql, test_keyspace):
-    schema = 'p text primary key, m map<int, int>'
+    schema = "p text primary key, m map<int, int>"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"INSERT INTO {table} (p) VALUES ('dog')")
-        assert list(cql.execute(f"SELECT p FROM {table} WHERE m[2] = 3 ALLOW FILTERING")) == []
+        assert (
+            list(cql.execute(f"SELECT p FROM {table} WHERE m[2] = 3 ALLOW FILTERING"))
+            == []
+        )
+
 
 # Test whether it is allowed to specify more than on restriction on the same
 # column. For example, "c=0 and c>0".
@@ -299,27 +399,77 @@ def test_filtering_null_map_with_subscript(cql, test_keyspace):
 # This test is marked scylla_only because the support for such expressions
 # is a Scylla extension.
 def test_multiple_restrictions_on_same_column(cql, test_keyspace, scylla_only):
-    schema = 'p int, c int, primary key (p, c)'
+    schema = "p int, c int, primary key (p, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         p = 1
         cql.execute(f"INSERT INTO {table} (p,c) VALUES ({p}, 0)")
         cql.execute(f"INSERT INTO {table} (p,c) VALUES ({p}, 1)")
         cql.execute(f"INSERT INTO {table} (p,c) VALUES ({p}, 2)")
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 0 and c > 0")) == []
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 0 and c = 0")) == []
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 1 and c > 0")) == [(1,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 0 and c = 1")) == [(1,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 1 and c = 1")) == [(1,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 0 and c = 1")) == []
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 0 and c > 1")) == [(2,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 1 and c > 0")) == [(2,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 1 and c >= 1")) == [(1,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c >= 1 and c = 1")) == [(1,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 1 and c < 1")) == []
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c >= 1 and c <= 1")) == [(1,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c >= 1 and c <= 2")) == [(1,),(2,)]
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 1 and c in (2, 3)")) == []
-        assert list(cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 2 and c in (2, 3)")) == [(2,)]
+        assert (
+            list(
+                cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 0 and c > 0")
+            )
+            == []
+        )
+        assert (
+            list(
+                cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 0 and c = 0")
+            )
+            == []
+        )
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 1 and c > 0")
+        ) == [(1,)]
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 0 and c = 1")
+        ) == [(1,)]
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 1 and c = 1")
+        ) == [(1,)]
+        assert (
+            list(
+                cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 0 and c = 1")
+            )
+            == []
+        )
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 0 and c > 1")
+        ) == [(2,)]
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 1 and c > 0")
+        ) == [(2,)]
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c = 1 and c >= 1")
+        ) == [(1,)]
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c >= 1 and c = 1")
+        ) == [(1,)]
+        assert (
+            list(
+                cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c > 1 and c < 1")
+            )
+            == []
+        )
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c >= 1 and c <= 1")
+        ) == [(1,)]
+        assert list(
+            cql.execute(f"SELECT c FROM {table} WHERE p = {p} and c >= 1 and c <= 2")
+        ) == [(1,), (2,)]
+        assert (
+            list(
+                cql.execute(
+                    f"SELECT c FROM {table} WHERE p = {p} and c = 1 and c in (2, 3)"
+                )
+            )
+            == []
+        )
+        assert list(
+            cql.execute(
+                f"SELECT c FROM {table} WHERE p = {p} and c = 2 and c in (2, 3)"
+            )
+        ) == [(2,)]
+
 
 # Cassandra does not allow IN restrictions on non-primary-key columns,
 # even when doing filtering (ALLOW FILTERING). Scylla does support this
@@ -328,19 +478,29 @@ def test_multiple_restrictions_on_same_column(cql, test_keyspace, scylla_only):
 # so we mark this test cassandra_bug (maybe one day it will start working
 # on Cassandra).
 def test_filter_in_restriction(cql, test_keyspace, cassandra_bug):
-    schema = 'pk int, ck int, x int, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, x int, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck, x) VALUES (?, ?, ?)')
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, ck, x) VALUES (?, ?, ?)")
         for i in range(3):
-            cql.execute(stmt, [1, i, i*2])
-        assert [(1,), (2,)] == list(cql.execute(f'SELECT ck FROM {table} WHERE x IN (2, 4) ALLOW FILTERING'))
-        assert [(1,)] == list(cql.execute(f'SELECT ck FROM {table} WHERE x IN (2, 7) ALLOW FILTERING'))
-        assert [] == list(cql.execute(f'SELECT ck FROM {table} WHERE x IN (3, 7) ALLOW FILTERING'))
+            cql.execute(stmt, [1, i, i * 2])
+        assert [(1,), (2,)] == list(
+            cql.execute(f"SELECT ck FROM {table} WHERE x IN (2, 4) ALLOW FILTERING")
+        )
+        assert [(1,)] == list(
+            cql.execute(f"SELECT ck FROM {table} WHERE x IN (2, 7) ALLOW FILTERING")
+        )
+        assert [] == list(
+            cql.execute(f"SELECT ck FROM {table} WHERE x IN (3, 7) ALLOW FILTERING")
+        )
 
-        prepared_select1 = cql.prepare(f'SELECT ck FROM {table} WHERE x IN (?, 4) ALLOW FILTERING')
+        prepared_select1 = cql.prepare(
+            f"SELECT ck FROM {table} WHERE x IN (?, 4) ALLOW FILTERING"
+        )
         assert [(1,), (2,)] == list(cql.execute(prepared_select1, [2]))
 
-        prepared_select2 = cql.prepare(f'SELECT ck FROM {table} WHERE x IN ? ALLOW FILTERING')
+        prepared_select2 = cql.prepare(
+            f"SELECT ck FROM {table} WHERE x IN ? ALLOW FILTERING"
+        )
         assert [(1,), (2,)] == list(cql.execute(prepared_select2, [[2, 4]]))
 
 
@@ -356,8 +516,12 @@ def test_filter_in_restriction(cql, test_keyspace, cassandra_bug):
 # but the frozen case is expected to pass.
 def test_filter_UDT_restriction_frozen(cql, test_keyspace):
     do_test_filter_UDT_restriction(cql, test_keyspace, frozen=True)
+
+
 def test_filter_UDT_restriction_nonfrozen(cql, test_keyspace, cassandra_bug):
     do_test_filter_UDT_restriction(cql, test_keyspace, frozen=False)
+
+
 def do_test_filter_UDT_restriction(cql, test_keyspace, frozen):
     # Single-integer UDT, should be comparable like a normal integer:
     with new_type(cql, test_keyspace, "(a int)") as typ:
@@ -366,7 +530,7 @@ def do_test_filter_UDT_restriction(cql, test_keyspace, frozen):
         with new_test_table(cql, test_keyspace, schema) as table:
             stmt = cql.prepare(f"INSERT INTO {table} (pk, ck, x) VALUES (?, ?, ?)")
             for i in range(5):
-                cql.execute(stmt, [1, i, user_type("a", i*2)])
+                cql.execute(stmt, [1, i, user_type("a", i * 2)])
             stmt = cql.prepare(f"SELECT ck FROM {table} WHERE x = ? ALLOW FILTERING")
             assert [(2,)] == list(cql.execute(stmt, [user_type("a", 4)]))
             assert [] == list(cql.execute(stmt, [user_type("a", 3)]))
@@ -380,14 +544,17 @@ def do_test_filter_UDT_restriction(cql, test_keyspace, frozen):
         with new_test_table(cql, test_keyspace, schema) as table:
             stmt = cql.prepare(f"INSERT INTO {table} (pk, ck, x) VALUES (?, ?, ?)")
             for i in range(5):
-                cql.execute(stmt, [1, i, user_type("a", i*2, "b", i*3)])
+                cql.execute(stmt, [1, i, user_type("a", i * 2, "b", i * 3)])
             stmt = cql.prepare(f"SELECT ck FROM {table} WHERE x = ? ALLOW FILTERING")
             assert [(2,)] == list(cql.execute(stmt, [user_type("a", 4, "b", 6)]))
             assert [] == list(cql.execute(stmt, [user_type("a", 4, "b", 5)]))
             stmt = cql.prepare(f"SELECT ck FROM {table} WHERE x < ? ALLOW FILTERING")
             assert [(0,), (1,)] == list(cql.execute(stmt, [user_type("a", 4, "b", 6)]))
-            assert [(0,), (1,), (2,)] == list(cql.execute(stmt, [user_type("a", 4, "b", 7)]))
+            assert [(0,), (1,), (2,)] == list(
+                cql.execute(stmt, [user_type("a", 4, "b", 7)])
+            )
             assert [] == list(cql.execute(stmt, [user_type("a", -1, "b", 7)]))
+
 
 # Reproducer for issue #12102, checking the meaning of fetch_size (page size
 # in paging) during a scan with filtering. We check both scanning a regular
@@ -396,14 +563,30 @@ def do_test_filter_UDT_restriction(cql, test_keyspace, frozen):
 # before filtering, after filtering, or something else. As noted in #12102,
 # in Cassandra the behavior is the former - and this is what this test
 # expects. In Scylla it's currently the latter, causing this test to fail.
-@pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12102")),
-        pytest.param(False, marks=pytest.mark.xfail(reason="#12102"))])
+@pytest.mark.parametrize(
+    "use_index",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="With filtering, page size counts unfiltered rows. Should be filtered rows? #12102"
+            ),
+        ),
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                reason="With filtering, page size counts unfiltered rows. Should be filtered rows? #12102"
+            ),
+        ),
+    ],
+)
 def test_filter_and_fetch_size(cql, test_keyspace, use_index, driver_bug_1):
-    with new_test_table(cql, test_keyspace, 'pk int primary key, x int, y int') as table:
+    with new_test_table(
+        cql, test_keyspace, "pk int primary key, x int, y int"
+    ) as table:
         if use_index:
-            cql.execute(f'CREATE INDEX ON {table}(x)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, x, y) VALUES (?, ?, ?)')
+            cql.execute(f"CREATE INDEX ON {table}(x)")
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, x, y) VALUES (?, ?, ?)")
         cql.execute(stmt, [0, 1, 0])
         cql.execute(stmt, [1, 1, 1])
         cql.execute(stmt, [2, 1, 0])
@@ -414,24 +597,31 @@ def test_filter_and_fetch_size(cql, test_keyspace, use_index, driver_bug_1):
         cql.execute(stmt, [7, 1, 1])
         # Fetch a filtered page with fetch_size=3 and expect to see 3 rows
         # in the post-filtering results.
-        s = cql.prepare(f'SELECT pk FROM {table} WHERE x = 1 AND y = 0 ALLOW FILTERING')
+        s = cql.prepare(f"SELECT pk FROM {table} WHERE x = 1 AND y = 0 ALLOW FILTERING")
         s.fetch_size = 3
         results = cql.execute(s)
         assert len(results.current_rows) == 3
+
 
 # token() function should either take all partition key components or none of them,
 # if the key(s) are specified, they should be listed in the partition key order
 # Reproduces #13468
 def test_filter_token(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'pk int, ck int, x int, PRIMARY KEY (pk, ck)') as table:
+    with new_test_table(
+        cql, test_keyspace, "pk int, ck int, x int, PRIMARY KEY (pk, ck)"
+    ) as table:
         # In this case token() expects just a single argument, if we pass
         # it the same one twice we get different errors in ScyllaDB and
         # Cassandra - in ScyllaDB we get "Invalid number of arguments",
         # Cassandra complains that the two arguments are the same - "The
         # token() function contains duplicate partition key components":
-        with pytest.raises(InvalidRequest, match='Invalid number of arguments|duplicate partition key'):
-            cql.execute(f'SELECT pk FROM {table} WHERE token(pk, pk) = 0')
-    with new_test_table(cql, test_keyspace, 'pk1 int, pk2 int, x int, PRIMARY KEY ((pk1, pk2))') as table:
+        with pytest.raises(
+            InvalidRequest, match="Invalid number of arguments|duplicate partition key"
+        ):
+            cql.execute(f"SELECT pk FROM {table} WHERE token(pk, pk) = 0")
+    with new_test_table(
+        cql, test_keyspace, "pk1 int, pk2 int, x int, PRIMARY KEY ((pk1, pk2))"
+    ) as table:
         # In the following cases, token() expects two arguments but they
         # should be the two partition key columns, not something else like
         # fewer columns or the same column twice. ScyllaDB and Cassandra
@@ -439,50 +629,85 @@ def test_filter_token(cql, test_keyspace):
         # specific problem in the request (e.g., duplicate pk1) while
         # Cassandra makes a general complaint about the that token() "must
         # be applied to all partition key components or none of them".
-        with pytest.raises(InvalidRequest, match='duplicate partition key|must be applied to all partition key components or none of them'):
-            cql.execute(f'SELECT pk1 FROM {table} WHERE token(pk1, pk1) = 0')
-        with pytest.raises(InvalidRequest, match='Invalid number of arguments|must be applied to all partition key components or none of them'):
-            cql.execute(f'SELECT pk1 FROM {table} WHERE token(x) = 0')
-        with pytest.raises(InvalidRequest, match='Invalid number of arguments|must be applied to all partition key components or none of them'):
-            cql.execute(f'SELECT pk1 FROM {table} WHERE token(pk1) = 0')
-        with pytest.raises(InvalidRequest, match='partition key order'):
-            cql.execute(f'SELECT pk1 FROM {table} WHERE token(pk2, pk1) = 0')
+        with pytest.raises(
+            InvalidRequest,
+            match="duplicate partition key|must be applied to all partition key components or none of them",
+        ):
+            cql.execute(f"SELECT pk1 FROM {table} WHERE token(pk1, pk1) = 0")
+        with pytest.raises(
+            InvalidRequest,
+            match="Invalid number of arguments|must be applied to all partition key components or none of them",
+        ):
+            cql.execute(f"SELECT pk1 FROM {table} WHERE token(x) = 0")
+        with pytest.raises(
+            InvalidRequest,
+            match="Invalid number of arguments|must be applied to all partition key components or none of them",
+        ):
+            cql.execute(f"SELECT pk1 FROM {table} WHERE token(pk1) = 0")
+        with pytest.raises(InvalidRequest, match="partition key order"):
+            cql.execute(f"SELECT pk1 FROM {table} WHERE token(pk2, pk1) = 0")
 
 
 # In a query with a token restriction the name assigned to the bind marker should be "partition key token".
 # Java driver relies on this assumption, having a different name there breaks it.
 # Reproduces #13769
 def test_token_bind_marker_name(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p1 int, p2 int, c1 int, c2 int, r int, PRIMARY KEY ((p1, p2), c1, c2)') as table:
-        stmt = cql.prepare(f'SELECT * FROM {table} WHERE token(p1, p2) = ?')
-        assert stmt.column_metadata[0].name == 'partition key token'
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p1 int, p2 int, c1 int, c2 int, r int, PRIMARY KEY ((p1, p2), c1, c2)",
+    ) as table:
+        stmt = cql.prepare(f"SELECT * FROM {table} WHERE token(p1, p2) = ?")
+        assert stmt.column_metadata[0].name == "partition key token"
 
 
-# In the following test we check what error message appears if multi-column relation contains null values.    
+# In the following test we check what error message appears if multi-column relation contains null values.
 # Reproduces #13217
 def test_multi_column_relation_tuples_null_check(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'a int, b int, c int, d int, primary key (a, b, c, d)') as table:
-         with pytest.raises(InvalidRequest, match='Invalid null value in condition for column'): 
-                cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((null, 2, 3), (2, 1, 4))')
-         with pytest.raises(InvalidRequest, match='Invalid null value in condition for column'): 
-                cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2, 3), (2, 1, null))')      
+    with new_test_table(
+        cql, test_keyspace, "a int, b int, c int, d int, primary key (a, b, c, d)"
+    ) as table:
+        with pytest.raises(
+            InvalidRequest, match="Invalid null value in condition for column"
+        ):
+            cql.execute(
+                f"SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((null, 2, 3), (2, 1, 4))"
+            )
+        with pytest.raises(
+            InvalidRequest, match="Invalid null value in condition for column"
+        ):
+            cql.execute(
+                f"SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2, 3), (2, 1, null))"
+            )
 
-#This test shows how Scylla handles invalid number of items in one of the tuples of multi-column relation.
-#If the number of items is lesser than required, Scylla throws "Expected {} elements in value tuple, but got {}"
-#But if the number of items is greater than required, Scylla throws different error: 
-#"Invalid list literal for IN((b,c,d)): value (1, 2, 3, 4) is not of type frozen<tuple<int, int, int>>"
+
+# This test shows how Scylla handles invalid number of items in one of the tuples of multi-column relation.
+# If the number of items is lesser than required, Scylla throws "Expected {} elements in value tuple, but got {}"
+# But if the number of items is greater than required, Scylla throws different error:
+# "Invalid list literal for IN((b,c,d)): value (1, 2, 3, 4) is not of type frozen<tuple<int, int, int>>"
 # Reproduces #13217
 def test_multi_column_relation_wrong_number_of_items_in_tuple(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'a int, b int, c int, d int, primary key (a, b, c, d)') as table:
-        with pytest.raises(InvalidRequest, match='elements in value tuple, but got'):
-            cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2), (2, 1, 4))')
-        with pytest.raises(InvalidRequest, match='Invalid list literal for IN'):
-            cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2, 3, 4, 5), (2, 1, 4))')
+    with new_test_table(
+        cql, test_keyspace, "a int, b int, c int, d int, primary key (a, b, c, d)"
+    ) as table:
+        with pytest.raises(InvalidRequest, match="elements in value tuple, but got"):
+            cql.execute(
+                f"SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2), (2, 1, 4))"
+            )
+        with pytest.raises(InvalidRequest, match="Invalid list literal for IN"):
+            cql.execute(
+                f"SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2, 3, 4, 5), (2, 1, 4))"
+            )
+
 
 # Test for a bug found while developing the fix for #10357. The bug was that if a regular column was selected
 # but not filtered, it could cause filtering of the static row to fail.
-def test_selecting_a_regular_column_does_not_poison_filtering_of_a_static_row(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'a int, b int, c int, s int static, primary key (a, b)') as table:
+def test_selecting_a_regular_column_does_not_poison_filtering_of_a_static_row(
+    cql, test_keyspace
+):
+    with new_test_table(
+        cql, test_keyspace, "a int, b int, c int, s int static, primary key (a, b)"
+    ) as table:
         cql.execute(f"INSERT INTO {table} (a, s) VALUES (1, 2)")
         res = cql.execute(f"SELECT a, b, c, s FROM {table} WHERE s = 2 ALLOW FILTERING")
         assert list(res) == [(1, None, None, 2)]

--- a/test/cqlpy/test_group_by.py
+++ b/test/cqlpy/test_group_by.py
@@ -10,13 +10,20 @@ import pytest
 from .util import new_test_table
 from cassandra.protocol import InvalidRequest
 
+
 # table1 has some pre-set data which the tests below SELECT on (the tests
 # shouldn't write to it).
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, v int, PRIMARY KEY (p, c1, c2)",
-                        extra="WITH default_time_to_live = 1000000") as table:
-        stmt = cql.prepare(f'INSERT INTO {table} (p, c1, c2, v) VALUES (?, ?, ?, ?) USING TIMESTAMP ?')
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int, c1 int, c2 int, v int, PRIMARY KEY (p, c1, c2)",
+        extra="WITH default_time_to_live = 1000000",
+    ) as table:
+        stmt = cql.prepare(
+            f"INSERT INTO {table} (p, c1, c2, v) VALUES (?, ?, ?, ?) USING TIMESTAMP ?"
+        )
         cql.execute(stmt, [0, 0, 0, 1, 100000001])
         cql.execute(stmt, [0, 0, 1, 2, 100000002])
         cql.execute(stmt, [0, 1, 0, 3, 100000003])
@@ -29,12 +36,17 @@ def table1(cql, test_keyspace):
         # from messing with it accidentally.
         yield table
 
+
 ### GROUP BY without aggregation:
+
 
 # GROUP BY partition key picks a single row from each partition, the
 # first row (in the clustering order).
 def test_group_by_partition(cql, table1):
-    assert {(0,0,0,1), (1,0,0,5)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p'))
+    assert {(0, 0, 0, 1), (1, 0, 0, 5)} == set(
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p")
+    )
+
 
 # Adding a LIMIT should be honored.
 # Reproduces #17237 - more results than the limit were generated.
@@ -42,7 +54,10 @@ def test_group_by_partition_with_limit(cql, table1):
     # "LIMIT 1" should return only one of the two matches (0,0,0,1) and
     # (1,0,0,5). The partition key 1 happens to be the first one in
     # murmur3 order, so this is what should be returned.
-    assert {(1,0,0,5)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p LIMIT 1'))
+    assert {(1, 0, 0, 5)} == set(
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p LIMIT 1")
+    )
+
 
 def test_group_by_partition_count_with_limit(cql, test_keyspace):
     def execute_query(qry):
@@ -50,198 +65,323 @@ def test_group_by_partition_count_with_limit(cql, test_keyspace):
         stmt = cql.prepare(qry)
         stmt.fetch_size = 3
         return list(cql.execute(stmt))
-    with new_test_table(cql, test_keyspace, "a int, b int, c int, PRIMARY KEY (a, b)") as table:
+
+    with new_test_table(
+        cql, test_keyspace, "a int, b int, c int, PRIMARY KEY (a, b)"
+    ) as table:
         # Insert a number rows into the table. 29, 31, 37, 41 as well as
         # 293, 317, 379, 419 are prime numbers and essentially magic numbers,
         # but they guaranteed to have no common factors with each other and
         # with LIMIT values we are going to use. They are also high enough to
         # avoid accidental collisions with the LIMIT values.
         for i in range(29):
-            cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (293,{i+1},293);");
+            cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (293,{i + 1},293);")
         for i in range(31):
-            cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (317,{i+1},317);");
+            cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (317,{i + 1},317);")
         for i in range(37):
-            cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (379,{i+1},379);");
+            cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (379,{i + 1},379);")
         for i in range(41):
-            cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (419,{i+1},419);");
+            cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (419,{i + 1},419);")
 
-        assert [379, 293, 419, 317] == list(map(lambda x: x[0], execute_query(f'SELECT a FROM {table} GROUP BY a')))
+        assert [379, 293, 419, 317] == list(
+            map(lambda x: x[0], execute_query(f"SELECT a FROM {table} GROUP BY a"))
+        )
 
         # Testing up to 5 to ensure that the correct results are returned if fewer
         # results are generated than the LIMIT
-        for i in range(1,6):
-            query_result = [x[0] for x in execute_query(f'SELECT a FROM {table} GROUP BY a LIMIT {i}')]
+        for i in range(1, 6):
+            query_result = [
+                x[0]
+                for x in execute_query(f"SELECT a FROM {table} GROUP BY a LIMIT {i}")
+            ]
             assert query_result == [379, 293, 419, 317][:i]
 
-        assert [37, 29, 41, 31] == [x[0] for x in execute_query(f'SELECT COUNT(a) FROM {table} GROUP BY a')]
+        assert [37, 29, 41, 31] == [
+            x[0] for x in execute_query(f"SELECT COUNT(a) FROM {table} GROUP BY a")
+        ]
 
-        for i in range(1,5):
-            assert [37, 29, 41, 31][:i] == [x[0] for x in execute_query(f'SELECT COUNT(a) FROM {table} GROUP BY a LIMIT {i}')]
+        for i in range(1, 5):
+            assert [37, 29, 41, 31][:i] == [
+                x[0]
+                for x in execute_query(
+                    f"SELECT COUNT(a) FROM {table} GROUP BY a LIMIT {i}"
+                )
+            ]
+
 
 # Try the same restricting the scan to a single partition instead of a
 # whole-table scan. We should get just one row (the first row in the
 # clustering order).
 def test_group_by_partition_one_partition(cql, table1):
-    assert {(0,0,0,1)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY p'))
+    assert {(0, 0, 0, 1)} == set(
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY p")
+    )
+
 
 # Same as previous test, but use ""SELECT *" instead of "SELECT p,c1,c2,v".
 # This shouldn't make any difference, but reproduces bug #16531 where it did.
 def test_group_by_partition_one_partition_star(cql, table1):
-    assert {(0,0,0,1)} == set(cql.execute(f'SELECT * FROM {table1} WHERE p=0 GROUP BY p'))
+    assert {(0, 0, 0, 1)} == set(
+        cql.execute(f"SELECT * FROM {table1} WHERE p=0 GROUP BY p")
+    )
     # Try the same with filtering, the GROUP BY should return the first row that
     # matches that filter.
-    assert {(0,0,1,2)} == set(cql.execute(f'SELECT * FROM {table1} WHERE p=0 AND c2>0 GROUP BY p ALLOW FILTERING'))
+    assert {(0, 0, 1, 2)} == set(
+        cql.execute(
+            f"SELECT * FROM {table1} WHERE p=0 AND c2>0 GROUP BY p ALLOW FILTERING"
+        )
+    )
+
 
 # And if filtering excludes some rows, the GROUP BY should return the first
 # row that matches the filter.
 def test_group_by_partition_with_filtering(cql, table1):
-    assert {(0,0,1,2), (1,0,1,6)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} WHERE c2>0 GROUP BY p ALLOW FILTERING'))
+    assert {(0, 0, 1, 2), (1, 0, 1, 6)} == set(
+        cql.execute(
+            f"SELECT p,c1,c2,v FROM {table1} WHERE c2>0 GROUP BY p ALLOW FILTERING"
+        )
+    )
+
 
 # Similarly, GROUP BY a partition key plus just a prefix of the clustering
 # key retrieves the first row in each of the clustering ranges
 def test_group_by_clustering_prefix(cql, table1):
-    assert {(0,0,0,1), (0,1,0,3), (1,0,0,5), (1,1,0,7)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1'))
+    assert {(0, 0, 0, 1), (0, 1, 0, 3), (1, 0, 0, 5), (1, 1, 0, 7)} == set(
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1")
+    )
     # Try the same restricting the scan to a single partition instead of
     # a whole-table scan
-    assert [(0,0,0,1), (0,1,0,3)] == list(cql.execute(f'SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY p,c1'))
+    assert [(0, 0, 0, 1), (0, 1, 0, 3)] == list(
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY p,c1")
+    )
+
 
 # Adding a LIMIT should be honored.
 # Reproduces #5362 - fewer results than the limit were generated.
 def test_group_by_clustering_prefix_with_limit(cql, table1):
-    results = list(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1'))
+    results = list(cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1"))
     assert len(results) == 4
-    for i in range(1,4):
-        assert results[:i] == list(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1 LIMIT {i}'))
+    for i in range(1, 4):
+        assert results[:i] == list(
+            cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1 LIMIT {i}")
+        )
+
 
 # Same as the above test, but also add paging, and check that the LIMIT
 # is handled correctly (limits the total number of returned results)
-@pytest.mark.xfail(reason="issue #5362")
+@pytest.mark.xfail(reason="LIMIT is not doing it right when using GROUP BY #5362")
 def test_group_by_clustering_prefix_with_limit_and_paging(cql, table1):
-    results = list(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1'))
+    results = list(cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1"))
     assert len(results) == 4
-    stmt = cql.prepare(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1 LIMIT ?')
+    stmt = cql.prepare(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1 LIMIT ?")
     page_size = 1
     stmt.fetch_size = page_size
-    for i in range(1,4):
+    for i in range(1, 4):
         r = cql.execute(stmt, [i])
         # First page should only have page_size rows. Then finish reading all
         # the pages, and expect the LIMIT to have worked.
         assert len(r.current_rows) == page_size
         assert results[:i] == list(r)
 
+
 # Adding a PER PARTITION LIMIT should be honored
 # Reproduces #5363 - fewer results than the limit were generated
 def test_group_by_clustering_prefix_with_pplimit(cql, table1):
     # Without per-partition limit we get 4 results, 2 from each partition:
-    assert {(0,0,0,1), (0,1,0,3), (1,0,0,5), (1,1,0,7)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1'))
+    assert {(0, 0, 0, 1), (0, 1, 0, 3), (1, 0, 0, 5), (1, 1, 0, 7)} == set(
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1")
+    )
     # With per-partition limit of 2, no change:
     # But in issue #5363, we got here fewer results.
-    assert {(0,0,0,1), (0,1,0,3), (1,0,0,5), (1,1,0,7)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1 PER PARTITION LIMIT 2'))
+    assert {(0, 0, 0, 1), (0, 1, 0, 3), (1, 0, 0, 5), (1, 1, 0, 7)} == set(
+        cql.execute(
+            f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1 PER PARTITION LIMIT 2"
+        )
+    )
     # With per-partition limit of 1, we should get just two of the results -
     # the lower clustering key in each.
-    assert {(0,0,0,1), (1,0,0,5)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1 PER PARTITION LIMIT 1'))
+    assert {(0, 0, 0, 1), (1, 0, 0, 5)} == set(
+        cql.execute(
+            f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1 PER PARTITION LIMIT 1"
+        )
+    )
+
 
 # GROUP BY the entire primary key doesn't really do anything, but is
 # allowed
 def test_group_by_entire_primary_key(cql, table1):
-    assert [(0,0,0,1), (0,0,1,2), (0,1,0,3), (0,1,1,4)] == list(cql.execute(f'SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY p,c1,c2'))
+    assert [(0, 0, 0, 1), (0, 0, 1, 2), (0, 1, 0, 3), (0, 1, 1, 4)] == list(
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY p,c1,c2")
+    )
+
 
 # GROUP BY can only be given the primary key columns in order - anything
 # else is an error. If some of the key columns are restricted by equality,
 # they can be skipped in GROUP BY:
 def test_group_bad_columns(cql, table1):
     # non-existent column:
-    with pytest.raises(InvalidRequest, match='zzz'):
-        cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY zzz')
+    with pytest.raises(InvalidRequest, match="zzz"):
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY zzz")
     # Legal primary key prefixes are (p), (p,c1) and (p,c1,c2), already
     # tested above. Other combinations or orders like (c1) or (c1, p) are
     # illegal.
-    with pytest.raises(InvalidRequest, match='order'):
-        cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY c1')
-    with pytest.raises(InvalidRequest, match='order'):
-        cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY c1,c2')
-    with pytest.raises(InvalidRequest, match='order'):
-        cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c2')
-    with pytest.raises(InvalidRequest, match='order'):
-        cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY c1,p')
+    with pytest.raises(InvalidRequest, match="order"):
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY c1")
+    with pytest.raises(InvalidRequest, match="order"):
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY c1,c2")
+    with pytest.raises(InvalidRequest, match="order"):
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY p,c2")
+    with pytest.raises(InvalidRequest, match="order"):
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} GROUP BY c1,p")
     # Although we checked "GROUP BY c1" is not allowed, it becomes allowed
     # if p is restricted by equality
-    assert [(0,0,0,1), (0,1,0,3)] == list(cql.execute(f'SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY c1'))
+    assert [(0, 0, 0, 1), (0, 1, 0, 3)] == list(
+        cql.execute(f"SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY c1")
+    )
+
 
 ### GROUP BY with aggregation. For example, when asking for count()
 ### we get a separate count for each group.
 # NOTE: we have additional tests for combining aggregations and GROUP BY
 # in test_aggregate.py - e.g., a test for #12477.
 def test_group_by_count(cql, table1):
-    assert {(0,4), (1,4)} == set(cql.execute(f'SELECT p,count(*) FROM {table1} GROUP BY p'))
-    assert {(0,0,2), (0,1,2), (1,0,2), (1,1,2)} == set(cql.execute(f'SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1'))
-    assert {(0,0,0,1), (0,0,1,1), (0,1,0,1), (0,1,1,1), (1,0,0,1), (1,0,1,1), (1,1,0,1), (1,1,1,1)} == set(cql.execute(f'SELECT p,c1,c2,count(*) FROM {table1} GROUP BY p,c1,c2'))
+    assert {(0, 4), (1, 4)} == set(
+        cql.execute(f"SELECT p,count(*) FROM {table1} GROUP BY p")
+    )
+    assert {(0, 0, 2), (0, 1, 2), (1, 0, 2), (1, 1, 2)} == set(
+        cql.execute(f"SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1")
+    )
+    assert {
+        (0, 0, 0, 1),
+        (0, 0, 1, 1),
+        (0, 1, 0, 1),
+        (0, 1, 1, 1),
+        (1, 0, 0, 1),
+        (1, 0, 1, 1),
+        (1, 1, 0, 1),
+        (1, 1, 1, 1),
+    } == set(cql.execute(f"SELECT p,c1,c2,count(*) FROM {table1} GROUP BY p,c1,c2"))
+
 
 # Adding a LIMIT should be honored.
 # Reproduces #5361 - more results than the limit were generated (seems the
 # limit was outright ignored).
 def test_group_by_count_with_limit(cql, table1):
-    results = list(cql.execute(f'SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1'))
+    results = list(cql.execute(f"SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1"))
     assert len(results) == 4
-    for i in range(1,4):
-        assert results[:i] == list(cql.execute(f'SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1 LIMIT {i}'))
+    for i in range(1, 4):
+        assert results[:i] == list(
+            cql.execute(f"SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1 LIMIT {i}")
+        )
+
 
 # Adding a PER PARTITION LIMIT should be honored
 # Reproduces #5363 - more results than the limit were generated
 def test_group_by_count_with_pplimit(cql, table1):
     # Without per-partition limit we get 4 results, 2 from each partition:
-    assert {(0,0,2), (0,1,2), (1,0,2), (1,1,2)} == set(cql.execute(f'SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1'))
+    assert {(0, 0, 2), (0, 1, 2), (1, 0, 2), (1, 1, 2)} == set(
+        cql.execute(f"SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1")
+    )
     # With per-partition limit of 2, no change:
-    assert {(0,0,2), (0,1,2), (1,0,2), (1,1,2)} == set(cql.execute(f'SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1 PER PARTITION LIMIT 2'))
+    assert {(0, 0, 2), (0, 1, 2), (1, 0, 2), (1, 1, 2)} == set(
+        cql.execute(
+            f"SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1 PER PARTITION LIMIT 2"
+        )
+    )
     # With per-partition limit of 1, we should get just two of the results -
     # the lower clustering key in each.
     # In issue #5363 we wrongly got here all four results (the PER PARTITION
     # LIMIT appears to have been ignored)
-    assert {(0,0,2), (1,0,2)} == set(cql.execute(f'SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1 PER PARTITION LIMIT 1'))
+    assert {(0, 0, 2), (1, 0, 2)} == set(
+        cql.execute(
+            f"SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1 PER PARTITION LIMIT 1"
+        )
+    )
+
 
 def test_group_by_sum(cql, table1):
-    assert {(0,10), (1,26)} == set(cql.execute(f'SELECT p,sum(v) FROM {table1} GROUP BY p'))
-    assert {(0,0,3), (0,1,7), (1,0,11), (1,1,15)} == set(cql.execute(f'SELECT p,c1,sum(v) FROM {table1} GROUP BY p,c1'))
-    assert {(0,0,0,1), (0,0,1,2), (0,1,0,3), (0,1,1,4), (1,0,0,5), (1,0,1,6), (1,1,0,7), (1,1,1,8)} == set(cql.execute(f'SELECT p,c1,c2,sum(v) FROM {table1} GROUP BY p,c1,c2'))
+    assert {(0, 10), (1, 26)} == set(
+        cql.execute(f"SELECT p,sum(v) FROM {table1} GROUP BY p")
+    )
+    assert {(0, 0, 3), (0, 1, 7), (1, 0, 11), (1, 1, 15)} == set(
+        cql.execute(f"SELECT p,c1,sum(v) FROM {table1} GROUP BY p,c1")
+    )
+    assert {
+        (0, 0, 0, 1),
+        (0, 0, 1, 2),
+        (0, 1, 0, 3),
+        (0, 1, 1, 4),
+        (1, 0, 0, 5),
+        (1, 0, 1, 6),
+        (1, 1, 0, 7),
+        (1, 1, 1, 8),
+    } == set(cql.execute(f"SELECT p,c1,c2,sum(v) FROM {table1} GROUP BY p,c1,c2"))
+
 
 # If selecting both an aggregation and real columns, we get both the result
 # from *one* of the group rows (the first row by clustering order), and the
 # aggregation from all of them.
 def test_group_by_v_and_sum(cql, table1):
-    assert {(0,1,10), (1,5,26)} == set(cql.execute(f'SELECT p,v,sum(v) FROM {table1} GROUP BY p'))
-    assert {(0,1,3), (0,3,7), (1,5,11), (1,7,15)} == set(cql.execute(f'SELECT p,v,sum(v) FROM {table1} GROUP BY p,c1'))
-    assert {(0,1,1), (0,2,2), (0,3,3), (0,4,4), (1,5,5), (1,6,6), (1,7,7), (1,8,8)} == set(cql.execute(f'SELECT p,v,sum(v) FROM {table1} GROUP BY p,c1,c2'))
+    assert {(0, 1, 10), (1, 5, 26)} == set(
+        cql.execute(f"SELECT p,v,sum(v) FROM {table1} GROUP BY p")
+    )
+    assert {(0, 1, 3), (0, 3, 7), (1, 5, 11), (1, 7, 15)} == set(
+        cql.execute(f"SELECT p,v,sum(v) FROM {table1} GROUP BY p,c1")
+    )
+    assert {
+        (0, 1, 1),
+        (0, 2, 2),
+        (0, 3, 3),
+        (0, 4, 4),
+        (1, 5, 5),
+        (1, 6, 6),
+        (1, 7, 7),
+        (1, 8, 8),
+    } == set(cql.execute(f"SELECT p,v,sum(v) FROM {table1} GROUP BY p,c1,c2"))
+
 
 # Adding a LIMIT should be honored.
 # Reproduces #5361 - more results than the limit were generated (seems the
 # limit was outright ignored).
 def test_group_by_v_and_sum_with_limit(cql, table1):
-    results = list(cql.execute(f'SELECT p,v,sum(v) FROM {table1} GROUP BY p,c1'))
+    results = list(cql.execute(f"SELECT p,v,sum(v) FROM {table1} GROUP BY p,c1"))
     assert len(results) == 4
-    for i in range(1,4):
-        assert results[:i] == list(cql.execute(f'SELECT p,v,sum(v) FROM {table1} GROUP BY p,c1 LIMIT {i}'))
+    for i in range(1, 4):
+        assert results[:i] == list(
+            cql.execute(f"SELECT p,v,sum(v) FROM {table1} GROUP BY p,c1 LIMIT {i}")
+        )
+
 
 # GROUP BY of a non-aggregated column qualified by ttl or writetime should work (#14715)
 def test_group_by_non_aggregated_mutation_attribute_of_column(cql, table1):
-    results = list(cql.execute(f'SELECT v, writetime(v), ttl(v) FROM {table1} GROUP BY p, c1'))
+    results = list(
+        cql.execute(f"SELECT v, writetime(v), ttl(v) FROM {table1} GROUP BY p, c1")
+    )
     assert len(results) == 4
     results = sorted(results, key=lambda row: row[0])
     assert [row[0] for row in results] == [1, 3, 5, 7]
     assert [row[1] for row in results] == [100000001, 100000003, 100000005, 100000007]
     assert all([[row[2] > 900000] for row in results])
 
+
 # This test is from cassandra_tests/validation/operations/select_group_by_test.py::testGroupByWithPaging()
 # Reproduces #21267
-@pytest.mark.xfail(reason="issue #21267")
+@pytest.mark.xfail(
+    reason="GROUP BY returns incorrect values for rows with only static column set #21267"
+)
 def test_group_by_static_column(cql, test_keyspace):
 
-    with new_test_table(cql, test_keyspace, "a int, b int, c int, s int static, d int, primary key (a, b, c)") as table:
-        cql.execute(f'UPDATE {table} SET s = 3 WHERE a = 1;')
-        cql.execute(f'UPDATE {table} SET s = 2 WHERE a = 2;')
-        cql.execute(f'UPDATE {table} SET s = 3 WHERE a = 3;')
-        cql.execute(f'UPDATE {table} SET s = 3 WHERE a = 4;')
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "a int, b int, c int, s int static, d int, primary key (a, b, c)",
+    ) as table:
+        cql.execute(f"UPDATE {table} SET s = 3 WHERE a = 1;")
+        cql.execute(f"UPDATE {table} SET s = 2 WHERE a = 2;")
+        cql.execute(f"UPDATE {table} SET s = 3 WHERE a = 3;")
+        cql.execute(f"UPDATE {table} SET s = 3 WHERE a = 4;")
 
-        stmt = cql.prepare(f'INSERT INTO {table} (a, b, c, d) VALUES (?, ?, ?, ?)')
+        stmt = cql.prepare(f"INSERT INTO {table} (a, b, c, d) VALUES (?, ?, ?, ?)")
         cql.execute(stmt, [1, 2, 1, 3])
         cql.execute(stmt, [1, 2, 2, 6])
         cql.execute(stmt, [1, 4, 2, 12])
@@ -250,16 +390,25 @@ def test_group_by_static_column(cql, test_keyspace):
         cql.execute(stmt, [2, 4, 3, 6])
         cql.execute(stmt, [4, 8, 2, 12])
 
-        result = cql.execute(f'SELECT a, b, s, count(b), count(s) FROM {table} WHERE a = 3 GROUP BY a')
+        result = cql.execute(
+            f"SELECT a, b, s, count(b), count(s) FROM {table} WHERE a = 3 GROUP BY a"
+        )
         # This is the expected and correct result of the query:
         assert {(3, None, 3, 0, 1)} == set(result)
 
         # When we remove the WHERE clause, we get all the rows, and b and count(b)
         # the wrong values (it seems they have leftover values from the previous row)
-        result = cql.execute(f'SELECT a, b, s, count(b), count(s) FROM {table} GROUP BY a')
+        result = cql.execute(
+            f"SELECT a, b, s, count(b), count(s) FROM {table} GROUP BY a"
+        )
         # FIXME: this test reproduces bug #21267
         # the assert below is the correct result set
-        assert {(1, 2, 3, 4, 4), (2, 2, 2, 2, 2), (4, 8, 3, 1, 1), (3, None, 3, 0, 1)} == set(result)
+        assert {
+            (1, 2, 3, 4, 4),
+            (2, 2, 2, 2, 2),
+            (4, 8, 3, 1, 1),
+            (3, None, 3, 0, 1),
+        } == set(result)
 
 
 # NOTE: we have tests for the combination of GROUP BY and SELECT DISTINCT

--- a/test/cqlpy/test_json.py
+++ b/test/cqlpy/test_json.py
@@ -22,12 +22,14 @@ from decimal import Decimal
 from datetime import datetime
 from uuid import UUID
 
+
 @pytest.fixture(scope="module")
 def type1(cql, test_keyspace):
     type_name = test_keyspace + "." + unique_name()
     cql.execute("CREATE TYPE " + type_name + " (t text, b boolean)")
     yield type_name
     cql.execute("DROP TYPE " + type_name)
+
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace, type1):
@@ -68,6 +70,7 @@ def table1(cql, test_keyspace, type1):
     yield table
     cql.execute("DROP TABLE " + table)
 
+
 # The EquivalentJson class wraps a JSON string, and compare equal to other
 # strings if both are valid JSON strings which decode to the same object.
 # EquivalentJson("....") can be used in equality assertions below, to check
@@ -76,16 +79,19 @@ def table1(cql, test_keyspace, type1):
 class EquivalentJson:
     def __init__(self, s):
         self.obj = json.loads(s)
+
     def __eq__(self, other):
         if isinstance(other, EquivalentJson):
             return self.obj == other.obj
         elif isinstance(other, str):
             return self.obj == json.loads(other)
         return NotImplemented
+
     # Implementing __repr__ is useful because when a comparison fails, pytest
     # helpfully prints what it tried to compare, and uses __repr__ for that.
     def __repr__(self):
         return f'EquivalentJson("{self.obj}")'
+
 
 # Test that failed fromJson() parsing an invalid JSON results in the expected
 # error - FunctionFailure - and not some weird internal error.
@@ -94,11 +100,14 @@ def test_failed_json_parsing_unprepared(cql, table1):
     p = unique_key_int()
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, fromJson('dog'))")
+
+
 def test_failed_json_parsing_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
-        cql.execute(stmt, [p, 'dog'])
+        cql.execute(stmt, [p, "dog"])
+
 
 # Similarly, if the JSON parsing did not fail, but yielded a type which is
 # incompatible with the type we want it to yield, we should get a clean
@@ -113,6 +122,8 @@ def test_fromjson_wrong_type_unprepared(cql, table1):
         cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, fromJson('\"dog\"'))")
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, a) VALUES ({p}, fromJson('3'))")
+
+
 def test_fromjson_wrong_type_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
@@ -120,25 +131,34 @@ def test_fromjson_wrong_type_prepared(cql, table1):
         cql.execute(stmt, [p, '"dog"'])
     stmt = cql.prepare(f"INSERT INTO {table1} (p, a) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
-        cql.execute(stmt, [p, '3'])
+        cql.execute(stmt, [p, "3"])
+
+
 def test_fromjson_bad_ascii_unprepared(cql, table1):
     p = unique_key_int()
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, a) VALUES ({p}, fromJson('\"שלום\"'))")
+
+
 def test_fromjson_bad_ascii_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, a) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
         cql.execute(stmt, [p, '"שלום"'])
+
+
 def test_fromjson_nonint_unprepared(cql, table1):
     p = unique_key_int()
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, fromJson('1.2'))")
+
+
 def test_fromjson_nonint_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
-        cql.execute(stmt, [p, '1.2'])
+        cql.execute(stmt, [p, "1.2"])
+
 
 # In test_fromjson_nonint_*() above we noted that the floating point number 1.2
 # cannot be assigned into an integer column v. In contrast, the numbers 1e6
@@ -151,18 +171,31 @@ def test_fromjson_nonint_prepared(cql, table1):
 # well and we consider this failure a bug.
 def test_fromjson_int_scientific_notation_unprepared(cql, table1, cassandra_bug):
     p = unique_key_int()
-    cql.execute(f"INSERT INTO {table1} (p, bigv) VALUES ({p}, fromJson('1.23456789E+9'))")
-    assert list(cql.execute(f"SELECT p, bigv from {table1} where p = {p}")) == [(p, 1234567890)]
+    cql.execute(
+        f"INSERT INTO {table1} (p, bigv) VALUES ({p}, fromJson('1.23456789E+9'))"
+    )
+    assert list(cql.execute(f"SELECT p, bigv from {table1} where p = {p}")) == [
+        (p, 1234567890)
+    ]
     cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, fromJson('1e6'))")
-    assert list(cql.execute(f"SELECT p, v from {table1} where p = {p}")) == [(p, 1000000)]
+    assert list(cql.execute(f"SELECT p, v from {table1} where p = {p}")) == [
+        (p, 1000000)
+    ]
+
+
 def test_fromjson_int_scientific_notation_prepared(cql, table1, cassandra_bug):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, bigv) VALUES (?, fromJson(?))")
-    cql.execute(stmt, [p, '1.23456789E+9'])
-    assert list(cql.execute(f"SELECT p, bigv from {table1} where p = {p}")) == [(p, 1234567890)]
+    cql.execute(stmt, [p, "1.23456789E+9"])
+    assert list(cql.execute(f"SELECT p, bigv from {table1} where p = {p}")) == [
+        (p, 1234567890)
+    ]
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
-    cql.execute(stmt, [p, '1e6'])
-    assert list(cql.execute(f"SELECT p, v from {table1} where p = {p}")) == [(p, 1000000)]
+    cql.execute(stmt, [p, "1e6"])
+    assert list(cql.execute(f"SELECT p, v from {table1} where p = {p}")) == [
+        (p, 1000000)
+    ]
+
 
 # The JSON standard does not define or limit the range or precision of
 # numbers. However, if a number is assigned to a Scylla number type, the
@@ -176,20 +209,29 @@ def test_fromjson_int_overflow_unprepared(cql, table1):
     # wraparound to -2147483648 as happened in Scylla.
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, fromJson('2147483648'))")
+
+
 def test_fromjson_bigint_overflow_unprepared(cql, table1):
     p = unique_key_int()
     with pytest.raises(FunctionFailure):
-        cql.execute(f"INSERT INTO {table1} (p, bigv) VALUES ({p}, fromJson('9223372036854775808'))")
+        cql.execute(
+            f"INSERT INTO {table1} (p, bigv) VALUES ({p}, fromJson('9223372036854775808'))"
+        )
+
+
 def test_fromjson_int_overflow_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
-        cql.execute(stmt, [p, '2147483648'])
+        cql.execute(stmt, [p, "2147483648"])
+
+
 def test_fromjson_bigint_overflow_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, bigv) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
-        cql.execute(stmt, [p, '9223372036854775808'])
+        cql.execute(stmt, [p, "9223372036854775808"])
+
 
 # On the other hand, let's check a case of the biggest bigint (64-bit
 # integer) which should *not* overflow. Let's check that we handle it
@@ -197,8 +239,11 @@ def test_fromjson_bigint_overflow_prepared(cql, table1):
 def test_fromjson_bigint_nonoverflow(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, bigv) VALUES (?, fromJson(?))")
-    cql.execute(stmt, [p, '9223372036854775807'])
-    assert list(cql.execute(f"SELECT bigv from {table1} where p = {p}")) == [(9223372036854775807,)]
+    cql.execute(stmt, [p, "9223372036854775807"])
+    assert list(cql.execute(f"SELECT bigv from {table1} where p = {p}")) == [
+        (9223372036854775807,)
+    ]
+
 
 # Test the same non-overflowing integer with scientific notation. This is the
 # same test as test_fromjson_int_scientific_notation_prepared above (so
@@ -215,7 +260,9 @@ def test_fromjson_bigint_nonoverflow(cql, table1):
 # standard suggests it may be fine to botch it up, so it might be acceptable
 # to fail this test.
 # Reproduces #10100 and #10137.
-@pytest.mark.xfail(reason="issue #10137")
+@pytest.mark.xfail(
+    reason="INSERT JSON of bigint (64-bit) in scientific notation is not accurate above 2^53 #10137"
+)
 def test_fromjson_bigint_nonoverflow_scientific(cql, table1, cassandra_bug):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, bigv) VALUES (?, fromJson(?))")
@@ -224,8 +271,11 @@ def test_fromjson_bigint_nonoverflow_scientific(cql, table1, cassandra_bug):
     # an inaccuracy there in the up direction can lead us to overflowing
     # the signed integer and UBSAN errors - while we want to detect the
     # inaccuracy cleanly, here.
-    cql.execute(stmt, [p, '115292150460684697.5e1'])
-    assert list(cql.execute(f"SELECT bigv from {table1} where p = {p}")) == [(1152921504606846975,)]
+    cql.execute(stmt, [p, "115292150460684697.5e1"])
+    assert list(cql.execute(f"SELECT bigv from {table1} where p = {p}")) == [
+        (1152921504606846975,)
+    ]
+
 
 # When writing to an integer column, Cassandra's fromJson() function allows
 # not just JSON number constants, it also allows a string containing a number.
@@ -239,22 +289,33 @@ def test_fromjson_int_empty_string_unprepared(cql, table1, cassandra_bug):
     p = unique_key_int()
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, fromJson('\"\"'))")
+
+
 def test_fromjson_int_empty_string_prepared(cql, table1, cassandra_bug):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
         cql.execute(stmt, [p, '""'])
-@pytest.mark.xfail(reason="issue #7944")
+
+
+@pytest.mark.xfail(
+    reason="fromJson() should not accept the empty string as a number #7944"
+)
 def test_fromjson_varint_empty_string_unprepared(cql, table1):
     p = unique_key_int()
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, vi) VALUES ({p}, fromJson('\"\"'))")
-@pytest.mark.xfail(reason="issue #7944")
+
+
+@pytest.mark.xfail(
+    reason="fromJson() should not accept the empty string as a number #7944"
+)
 def test_fromjson_varint_empty_string_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, vi) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
         cql.execute(stmt, [p, '""'])
+
 
 # Cassandra allows the strings "true" and "false", not just the JSON constants
 # true and false, to be assigned to a boolean column.
@@ -265,6 +326,8 @@ def test_fromjson_boolean_string_unprepared(cql, table1):
     assert list(cql.execute(f"SELECT p, b from {table1} where p = {p}")) == [(p, True)]
     cql.execute(f"INSERT INTO {table1} (p, b) VALUES ({p}, fromJson('\"false\"'))")
     assert list(cql.execute(f"SELECT p, b from {table1} where p = {p}")) == [(p, False)]
+
+
 # Reproduces issue #7915
 def test_fromjson_boolean_string_prepared(cql, table1):
     p = unique_key_int()
@@ -276,12 +339,14 @@ def test_fromjson_boolean_string_prepared(cql, table1):
     cql.execute(stmt, [p, '"fALSe"'])
     assert list(cql.execute(f"SELECT p, b from {table1} where p = {p}")) == [(p, False)]
 
+
 # Test that null argument is allowed for fromJson(), with unprepared statement
 # Reproduces issue #7912.
 def test_fromjson_null_unprepared(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, fromJson(null))")
     assert list(cql.execute(f"SELECT p, v from {table1} where p = {p}")) == [(p, None)]
+
 
 # Test that null argument is allowed for fromJson(), with prepared statement
 # Reproduces issue #7912.
@@ -291,18 +356,32 @@ def test_fromjson_null_prepared(cql, table1):
     cql.execute(stmt, [p, None])
     assert list(cql.execute(f"SELECT p, v from {table1} where p = {p}")) == [(p, None)]
 
+
 # Test that fromJson can parse a map<ascii,int>. Strangely Scylla had a bug
 # setting a map<ascii,int> with fromJson(), while map<text,int> worked well.
 # Reproduces #7949.
 def test_fromjson_map_ascii_unprepared(cql, table1):
     p = unique_key_int()
-    cql.execute("INSERT INTO " + table1 + " (p, mai) VALUES (" + str(p) + ", fromJson('{\"a\": 1, \"b\": 2}'))")
-    assert list(cql.execute(f"SELECT p, mai from {table1} where p = {p}")) == [(p, {'a': 1, 'b': 2})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + " (p, mai) VALUES ("
+        + str(p)
+        + ', fromJson(\'{"a": 1, "b": 2}\'))'
+    )
+    assert list(cql.execute(f"SELECT p, mai from {table1} where p = {p}")) == [
+        (p, {"a": 1, "b": 2})
+    ]
+
+
 def test_fromjson_map_ascii_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, mai) VALUES (?, fromJson(?))")
     cql.execute(stmt, [p, '{"a": 1, "b": 2}'])
-    assert list(cql.execute(f"SELECT p, mai from {table1} where p = {p}")) == [(p, {'a': 1, 'b': 2})]
+    assert list(cql.execute(f"SELECT p, mai from {table1} where p = {p}")) == [
+        (p, {"a": 1, "b": 2})
+    ]
+
 
 # After the above test for map<ascii,int> was fixed, it turned out (see
 # issue #18477) that we have the same bug for fromJson() or INSERT JSON
@@ -313,33 +392,84 @@ def test_fromjson_map_ascii_prepared(cql, table1):
 # Reproduces #18477:
 def test_fromjson_map_key_timeuuid(cql, table1):
     p = unique_key_int()
-    cql.execute("INSERT INTO " + table1 + " (p, timeuuidmap) VALUES (" + str(p) + ", fromJson('{\"a4a70900-24e1-11df-8924-001ff3591711\": 3}'))")
-    assert list(cql.execute(f"SELECT p, timeuuidmap from {table1} where p = {p}")) == [(p, {UUID('a4a70900-24e1-11df-8924-001ff3591711'): 3})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + " (p, timeuuidmap) VALUES ("
+        + str(p)
+        + ", fromJson('{\"a4a70900-24e1-11df-8924-001ff3591711\": 3}'))"
+    )
+    assert list(cql.execute(f"SELECT p, timeuuidmap from {table1} where p = {p}")) == [
+        (p, {UUID("a4a70900-24e1-11df-8924-001ff3591711"): 3})
+    ]
+
 
 def test_fromjson_map_key_uuid(cql, table1):
     p = unique_key_int()
-    cql.execute("INSERT INTO " + table1 + " (p, uuidmap) VALUES (" + str(p) + ", fromJson('{\"a4a70900-24e1-11df-8924-001ff3591711\": 3}'))")
-    assert list(cql.execute(f"SELECT p, uuidmap from {table1} where p = {p}")) == [(p, {UUID('a4a70900-24e1-11df-8924-001ff3591711'): 3})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + " (p, uuidmap) VALUES ("
+        + str(p)
+        + ", fromJson('{\"a4a70900-24e1-11df-8924-001ff3591711\": 3}'))"
+    )
+    assert list(cql.execute(f"SELECT p, uuidmap from {table1} where p = {p}")) == [
+        (p, {UUID("a4a70900-24e1-11df-8924-001ff3591711"): 3})
+    ]
+
 
 def test_fromjson_map_key_number(cql, table1):
     # For all number types, the JSON should contain as a map key a quoted
     # version of the number, e.g, "17" with the quotes. An unquoted version
     # is not supported (even though it looks like legal JSON), and generates
     # a FunctionFailure error:
-    for t in ["bigint", "decimal", "double", "float", "int", "smallint", "tinyint", "varint"]:
+    for t in [
+        "bigint",
+        "decimal",
+        "double",
+        "float",
+        "int",
+        "smallint",
+        "tinyint",
+        "varint",
+    ]:
         p = unique_key_int()
         with pytest.raises(FunctionFailure):
-            cql.execute("INSERT INTO " + table1 + f" (p, {t}map) VALUES (" + str(p) + ", fromJson('{17: 3}'))")
-        cql.execute("INSERT INTO " + table1 + f" (p, {t}map) VALUES (" + str(p) + ", fromJson('{\"17\": 3}'))")
-        assert list(cql.execute(f"SELECT p, {t}map from {table1} where p = {p}")) == [(p, {17: 3})]
+            cql.execute(
+                "INSERT INTO "
+                + table1
+                + f" (p, {t}map) VALUES ("
+                + str(p)
+                + ", fromJson('{17: 3}'))"
+            )
+        cql.execute(
+            "INSERT INTO "
+            + table1
+            + f" (p, {t}map) VALUES ("
+            + str(p)
+            + ", fromJson('{\"17\": 3}'))"
+        )
+        assert list(cql.execute(f"SELECT p, {t}map from {table1} where p = {p}")) == [
+            (p, {17: 3})
+        ]
+
 
 # Reproduces #18477:
 def test_fromjson_map_key_blob(cql, table1):
     p = unique_key_int()
     # A blob is encoded in JSON as string containing 0x and then hex, e.g.,
     # "0x12ab3e".
-    cql.execute("INSERT INTO " + table1 + f" (p, blobmap) VALUES (" + str(p) + ", fromJson('{\"0x12ab3e\": 3}'))")
-    assert list(cql.execute(f"SELECT p, blobmap from {table1} where p = {p}")) == [(p, {b'\x12\xab\x3e': 3})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + f" (p, blobmap) VALUES ("
+        + str(p)
+        + ", fromJson('{\"0x12ab3e\": 3}'))"
+    )
+    assert list(cql.execute(f"SELECT p, blobmap from {table1} where p = {p}")) == [
+        (p, {b"\x12\xab\x3e": 3})
+    ]
+
 
 def test_fromjson_map_key_boolean(cql, table1):
     # While in general, Cassandra and Scylla allow boolean to be encoded in
@@ -347,26 +477,62 @@ def test_fromjson_map_key_boolean(cql, table1):
     # strings "true"/"false", for map keys only the quoted version is
     # supported.
     p = unique_key_int()
-    cql.execute("INSERT INTO " + table1 + f" (p, booleanmap) VALUES (" + str(p) + ", fromJson('{\"true\": 3}'))")
-    assert list(cql.execute(f"SELECT p, booleanmap from {table1} where p = {p}")) == [(p, {True: 3})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + f" (p, booleanmap) VALUES ("
+        + str(p)
+        + ", fromJson('{\"true\": 3}'))"
+    )
+    assert list(cql.execute(f"SELECT p, booleanmap from {table1} where p = {p}")) == [
+        (p, {True: 3})
+    ]
+
 
 # Reproduces #18477:
 def test_fromjson_map_key_date(cql, table1):
     p = unique_key_int()
-    cql.execute("INSERT INTO " + table1 + f" (p, datemap) VALUES (" + str(p) + ", fromJson('{\"2011-02-03\": 3}'))")
-    assert list(cql.execute(f"SELECT p, datemap from {table1} where p = {p}")) == [(p, {Date('2011-02-03'): 3})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + f" (p, datemap) VALUES ("
+        + str(p)
+        + ", fromJson('{\"2011-02-03\": 3}'))"
+    )
+    assert list(cql.execute(f"SELECT p, datemap from {table1} where p = {p}")) == [
+        (p, {Date("2011-02-03"): 3})
+    ]
+
 
 # Reproduces #18477:
 def test_fromjson_map_key_inet(cql, table1):
     p = unique_key_int()
-    cql.execute("INSERT INTO " + table1 + f" (p, inetmap) VALUES (" + str(p) + ", fromJson('{\"1.2.3.4\": 3}'))")
-    assert list(cql.execute(f"SELECT p, inetmap from {table1} where p = {p}")) == [(p, {'1.2.3.4': 3})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + f" (p, inetmap) VALUES ("
+        + str(p)
+        + ", fromJson('{\"1.2.3.4\": 3}'))"
+    )
+    assert list(cql.execute(f"SELECT p, inetmap from {table1} where p = {p}")) == [
+        (p, {"1.2.3.4": 3})
+    ]
+
 
 # Reproduces #18477:
 def test_fromjson_map_key_time(cql, table1):
     p = unique_key_int()
-    cql.execute("INSERT INTO " + table1 + f" (p, timemap) VALUES (" + str(p) + ", fromJson('{\"07:35:07.000111222\": 3}'))")
-    assert list(cql.execute(f"SELECT p, timemap from {table1} where p = {p}")) == [(p, {Time('07:35:07.000111222'): 3})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + f" (p, timemap) VALUES ("
+        + str(p)
+        + ", fromJson('{\"07:35:07.000111222\": 3}'))"
+    )
+    assert list(cql.execute(f"SELECT p, timemap from {table1} where p = {p}")) == [
+        (p, {Time("07:35:07.000111222"): 3})
+    ]
+
 
 # Reproduces #18477:
 def test_fromjson_map_key_timestamp(cql, table1):
@@ -375,8 +541,16 @@ def test_fromjson_map_key_timestamp(cql, table1):
     # We have other tests above for the other allowed formats - here our
     # goal isn't to check all of them, but just check on in the context
     # of a map's key.
-    cql.execute("INSERT INTO " + table1 + f" (p, timestampmap) VALUES (" + str(p) + ", fromJson('{\"2014-01-01 12:15:45+0000\": 3}'))")
-    assert list(cql.execute(f"SELECT p, timestampmap from {table1} where p = {p}")) == [(p, {datetime(2014, 1, 1, 12, 15, 45): 3})]
+    cql.execute(
+        "INSERT INTO "
+        + table1
+        + f" (p, timestampmap) VALUES ("
+        + str(p)
+        + ", fromJson('{\"2014-01-01 12:15:45+0000\": 3}'))"
+    )
+    assert list(cql.execute(f"SELECT p, timestampmap from {table1} where p = {p}")) == [
+        (p, {datetime(2014, 1, 1, 12, 15, 45): 3})
+    ]
 
 
 # With fromJson() the JSON "null" constant can be used to unset a column,
@@ -386,29 +560,36 @@ def test_fromjson_map_key_timestamp(cql, table1):
 # that a normal value is allowed. For example, it cannot be given as an
 # element of a list.
 # Reproduces #7954.
-@pytest.mark.xfail(reason="issue #7954")
+@pytest.mark.xfail(reason="fromJson() fails to set null tuple elements #7954")
 def test_fromjson_null_constant(cql, table1):
     p = unique_key_int()
     # Check that a "null" JSON constant can be used to unset a column
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
-    cql.execute(stmt, [p, '1'])
+    cql.execute(stmt, [p, "1"])
     assert list(cql.execute(f"SELECT p, v from {table1} where p = {p}")) == [(p, 1)]
-    cql.execute(stmt, [p, 'null'])
+    cql.execute(stmt, [p, "null"])
     assert list(cql.execute(f"SELECT p, v from {table1} where p = {p}")) == [(p, None)]
     # Check that a "null" JSON constant can be used to unset part of a tuple
     stmt = cql.prepare(f"INSERT INTO {table1} (p, tup) VALUES (?, fromJson(?))")
     cql.execute(stmt, [p, '["a", 1]'])
-    assert list(cql.execute(f"SELECT p, tup from {table1} where p = {p}")) == [(p, ('a', 1))]
+    assert list(cql.execute(f"SELECT p, tup from {table1} where p = {p}")) == [
+        (p, ("a", 1))
+    ]
     cql.execute(stmt, [p, '["a", null]'])
-    assert list(cql.execute(f"SELECT p, tup from {table1} where p = {p}")) == [(p, ('a', None))]
-    cql.execute(stmt, [p, '[null, 2]'])
-    assert list(cql.execute(f"SELECT p, tup from {table1} where p = {p}")) == [(p, (None, 2))]
+    assert list(cql.execute(f"SELECT p, tup from {table1} where p = {p}")) == [
+        (p, ("a", None))
+    ]
+    cql.execute(stmt, [p, "[null, 2]"])
+    assert list(cql.execute(f"SELECT p, tup from {table1} where p = {p}")) == [
+        (p, (None, 2))
+    ]
     # However, a "null" JSON constant is not just allowed everywhere that a
     # normal value is allowed. E.g, it cannot be part of a list. Let's
     # verify that we didn't overdo the fix.
     stmt = cql.prepare(f"INSERT INTO {table1} (p, l) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
         cql.execute(stmt, [p, '["a", null]'])
+
 
 # Check that toJson() correctly formats double values. Strangely, we had a bug`
 # (issue #7972) where the double value 123.456 was correctly formatted, but
@@ -418,11 +599,16 @@ def test_tojson_double(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, d) VALUES (?, ?)")
     cql.execute(stmt, [p, 123.456])
-    assert list(cql.execute(f"SELECT d, toJson(d) from {table1} where p = {p}")) == [(123.456, "123.456")]
+    assert list(cql.execute(f"SELECT d, toJson(d) from {table1} where p = {p}")) == [
+        (123.456, "123.456")
+    ]
     # While 123.456 above worked, in issue #7972 we note that 123123.123123
     # does not work.
     cql.execute(stmt, [p, 123123.123123])
-    assert list(cql.execute(f"SELECT d, toJson(d) from {table1} where p = {p}")) == [(123123.123123, "123123.123123")]
+    assert list(cql.execute(f"SELECT d, toJson(d) from {table1} where p = {p}")) == [
+        (123123.123123, "123123.123123")
+    ]
+
 
 # Check that toJson() correctly formats "time" values. The JSON translation
 # is a string containing the time (there is no time type in JSON), and of
@@ -432,7 +618,10 @@ def test_tojson_time(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, t) VALUES (?, ?)")
     cql.execute(stmt, [p, 123])
-    assert list(cql.execute(f"SELECT toJson(t) from {table1} where p = {p}")) == [('"00:00:00.000000123"',)]
+    assert list(cql.execute(f"SELECT toJson(t) from {table1} where p = {p}")) == [
+        ('"00:00:00.000000123"',)
+    ]
+
 
 # Test the same thing in test_tojson_time above, with SELECT JSON instead
 # of SELECT toJson(). Also reproduces issue #7988.
@@ -440,7 +629,10 @@ def test_select_json_time(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, t) VALUES (?, ?)")
     cql.execute(stmt, [p, 123])
-    assert list(cql.execute(f"SELECT JSON t from {table1} where p = {p}")) == [(EquivalentJson('{"t": "00:00:00.000000123"}'),)]
+    assert list(cql.execute(f"SELECT JSON t from {table1} where p = {p}")) == [
+        (EquivalentJson('{"t": "00:00:00.000000123"}'),)
+    ]
+
 
 # Check that toJson() returns timestamp string in correct cassandra compatible format (issue #7997)
 # with milliseconds and timezone specification
@@ -448,7 +640,10 @@ def test_tojson_timestamp(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, ts) VALUES (?, ?)")
     cql.execute(stmt, [p, datetime(2014, 1, 1, 12, 15, 45)])
-    assert list(cql.execute(f"SELECT toJson(ts) from {table1} where p = {p}")) == [('"2014-01-01 12:15:45.000Z"',)]
+    assert list(cql.execute(f"SELECT toJson(ts) from {table1} where p = {p}")) == [
+        ('"2014-01-01 12:15:45.000Z"',)
+    ]
+
 
 # Although toJson() converts a timestamp to one specific textual format (as we
 # saw in the previous test), following Postel's law several other alternative
@@ -463,7 +658,10 @@ def test_fromjson_timestamp(cql, table1):
     ]:
         p = unique_key_int()
         cql.execute(stmt, [p, json])
-        assert list(cql.execute(f"SELECT ts from {table1} where p = {p}")) == [(datetime(2014, 1, 1, 12, 15, 45),)]
+        assert list(cql.execute(f"SELECT ts from {table1} where p = {p}")) == [
+            (datetime(2014, 1, 1, 12, 15, 45),)
+        ]
+
 
 # However, there is one variation on the timestamp format that Scylla refuses
 # to accept, while Cassandra allows: Scylla allows the *fractional* second
@@ -483,9 +681,12 @@ def test_fromjson_timestamp_submilli(cql, table1, cassandra_bug):
     stmt = cql.prepare(f"INSERT INTO {table1} (p, ts) VALUES (?, fromJson(?))")
     p = unique_key_int()
     json = '"2014-01-01 12:15:45.0000000Z"'
-    with pytest.raises(FunctionFailure, match='Milliseconds'):
+    with pytest.raises(FunctionFailure, match="Milliseconds"):
         cql.execute(stmt, [p, json])
-        assert list(cql.execute(f"SELECT ts from {table1} where p = {p}")) == [(datetime(2014, 1, 1, 12, 15, 45),)]
+        assert list(cql.execute(f"SELECT ts from {table1} where p = {p}")) == [
+            (datetime(2014, 1, 1, 12, 15, 45),)
+        ]
+
 
 # Test that toJson() can prints a decimal type with a very high mantissa.
 # Reproduces issue #8002, where it was written as 1 and a billion zeroes,
@@ -493,29 +694,37 @@ def test_fromjson_timestamp_submilli(cql, table1, cassandra_bug):
 # We need to skip this test because in debug mode memory allocation is not
 # bounded, and this test can hang or crash instead of failing immediately.
 # We also have a smaller xfailing test below, test_tojson_decimal_high_mantissa2.
-@pytest.mark.skip(reason="issue #8002")
+@pytest.mark.skip(
+    reason="toJson() of decimal type doesn't use exponents so can produce huge output #8002"
+)
 def test_tojson_decimal_high_mantissa(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, dec) VALUES ({p}, ?)")
-    high = '1e1000000000'
+    high = "1e1000000000"
     cql.execute(stmt, [Decimal(high)])
-    assert list(cql.execute(f"SELECT toJson(dec) from {table1} where p = {p}")) == [(EquivalentJson(high),)]
+    assert list(cql.execute(f"SELECT toJson(dec) from {table1} where p = {p}")) == [
+        (EquivalentJson(high),)
+    ]
+
 
 # This is a smaller version of test_tojson_decimal_high_mantissa, showing
 # that a much smaller exponent, 1e1000 works (this is not surprising) but
 # results in 1000 digits of output. This hints that 1e1000000000 will not
 # work at all, without testing it directly as above.
-@pytest.mark.xfail(reason="issue #8002")
+@pytest.mark.xfail(
+    reason="toJson() of decimal type doesn't use exponents so can produce huge output #8002"
+)
 def test_tojson_decimal_high_mantissa2(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, dec) VALUES ({p}, ?)")
     # Although 1e1000 is higher than a normal double, it should be fine for
     # Scylla's "decimal" type:
-    high = '1e1000'
+    high = "1e1000"
     cql.execute(stmt, [Decimal(high)])
     result = cql.execute(f"SELECT toJson(dec) from {table1} where p = {p}").one()[0]
     # We expect the "result" JSON string to be 1E+1000 - not 100000000....000000.
     assert len(result) < 10
+
 
 # Reproducers for issue #8077: SELECT JSON on a function call should result
 # in the same JSON strings as it does on Cassandra.
@@ -523,17 +732,20 @@ def test_select_json_function_call(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, v) VALUES ({p}, 17) USING TIMESTAMP 1234")
     input_and_output = {
-        'v':                       '{"v": 17}',
-        'count(*)':                '{"count": 1}',
-        'ttl(v)':                  '{"ttl(v)": null}',
-        'writetime(v)':            '{"writetime(v)": 1234}',
-        'intAsBlob(v)':            '{"system.intasblob(v)": "0x00000011"}',
-        'blobasInt(intAsBlob(v))': '{"system.blobasint(system.intasblob(v))": 17}',
-        'tojson(v)':               '{"system.tojson(v)": "17"}',
-        'CAST(v AS FLOAT)':        '{"cast(v as float)": 17.0}',
+        "v": '{"v": 17}',
+        "count(*)": '{"count": 1}',
+        "ttl(v)": '{"ttl(v)": null}',
+        "writetime(v)": '{"writetime(v)": 1234}',
+        "intAsBlob(v)": '{"system.intasblob(v)": "0x00000011"}',
+        "blobasInt(intAsBlob(v))": '{"system.blobasint(system.intasblob(v))": 17}',
+        "tojson(v)": '{"system.tojson(v)": "17"}',
+        "CAST(v AS FLOAT)": '{"cast(v as float)": 17.0}',
     }
     for input, output in input_and_output.items():
-        assert list(cql.execute(f"SELECT JSON {input} from {table1} where p = {p}")) == [(EquivalentJson(output),)]
+        assert list(
+            cql.execute(f"SELECT JSON {input} from {table1} where p = {p}")
+        ) == [(EquivalentJson(output),)]
+
 
 # Whereas in CQL map keys might be of many types, in JSON map keys must always
 # be strings. So when SELECT JSON prints a map value with a non-string key to
@@ -543,13 +755,18 @@ def test_select_json_function_call(cql, table1):
 # This is issue #8087.
 # This issue is also reproduced by the much more comprehensive test
 # cassandra_tests/validation/entities/json_test.py::testInsertJsonSyntaxWithNonNativeMapKeys
-@pytest.mark.xfail(reason="issue #8087")
+@pytest.mark.xfail(
+    reason="SELECT JSON incorrectly quotes strings inside map keys #8087"
+)
 def test_select_json_string_in_nonstring_map_key(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, tupmap) VALUES ({p}, ?)")
-    cql.execute(stmt, [{('hello', 3): 7}])
+    cql.execute(stmt, [{("hello", 3): 7}])
     expected = '{"tupmap": {"[\\"hello\\", 3]": 7}}'
-    assert list(cql.execute(f"SELECT JSON tupmap from {table1} where p = {p}")) == [(expected,)]
+    assert list(cql.execute(f"SELECT JSON tupmap from {table1} where p = {p}")) == [
+        (expected,)
+    ]
+
 
 # Test that SELECT JSON correctly prints unset components of a UDT or tuple
 # as "null". This test passes which demonstrates that issue #8092 is specific
@@ -558,12 +775,17 @@ def test_select_json_string_in_nonstring_map_key(cql, table1):
 def test_select_json_null_component(cql, table1, type1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, tup) VALUES ({p}, ?)")
-    cql.execute(stmt, [('hello', None)])
-    assert list(cql.execute(f"SELECT JSON tup from {table1} where p = {p}")) == [('{"tup": ["hello", null]}',)]
+    cql.execute(stmt, [("hello", None)])
+    assert list(cql.execute(f"SELECT JSON tup from {table1} where p = {p}")) == [
+        ('{"tup": ["hello", null]}',)
+    ]
 
     stmt = cql.prepare(f"INSERT INTO {table1} (p, t1) VALUES ({p}, ?)")
-    cql.execute(stmt, [('hello', None)])
-    assert list(cql.execute(f"SELECT JSON t1 from {table1} where p = {p}")) == [('{"t1": {"t": "hello", "b": null}}',)]
+    cql.execute(stmt, [("hello", None)])
+    assert list(cql.execute(f"SELECT JSON t1 from {table1} where p = {p}")) == [
+        ('{"t1": {"t": "hello", "b": null}}',)
+    ]
+
 
 # Reproducer for issue #8078: Test that the "AS" clause (alias) in
 # a SELECT JSON is honored, and the returned JSON string contains the
@@ -575,37 +797,44 @@ def test_select_json_null_component(cql, table1, type1):
 # cassandra_tests/validation/entities/json_test.py::testCaseSensitivity
 def test_select_json_with_alias(cql, table1):
     p = unique_key_int()
-    cql.execute(f"INSERT INTO {table1} (p, v, bigv, a, \"CaseSensitive\") VALUES ({p}, 17, 34, 'dog', 99)")
+    cql.execute(
+        f"INSERT INTO {table1} (p, v, bigv, a, \"CaseSensitive\") VALUES ({p}, 17, 34, 'dog', 99)"
+    )
     # We aim here to cover many interesting cases: alias for one column,
     # aliases for several columns, some columns with alias and some without,
     # aliasing a function call, case-sensitive aliases and case-sensitive
     # column names.
     input_and_output = {
-        'v':                       '{"v": 17}',
-        'v as hello':              '{"hello": 17}',
-        'v as Hello':              '{"hello": 17}',
-        'v as "Hello"':            '{"\\"Hello\\"": 17}',
-        'v as "Hello World!"':     '{"\\"Hello World!\\"": 17}',
-        'ttl(v)':                  '{"ttl(v)": null}',
-        'ttl(v) as hi':            '{"hi": null}',
-        '"CaseSensitive"':         '{"\\"CaseSensitive\\"": 99}',
-        '"CaseSensitive" as cs':   '{"cs": 99}',
-        'v, p':                    '{"v": 17, "p": ' + str(p) + '}',
-        'v, p as xyz':             '{"v": 17, "xyz": ' + str(p) + '}',
-        'v, bigv, a':              '{"v": 17, "bigv": 34, "a": "dog"}',
-        'v, bigv as xyz, a':       '{"v": 17, "xyz": 34, "a": "dog"}',
-        'v as qwe, bigv as xyz, a' :'{"qwe": 17, "xyz": 34, "a": "dog"}',
-        'v as q, bigv as x, a as z':'{"q": 17, "x": 34, "z": "dog"}',
+        "v": '{"v": 17}',
+        "v as hello": '{"hello": 17}',
+        "v as Hello": '{"hello": 17}',
+        'v as "Hello"': '{"\\"Hello\\"": 17}',
+        'v as "Hello World!"': '{"\\"Hello World!\\"": 17}',
+        "ttl(v)": '{"ttl(v)": null}',
+        "ttl(v) as hi": '{"hi": null}',
+        '"CaseSensitive"': '{"\\"CaseSensitive\\"": 99}',
+        '"CaseSensitive" as cs': '{"cs": 99}',
+        "v, p": '{"v": 17, "p": ' + str(p) + "}",
+        "v, p as xyz": '{"v": 17, "xyz": ' + str(p) + "}",
+        "v, bigv, a": '{"v": 17, "bigv": 34, "a": "dog"}',
+        "v, bigv as xyz, a": '{"v": 17, "xyz": 34, "a": "dog"}',
+        "v as qwe, bigv as xyz, a": '{"qwe": 17, "xyz": 34, "a": "dog"}',
+        "v as q, bigv as x, a as z": '{"q": 17, "x": 34, "z": "dog"}',
         # Although it's not useful, it's allowed to use the same alias
         # for multiple columns...
-        'v as q, bigv as q, a as q':'{"q": 17, "q": 34, "q": "dog"}',
+        "v as q, bigv as q, a as q": '{"q": 17, "q": 34, "q": "dog"}',
     }
     for input, output in input_and_output.items():
-        assert list(cql.execute(f"SELECT JSON {input} from {table1} where p = {p}")) == [(EquivalentJson(output),)]
+        assert list(
+            cql.execute(f"SELECT JSON {input} from {table1} where p = {p}")
+        ) == [(EquivalentJson(output),)]
+
 
 # The grammar around DISTINCT and JSON is hairy. Test the combination.
 def test_select_distinct_json(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)"
+    ) as table:
         p1 = unique_key_int()
         p2 = unique_key_int()
         # Insert two rows per partition
@@ -615,11 +844,15 @@ def test_select_distinct_json(cql, test_keyspace):
         cql.execute(f"INSERT INTO {table} (p, c, v) VALUES ({p2}, 2, 40)")
         # DISTINCT can only select partition key columns (p)
         # Should return exactly 2 rows (one per partition)
-        result = list(cql.execute(f"SELECT JSON DISTINCT p FROM {table} WHERE p IN ({p1}, {p2})"))
+        result = list(
+            cql.execute(f"SELECT JSON DISTINCT p FROM {table} WHERE p IN ({p1}, {p2})")
+        )
         # Check that the results are valid JSON with the expected structure
         json_values = sorted([json.loads(row[0])["p"] for row in result])
         assert json_values == sorted([p1, p2])
         # Without DISTINCT, should return all 4 rows
-        result = list(cql.execute(f"SELECT JSON p FROM {table} WHERE p IN ({p1}, {p2})"))
+        result = list(
+            cql.execute(f"SELECT JSON p FROM {table} WHERE p IN ({p1}, {p2})")
+        )
         json_values = [json.loads(row[0])["p"] for row in result]
         assert sorted(json_values) == sorted([p1, p1, p2, p2])

--- a/test/cqlpy/test_key_length.py
+++ b/test/cqlpy/test_key_length.py
@@ -27,38 +27,48 @@ from cassandra.util import SortedSet
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p text, c text, v int, PRIMARY KEY (p, c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p text, c text, v int, PRIMARY KEY (p, c)"
+    ) as table:
         yield table
+
 
 # Trying to insert a 65KB (clearly over 64KB) value to a clustering key or
 # partition key should fail, with a clean InvalidRequest - not some internal
 # server error or worse.
 # Reproduces #12247
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def test_insert_65k_pk(cql, table1):
-    stmt = cql.prepare(f'INSERT INTO {table1} (p, c) VALUES (?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table1} (p, c) VALUES (?,?)")
     # Cassandra writes: "Key length of 66560 is longer than maximum of 65535"
-    with pytest.raises(InvalidRequest, match='Key length'):
-        cql.execute(stmt, ['x'*(65*1024), 'hello'])
+    with pytest.raises(InvalidRequest, match="Key length"):
+        cql.execute(stmt, ["x" * (65 * 1024), "hello"])
+
 
 # Reproduces #12247
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def test_insert_65k_ck(cql, table1):
-    stmt = cql.prepare(f'INSERT INTO {table1} (p, c) VALUES (?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table1} (p, c) VALUES (?,?)")
     # Cassandra writes: "Key length of 66560 is longer than maximum of 65535"
-    with pytest.raises(InvalidRequest, match='Key length'):
-        cql.execute(stmt, ['hello', 'x'*(65*1024)])
+    with pytest.raises(InvalidRequest, match="Key length"):
+        cql.execute(stmt, ["hello", "x" * (65 * 1024)])
+
 
 # Trying to read with a 65KB (clearly over 64KB) clustering key or partition
 # key should fail, with a clean InvalidRequest - not some internal server
 # error or worse.
 # Reproduces #10366.
-@pytest.mark.xfail(reason="Issue #10366")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #10366")
 def test_where_65k_pk(cql, table1):
-    stmt = cql.prepare(f'SELECT * FROM {table1} WHERE p = ?')
+    stmt = cql.prepare(f"SELECT * FROM {table1} WHERE p = ?")
     # Cassandra writes: "Key length of 66560 is longer than maximum of 65535"
-    with pytest.raises(InvalidRequest, match='Key length'):
-        cql.execute(stmt, ['x'*(65*1024)])
+    with pytest.raises(InvalidRequest, match="Key length"):
+        cql.execute(stmt, ["x" * (65 * 1024)])
+
 
 # While "WHERE p = ?" gives an InvalidRequest error on an oversized key (as
 # the previous test checks), in Cassandra the clustering-key version
@@ -68,15 +78,16 @@ def test_where_65k_pk(cql, table1):
 # return no match as Cassandra does. In any case, returning some ugly internal
 # error (as happened in Scylla) is a bug.
 # Reproduces #10366.
-@pytest.mark.xfail(reason="Issue #10366")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #10366")
 def test_where_65k_ck(cql, table1):
-    stmt = cql.prepare(f'SELECT * FROM {table1} WHERE p = ? AND c = ?')
+    stmt = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND c = ?")
     try:
-        assert [] == list(cql.execute(stmt, ['dog', 'x'*(65*1024)]))
+        assert [] == list(cql.execute(stmt, ["dog", "x" * (65 * 1024)]))
     except InvalidRequest:
         # Acceptable as an alternative to Cassandra's silently returning
         # nothing (see explanation above)
         pass
+
 
 # What is the exact size limit of the key? It turns out that Cassandra allows
 # the partition key length to reach all the way to 65535 (2^16-1), and the
@@ -87,23 +98,30 @@ def test_where_65k_ck(cql, table1):
 # Scylla shouldn't impose its own smaller size limit - but in issue #16772,
 # it did (the limit was 65533).
 
-@pytest.mark.xfail(reason="Issue #16772")
+
+@pytest.mark.xfail(
+    reason="Key length should be limited to exactly 65535, not less #16772"
+)
 def test_insert_65535_pk(cql, table1):
-    stmt = cql.prepare(f'INSERT INTO {table1} (p, c) VALUES (?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table1} (p, c) VALUES (?,?)")
     p = random_string(length=65535)
     c = unique_key_string()  # not particularly long
     cql.execute(stmt, [p, c])
-    stmt = cql.prepare(f'SELECT p,c FROM {table1} WHERE p=?')
+    stmt = cql.prepare(f"SELECT p,c FROM {table1} WHERE p=?")
     assert list(cql.execute(stmt, [p])) == [(p, c)]
 
-@pytest.mark.xfail(reason="Issue #16772")
+
+@pytest.mark.xfail(
+    reason="Key length should be limited to exactly 65535, not less #16772"
+)
 def test_insert_65535_ck(cql, table1):
-    stmt = cql.prepare(f'INSERT INTO {table1} (p, c) VALUES (?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table1} (p, c) VALUES (?,?)")
     p = unique_key_string()  # not particularly long
     c = random_string(length=65535)
     cql.execute(stmt, [p, c])
-    stmt = cql.prepare(f'SELECT p,c FROM {table1} WHERE p=?')
+    stmt = cql.prepare(f"SELECT p,c FROM {table1} WHERE p=?")
     assert list(cql.execute(stmt, [p])) == [(p, c)]
+
 
 # Same as test_insert_65535_ck() but also set a regular column. Scylla's
 # implementation docs/architecture/sstable/sstable2/sstable-interpretation.rst
@@ -111,15 +129,18 @@ def test_insert_65535_ck(cql, table1):
 # first component, and the regular column *name* as the second component.
 # This should work - Scylla shouldn't try to limit the sum of these lengths
 # or something.
-@pytest.mark.xfail(reason="Issue #16772")
+@pytest.mark.xfail(
+    reason="Key length should be limited to exactly 65535, not less #16772"
+)
 def test_insert_65535_ck_with_regular_column(cql, table1):
-    stmt = cql.prepare(f'INSERT INTO {table1} (p, c, v) VALUES (?,?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table1} (p, c, v) VALUES (?,?,?)")
     p = unique_key_string()  # not particularly long
     c = random_string(length=65535)
     v = unique_key_int()
     cql.execute(stmt, [p, c, v])
-    stmt = cql.prepare(f'SELECT p,c,v FROM {table1} WHERE p=?')
+    stmt = cql.prepare(f"SELECT p,c,v FROM {table1} WHERE p=?")
     assert list(cql.execute(stmt, [p])) == [(p, c, v)]
+
 
 # The following are tests for compound partition key and composite clustering
 # key - i.e., keys containing multiple columns.
@@ -127,10 +148,16 @@ def test_insert_65535_ck_with_regular_column(cql, table1):
 # the total size, and the compound format has some overheads which limits
 # the maximum size, and we want to check all of this below.
 
+
 @pytest.fixture(scope="module")
 def table2(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p1 text, p2 text, c1 text, c2 text, PRIMARY KEY ((p1, p2), c1, c2)") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p1 text, p2 text, c1 text, c2 text, PRIMARY KEY ((p1, p2), c1, c2)",
+    ) as table:
         yield table
+
 
 # As we checked above for single-component keys, a 65 KB key is definitely
 # oversized and no key component can be this big.
@@ -138,23 +165,29 @@ def table2(cql, test_keyspace):
 # instead of the expected InvalidRequest error, it generates an internal
 # server error (i.e., NoHostAvailable) with the message "'H' format requires
 # 0 <= number <= 65535".
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def test_insert_65k_pk_compound(cql, table2, cassandra_bug):
-    stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
-    big = 'x'*(65*1024)
-    with pytest.raises(InvalidRequest, match='Key length'):
-        cql.execute(stmt, [big, 'dog', 'cat', 'mouse'])
-    with pytest.raises(InvalidRequest, match='Key length'):
-        cql.execute(stmt, ['dog', big, 'cat', 'mouse'])
+    stmt = cql.prepare(f"INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)")
+    big = "x" * (65 * 1024)
+    with pytest.raises(InvalidRequest, match="Key length"):
+        cql.execute(stmt, [big, "dog", "cat", "mouse"])
+    with pytest.raises(InvalidRequest, match="Key length"):
+        cql.execute(stmt, ["dog", big, "cat", "mouse"])
 
-@pytest.mark.xfail(reason="Issue #12247")
+
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def test_insert_65k_ck_composite(cql, table2):
-    stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
-    big = 'x'*(65*1024)
-    with pytest.raises(InvalidRequest, match='Key length'):
-        cql.execute(stmt, ['dog', 'cat', big, 'mouse'])
-    with pytest.raises(InvalidRequest, match='Key length'):
-        cql.execute(stmt, ['dog', 'cat', 'mouse', big])
+    stmt = cql.prepare(f"INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)")
+    big = "x" * (65 * 1024)
+    with pytest.raises(InvalidRequest, match="Key length"):
+        cql.execute(stmt, ["dog", "cat", big, "mouse"])
+    with pytest.raises(InvalidRequest, match="Key length"):
+        cql.execute(stmt, ["dog", "cat", "mouse", big])
+
 
 # The above test_insert_65535_pk tried to reach the limit 65535 bytes in the
 # case of a single-component partition key, and checked that see we can
@@ -165,36 +198,40 @@ def test_insert_65k_ck_composite(cql, table2):
 # In Scylla, we can reach 65535-4 bytes of keys, apparently two extra bytes
 # (lengths?) are used per component, but in Cassandra the limit we can reach
 # with two key components is 65535-6, perhaps there's an additional count
-# of components? 
-# 
+# of components?
+#
 # of components?). It's not at all clear that this is
 # correct (see issue #16772) but we'll enshirine it for the moment because
 # Cassandra is even more broken in this case :-(
 def test_insert_total_compound_pk_ok(cql, table2):
-    stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)")
     # A total compound pk of size 65535-6 will work (in Scylla, even -4 works)
     length = 65535 - 6
     p1 = random_string(length=100)
-    p2 = random_string(length=(length-len(p1)))
+    p2 = random_string(length=(length - len(p1)))
     c1 = unique_key_string()  # not particularly long
     c2 = unique_key_string()  # not particularly long
     cql.execute(stmt, [p1, p2, c1, c2])
-    stmt = cql.prepare(f'SELECT * FROM {table2} WHERE p1=? AND p2=?')
+    stmt = cql.prepare(f"SELECT * FROM {table2} WHERE p1=? AND p2=?")
     assert list(cql.execute(stmt, [p1, p2])) == [(p1, p2, c1, c2)]
 
-@pytest.mark.xfail(reason="Issue #12247")
+
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def test_insert_total_compound_pk_err(cql, table2):
-    stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)")
     # A total compound pk of size 65536 is definitely too long
     length = 65536
-    p1 = random_string(length=length//2)
+    p1 = random_string(length=length // 2)
     p2 = p1
     c1 = unique_key_string()  # not particularly long
     c2 = unique_key_string()  # not particularly long
     # In issue #12247, Scylla returned an internal server error instead of
     # a clean InvalidRequest here.
-    with pytest.raises(InvalidRequest, match='Key length'):
+    with pytest.raises(InvalidRequest, match="Key length"):
         cql.execute(stmt, [p1, p2, c1, c2])
+
 
 # The case of a composite clustering key (clustering key composed of multiple
 # columns) is similar to the case we saw above of compound partition key -
@@ -213,31 +250,35 @@ def test_insert_total_compound_pk_err(cql, table2):
 # why the sum is limited, it should include everything, including length
 # bytes).
 def test_insert_total_composite_ck_ok(cql, table2):
-    stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)")
     # A total composite ck of size 65535-4 will work (in Cassandra 5, even
     # 65535 works, I suspect this might be a bug)
     length = 65535 - 4
     c1 = random_string(length=100)
-    c2 = random_string(length=(length-len(c1)))
+    c2 = random_string(length=(length - len(c1)))
     p1 = unique_key_string()  # not particularly long
     p2 = unique_key_string()  # not particularly long
     cql.execute(stmt, [p1, p2, c1, c2])
-    stmt = cql.prepare(f'SELECT * FROM {table2} WHERE p1=? AND p2=?')
+    stmt = cql.prepare(f"SELECT * FROM {table2} WHERE p1=? AND p2=?")
     assert list(cql.execute(stmt, [p1, p2])) == [(p1, p2, c1, c2)]
 
-@pytest.mark.xfail(reason="Issue #12247")
+
+@pytest.mark.xfail(
+    reason="Better error reporting for oversized keys during INSERT #12247"
+)
 def test_insert_total_composite_ck_err(cql, table2):
-    stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
+    stmt = cql.prepare(f"INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)")
     # A total composite ck of size 65536 is definitely too long
     length = 65536
-    c1 = random_string(length=length//2)
+    c1 = random_string(length=length // 2)
     c2 = c1
     p1 = unique_key_string()  # not particularly long
     p2 = unique_key_string()  # not particularly long
     # In issue #12247, Scylla returned an internal server error instead of
     # a clean InvalidRequest here.
-    with pytest.raises(InvalidRequest, match='Key length'):
+    with pytest.raises(InvalidRequest, match="Key length"):
         cql.execute(stmt, [p1, p2, c1, c2])
+
 
 # The following tests check length limits on parts of collections.
 # These tests belong in this file, i.e., are related to the limit on key
@@ -245,10 +286,16 @@ def test_insert_total_composite_ck_err(cql, table2):
 # in the same way as clustering keys - see
 # docs/architecture/sstable/sstable2/sstable-interpretation.rst.
 
+
 @pytest.fixture(scope="module")
 def table3(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, set_column set<text>, list_column list<text>, map_column map<text,text>") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int PRIMARY KEY, set_column set<text>, list_column list<text>, map_column map<text,text>",
+    ) as table:
         yield table
+
 
 # Ever since CASSANDRA-10374 was fixed in 2015, set values are no longer
 # limited to 64KB - and even though internally they behave like column names,
@@ -258,11 +305,11 @@ def table3(cql, test_keyspace):
 # Note that because of #7745, this test needs to use prepared statements
 # for the writes.
 def test_set_65k(cql, table3):
-    stmt = cql.prepare(f'UPDATE {table3} SET set_column = set_column + ? WHERE p = ?')
+    stmt = cql.prepare(f"UPDATE {table3} SET set_column = set_column + ? WHERE p = ?")
     p = unique_key_int()
-    val = random_string(length=65*1024)
+    val = random_string(length=65 * 1024)
     cql.execute(stmt, [{val}, p])
-    results = list(cql.execute(f'SELECT p, set_column FROM {table3} WHERE p={p}'))
+    results = list(cql.execute(f"SELECT p, set_column FROM {table3} WHERE p={p}"))
     assert results == [(p, SortedSet([val]))]
     # Reproduces issue #3017: After the above code worked well, and correctly
     # supported the more-than-64KB set value, if we now write it to an sstable
@@ -270,15 +317,17 @@ def test_set_65k(cql, table3):
     nodetool.flush(cql, table3)
     nodetool.compact(cql, table3)
 
+
 # For lists, it's even more obvious that the size of the value is not
 # limited to 64KB, because it's *not* represented as a column name.
 def test_list_65k(cql, table3):
-    stmt = cql.prepare(f'UPDATE {table3} SET list_column = list_column + ? WHERE p = ?')
+    stmt = cql.prepare(f"UPDATE {table3} SET list_column = list_column + ? WHERE p = ?")
     p = unique_key_int()
-    val = random_string(length=65*1024)
+    val = random_string(length=65 * 1024)
     cql.execute(stmt, [[val], p])
-    results = list(cql.execute(f'SELECT p, list_column FROM {table3} WHERE p={p}'))
+    results = list(cql.execute(f"SELECT p, list_column FROM {table3} WHERE p={p}"))
     assert results == [(p, [val])]
+
 
 # Map keys behave like set values, similar to clustering keys, so it's
 # important to check that they really allow more than 64KB, even with
@@ -286,12 +335,12 @@ def test_list_65k(cql, table3):
 # Reproduces #3017 where Scylla did the worst of both worlds: It allowed
 # oversized map keys, but then crashed on compaction.
 def test_map_65k(cql, table3):
-    stmt = cql.prepare(f'UPDATE {table3} SET map_column[?] = ? WHERE p = ?')
+    stmt = cql.prepare(f"UPDATE {table3} SET map_column[?] = ? WHERE p = ?")
     p = unique_key_int()
-    key = random_string(length=65*1024)
-    val = random_string(length=65*1024)
+    key = random_string(length=65 * 1024)
+    val = random_string(length=65 * 1024)
     cql.execute(stmt, [key, val, p])
-    results = list(cql.execute(f'SELECT p, map_column FROM {table3} WHERE p={p}'))
+    results = list(cql.execute(f"SELECT p, map_column FROM {table3} WHERE p={p}"))
     assert results == [(p, {key: val})]
     # Reproduces issue #3017: After the above code worked well, and correctly
     # supported the more-than-64KB map key, if we now write it to an sstable

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -14,11 +14,13 @@ from cassandra.protocol import InvalidRequest
 
 from .util import new_test_table, unique_key_int
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    schema='p int, c int, r int, s int static, PRIMARY KEY(p, c)'
+    schema = "p int, c int, r int, s int static, PRIMARY KEY(p, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         yield table
+
 
 # An LWT UPDATE whose condition uses non-static columns begins by reading
 # the clustering row which must be specified by the WHERE. If there is a
@@ -30,14 +32,19 @@ def table1(cql, test_keyspace):
 def test_lwt_missing_row_with_static(cql, table1):
     p = unique_key_int()
     # Insert into partition p just the static column - and no clustering rows.
-    cql.execute(f'INSERT INTO {table1}(p, s) values ({p}, 1)')
+    cql.execute(f"INSERT INTO {table1}(p, s) values ({p}, 1)")
     # Now, do an update with WHERE p={p} AND c=1. This clustering row does
     # *not* exist, so we expect to see r=null - and s=1 from before.
-    r = list(cql.execute(f'UPDATE {table1} SET s=2,r=1 WHERE p={p} AND c=1 IF s=1 and r=null'))
+    r = list(
+        cql.execute(
+            f"UPDATE {table1} SET s=2,r=1 WHERE p={p} AND c=1 IF s=1 and r=null"
+        )
+    )
     assert len(r) == 1
     assert r[0].applied == True
-    # At this point we should have one row, for c=1 
-    assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == [(p, 1, 2, 1)]
+    # At this point we should have one row, for c=1
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p={p}")) == [(p, 1, 2, 1)]
+
 
 # The fact that to reproduce #10081 above we needed the condition (IF) to
 # mention a non-static column as well, suggests that Scylla has a different code
@@ -47,35 +54,44 @@ def test_lwt_missing_row_with_static(cql, table1):
 # is indeed the case.
 def test_lwt_static_condition(cql, table1):
     p = unique_key_int()
-    cql.execute(f'INSERT INTO {table1}(p, s) values ({p}, 1)')
+    cql.execute(f"INSERT INTO {table1}(p, s) values ({p}, 1)")
     # When the condition only mentions static (partition-wide) columns,
     # it is allowed not to specify the clustering key in the WHERE:
-    r = list(cql.execute(f'UPDATE {table1} SET s=2 WHERE p={p} IF s=1'))
+    r = list(cql.execute(f"UPDATE {table1} SET s=2 WHERE p={p} IF s=1"))
     assert len(r) == 1
     assert r[0].applied == True
-    assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == [(p, None, 2, None)]
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p={p}")) == [
+        (p, None, 2, None)
+    ]
     # When the condition also mentions a non-static column, WHERE must point
     # to a clustering column, i.e., mention the clustering key. If the
     # clustering key is missing, we get an InvalidRequest error, where the
     # message is slightly different between Scylla and Cassandra ("Missing
     # mandatory PRIMARY KEY part c" and "Some clustering keys are missing: c",
     # respectively.
-    with pytest.raises(InvalidRequest, match=re.compile('missing', re.IGNORECASE)):
-        cql.execute(f'UPDATE {table1} SET s=2 WHERE p={p} IF r=1')
+    with pytest.raises(InvalidRequest, match=re.compile("missing", re.IGNORECASE)):
+        cql.execute(f"UPDATE {table1} SET s=2 WHERE p={p} IF r=1")
+
 
 # Generate an LWT update where there is no value for the partition key,
 # as the WHERE restricts it using `p = {p} AND p = {p+1}`.
 # Such queries are rejected.
 def test_lwt_empty_partition_range(cql, table1):
     with pytest.raises(InvalidRequest):
-        cql.execute(f"UPDATE {table1} SET r = 9000 WHERE p = 1 AND p = 1000 AND c = 2 IF r = 3")
+        cql.execute(
+            f"UPDATE {table1} SET r = 9000 WHERE p = 1 AND p = 1000 AND c = 2 IF r = 3"
+        )
+
 
 # Generate an LWT update where there is no value for the clustering key,
 # as the WHERE restricts it using `c = 2 AND c = 3`.
 # Such queries are rejected.
 def test_lwt_empty_clustering_range(cql, table1):
     with pytest.raises(InvalidRequest):
-        cql.execute(f"UPDATE {table1} SET r = 9000 WHERE p = 1  AND c = 2 AND c = 2000 IF r = 3")
+        cql.execute(
+            f"UPDATE {table1} SET r = 9000 WHERE p = 1  AND c = 2 AND c = 2000 IF r = 3"
+        )
+
 
 # In an LWT batch, if one of the condition fails the entire batch is not
 # applied. All conditions in a batch use the same values before the batch,
@@ -90,50 +106,66 @@ def test_lwt_empty_clustering_range(cql, table1):
 # report an error, not a batch failure.
 def test_lwt_with_batch_conflict_1(cql, table1, scylla_only):
     p = unique_key_int()
-    rs = cql.execute(f'BEGIN BATCH DELETE FROM {table1} WHERE p={p} AND c=1 IF EXISTS; INSERT INTO {table1}(p,c,r) VALUES ({p},1,2) IF NOT EXISTS; APPLY BATCH;')
+    rs = cql.execute(
+        f"BEGIN BATCH DELETE FROM {table1} WHERE p={p} AND c=1 IF EXISTS; INSERT INTO {table1}(p,c,r) VALUES ({p},1,2) IF NOT EXISTS; APPLY BATCH;"
+    )
     # Cassandra fails with: "Cannot mix IF EXISTS and IF NOT EXISTS conditions for the same row"
     for r in rs:
         assert r.applied == False
+
 
 # However, Cassandra does not detect every case of a conflict between
 # different conditions in a batch. For example, trying both "IF r=1"
 # and "IF r=2" returns a not-applied - not an error message.
 def test_lwt_with_batch_conflict_2(cql, table1):
     p = unique_key_int()
-    rs = list(cql.execute(f'BEGIN BATCH UPDATE {table1} SET r=10 WHERE p={p} AND c=1 IF r=1; UPDATE {table1} SET r=20 WHERE p={p} AND c=1 IF r=2;  APPLY BATCH;'))
+    rs = list(
+        cql.execute(
+            f"BEGIN BATCH UPDATE {table1} SET r=10 WHERE p={p} AND c=1 IF r=1; UPDATE {table1} SET r=20 WHERE p={p} AND c=1 IF r=2;  APPLY BATCH;"
+        )
+    )
     # Note that as a documented difference between Scylla and Cassandra,
     # Cassandra returns just one applied=False in the result r, while
     # Scylla returns a separate row for each of the two conditions.
     for r in rs:
         assert r.applied == False
 
+
 # Moreover, there are cases where Cassandra prevents mixing
 # IF EXISTS with different conditions such as IF r=1, despite
 # the fact that the conditions are not contradictory.
 def test_lwt_with_batch_conflict_3(cql, table1, scylla_only):
     p = unique_key_int()
-    cql.execute(f'INSERT INTO {table1}(p,c,r) VALUES ({p},1,1)')
-    rs = cql.execute(f'BEGIN BATCH UPDATE {table1} SET r=10 WHERE p={p} AND c=1 IF r=1; UPDATE {table1} SET r=20 WHERE p={p} AND c=1 IF EXISTS;  APPLY BATCH;')
+    cql.execute(f"INSERT INTO {table1}(p,c,r) VALUES ({p},1,1)")
+    rs = cql.execute(
+        f"BEGIN BATCH UPDATE {table1} SET r=10 WHERE p={p} AND c=1 IF r=1; UPDATE {table1} SET r=20 WHERE p={p} AND c=1 IF EXISTS;  APPLY BATCH;"
+    )
     # Cassandra fails with: "Cannot mix IF conditions and IF EXISTS for the same row"
     for r in rs:
         assert r.applied == True
+
 
 # During a static column update, the clustering key is not required in the WHERE clause.
 # A batch composed of a query that updates a static column and a query that inserts
 # a new row is allowed and will be applied successfully.
 def test_lwt_with_batch_conflict_4(cql, table1):
     p = unique_key_int()
-    cql.execute(f'INSERT INTO {table1}(p,c,r,s) VALUES ({p},1,1,1)')
-    rs = cql.execute(f'BEGIN BATCH UPDATE {table1} SET s=NULL WHERE p={p} IF EXISTS; INSERT INTO {table1}(p,c,r) VALUES ({p},2,2) IF NOT EXISTS; APPLY BATCH;')
+    cql.execute(f"INSERT INTO {table1}(p,c,r,s) VALUES ({p},1,1,1)")
+    rs = cql.execute(
+        f"BEGIN BATCH UPDATE {table1} SET s=NULL WHERE p={p} IF EXISTS; INSERT INTO {table1}(p,c,r) VALUES ({p},2,2) IF NOT EXISTS; APPLY BATCH;"
+    )
     for r in rs:
         assert r.applied == True
+
 
 # However, even for static columns, mixing IF EXISTS and other conditions
 # is disallowed in Cassandra.
 def test_lwt_with_batch_conflict_5(cql, table1, scylla_only):
     p = unique_key_int()
-    cql.execute(f'INSERT INTO {table1}(p,c,r,s) VALUES ({p},1,1,1)')
-    rs = cql.execute(f'BEGIN BATCH UPDATE {table1} SET s=NULL WHERE p={p} IF EXISTS; UPDATE {table1} SET s=NULL WHERE p={p} IF s = 1; APPLY BATCH;')
+    cql.execute(f"INSERT INTO {table1}(p,c,r,s) VALUES ({p},1,1,1)")
+    rs = cql.execute(
+        f"BEGIN BATCH UPDATE {table1} SET s=NULL WHERE p={p} IF EXISTS; UPDATE {table1} SET s=NULL WHERE p={p} IF s = 1; APPLY BATCH;"
+    )
     # Cassandra fails with: "Cannot mix IF conditions and IF NOT EXISTS for the same row"
     # The fact that "IF NOT EXISTS" is used in the error message is a bit misleading,
     # but that's what Cassandra returns
@@ -147,25 +179,40 @@ def test_lwt_with_batch_conflict_5(cql, table1, scylla_only):
 # indicating its grammar only supports this for WHERE, not IF.
 def test_lwt_not_in(cql, table1, cassandra_bug):
     p = unique_key_int()
-    cql.execute(f'INSERT INTO {table1}(p, c, r) values ({p}, 1, 1)')
-    rs = list(cql.execute(f'UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (1, 2)'))
+    cql.execute(f"INSERT INTO {table1}(p, c, r) values ({p}, 1, 1)")
+    rs = list(
+        cql.execute(f"UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (1, 2)")
+    )
     for r in rs:
         assert r.applied == False
     # Check that we look at the entire list, not just the first element
-    rs = list(cql.execute(f'UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (2, 1)'))
+    rs = list(
+        cql.execute(f"UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (2, 1)")
+    )
     for r in rs:
         assert r.applied == False
-    rs = list(cql.execute(f'UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (7, 8)'))
+    rs = list(
+        cql.execute(f"UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (7, 8)")
+    )
     for r in rs:
         assert r.applied == True
     # LWT IF conditions don't treat NULL as a special value
-    rs = list(cql.execute(f'UPDATE {table1} SET r=NULL WHERE p={p} AND c=1 IF r NOT IN (NULL, 7, 8)'))
+    rs = list(
+        cql.execute(
+            f"UPDATE {table1} SET r=NULL WHERE p={p} AND c=1 IF r NOT IN (NULL, 7, 8)"
+        )
+    )
     for r in rs:
         assert r.applied == True
     # Similar, but now show that NULL input fails the condition
-    rs = list(cql.execute(f'UPDATE {table1} SET r=NULL WHERE p={p} AND c=1 IF r NOT IN (NULL, 7, 8)'))
+    rs = list(
+        cql.execute(
+            f"UPDATE {table1} SET r=NULL WHERE p={p} AND c=1 IF r NOT IN (NULL, 7, 8)"
+        )
+    )
     for r in rs:
         assert r.applied == False
+
 
 # Currently in Cassandra and in Scylla (see discussion in #24229), the full
 # LWT "IF" syntax is allowed on UPDATE and DELETE, but only the IF NOT EXISTS
@@ -177,34 +224,49 @@ def test_lwt_not_in(cql, table1, cassandra_bug):
 def test_lwt_insert_if_not_exists(cql, table1):
     p = unique_key_int()
     # The row doesn't yet exist, IF NOT EXISTS will insert it.
-    rs = list(cql.execute(f'INSERT INTO {table1}(p, c, r) values ({p}, 1, 1) IF NOT EXISTS'))
+    rs = list(
+        cql.execute(f"INSERT INTO {table1}(p, c, r) values ({p}, 1, 1) IF NOT EXISTS")
+    )
     assert len(rs) == 1
     assert rs[0].applied
-    assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == [(p, 1, None, 1)]
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p={p}")) == [(p, 1, None, 1)]
     # Try again to insert the same row with IF NOT EXISTS, it won't do it,
     # and the row won't change:
-    rs = list(cql.execute(f'INSERT INTO {table1}(p, c, r) values ({p}, 1, 2) IF NOT EXISTS'))
+    rs = list(
+        cql.execute(f"INSERT INTO {table1}(p, c, r) values ({p}, 1, 2) IF NOT EXISTS")
+    )
     assert len(rs) == 1
     assert not rs[0].applied
-    assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == [(p, 1, None, 1)]
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p={p}")) == [(p, 1, None, 1)]
+
 
 # Similarly to the above test, INSERT JSON should also accept IF NOT EXISTS
 # and work as expected with it. Reproduces issue #8682.
-@pytest.mark.xfail(reason="issue #8682")
+@pytest.mark.xfail(reason="INSERT JSON ... IF NOT EXISTS ignores IF_NOT_EXISTS #8682")
 def test_lwt_insert_json_if_not_exists(cql, table1):
     p = unique_key_int()
     # The row doesn't yet exist, IF NOT EXISTS will insert it.
-    rs = list(cql.execute("""INSERT INTO %s JSON '{"p": %s, "c": 1, "r": 1}' IF NOT EXISTS""" % (table1, p)))
+    rs = list(
+        cql.execute(
+            """INSERT INTO %s JSON '{"p": %s, "c": 1, "r": 1}' IF NOT EXISTS"""
+            % (table1, p)
+        )
+    )
     # The following assert failed in #8682 (INSERT didn't return a response
     # row).
     assert len(rs) == 1
     assert rs[0].applied
-    assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == [(p, 1, None, 1)]
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p={p}")) == [(p, 1, None, 1)]
     # Try again to insert the same row with IF NOT EXISTS, it won't do it,
     # and the row won't change:
-    rs = list(cql.execute("""INSERT INTO %s JSON '{"p": %s, "c": 1, "r": 2}' IF NOT EXISTS""" % (table1, p)))
+    rs = list(
+        cql.execute(
+            """INSERT INTO %s JSON '{"p": %s, "c": 1, "r": 2}' IF NOT EXISTS"""
+            % (table1, p)
+        )
+    )
     assert len(rs) == 1
     assert not rs[0].applied
     # The following assert failed in #8682 (the INSERT was done despite the
     # row existing).
-    assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == [(p, 1, None, 1)]
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p={p}")) == [(p, 1, None, 1)]

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -8,51 +8,80 @@ import time
 import pytest
 from . import rest_api
 
-from .util import new_test_table, unique_name, new_materialized_view, new_secondary_index
+from .util import (
+    new_test_table,
+    unique_name,
+    new_materialized_view,
+    new_secondary_index,
+)
 from cassandra.protocol import ConfigurationException, InvalidRequest, SyntaxException
 from cassandra.cluster import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
 from . import nodetool
 
+
 def get_id_of_cf(cql, cf_name):
     ks, cf = cf_name.split(".")
-    return cql.execute(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{cf}'").one().id
+    return (
+        cql.execute(
+            f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{cf}'"
+        )
+        .one()
+        .id
+    )
+
 
 def get_id_of_mv(cql, mv_name):
     ks, mv = mv_name.split(".")
-    return cql.execute(f"SELECT id FROM system_schema.views WHERE keyspace_name = '{ks}' AND view_name = '{mv}'").one().id
+    return (
+        cql.execute(
+            f"SELECT id FROM system_schema.views WHERE keyspace_name = '{ks}' AND view_name = '{mv}'"
+        )
+        .one()
+        .id
+    )
+
 
 # Utility function for waiting for given view (given as ksname.viewname)
 # to finish its "view building" phase.
 def wait_for_view_built(cql, mv_name, timeout=60):
-    ks, mv = mv_name.split('.')
+    ks, mv = mv_name.split(".")
     start_time = time.time()
     while time.time() < start_time + timeout:
         # In Scylla, system_distributed has RF>1 even on a single-node cluster,
         # so the default CL=QUORUM doesn't work and we need to choose CL=ONE.
-        query = SimpleStatement(f"SELECT status FROM system_distributed.view_build_status WHERE keyspace_name='{ks}' AND view_name='{mv}'",
-                    consistency_level=ConsistencyLevel.ONE)
+        query = SimpleStatement(
+            f"SELECT status FROM system_distributed.view_build_status WHERE keyspace_name='{ks}' AND view_name='{mv}'",
+            consistency_level=ConsistencyLevel.ONE,
+        )
         res = list(cql.execute(query))
-        if res and res[0].status == 'SUCCESS':
+        if res and res[0].status == "SUCCESS":
             return
         time.sleep(0.1)
-    pytest.fail(f'Timed out ({timeout} seconds) waiting for view {mv_name} to get built.')
+    pytest.fail(
+        f"Timed out ({timeout} seconds) waiting for view {mv_name} to get built."
+    )
+
 
 # Test that building a view with a large value succeeds. Regression test
 # for a bug where values larger than 10MB were rejected during building (#9047)
 def test_build_view_with_large_row(cql, test_keyspace):
-    schema = 'p int, c int, v text, primary key (p,c)'
+    schema = "p int, c int, v text, primary key (p,c)"
     mv = unique_name()
     with new_test_table(cql, test_keyspace, schema) as table:
-        big = 'x'*11*1024*1024
+        big = "x" * 11 * 1024 * 1024
         cql.execute(f"INSERT INTO {table}(p,c,v) VALUES (1,1,'{big}')")
-        cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c,p)")
+        cql.execute(
+            f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c,p)"
+        )
         try:
             retrieved_row = False
             start_time = time.time()
             while time.time() < start_time + 60:
-                res = [row for row in cql.execute(f"SELECT * FROM {test_keyspace}.{mv}")]
+                res = [
+                    row for row in cql.execute(f"SELECT * FROM {test_keyspace}.{mv}")
+                ]
                 if len(res) == 1 and res[0].v == big:
                     retrieved_row = True
                     break
@@ -62,33 +91,40 @@ def test_build_view_with_large_row(cql, test_keyspace):
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW {test_keyspace}.{mv}")
 
+
 # Test that updating a view with a large value succeeds. Regression test
 # for a bug where values larger than 10MB were rejected during building (#9047)
 def test_update_view_with_large_row(cql, test_keyspace):
-    schema = 'p int, c int, v text, primary key (p,c)'
+    schema = "p int, c int, v text, primary key (p,c)"
     mv = unique_name()
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c,p)")
+        cql.execute(
+            f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c,p)"
+        )
         try:
-            big = 'x'*11*1024*1024
+            big = "x" * 11 * 1024 * 1024
             cql.execute(f"INSERT INTO {table}(p,c,v) VALUES (1,1,'{big}')")
             res = [row for row in cql.execute(f"SELECT * FROM {test_keyspace}.{mv}")]
             assert len(res) == 1 and res[0].v == big
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW {test_keyspace}.{mv}")
 
+
 # Test that a `CREATE MATERIALIZED VIEW` request, that contains bind markers in
 # its SELECT statement, fails gracefully with `InvalidRequest` exception and
 # doesn't lead to a database crash.
 def test_mv_select_stmt_bound_values(cql, test_keyspace):
-    schema = 'p int PRIMARY KEY'
+    schema = "p int PRIMARY KEY"
     mv = unique_name()
     with new_test_table(cql, test_keyspace, schema) as table:
         try:
             with pytest.raises(InvalidRequest, match="CREATE MATERIALIZED VIEW"):
-                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p = ? PRIMARY KEY (p)")
+                cql.execute(
+                    f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p = ? PRIMARY KEY (p)"
+                )
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
+
 
 # In test_null.py::test_empty_string_key() we noticed that an empty string
 # is not allowed as a partition key. However, an empty string is a valid
@@ -99,9 +135,11 @@ def test_mv_select_stmt_bound_values(cql, test_keyspace):
 # eliminate this row (an empty string is *not* considered NULL).
 # Reproduces issue #9375.
 def test_mv_empty_string_partition_key(cql, test_keyspace):
-    schema = 'p int, v text, primary key (p)'
+    schema = "p int, v text, primary key (p)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        with new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as mv:
+        with new_materialized_view(
+            cql, table, "*", "v, p", "v is not null and p is not null"
+        ) as mv:
             cql.execute(f"INSERT INTO {table} (p,v) VALUES (123, '')")
             # Note that because cqlpy runs on a single node, view
             # updates are synchronous, and we can read the view immediately
@@ -109,42 +147,61 @@ def test_mv_empty_string_partition_key(cql, test_keyspace):
             # retries.
             # The view row with the empty partition key should exist.
             # In #9375, this failed in Scylla:
-            assert list(cql.execute(f"SELECT * FROM {mv}")) == [('', 123)]
+            assert list(cql.execute(f"SELECT * FROM {mv}")) == [("", 123)]
             # Verify that we can flush an sstable with just an one partition
             # with an empty-string key (in the past we had a summary-file
             # sanity check preventing this from working).
             nodetool.flush(cql, mv)
 
+
 # Reproducer for issue #9450 - when a view's key column name is a (quoted)
 # keyword, writes used to fail because they generated internally broken CQL
 # with the column name not quoted.
 def test_mv_quoted_column_names(cql, test_keyspace):
-    for colname in ['"dog"', '"Dog"', 'DOG', '"to"', 'int']:
-        with new_test_table(cql, test_keyspace, f'p int primary key, {colname} int') as table:
-            with new_materialized_view(cql, table, '*', f'{colname}, p', f'{colname} is not null and p is not null') as mv:
-                cql.execute(f'INSERT INTO {table} (p, {colname}) values (1, 2)')
+    for colname in ['"dog"', '"Dog"', "DOG", '"to"', "int"]:
+        with new_test_table(
+            cql, test_keyspace, f"p int primary key, {colname} int"
+        ) as table:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                f"{colname}, p",
+                f"{colname} is not null and p is not null",
+            ) as mv:
+                cql.execute(f"INSERT INTO {table} (p, {colname}) values (1, 2)")
                 # Validate that not only the write didn't fail, it actually
                 # write the right thing to the view. NOTE: on a single-node
                 # Scylla, view update is synchronous so we can just read and
                 # don't need to wait or retry.
-                assert list(cql.execute(f'SELECT * from {mv}')) == [(2, 1)]
+                assert list(cql.execute(f"SELECT * from {mv}")) == [(2, 1)]
+
 
 # Same as test_mv_quoted_column_names above (reproducing issue #9450), just
 # check *view building* - i.e., pre-existing data in the base table that
 # needs to be copied to the view. The view building cannot return an error
 # to the user, but can fail to write the desired data into the view.
 def test_mv_quoted_column_names_build(cql, test_keyspace):
-    for colname in ['"dog"', '"Dog"', 'DOG', '"to"', 'int']:
-        with new_test_table(cql, test_keyspace, f'p int primary key, {colname} int') as table:
-            cql.execute(f'INSERT INTO {table} (p, {colname}) values (1, 2)')
-            with new_materialized_view(cql, table, '*', f'{colname}, p', f'{colname} is not null and p is not null') as mv:
+    for colname in ['"dog"', '"Dog"', "DOG", '"to"', "int"]:
+        with new_test_table(
+            cql, test_keyspace, f"p int primary key, {colname} int"
+        ) as table:
+            cql.execute(f"INSERT INTO {table} (p, {colname}) values (1, 2)")
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                f"{colname}, p",
+                f"{colname} is not null and p is not null",
+            ) as mv:
                 # When Scylla's view builder fails as it did in issue #9450,
                 # there is no way to tell this state apart from a view build
                 # that simply hasn't completed (besides looking at the logs,
                 # which we don't). This means, unfortunately, that a failure
                 # of this test is slow - it needs to wait for a timeout.
                 wait_for_view_built(cql, mv)
-                assert list(cql.execute(f'SELECT * from {mv}')) == [(2, 1)]
+                assert list(cql.execute(f"SELECT * from {mv}")) == [(2, 1)]
+
 
 # The previous test (test_mv_empty_string_partition_key) verifies that a
 # row with an empty-string partition key can appear in the view. This was
@@ -158,14 +215,16 @@ def test_mv_quoted_column_names_build(cql, test_keyspace):
 # a Cassandra bug and want Scylla to pass it.
 # Reproduces issue #9375 and #9352.
 def test_mv_empty_string_partition_key_individual(cassandra_bug, cql, test_keyspace):
-    schema = 'p int, v text, primary key (p)'
+    schema = "p int, v text, primary key (p)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        with new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as mv:
+        with new_materialized_view(
+            cql, table, "*", "v, p", "v is not null and p is not null"
+        ) as mv:
             # Insert a bunch of (p,v) rows. One of the v's is the empty
             # string, which we would like to test, but let's insert more
             # rows to make it more likely to exercise various possibilities
             # of token ordering (see #9352).
-            rows = [[123, ''], [1, 'dog'], [2, 'cat'], [700, 'hello'], [3, 'horse']]
+            rows = [[123, ""], [1, "dog"], [2, "cat"], [700, "hello"], [3, "horse"]]
             for row in rows:
                 cql.execute(f"INSERT INTO {table} (p,v) VALUES ({row[0]}, '{row[1]}')")
             # Note that because cqlpy runs on a single node, view
@@ -174,7 +233,7 @@ def test_mv_empty_string_partition_key_individual(cassandra_bug, cql, test_keysp
             # retries.
             # Check that we can read the individual partition with the
             # empty-string key:
-            assert list(cql.execute(f"SELECT * FROM {mv} WHERE v=''")) == [('', 123)]
+            assert list(cql.execute(f"SELECT * FROM {mv} WHERE v=''")) == [("", 123)]
             # The SELECT above works from cache. However, empty partition
             # keys also used to be special-cased and be buggy when reading
             # and writing sstables, so let's verify that the empty partition
@@ -186,20 +245,26 @@ def test_mv_empty_string_partition_key_individual(cassandra_bug, cql, test_keysp
             # First try a full-table scan, and then try to read the
             # individual partition with the empty key:
             assert set(cql.execute(f"SELECT * FROM {mv} BYPASS CACHE")) == {
-                (x[1], x[0]) for x in rows}
+                (x[1], x[0]) for x in rows
+            }
             # Issue #9352 used to prevent us finding WHERE v='' here, even
             # when the data is known to exist (the above full-table scan
             # saw it!) and despite the fact that WHERE v='' is parsed
             # correctly because we tested above it works from memtables.
-            assert list(cql.execute(f"SELECT * FROM {mv} WHERE v='' BYPASS CACHE")) == [('', 123)]
+            assert list(cql.execute(f"SELECT * FROM {mv} WHERE v='' BYPASS CACHE")) == [
+                ("", 123)
+            ]
+
 
 # Test that the "IS NOT NULL" clause in the materialized view's SELECT
 # functions as expected - namely, rows which have their would-be view
 # key column unset (aka null) do not get copied into the view.
 def test_mv_is_not_null(cql, test_keyspace):
-    schema = 'p int, v text, primary key (p)'
+    schema = "p int, v text, primary key (p)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        with new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as mv:
+        with new_materialized_view(
+            cql, table, "*", "v, p", "v is not null and p is not null"
+        ) as mv:
             cql.execute(f"INSERT INTO {table} (p,v) VALUES (123, 'dog')")
             cql.execute(f"INSERT INTO {table} (p,v) VALUES (17, null)")
             # Note that because cqlpy runs on a single node, view
@@ -208,15 +273,16 @@ def test_mv_is_not_null(cql, test_keyspace):
             # retries.
             # The row with 123 should appear in the view, but the row with
             # 17 should not, because v *is* null.
-            assert list(cql.execute(f"SELECT * FROM {mv}")) == [('dog', 123)]
+            assert list(cql.execute(f"SELECT * FROM {mv}")) == [("dog", 123)]
             # The view row should disappear and reappear if its key is
             # changed to null and back in the base table:
             cql.execute(f"UPDATE {table} SET v=null WHERE p=123")
             assert list(cql.execute(f"SELECT * FROM {mv}")) == []
             cql.execute(f"UPDATE {table} SET v='cat' WHERE p=123")
-            assert list(cql.execute(f"SELECT * FROM {mv}")) == [('cat', 123)]
+            assert list(cql.execute(f"SELECT * FROM {mv}")) == [("cat", 123)]
             cql.execute(f"DELETE v FROM {table} WHERE p=123")
             assert list(cql.execute(f"SELECT * FROM {mv}")) == []
+
 
 # Refs #10851. The code used to create a wildcard selection for all columns,
 # which erroneously also includes static columns if such are present in the
@@ -227,17 +293,24 @@ def test_mv_is_not_null(cql, test_keyspace):
 # This test goes over all combinations of filters for partition, clustering and regular
 # base columns.
 def test_filter_with_unused_static_column(cql, test_keyspace, scylla_only):
-    schema = 'p int, c int, v int, s int static, primary key (p,c)'
+    schema = "p int, c int, v int, s int static, primary key (p,c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        for p_condition in ['p = 42', 'p IS NOT NULL']:
-            for c_condition in ['c = 43', 'c IS NOT NULL']:
-                for v_condition in ['v = 44', 'v IS NOT NULL']:
+        for p_condition in ["p = 42", "p IS NOT NULL"]:
+            for c_condition in ["c = 43", "c IS NOT NULL"]:
+                for v_condition in ["v = 44", "v IS NOT NULL"]:
                     where = f"{p_condition} AND {c_condition} AND {v_condition}"
-                    with new_materialized_view(cql, table, select='p,c,v', pk='p,c,v', where=where) as mv:
+                    with new_materialized_view(
+                        cql, table, select="p,c,v", pk="p,c,v", where=where
+                    ) as mv:
                         cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (42,43,44)")
                         cql.execute(f"INSERT INTO {table} (p,c,v) VALUES (1,2,3)")
-                        expected = [(42,43,44)] if '4' in where else [(42,43,44),(1,2,3)]
+                        expected = (
+                            [(42, 43, 44)]
+                            if "4" in where
+                            else [(42, 43, 44), (1, 2, 3)]
+                        )
                         assert list(cql.execute(f"SELECT * FROM {mv}")) == expected
+
 
 # It is currently not supported (in neither Scylla nor Cassandra) to use
 # a static column in a materialized view's filter (WHERE clause).
@@ -253,30 +326,37 @@ def test_filter_with_unused_static_column(cql, test_keyspace, scylla_only):
 # partition key is the same (up to reordering) as the base's partition key.
 # (issue #8199)
 def test_filter_with_static_column(cql, test_keyspace):
-    schema = 'p int, c int, v int, s int static, primary key (p,c)'
+    schema = "p int, c int, v int, s int static, primary key (p,c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        where = f's = 6 AND p IS NOT NULL AND c IS NOT NULL AND v IS NOT NULL'
-        with pytest.raises(InvalidRequest, match='Non-primary'):
-            with new_materialized_view(cql, table, select='p,c,v', pk='p,c,v', where=where) as mv:
+        where = f"s = 6 AND p IS NOT NULL AND c IS NOT NULL AND v IS NOT NULL"
+        with pytest.raises(InvalidRequest, match="Non-primary"):
+            with new_materialized_view(
+                cql, table, select="p,c,v", pk="p,c,v", where=where
+            ) as mv:
                 pass
+
 
 # Ensure that we don't allow materialized views which contain static rows.
 # Neither Cassandra nor Scylla support this at the moment.
 def test_static_columns_are_disallowed(cql, test_keyspace):
-    schema = 'p int, c int, v int, s int static, primary key (p,c)'
+    schema = "p int, c int, v int, s int static, primary key (p,c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # Case 1: 's' not in primary key
         mv = unique_name()
         try:
             with pytest.raises(InvalidRequest, match="[Ss]tatic column"):
-                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT p, s FROM {table} PRIMARY KEY (p)")
+                cql.execute(
+                    f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT p, s FROM {table} PRIMARY KEY (p)"
+                )
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
         # Case 1a: 's' not in primary key, and listed as "*" and not explicitly
         mv = unique_name()
         try:
             with pytest.raises(InvalidRequest, match="[Ss]tatic column"):
-                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} PRIMARY KEY (p)")
+                cql.execute(
+                    f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} PRIMARY KEY (p)"
+                )
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
 
@@ -284,22 +364,28 @@ def test_static_columns_are_disallowed(cql, test_keyspace):
         mv = unique_name()
         try:
             with pytest.raises(InvalidRequest, match="[Ss]tatic column"):
-                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT p, s FROM {table} WHERE s IS NOT NULL PRIMARY KEY (s, p)")
+                cql.execute(
+                    f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT p, s FROM {table} WHERE s IS NOT NULL PRIMARY KEY (s, p)"
+                )
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
+
 
 # IS_NOT operator can only be used in the context of materialized view creation and it must be of the form IS NOT NULL.
 # Trying to do something like IS NOT 42 should fail.
 # The error is a SyntaxException because Scylla and Cassandra check this during parsing.
 def test_is_not_operator_must_be_null(cql, test_keyspace):
-    schema = 'p int PRIMARY KEY'
+    schema = "p int PRIMARY KEY"
     mv = unique_name()
     with new_test_table(cql, test_keyspace, schema) as table:
         try:
             with pytest.raises(SyntaxException, match="NULL"):
-                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT 42 PRIMARY KEY (p)")
+                cql.execute(
+                    f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT 42 PRIMARY KEY (p)"
+                )
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
+
 
 # The IS NOT NULL operator was first added to Cassandra and Scylla for use
 # just in key columns in materialized views. It was not supported in general
@@ -312,7 +398,7 @@ def test_is_not_operator_must_be_null(cql, test_keyspace):
 # replace this test by a test that checks that the filter works as expected,
 # both in ordinary base-table SELECT and in materialized-view definition.
 def test_is_not_null_forbidden_in_filter(cql, test_keyspace, cassandra_bug):
-    with new_test_table(cql, test_keyspace, 'p int primary key, xyz int') as table:
+    with new_test_table(cql, test_keyspace, "p int primary key, xyz int") as table:
         # Check that "IS NOT NULL" is not supported in a regular (base table)
         # SELECT filter. Cassandra reports an InvalidRequest: "Unsupported
         # restriction: xyz IS NOT NULL". In Scylla the message is different:
@@ -320,14 +406,16 @@ def test_is_not_null_forbidden_in_filter(cql, test_keyspace, cassandra_bug):
         # view creation".
         #
         with pytest.raises(InvalidRequest, match="xyz"):
-            cql.execute(f'SELECT * FROM {table} WHERE xyz IS NOT NULL ALLOW FILTERING')
+            cql.execute(f"SELECT * FROM {table} WHERE xyz IS NOT NULL ALLOW FILTERING")
         # Check that "xyz IS NOT NULL" is also not supported in a
         # materialized-view definition (where xyz is not a key column)
         # Reproduces #8517
         mv = unique_name()
         try:
             with pytest.raises(InvalidRequest, match="xyz"):
-                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND xyz IS NOT NULL PRIMARY KEY (p)")
+                cql.execute(
+                    f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND xyz IS NOT NULL PRIMARY KEY (p)"
+                )
                 # There is no need to continue the test - if the CREATE
                 # MATERIALIZED VIEW above succeeded, it is already not what we
                 # expect without #8517. However, let's demonstrate that it's
@@ -337,34 +425,67 @@ def test_is_not_null_forbidden_in_filter(cql, test_keyspace, cassandra_bug):
                 # in the following example:
                 cql.execute(f"INSERT INTO {table} (p,xyz) VALUES (123, 456)")
                 cql.execute(f"INSERT INTO {table} (p) VALUES (124)")
-                assert sorted(list(cql.execute(f"SELECT p FROM {test_keyspace}.{mv}")))==[(123,)]
+                assert sorted(
+                    list(cql.execute(f"SELECT p FROM {test_keyspace}.{mv}"))
+                ) == [(123,)]
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
+
 
 # Test that a view can be altered with synchronous_updates property and that
 # the synchronous updates code path is then reached for such view.
 # The synchronous_updates feature is a ScyllaDB extension, so this is a
 # scylla_only test.
 def test_mv_synchronous_updates(cql, test_keyspace, scylla_only):
-    schema = 'p int, v text, primary key (p)'
+    schema = "p int, v text, primary key (p)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        with new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as sync_mv, \
-             new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as async_mv, \
-             new_materialized_view(cql, table, '*', 'v,p', 'v is not null and p is not null', extra='with synchronous_updates = true') as sync_mv_from_the_start, \
-             new_materialized_view(cql, table, '*', 'v,p', 'v is not null and p is not null', extra='with synchronous_updates = true') as async_mv_altered:
+        with (
+            new_materialized_view(
+                cql, table, "*", "v, p", "v is not null and p is not null"
+            ) as sync_mv,
+            new_materialized_view(
+                cql, table, "*", "v, p", "v is not null and p is not null"
+            ) as async_mv,
+            new_materialized_view(
+                cql,
+                table,
+                "*",
+                "v,p",
+                "v is not null and p is not null",
+                extra="with synchronous_updates = true",
+            ) as sync_mv_from_the_start,
+            new_materialized_view(
+                cql,
+                table,
+                "*",
+                "v,p",
+                "v is not null and p is not null",
+                extra="with synchronous_updates = true",
+            ) as async_mv_altered,
+        ):
             # Make one view synchronous
-            cql.execute(f"ALTER MATERIALIZED VIEW {sync_mv} WITH synchronous_updates = true")
+            cql.execute(
+                f"ALTER MATERIALIZED VIEW {sync_mv} WITH synchronous_updates = true"
+            )
             # Make another one asynchronous
-            cql.execute(f"ALTER MATERIALIZED VIEW {async_mv_altered} WITH synchronous_updates = false")
+            cql.execute(
+                f"ALTER MATERIALIZED VIEW {async_mv_altered} WITH synchronous_updates = false"
+            )
 
             # Execute a query and inspect its tracing info
-            res = cql.execute(f"INSERT INTO {table} (p,v) VALUES (123, 'dog')", trace=True)
+            res = cql.execute(
+                f"INSERT INTO {table} (p,v) VALUES (123, 'dog')", trace=True
+            )
             trace = res.get_query_trace()
 
             wanted_trace1 = f"Forcing {sync_mv} view update to be synchronous"
-            wanted_trace2 = f"Forcing {sync_mv_from_the_start} view update to be synchronous"
+            wanted_trace2 = (
+                f"Forcing {sync_mv_from_the_start} view update to be synchronous"
+            )
             unwanted_trace1 = f"Forcing {async_mv} view update to be synchronous"
-            unwanted_trace2 = f"Forcing {async_mv_altered} view update to be synchronous"
+            unwanted_trace2 = (
+                f"Forcing {async_mv_altered} view update to be synchronous"
+            )
 
             wanted_traces_were_found = [False, False]
             for event in trace.events:
@@ -375,6 +496,7 @@ def test_mv_synchronous_updates(cql, test_keyspace, scylla_only):
                 if wanted_trace2 in event.description:
                     wanted_traces_were_found[1] = True
             assert all(wanted_traces_were_found)
+
 
 # Reproduces #8627:
 # Whereas regular columns values are limited in size to 2GB, key columns are
@@ -391,17 +513,22 @@ def test_mv_synchronous_updates(cql, test_keyspace, scylla_only):
 # message about a key being too long appears in the log.
 # Note that the same issue also applies to secondary indexes, and this is
 # tested in test_secondary_index.py.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627"
+)
 def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
-    with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
-        with new_materialized_view(cql, table, select='*', pk='v,p', where='v is not null and p is not null') as mv:
-            big = 'x'*66536
-            with pytest.raises(InvalidRequest, match='size'):
+    with new_test_table(cql, test_keyspace, "p int primary key, v text") as table:
+        with new_materialized_view(
+            cql, table, select="*", pk="v,p", where="v is not null and p is not null"
+        ) as mv:
+            big = "x" * 66536
+            with pytest.raises(InvalidRequest, match="size"):
                 cql.execute(f"INSERT INTO {table}(p,v) VALUES (1,'{big}')")
             # Ideally, the entire write operation should be considered
             # invalid, and no part of it will be done. In particular, the
             # base write will also not happen.
             assert [] == list(cql.execute(f"SELECT * FROM {table} WHERE p=1"))
+
 
 # Reproduces #8627:
 # Same as test_oversized_base_regular_view_key above, just check *view
@@ -409,23 +536,29 @@ def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
 # copied to the view. The view building cannot return an error to the user,
 # but we do expect it to skip the problematic row and continue to complete
 # the rest of the view build.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627"
+)
 # This test currently breaks the build (it repeats a failing build step,
 # and never complete) and we cannot quickly recognize this failure, so
 # to avoid a very slow failure, we currently "skip" this test.
-@pytest.mark.skip(reason="issue #8627, fails very slow")
+@pytest.mark.skip(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627, fails very slow"
+)
 def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug):
-    with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
+    with new_test_table(cql, test_keyspace, "p int primary key, v text") as table:
         # No materialized view yet - a "big" value in v is perfectly fine:
-        stmt = cql.prepare(f'INSERT INTO {table} (p,v) VALUES (?, ?)')
+        stmt = cql.prepare(f"INSERT INTO {table} (p,v) VALUES (?, ?)")
         for i in range(30):
             cql.execute(stmt, [i, str(i)])
-        big = 'x'*66536
+        big = "x" * 66536
         cql.execute(stmt, [30, big])
-        assert [(30,big)] == list(cql.execute(f'SELECT * FROM {table} WHERE p=30'))
+        assert [(30, big)] == list(cql.execute(f"SELECT * FROM {table} WHERE p=30"))
         # Add a materialized view with v as the new key. The view build,
         # copying data from the base table to the view, should start promptly.
-        with new_materialized_view(cql, table, select='*', pk='v,p', where='v is not null and p is not null') as mv:
+        with new_materialized_view(
+            cql, table, select="*", pk="v,p", where="v is not null and p is not null"
+        ) as mv:
             # If Scylla's view builder hangs or stops, there is no way to
             # tell this state apart from a view build that simply hasn't
             # completed yet (besides looking at the logs, which we don't).
@@ -433,7 +566,7 @@ def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug
             # it needs to wait for a timeout.
             start_time = time.time()
             while time.time() < start_time + 60:
-                results = set(list(cql.execute(f'SELECT * from {mv}')))
+                results = set(list(cql.execute(f"SELECT * from {mv}")))
                 # The oversized "big" cannot be a key in the view, so
                 # shouldn't be in results:
                 assert not (big, 30) in results
@@ -441,9 +574,10 @@ def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug
                 # The rest of the items in the base table should be in
                 # the view:
                 if results == {(str(i), i) for i in range(30)}:
-                        break
+                    break
                 time.sleep(0.1)
             assert results == {(str(i), i) for i in range(30)}
+
 
 # Reproduces #11668
 # When the view builder resumes building a partition, it reuses the reader
@@ -455,9 +589,16 @@ def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug
 # `view_builder::batch_size` (that is 128) rows. So in this test we create a
 # table which has at least 2X that many rows and add a range tombstone so that
 # it covers half of the rows (even rows are covered why odd rows aren't).
-def test_view_builder_suspend_with_active_range_tombstone(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, "pk int, ck int, v int, PRIMARY KEY(pk, ck)", "WITH compaction = {'class': 'NullCompactionStrategy'}") as table:
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)')
+def test_view_builder_suspend_with_active_range_tombstone(
+    cql, test_keyspace, scylla_only
+):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int, ck int, v int, PRIMARY KEY(pk, ck)",
+        "WITH compaction = {'class': 'NullCompactionStrategy'}",
+    ) as table:
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
 
         # sstable 1 - even rows
         for ck in range(0, 512, 2):
@@ -475,22 +616,34 @@ def test_view_builder_suspend_with_active_range_tombstone(cql, test_keyspace, sc
         res = [r.ck for r in cql.execute(f"SELECT ck FROM {table} WHERE pk = 0")]
         assert res == list(range(1, 512, 2))
 
-        with new_materialized_view(cql, table, select='*', pk='v,pk,ck', where='v is not null and pk is not null and ck is not null') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            select="*",
+            pk="v,pk,ck",
+            where="v is not null and pk is not null and ck is not null",
+        ) as mv:
             start_time = time.time()
             while time.time() < start_time + 60:
                 res = sorted([r.v for r in cql.execute(f"SELECT * FROM {mv}")])
-                if len(res) >= 512/2:
+                if len(res) >= 512 / 2:
                     break
                 time.sleep(0.1)
             # again, we should not see any even rows in the materialized-view,
             # they are covered with a range tombstone in the base-table
             assert res == list(range(1, 512, 2))
 
+
 # A variant of the above using a partition-tombstone, which is also lost similar
 # to range tombstones.
 def test_view_builder_suspend_with_partition_tombstone(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, "pk int, ck int, v int, PRIMARY KEY(pk, ck)", "WITH compaction = {'class': 'NullCompactionStrategy'}") as table:
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)')
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int, ck int, v int, PRIMARY KEY(pk, ck)",
+        "WITH compaction = {'class': 'NullCompactionStrategy'}",
+    ) as table:
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
 
         # sstable 1 - even rows
         for ck in range(0, 512, 2):
@@ -508,16 +661,23 @@ def test_view_builder_suspend_with_partition_tombstone(cql, test_keyspace, scyll
         res = [r.ck for r in cql.execute(f"SELECT ck FROM {table} WHERE pk = 0")]
         assert res == list(range(1, 512, 2))
 
-        with new_materialized_view(cql, table, select='*', pk='v,pk,ck', where='v is not null and pk is not null and ck is not null') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            select="*",
+            pk="v,pk,ck",
+            where="v is not null and pk is not null and ck is not null",
+        ) as mv:
             start_time = time.time()
             while time.time() < start_time + 60:
                 res = sorted([r.v for r in cql.execute(f"SELECT * FROM {mv}")])
-                if len(res) >= 512/2:
+                if len(res) >= 512 / 2:
                     break
                 time.sleep(0.1)
             # again, we should not see any even rows in the materialized-view,
             # they are covered with a partition tombstone in the base-table
             assert res == list(range(1, 512, 2))
+
 
 # Test when IS NOT NULL is required, vs. not required, for the key columns
 # of a materialized view WHERE clause.
@@ -532,44 +692,101 @@ def test_view_builder_suspend_with_partition_tombstone(cql, test_keyspace, scyll
 # columns.
 # This test reproduces issue issue #11979, that Scylla used to require
 # IS NOT NULL inconsistently.
-@pytest.mark.xfail(reason="issue #11979")
+@pytest.mark.xfail(
+    reason='Make requirement of "IS NOT NULL" in materialized view more consistent #11979'
+)
 def test_is_not_null_requirement(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, v int, primary key (p, c)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, v int, primary key (p, c)"
+    ) as table:
         # missing "v is not null":
         with pytest.raises(InvalidRequest, match="IS NOT NULL"):
-            with new_materialized_view(cql, table, select='*', pk='p,c,v', where='p is not null and c is not null') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                select="*",
+                pk="p,c,v",
+                where="p is not null and c is not null",
+            ) as mv:
                 pass
         # missing "c is not null":
         with pytest.raises(InvalidRequest, match="IS NOT NULL"):
-            with new_materialized_view(cql, table, select='*', pk='p,c,v', where='v is not null and p is not null') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                select="*",
+                pk="p,c,v",
+                where="v is not null and p is not null",
+            ) as mv:
                 pass
         # missing "p is not null":
         # This check reproduces issue #11979:
         with pytest.raises(InvalidRequest, match="IS NOT NULL"):
-            with new_materialized_view(cql, table, select='*', pk='p,c,v', where='c is not null and v is not null') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                select="*",
+                pk="p,c,v",
+                where="c is not null and v is not null",
+            ) as mv:
                 pass
     # Similar test, with composite keys
-    with new_test_table(cql, test_keyspace, 'p1 int, p2 int, c1 int, c2 int, v int, primary key ((p1, p2), c1, c2)') as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p1 int, p2 int, c1 int, c2 int, v int, primary key ((p1, p2), c1, c2)",
+    ) as table:
         # missing "p1 is not null":
         with pytest.raises(InvalidRequest, match="IS NOT NULL"):
-            with new_materialized_view(cql, table, select='*', pk='p1,p2,c1,c2,v', where='p2 is not null and c1 is not null and c2 is not null and v is not null') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                select="*",
+                pk="p1,p2,c1,c2,v",
+                where="p2 is not null and c1 is not null and c2 is not null and v is not null",
+            ) as mv:
                 pass
         # missing "p2 is not null":
         with pytest.raises(InvalidRequest, match="IS NOT NULL"):
-            with new_materialized_view(cql, table, select='*', pk='p1,p2,c1,c2,v', where='p1 is not null and c1 is not null and c2 is not null and v is not null') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                select="*",
+                pk="p1,p2,c1,c2,v",
+                where="p1 is not null and c1 is not null and c2 is not null and v is not null",
+            ) as mv:
                 pass
         # missing "c1 is not null":
         with pytest.raises(InvalidRequest, match="IS NOT NULL"):
-            with new_materialized_view(cql, table, select='*', pk='p1,p2,c1,c2,v', where='p1 is not null and p2 is not null and c2 is not null and v is not null') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                select="*",
+                pk="p1,p2,c1,c2,v",
+                where="p1 is not null and p2 is not null and c2 is not null and v is not null",
+            ) as mv:
                 pass
         # missing "c2 is not null":
         with pytest.raises(InvalidRequest, match="IS NOT NULL"):
-            with new_materialized_view(cql, table, select='*', pk='p1,p2,c1,c2,v', where='p1 is not null and p2 is not null and c1 is not null and v is not null') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                select="*",
+                pk="p1,p2,c1,c2,v",
+                where="p1 is not null and p2 is not null and c1 is not null and v is not null",
+            ) as mv:
                 pass
         # missing "v is not null":
         with pytest.raises(InvalidRequest, match="IS NOT NULL"):
-            with new_materialized_view(cql, table, select='*', pk='p1,p2,c1,c2,v', where='p1 is not null and p2 is not null and c1 is not null and c2 is not null') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                select="*",
+                pk="p1,p2,c1,c2,v",
+                where="p1 is not null and p2 is not null and c1 is not null and c2 is not null",
+            ) as mv:
                 pass
+
 
 # Reproducer for issue #11542 and #10026: We have a table with with a
 # materialized view with a filter and some data, at which point we modify
@@ -583,9 +800,11 @@ def test_is_not_null_requirement(cql, test_keyspace):
 # This test is Scylla-only because Cassandra does not support filtering
 # on a base-regular column v that is only a key column in the view.
 def test_view_update_and_alter_base(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, 'p int primary key, v int') as table:
-        with new_materialized_view(cql, table, '*', 'v, p', 'v >= 0 and p is not null') as mv:
-            cql.execute(f'INSERT INTO {table} (p,v) VALUES (1,1)')
+    with new_test_table(cql, test_keyspace, "p int primary key, v int") as table:
+        with new_materialized_view(
+            cql, table, "*", "v, p", "v >= 0 and p is not null"
+        ) as mv:
+            cql.execute(f"INSERT INTO {table} (p,v) VALUES (1,1)")
             # In our tests, MV writes are synchronous, so we can read
             # immediately
             assert len(list(cql.execute(f"SELECT v from {mv}"))) == 1
@@ -593,8 +812,9 @@ def test_view_update_and_alter_base(cql, test_keyspace, scylla_only):
             # change anything important - but still the base schema changes.
             cql.execute(f"ALTER TABLE {table} WITH COMMENT = '{unique_name()}'")
             # Try to modify an item. This failed in #11542.
-            cql.execute(f'UPDATE {table} SET v=-1 WHERE p=1')
+            cql.execute(f"UPDATE {table} SET v=-1 WHERE p=1")
             assert len(list(cql.execute(f"SELECT v from {mv}"))) == 0
+
 
 # Reproducer for issue #12297, reproducing a specific way in which a view
 # table could be made inconsistent with the base table:
@@ -611,24 +831,41 @@ def test_view_update_and_alter_base(cql, test_keyspace, scylla_only):
 # have a bug (the view rows were deleted fine).
 @pytest.mark.parametrize("size", [100, 113, 500])
 def test_long_skipped_view_update_delete_with_timestamp(cql, test_keyspace, size):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)') as table:
-        with new_materialized_view(cql, table, '*', 'p, x, c', 'p is not null and x is not null and c is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, y int, primary key (p,c)"
+    ) as table:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p, x, c",
+            "p is not null and x is not null and c is not null",
+        ) as mv:
             # Write size rows with c=0..(size-1). Because the iteration is in
             # reverse order, the first row in clustering order (c=0) will
             # have the latest write timestamp.
             for i in reversed(range(size)):
-                cql.execute(f'INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})')
-            assert list(cql.execute(f"SELECT c FROM {table} WHERE p = 1")) == list(cql.execute(f"SELECT c FROM {mv} WHERE p = 1"))
+                cql.execute(f"INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})")
+            assert list(cql.execute(f"SELECT c FROM {table} WHERE p = 1")) == list(
+                cql.execute(f"SELECT c FROM {mv} WHERE p = 1")
+            )
             # Get the timestamp of the size*0.9th item. Because we wrote items
             # in reverse, items 0.9-1.0*size all have earlier timestamp than
             # that.
-            t = list(cql.execute(f"SELECT writetime(y) FROM {table} WHERE p = 1 and c = {int(size*0.9)}"))[0].writetime_y
-            cql.execute(f'DELETE FROM {table} USING TIMESTAMP {t} WHERE p=1')
+            t = list(
+                cql.execute(
+                    f"SELECT writetime(y) FROM {table} WHERE p = 1 and c = {int(size * 0.9)}"
+                )
+            )[0].writetime_y
+            cql.execute(f"DELETE FROM {table} USING TIMESTAMP {t} WHERE p=1")
             # After the deletion we expect to see size*0.9 rows remaining
             # (timestamp ties cannot happen for separate writes, if they
             # did we could have a bit less), but most importantly, the view
             # should have exactly the same rows.
-            assert list(cql.execute(f"SELECT c FROM {table} WHERE p = 1")) == list(cql.execute(f"SELECT c FROM {mv} WHERE p = 1"))
+            assert list(cql.execute(f"SELECT c FROM {table} WHERE p = 1")) == list(
+                cql.execute(f"SELECT c FROM {mv} WHERE p = 1")
+            )
+
 
 # Same test as above, just that in this version the view partition key is
 # different from the base's, so we can be sure that Scylla needs to go
@@ -638,14 +875,31 @@ def test_long_skipped_view_update_delete_with_timestamp(cql, test_keyspace, size
 # code path.
 def test_long_skipped_view_update_delete_with_timestamp2(cql, test_keyspace):
     size = 200
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)') as table:
-        with new_materialized_view(cql, table, '*', 'x, p, c', 'p is not null and x is not null and c is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, y int, primary key (p,c)"
+    ) as table:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "x, p, c",
+            "p is not null and x is not null and c is not null",
+        ) as mv:
             for i in reversed(range(size)):
-                cql.execute(f'INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})')
-            assert list(cql.execute(f"SELECT c FROM {table}")) == sorted(list(cql.execute(f"SELECT c FROM {mv}")))
-            t = list(cql.execute(f"SELECT writetime(y) FROM {table} WHERE p = 1 and c = {int(size*0.9)}"))[0].writetime_y
-            cql.execute(f'DELETE FROM {table} USING TIMESTAMP {t} WHERE p=1')
-            assert list(cql.execute(f"SELECT c FROM {table}")) == sorted(list(cql.execute(f"SELECT c FROM {mv}")))
+                cql.execute(f"INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})")
+            assert list(cql.execute(f"SELECT c FROM {table}")) == sorted(
+                list(cql.execute(f"SELECT c FROM {mv}"))
+            )
+            t = list(
+                cql.execute(
+                    f"SELECT writetime(y) FROM {table} WHERE p = 1 and c = {int(size * 0.9)}"
+                )
+            )[0].writetime_y
+            cql.execute(f"DELETE FROM {table} USING TIMESTAMP {t} WHERE p=1")
+            assert list(cql.execute(f"SELECT c FROM {table}")) == sorted(
+                list(cql.execute(f"SELECT c FROM {mv}"))
+            )
+
 
 # Another, more fundamental, reproducer for issue #12297 where a certain
 # modification to a base partition modifying more than 100 rows was not
@@ -664,24 +918,35 @@ def test_long_skipped_view_update_delete_with_timestamp2(cql, test_keyspace):
 # missing in the view.
 def test_long_skipped_view_update_irrelevant_column(cql, test_keyspace):
     size = 200
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, y int, primary key (p,c)"
+    ) as table:
         # Note that column "y" is not selected by the materialized view
-        with new_materialized_view(cql, table, 'p, x, c', 'p, x, c', 'p is not null and x is not null and c is not null') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "p, x, c",
+            "p, x, c",
+            "p is not null and x is not null and c is not null",
+        ) as mv:
             for i in range(size):
-                cql.execute(f'INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})')
+                cql.execute(f"INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})")
             # In a single batch (a single mutation), update "y" column in all
             # 'size' existing rows, plus add one new row in the last position
             # (the partition is sorted by the "c" column). The first 'size'
             # UPDATEs can be skipped in the view (because y isn't selected),
             # but the last INSERT can't be skipped - it really adds a new row.
-            cmd = 'BEGIN BATCH '
+            cmd = "BEGIN BATCH "
             for i in range(size):
-                cmd += f'UPDATE {table} SET y=7 where p=1 and c={i}; '
-            cmd += f'INSERT INTO {table} (p,c,x,y) VALUES (1,{size+1},{size+1},{size+1}); '
-            cmd += 'APPLY BATCH;'
+                cmd += f"UPDATE {table} SET y=7 where p=1 and c={i}; "
+            cmd += f"INSERT INTO {table} (p,c,x,y) VALUES (1,{size + 1},{size + 1},{size + 1}); "
+            cmd += "APPLY BATCH;"
             cql.execute(cmd)
             # We should now have the same size+1 rows in both base and view
-            assert list(cql.execute(f"SELECT c FROM {table} WHERE p = 1")) == list(cql.execute(f"SELECT c FROM {mv} WHERE p = 1"))
+            assert list(cql.execute(f"SELECT c FROM {table} WHERE p = 1")) == list(
+                cql.execute(f"SELECT c FROM {mv} WHERE p = 1")
+            )
+
 
 # After the previous tests checked elaborate conditions where modifying a
 # base-table partition resulted in many skipped view updates, let's also
@@ -691,79 +956,175 @@ def test_long_skipped_view_update_irrelevant_column(cql, test_keyspace):
 # several batches of 100 (for example).
 def test_mv_long_delete(cql, test_keyspace):
     size = 300
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)') as table:
-        with new_materialized_view(cql, table, '*', 'p, x, c', 'p is not null and x is not null and c is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, y int, primary key (p,c)"
+    ) as table:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p, x, c",
+            "p is not null and x is not null and c is not null",
+        ) as mv:
             for i in range(size):
-                cql.execute(f'INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})')
-            cql.execute(f'DELETE FROM {table} WHERE p=1')
+                cql.execute(f"INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})")
+            cql.execute(f"DELETE FROM {table} WHERE p=1")
             assert list(cql.execute(f"SELECT c FROM {table} WHERE p = 1")) == []
             assert list(cql.execute(f"SELECT c FROM {mv} WHERE p = 1")) == []
 
+
 # Several tests for how "CLUSTERING ORDER BY" interacts with materialized
 # views:
+
 
 # In Cassandra, when a base table has a reversed-order clustering column and
 # this column is used in a materialized view, its order in the view inherits
 # the same reversed sort order it had in the base table.
 # Reproduces #12308
-@pytest.mark.xfail(reason="issue #12308")
+@pytest.mark.xfail(
+    reason="In Scylla, MV CLUSTERING ORDER BY defaults to natural order. In Cassandra the base's order is inherited #12308"
+)
 def test_mv_inherit_clustering_order(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)', 'with clustering order by (c DESC)') as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int, c int, x int, y int, primary key (p,c)",
+        "with clustering order by (c DESC)",
+    ) as table:
         # note no explicit clustering order on c in the materialized view:
-        with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p, c, x",
+            "p is not null and c is not null and x is not null",
+        ) as mv:
             for i in range(4):
-                cql.execute(f'INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})')
+                cql.execute(f"INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})")
             # The base table's clustering order is reversed, and it should
             # also be in the view (at least, it's so in Cassandra).
-            assert list(cql.execute(f'SELECT y from {table}')) == [(3,),(2,),(1,),(0,)]
-            assert list(cql.execute(f'SELECT y from {mv}')) == [(3,),(2,),(1,),(0,)]
+            assert list(cql.execute(f"SELECT y from {table}")) == [
+                (3,),
+                (2,),
+                (1,),
+                (0,),
+            ]
+            assert list(cql.execute(f"SELECT y from {mv}")) == [(3,), (2,), (1,), (0,)]
+
 
 # When a materialized view specification declares the clustering keys of
 # they view, they default to the base table's clustering order (see test
 # above), but the order can be overridden by an explicit "with clustering
 # order by" in the materialized view definition:
 def test_mv_override_clustering_order_1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)', 'with clustering order by (c DESC)') as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int, c int, x int, y int, primary key (p,c)",
+        "with clustering order by (c DESC)",
+    ) as table:
         # explicitly reverse the clustering order of "c" to be ascending.
         # note that if we specify c's clustering order, we are also forced
         # to specify x's even though we just want it to be the default:
-        with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by (c ASC, x ASC)') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p, c, x",
+            "p is not null and c is not null and x is not null",
+            "with clustering order by (c ASC, x ASC)",
+        ) as mv:
             for i in range(4):
-                cql.execute(f'INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})')
+                cql.execute(f"INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})")
             # The base table's clustering order is descending, but in the view
             # it should be ascending.
-            assert list(cql.execute(f'SELECT y from {table}')) == [(3,),(2,),(1,),(0,)]
-            assert list(cql.execute(f'SELECT y from {mv}')) == [(0,),(1,),(2,),(3,)]
+            assert list(cql.execute(f"SELECT y from {table}")) == [
+                (3,),
+                (2,),
+                (1,),
+                (0,),
+            ]
+            assert list(cql.execute(f"SELECT y from {mv}")) == [(0,), (1,), (2,), (3,)]
+
 
 def test_mv_override_clustering_order_2(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)', 'with clustering order by (c ASC)') as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int, c int, x int, y int, primary key (p,c)",
+        "with clustering order by (c ASC)",
+    ) as table:
         # explicitly reverse the clustering order of "c" to be descending.
         # note that if we specify c's clustering order, we are also forced
         # to specify x's even though we just want it to be the default:
-        with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by (c DESC, x ASC)') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p, c, x",
+            "p is not null and c is not null and x is not null",
+            "with clustering order by (c DESC, x ASC)",
+        ) as mv:
             for i in range(4):
-                cql.execute(f'INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})')
+                cql.execute(f"INSERT INTO {table} (p,c,x,y) VALUES (1,{i},{i},{i})")
             # The base table's clustering order is ascending, but in the view
             # it should be descending.
-            assert list(cql.execute(f'SELECT y from {table}')) == [(0,),(1,),(2,),(3,)]
-            assert list(cql.execute(f'SELECT y from {mv}')) == [(3,),(2,),(1,),(0,)]
+            assert list(cql.execute(f"SELECT y from {table}")) == [
+                (0,),
+                (1,),
+                (2,),
+                (3,),
+            ]
+            assert list(cql.execute(f"SELECT y from {mv}")) == [(3,), (2,), (1,), (0,)]
+
 
 # Another test for CLUSTERING ORDER BY, using quoted and unquoted column
 # names and checking they are matched properly
 def test_mv_override_clustering_order_quoted(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, "Hello" int, primary key (p,c)') as table:
+    with new_test_table(
+        cql, test_keyspace, 'p int, c int, x int, "Hello" int, primary key (p,c)'
+    ) as table:
         # X and "x" are the same as x:
-        with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by (c DESC, X ASC)') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p, c, x",
+            "p is not null and c is not null and x is not null",
+            "with clustering order by (c DESC, X ASC)",
+        ) as mv:
             pass
-        with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by (c DESC, "x" ASC)') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p, c, x",
+            "p is not null and c is not null and x is not null",
+            'with clustering order by (c DESC, "x" ASC)',
+        ) as mv:
             pass
         # But "Hello" is not the same as "HELLO" or hello
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, "Hello"', 'p is not null and c is not null and "Hello" is not null', 'with clustering order by (c DESC, hello ASC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                'p, c, "Hello"',
+                'p is not null and c is not null and "Hello" is not null',
+                "with clustering order by (c DESC, hello ASC)",
+            ) as mv:
                 pass
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, "Hello"', 'p is not null and c is not null and "Hello" is not null', 'with clustering order by (c DESC, "HELLO" ASC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                'p, c, "Hello"',
+                'p is not null and c is not null and "Hello" is not null',
+                'with clustering order by (c DESC, "HELLO" ASC)',
+            ) as mv:
                 pass
+
 
 # Cassandra requires that if we specify WITH CLUSTERING ORDER BY in the
 # materialized view definition, it must mention all clustering key columns
@@ -777,31 +1138,66 @@ def test_mv_override_clustering_order_quoted(cql, test_keyspace):
 # The following test verifies that these bad WITH CLUSTERING ORDER BY
 # clauses are indeed rejected.
 # Reproduces #12936.
-@pytest.mark.xfail(reason="issue #12936")
+@pytest.mark.xfail(
+    reason="In MV definition, CLUSTERING ORDER BY should require strict clustering-column order #12936"
+)
 def test_mv_override_clustering_order_bad1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, y int, primary key (p,c)"
+    ) as table:
         # Mis-ordered clustering columns: c,x on PRIMARY KEY, but
         # x,c in WITH CLUSTERING ORDER:
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'WITH CLUSTERING ORDER BY (x ASC, c ASC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p, c, x",
+                "p is not null and c is not null and x is not null",
+                "WITH CLUSTERING ORDER BY (x ASC, c ASC)",
+            ) as mv:
                 pass
         # Missing clustering columns: c,x on PRIMARY KEY, but
         # x or c in WITH CLUSTERING ORDER:
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'WITH CLUSTERING ORDER BY (c ASC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p, c, x",
+                "p is not null and c is not null and x is not null",
+                "WITH CLUSTERING ORDER BY (c ASC)",
+            ) as mv:
                 pass
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'WITH CLUSTERING ORDER BY (x ASC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p, c, x",
+                "p is not null and c is not null and x is not null",
+                "WITH CLUSTERING ORDER BY (x ASC)",
+            ) as mv:
                 pass
         # Duplicate clustering column: c,x on PRIMARY KEY, but c,x,x
         # (with same or different order for x) in WITH CLUSTERING ORDER:
-        for order in ['c ASC, x ASC, x ASC',
-                      'c ASC, x ASC, x DESC',
-                      'c ASC, c ASC, x ASC',
-                      'c ASC, c DESC, x ASC']:
+        for order in [
+            "c ASC, x ASC, x ASC",
+            "c ASC, x ASC, x DESC",
+            "c ASC, c ASC, x ASC",
+            "c ASC, c DESC, x ASC",
+        ]:
             with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-                with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', f'WITH CLUSTERING ORDER BY ({order})') as mv:
+                with new_materialized_view(
+                    cql,
+                    table,
+                    "*",
+                    "p, c, x",
+                    "p is not null and c is not null and x is not null",
+                    f"WITH CLUSTERING ORDER BY ({order})",
+                ) as mv:
                     pass
+
 
 # Cassandra is strict about the WITH CLUSTERING ORDER BY clause in the
 # definition of the materialized view that must, if it exists, list all
@@ -810,33 +1206,78 @@ def test_mv_override_clustering_order_bad1(cql, test_keyspace):
 # not allow to list spurious names of non-clustering keys in the CLUSTERING
 # ORDER BY clause. Reproduces #10767.
 def test_mv_override_clustering_order_bad2(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, y int, primary key (p,c)"
+    ) as table:
         # Only a non-clustering-key column y (clustering key c and x missing):
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by (y DESC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p, c, x",
+                "p is not null and c is not null and x is not null",
+                "with clustering order by (y DESC)",
+            ) as mv:
                 pass
         # The two clustering key column (c and x) plus a regular column y
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by (c ASC, x ASC, y DESC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p, c, x",
+                "p is not null and c is not null and x is not null",
+                "with clustering order by (c ASC, x ASC, y DESC)",
+            ) as mv:
                 pass
         # The two clustering key column (c and x) plus a partition key p
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by (c ASC, x ASC, p DESC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p, c, x",
+                "p is not null and c is not null and x is not null",
+                "with clustering order by (c ASC, x ASC, p DESC)",
+            ) as mv:
                 pass
         # The two clustering key column (c and x) plus non-existent z
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by (c ASC, x ASC, z DESC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p, c, x",
+                "p is not null and c is not null and x is not null",
+                "with clustering order by (c ASC, x ASC, z DESC)",
+            ) as mv:
                 pass
         # The clustering key column in the base (c) but it's no longer
         # a clustering key column in the view so can't be ordered
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'c, p', 'p is not null and c is not null', 'with clustering order by (c ASC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "c, p",
+                "p is not null and c is not null",
+                "with clustering order by (c ASC)",
+            ) as mv:
                 pass
         # Check that the case of quoted names is supported correctly,
         # "X" and x are not the same
         with pytest.raises(InvalidRequest, match="CLUSTERING ORDER BY"):
-            with new_materialized_view(cql, table, '*', 'p, c, x', 'p is not null and c is not null and x is not null', 'with clustering order by ("X" ASC)') as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p, c, x",
+                "p is not null and c is not null and x is not null",
+                'with clustering order by ("X" ASC)',
+            ) as mv:
                 pass
+
 
 # Test views that only refer to the primary key, exercising the invisible
 # empty type columns that are injected into the view schema in order to
@@ -844,37 +1285,55 @@ def test_mv_override_clustering_order_bad2(cql, test_keyspace):
 #
 # scylla_only because Cassandra doesn't support synchronous updates.
 def test_mv_with_only_primary_key_rows(scylla_only, cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'id int PRIMARY KEY, v1 int, v2 int') as base:
+    with new_test_table(
+        cql, test_keyspace, "id int PRIMARY KEY, v1 int, v2 int"
+    ) as base:
         # Use a synchronous view so we don't have to worry about races between flush and
         # view updates.
-        with new_materialized_view(cql, table=base, select='id', pk='id', where='id IS NOT NULL',
-                extra='WITH synchronous_updates = true') as view:
-            cql.execute(f'INSERT INTO {base} (id, v1) VALUES (1, 0)')
-            cql.execute(f'INSERT INTO {base} (id, v2) VALUES (2, 0)')
-            cql.execute(f'INSERT INTO {base} (id) VALUES (3)')
+        with new_materialized_view(
+            cql,
+            table=base,
+            select="id",
+            pk="id",
+            where="id IS NOT NULL",
+            extra="WITH synchronous_updates = true",
+        ) as view:
+            cql.execute(f"INSERT INTO {base} (id, v1) VALUES (1, 0)")
+            cql.execute(f"INSERT INTO {base} (id, v2) VALUES (2, 0)")
+            cql.execute(f"INSERT INTO {base} (id) VALUES (3)")
             # The following row is kept alive by the liveness of v1, since it doesn't have a row marker
-            cql.execute(f'UPDATE {base} SET v1 = 7 WHERE id = 4')
+            cql.execute(f"UPDATE {base} SET v1 = 7 WHERE id = 4")
             nodetool.flush(cql, view)
-            assert(set([row.id for row in cql.execute(f'SELECT id FROM {view}')]) == set([1, 2, 3, 4]))
+            assert set(
+                [row.id for row in cql.execute(f"SELECT id FROM {view}")]
+            ) == set([1, 2, 3, 4])
             # Remove that special row 4
-            cql.execute(f'DELETE v1 FROM {base} WHERE id = 4')
+            cql.execute(f"DELETE v1 FROM {base} WHERE id = 4")
             nodetool.flush(cql, view)
-            assert(set([row.id for row in cql.execute(f'SELECT id FROM {view}')]) == set([1, 2, 3]))
+            assert set(
+                [row.id for row in cql.execute(f"SELECT id FROM {view}")]
+            ) == set([1, 2, 3])
             # We now believe that empty value serialization/deserialization is correct
+
 
 # This test is regression testing added after fixing:
 # https://github.com/scylladb/scylladb/issues/16392 - the gist of the issue is that
 # prepared statements on views are not invalidated when the base table changes.
 def test_mv_prepared_statement_with_altered_base(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'id int PRIMARY KEY, v1 int') as base:
-        with new_materialized_view(cql, table=base, select='*', pk='id', where='id IS NOT NULL') as view:
+    with new_test_table(cql, test_keyspace, "id int PRIMARY KEY, v1 int") as base:
+        with new_materialized_view(
+            cql, table=base, select="*", pk="id", where="id IS NOT NULL"
+        ) as view:
             base_query = cql.prepare(f"SELECT * FROM {base} WHERE id=?")
             view_query = cql.prepare(f"SELECT * FROM {view} WHERE id=?")
             cql.execute(f"INSERT INTO {base} (id,v1) VALUES (0,0)")
-            assert cql.execute(base_query,[0]) == cql.execute(view_query,[0])
+            assert cql.execute(base_query, [0]) == cql.execute(view_query, [0])
             cql.execute(f"ALTER TABLE {base} ADD (v2 int)")
             cql.execute(f"INSERT INTO {base} (id,v1,v2) VALUES (1,1,1)")
-            assert list(cql.execute(base_query,[1])) == list(cql.execute(view_query,[1]))
+            assert list(cql.execute(base_query, [1])) == list(
+                cql.execute(view_query, [1])
+            )
+
 
 # A reproducer for issue #17117:
 # When a single base update generates many view updates to the same partition,
@@ -894,14 +1353,22 @@ def test_many_range_tombstone_base_update(cql, test_keyspace):
     # We need two clustering key columns in this test, so that deleting
     # each "WHERE c1=?" will cause a *range* tombstone - which is what
     # we want to reproduce in this test.
-    with new_test_table(cql, test_keyspace, 'p int, c1 int, c2 int, primary key (p, c1, c2)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c1 int, c2 int, primary key (p, c1, c2)"
+    ) as table:
         # For simplicity, the view is identical to the base. This is good
         # enough and still reproduces the bug. Remember that range tombstones
         # on the base are not copied to the view as-is - they are translated
         # to row tombstones in the view for the specific rows that really
         # exist in the base table.
-        with new_materialized_view(cql, table, '*', 'p, c1, c2', 'p is not null and c1 is not null and c2 is not null') as mv:
-            insert = cql.prepare(f'INSERT INTO {table} (p, c1, c2) VALUES (?,?,?)')
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p, c1, c2",
+            "p is not null and c1 is not null and c2 is not null",
+        ) as mv:
+            insert = cql.prepare(f"INSERT INTO {table} (p, c1, c2) VALUES (?,?,?)")
             # We need all of the rows to end up in the same view
             # partition, so all the deletions will be in the same
             # partition and will be divided into chunks. Hence we'll
@@ -911,15 +1378,16 @@ def test_many_range_tombstone_base_update(cql, test_keyspace):
                 cql.execute(insert, [p, i, i])
             # Remove all N rows using N *range* tombstones (deleting based
             # on p,c1 but not c2), all in one write to the base (a batch):
-            cmd = 'BEGIN BATCH '
+            cmd = "BEGIN BATCH "
             for i in range(N):
-                cmd += f'DELETE FROM {table} WHERE p={p} AND c1={i} '
-            cmd += 'APPLY BATCH;'
+                cmd += f"DELETE FROM {table} WHERE p={p} AND c1={i} "
+            cmd += "APPLY BATCH;"
             cql.execute(cmd)
             # At this point, both base table and view tables should be
             # empty.
-            assert [] == list(cql.execute(f'SELECT c1 FROM {table}'))
-            assert [] == list(cql.execute(f'SELECT c1 FROM {mv}'))
+            assert [] == list(cql.execute(f"SELECT c1 FROM {table}"))
+            assert [] == list(cql.execute(f"SELECT c1 FROM {mv}"))
+
 
 # Another more elaborate reproducer for issue #17117, which is closer to the
 # original use where we encountered this bug. It uses IN instead of BATCH, so
@@ -930,9 +1398,21 @@ def test_many_range_tombstone_base_update(cql, test_keyspace):
 # to the base, rather it combines several base partitions into one
 # view partition).
 def test_many_range_tombstone_base_update_2(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p1 int, p2 int, c1 int, c2 int, v1 int, v2 int, primary key ((p1,p2),c1,c2)') as table:
-        with new_materialized_view(cql, table, '*', '(v1,p2),c1,p1,c2', 'v1 is not null and p2 is not null and c1 is not null and p1 is not null and c2 is not null') as mv:
-            insert = cql.prepare(f'INSERT INTO {table} (p1,p2,c1,c2,v1,v2) VALUES (?,?,?,?,?,?)')
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p1 int, p2 int, c1 int, c2 int, v1 int, v2 int, primary key ((p1,p2),c1,c2)",
+    ) as table:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "(v1,p2),c1,p1,c2",
+            "v1 is not null and p2 is not null and c1 is not null and p1 is not null and c2 is not null",
+        ) as mv:
+            insert = cql.prepare(
+                f"INSERT INTO {table} (p1,p2,c1,c2,v1,v2) VALUES (?,?,?,?,?,?)"
+            )
             # Insert N items, with:
             #    * p1 cycles between NP1 different values.
             #    * c1 is unique per item.
@@ -947,18 +1427,20 @@ def test_many_range_tombstone_base_update_2(cql, test_keyspace):
             for i in range(N):
                 p1 = i % NP1
                 c1 = i
-                cql.execute(insert, [p1,p2,c1,c2,v1,v2])
+                cql.execute(insert, [p1, p2, c1, c2, v1, v2])
             # Delete slice with prefix p1,p2,c1 for multiple c1's (any c2)
-            delete_slices = cql.prepare(f'DELETE FROM {table} WHERE p1=? AND p2=? AND c1 in ?')
+            delete_slices = cql.prepare(
+                f"DELETE FROM {table} WHERE p1=? AND p2=? AND c1 in ?"
+            )
             # This test appears fail due to #17117 for any K>25 - the 26th
             # and every multiple of 26th deletion in the batch doesn't reach
             # the view.
-            K=80
+            K = 80
             for p1 in range(NP1):
                 # c1's for this p1 are i's such that i%NP1 = p1.
                 # Only take the c1's that are after N//2, to delete
                 # only the later half of the items.
-                start = N//2
+                start = N // 2
                 start -= start % NP1
                 c1s = range(start + p1, N, NP1)
                 # split c1s into chunks of length K
@@ -975,9 +1457,10 @@ def test_many_range_tombstone_base_update_2(cql, test_keyspace):
             list_view = sorted([x.c1 for x in cql.execute(f"SELECT c1 FROM {mv}")])
             print("Remaining base rows: ", len(list_base))
             print("Remaining base rows: ", len(list_view))
-            print("Only in base: ", sorted(list(set(list_base)-set(list_view))))
-            print("Only in view: ", sorted(list(set(list_view)-set(list_base))))
+            print("Only in base: ", sorted(list(set(list_base) - set(list_view))))
+            print("Only in view: ", sorted(list(set(list_view) - set(list_base))))
             assert list_base == list_view
+
 
 # Test that deleting a base partition works fine, even if it produces a
 # large batch of individual view updates. After issue #8852 was fixed,
@@ -994,13 +1477,21 @@ def test_many_range_tombstone_base_update_2(cql, test_keyspace):
 # output mutation correctly (the test doesn't check that this breaking up
 # happens, but rather that if it happens - it doesn't break correctness).
 def test_base_partition_deletion(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, v int, primary key (p,c)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, v int, primary key (p,c)"
+    ) as table:
         # All inserts go to the same base partition,  that we'll then delete
         p = 1
         v = 42
-        insert = cql.prepare(f'INSERT INTO {table} (p,c,v) VALUES ({p},?,{v})')
+        insert = cql.prepare(f"INSERT INTO {table} (p,c,v) VALUES ({p},?,{v})")
         # Case where all view-row deletions go to the same view partition:
-        with new_materialized_view(cql, table, '*', 'p,v,c', 'p is not null and v is not null and c is not null') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p,v,c",
+            "p is not null and v is not null and c is not null",
+        ) as mv:
             N = 345
             for i in range(N):
                 cql.execute(insert, [i])
@@ -1014,6 +1505,7 @@ def test_base_partition_deletion(cql, test_keyspace):
             assert [] == list(cql.execute(f"SELECT c FROM {table}"))
             assert [] == list(cql.execute(f"SELECT c FROM {mv}"))
 
+
 # Same as above test, just for a range tombstone, e.g., in a composite
 # clustering key c1,c2 deleting in the base all rows with some c1.
 # Here too Scylla generates a long list of view updates (individual row
@@ -1025,14 +1517,22 @@ def test_base_partition_deletion(cql, test_keyspace):
 # a large clustering prefix deletion into multiple batches without losing
 # any view deletions.
 def test_base_clustering_prefix_deletion(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c1 int, c2 int, v int, primary key (p,c1,c2)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c1 int, c2 int, v int, primary key (p,c1,c2)"
+    ) as table:
         # All inserts go to the same base c1, that we'll then delete
         p = 1
         c1 = 2
         v = 42
-        insert = cql.prepare(f'INSERT INTO {table} (p,c1,c2,v) VALUES ({p},{c1},?,{v})')
+        insert = cql.prepare(f"INSERT INTO {table} (p,c1,c2,v) VALUES ({p},{c1},?,{v})")
         # Case where all view-row deletions go to the same view partition:
-        with new_materialized_view(cql, table, '*', 'p,v,c1,c2', 'p is not null and v is not null and c1 is not null and c2 is not null') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p,v,c1,c2",
+            "p is not null and v is not null and c1 is not null and c2 is not null",
+        ) as mv:
             N = 345
             for i in range(N):
                 cql.execute(insert, [i])
@@ -1046,22 +1546,37 @@ def test_base_clustering_prefix_deletion(cql, test_keyspace):
             assert [] == list(cql.execute(f"SELECT c2 FROM {table}"))
             assert [] == list(cql.execute(f"SELECT c2 FROM {mv}"))
 
+
 # Test deleting an entire base partition, where there is a view with the same or
 # different partition key.  When the view has the same partition key as base,
 # the partition deletion can be done on the base in one update of partition
 # tombstone.  In other cases, a tombstone is generated for each row that
 # corresponds to the deleted base partition.
 def test_base_partition_deletion_with_same_view_partition_key(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, v int, primary key (p,c)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, v int, primary key (p,c)"
+    ) as table:
         # Insert into two base partitions. We will delete one of them
         v = 42
-        insert = cql.prepare(f'INSERT INTO {table} (p,c,v) VALUES (?,?,{v})')
+        insert = cql.prepare(f"INSERT INTO {table} (p,c,v) VALUES (?,?,{v})")
         # Create multiple views with different primary keys.
         # The first view has the same partition key as the base, so the entire partition will be deleted on the view as well.
         # The other views have different partition key than the base, so they will have individual rows removed.
-        with new_materialized_view(cql, table, '*', 'p,c', 'p is not null and c is not null') as mv1, \
-             new_materialized_view(cql, table, '*', 'c,p', 'p is not null and c is not null') as mv2, \
-             new_materialized_view(cql, table, '*', '(p,c),v', 'p is not null and c is not null and v is not null') as mv3:
+        with (
+            new_materialized_view(
+                cql, table, "*", "p,c", "p is not null and c is not null"
+            ) as mv1,
+            new_materialized_view(
+                cql, table, "*", "c,p", "p is not null and c is not null"
+            ) as mv2,
+            new_materialized_view(
+                cql,
+                table,
+                "*",
+                "(p,c),v",
+                "p is not null and c is not null and v is not null",
+            ) as mv3,
+        ):
             N = 10
             for i in range(N):
                 cql.execute(insert, [1, i])
@@ -1069,37 +1584,71 @@ def test_base_partition_deletion_with_same_view_partition_key(cql, test_keyspace
 
             # Before the deletion, all N rows should exist in the base and the view
             allN = list(range(N))
-            assert allN == [x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p=1")]
-            assert allN == sorted([x.c for x in cql.execute(f"SELECT c FROM {mv1} WHERE p=1")])
-            assert allN == [x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p=2")]
-            assert allN == sorted([x.c for x in cql.execute(f"SELECT c FROM {mv1} WHERE p=2")])
+            assert allN == [
+                x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p=1")
+            ]
+            assert allN == sorted(
+                [x.c for x in cql.execute(f"SELECT c FROM {mv1} WHERE p=1")]
+            )
+            assert allN == [
+                x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p=2")
+            ]
+            assert allN == sorted(
+                [x.c for x in cql.execute(f"SELECT c FROM {mv1} WHERE p=2")]
+            )
             for i in range(N):
-                assert [1,2] == sorted([x.p for x in cql.execute(f"SELECT p FROM {mv2} WHERE c={i}")])
+                assert [1, 2] == sorted(
+                    [x.p for x in cql.execute(f"SELECT p FROM {mv2} WHERE c={i}")]
+                )
 
             cql.execute(f"DELETE FROM {table} WHERE p=1")
 
             # After the deletion, all data should be gone from both base and view
             assert [] == list(cql.execute(f"SELECT c FROM {table} WHERE p=1"))
             assert [] == list(cql.execute(f"SELECT c FROM {mv1} WHERE p=1"))
-            assert [] == list(cql.execute(f"SELECT c FROM {mv2} WHERE p=1 ALLOW FILTERING"))
-            assert [] == list(cql.execute(f"SELECT c FROM {mv3} WHERE p=1 ALLOW FILTERING"))
+            assert [] == list(
+                cql.execute(f"SELECT c FROM {mv2} WHERE p=1 ALLOW FILTERING")
+            )
+            assert [] == list(
+                cql.execute(f"SELECT c FROM {mv3} WHERE p=1 ALLOW FILTERING")
+            )
 
-            assert allN == [x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p=2")]
-            assert allN == sorted([x.c for x in cql.execute(f"SELECT c FROM {mv1} WHERE p=2")])
+            assert allN == [
+                x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p=2")
+            ]
+            assert allN == sorted(
+                [x.c for x in cql.execute(f"SELECT c FROM {mv1} WHERE p=2")]
+            )
 
             for i in range(N):
-                assert [2] == sorted([x.p for x in cql.execute(f"SELECT p FROM {mv2} WHERE c={i}")])
+                assert [2] == sorted(
+                    [x.p for x in cql.execute(f"SELECT p FROM {mv2} WHERE c={i}")]
+                )
 
             for i in range(N):
-                assert [v] == sorted([x.v for x in cql.execute(f"SELECT v FROM {mv3} WHERE p=2 AND c={i}")])
+                assert [v] == sorted(
+                    [
+                        x.v
+                        for x in cql.execute(f"SELECT v FROM {mv3} WHERE p=2 AND c={i}")
+                    ]
+                )
+
 
 # The partition key of the view is strictly contained in the base partition key,
 # so multiple base partitions are combined into one view partition.
 # Test deleting a base partition and verify it is deleted correctly in the view.
 def test_base_partition_deletion_with_smaller_view_partition_key(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p1 int, p2 int, c int, primary key ((p1,p2),c)') as table:
-        insert = cql.prepare(f'INSERT INTO {table} (p1,p2,c) VALUES (?,?,?)')
-        with new_materialized_view(cql, table, '*', 'p1,p2,c', 'p1 is not null and p2 is not null and c is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p1 int, p2 int, c int, primary key ((p1,p2),c)"
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p1,p2,c) VALUES (?,?,?)")
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p1,p2,c",
+            "p1 is not null and p2 is not null and c is not null",
+        ) as mv:
             # Insert into two separate base partitions.
             # In the view, the rows have the same partition key.
             cql.execute(insert, [0, 0, 10])
@@ -1109,17 +1658,26 @@ def test_base_partition_deletion_with_smaller_view_partition_key(cql, test_keysp
             cql.execute(f"DELETE FROM {table} WHERE p1=0 AND p2=0")
 
             assert [] == list(cql.execute(f"SELECT c FROM {table} WHERE p1=0 AND p2=0"))
-            assert [20] == [x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p1=0 AND p2=1")]
+            assert [20] == [
+                x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p1=0 AND p2=1")
+            ]
 
-            assert [(1,20)] == [(x.p2, x.c) for x in cql.execute(f"SELECT p2, c FROM {mv} WHERE p1=0")]
+            assert [(1, 20)] == [
+                (x.p2, x.c) for x in cql.execute(f"SELECT p2, c FROM {mv} WHERE p1=0")
+            ]
+
 
 # Perform a batch operation, deleting a partition and also inserting a row
 # to that partition with a newer timestamp, and verify that the insertion
 # is not lost in the MV update.
 def test_base_partition_deletion_in_batch_with_insert(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, primary key (p,c)') as table:
-        insert = cql.prepare(f'INSERT INTO {table} (p,c) VALUES (?,?) USING TIMESTAMP 99')
-        with new_materialized_view(cql, table, '*', 'p,c', 'p is not null and c is not null') as mv:
+    with new_test_table(cql, test_keyspace, "p int, c int, primary key (p,c)") as table:
+        insert = cql.prepare(
+            f"INSERT INTO {table} (p,c) VALUES (?,?) USING TIMESTAMP 99"
+        )
+        with new_materialized_view(
+            cql, table, "*", "p,c", "p is not null and c is not null"
+        ) as mv:
             cql.execute(insert, [0, 1])
             cql.execute(insert, [0, 2])
             cql.execute(insert, [0, 3])
@@ -1127,55 +1685,84 @@ def test_base_partition_deletion_in_batch_with_insert(cql, test_keyspace):
             # This should delete all the existing partition rows, and the new
             # row insertion survives and remains the only row after the operation
             # since it has the most recent timestamp.
-            cmd = 'BEGIN UNLOGGED BATCH '
-            cmd += f'INSERT INTO {table} (p,c) VALUES (0,4) USING TIMESTAMP 98; '
-            cmd += f'DELETE FROM {table} USING TIMESTAMP 100 WHERE p=0; '
-            cmd += f'INSERT INTO {table} (p,c) VALUES (0,5) USING TIMESTAMP 101; '
-            cmd += 'APPLY BATCH;'
+            cmd = "BEGIN UNLOGGED BATCH "
+            cmd += f"INSERT INTO {table} (p,c) VALUES (0,4) USING TIMESTAMP 98; "
+            cmd += f"DELETE FROM {table} USING TIMESTAMP 100 WHERE p=0; "
+            cmd += f"INSERT INTO {table} (p,c) VALUES (0,5) USING TIMESTAMP 101; "
+            cmd += "APPLY BATCH;"
             cql.execute(cmd)
 
             # Verify it is correct both in the table and the view
             assert [5] == [x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p=0")]
             assert [5] == [x.c for x in cql.execute(f"SELECT c FROM {mv} WHERE p=0")]
 
+
 # Delete a base partition using a timestamp lower than some of the rows
 # in the partition. Verify it doesn't result new delete in the base
 # and the view partition.
 def test_base_partition_deletion_with_low_timestamp(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, primary key (p,c)') as table:
-        with new_materialized_view(cql, table, '*', 'p,c', 'p is not null and c is not null') as mv:
-            cql.execute(f'INSERT INTO {table} (p,c) VALUES (0,1) USING TIMESTAMP 99')
-            cql.execute(f'INSERT INTO {table} (p,c) VALUES (0,2) USING TIMESTAMP 101')
+    with new_test_table(cql, test_keyspace, "p int, c int, primary key (p,c)") as table:
+        with new_materialized_view(
+            cql, table, "*", "p,c", "p is not null and c is not null"
+        ) as mv:
+            cql.execute(f"INSERT INTO {table} (p,c) VALUES (0,1) USING TIMESTAMP 99")
+            cql.execute(f"INSERT INTO {table} (p,c) VALUES (0,2) USING TIMESTAMP 101")
 
             # Delete the partition with a timestamp which is older than some of
             # the rows and newer than other rows.
-            cql.execute(f'DELETE FROM {table} USING TIMESTAMP 100 WHERE p=0')
+            cql.execute(f"DELETE FROM {table} USING TIMESTAMP 100 WHERE p=0")
 
             # Verify we get only the row with the newer timestamp
             assert [2] == [x.c for x in cql.execute(f"SELECT c FROM {table} WHERE p=0")]
             assert [2] == [x.c for x in cql.execute(f"SELECT c FROM {mv} WHERE p=0")]
 
+
 # A few basic tests for the "WITH" option in CREATE MATERIALIZED VIEW.
 def test_create_mv_with(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int primary key, c int') as table:
+    with new_test_table(cql, test_keyspace, "p int primary key, c int") as table:
         # Check that "WITH COMMENT=..." is accepted, and just adds the
         # "WITH COMMENT=..." to the output of DESC but changes nothing else.
-        with new_materialized_view(cql, table, '*', 'p,c', 'p is not null and c is not null', "with comment = 'hello123'") as mv:
-            assert 'hello123' in cql.execute(f'DESC MATERIALIZED VIEW {mv}').one().create_statement
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "p,c",
+            "p is not null and c is not null",
+            "with comment = 'hello123'",
+        ) as mv:
+            assert (
+                "hello123"
+                in cql.execute(f"DESC MATERIALIZED VIEW {mv}").one().create_statement
+            )
         # Check that unrecognized WITH options are rejected with an error.
         # Recognized options are those listed in cf_prop_defs::validate() or
         # in one of the registered schema extensions or appearing with a
         # special syntax in cfamProperty in cql3/Cql.g. "garbagename" isn't
         # on of the recognized options.
         with pytest.raises(SyntaxException, match="Unknown property"):
-            with new_materialized_view(cql, table, '*', 'p,c', 'p is not null and c is not null', "with garbagename = 'dog234'") as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p,c",
+                "p is not null and c is not null",
+                "with garbagename = 'dog234'",
+            ) as mv:
                 pass
         # Check that COMPACT STORAGE is *not* allowed for materialized views
         # (Scylla and Cassandra 3 allow it just for regular tables, but this
         # isn't tested here).
         with pytest.raises(InvalidRequest, match="COMPACT STORAGE"):
-            with new_materialized_view(cql, table, '*', 'p,c', 'p is not null and c is not null', "with compact storage") as mv:
+            with new_materialized_view(
+                cql,
+                table,
+                "*",
+                "p,c",
+                "p is not null and c is not null",
+                "with compact storage",
+            ) as mv:
                 pass
+
 
 # Verify that creating a materialized view with an ID that is already used fails.
 #
@@ -1185,39 +1772,54 @@ def test_create_mv_with(cql, test_keyspace):
 # Note that Scylla's behavior is consistent with how we handle `WITH ID`
 # in the case of regular tables.
 def test_creating_mv_with_existing_id(cassandra_bug, cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY') as table:
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY") as table:
         # Case 1. Try to create an MV with the ID of another MV.
-        with new_materialized_view(cql, table, '*', 'p', 'p IS NOT NULL') as mv:
+        with new_materialized_view(cql, table, "*", "p", "p IS NOT NULL") as mv:
             mv_id = get_id_of_mv(cql, mv)
-            with pytest.raises(InvalidRequest, match=f'Table with ID {mv_id} already exists: {mv}'):
-                with new_materialized_view(cql, table, '*', 'p', 'p IS NOT NULL', f'WITH ID = {mv_id}'):
+            with pytest.raises(
+                InvalidRequest, match=f"Table with ID {mv_id} already exists: {mv}"
+            ):
+                with new_materialized_view(
+                    cql, table, "*", "p", "p IS NOT NULL", f"WITH ID = {mv_id}"
+                ):
                     pass
 
         # Case 2. Try to create an MV with the ID of a regular table.
         cf_id = get_id_of_cf(cql, table)
-        with pytest.raises(InvalidRequest, match=f'Table with ID {cf_id} already exists: {table}'):
-            with new_materialized_view(cql, table, '*', 'p', 'p IS NOT NULL', f'WITH ID = {cf_id}'):
+        with pytest.raises(
+            InvalidRequest, match=f"Table with ID {cf_id} already exists: {table}"
+        ):
+            with new_materialized_view(
+                cql, table, "*", "p", "p IS NOT NULL", f"WITH ID = {cf_id}"
+            ):
                 pass
+
 
 # Verify that creating an MV with a specified ID succeeds and the MV really bears it.
 def test_creating_mv_with_given_id(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY') as table:
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY") as table:
         # Step 1. We need an unused ID for the MV. Create a materialized view, obtain a statement
         #         to restore it, and extract its ID. Drop the MV.
-        with new_materialized_view(cql, table, '*', 'p', 'p IS NOT NULL') as mv:
+        with new_materialized_view(cql, table, "*", "p", "p IS NOT NULL") as mv:
             mv_id = get_id_of_mv(cql, mv)
 
         # Step 2. Create a new MV with a specific ID. Verify that it really uses it.
-        with new_materialized_view(cql, table, '*', 'p', 'p IS NOT NULL', f'WITH ID = {mv_id}') as mv:
+        with new_materialized_view(
+            cql, table, "*", "p", "p IS NOT NULL", f"WITH ID = {mv_id}"
+        ) as mv:
             assert mv_id == get_id_of_mv(cql, mv)
+
 
 # Verify that creating an MV fails when provided an invalid ID.
 def test_creating_mv_with_invalid_id(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY') as table:
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY") as table:
         for mv_id in ["'null'", "'something'", "'!@?'"]:
-            with pytest.raises(ConfigurationException, match='Invalid table id'):
-                with new_materialized_view(cql, table, '*', 'p', 'p IS NOT NULL', f'WITH ID = {mv_id}'):
+            with pytest.raises(ConfigurationException, match="Invalid table id"):
+                with new_materialized_view(
+                    cql, table, "*", "p", "p IS NOT NULL", f"WITH ID = {mv_id}"
+                ):
                     pass
+
 
 # Verify that creating an MV fails when the provided ID is null.
 #
@@ -1226,14 +1828,19 @@ def test_creating_mv_with_invalid_id(cql, test_keyspace):
 # Note that creating a table in Scylla using `WITH ID = null` also results in a ConfigurationException,
 # so MVs are consistent with that.
 def test_creating_mv_with_null_id(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY') as table:
-        with pytest.raises(ConfigurationException, match='Invalid table id'):
-            with new_materialized_view(cql, table, '*', 'p', 'p IS NOT NULL', 'WITH ID = null'):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY") as table:
+        with pytest.raises(ConfigurationException, match="Invalid table id"):
+            with new_materialized_view(
+                cql, table, "*", "p", "p IS NOT NULL", "WITH ID = null"
+            ):
                 pass
+
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, primary key (p)') as table:
+    with new_test_table(cql, test_keyspace, "p int, c int, primary key (p)") as table:
         yield table
+
 
 # Verify that oversized materialized view names are cleanly rejected,
 # as InvalidRequest (or, perhaps ConfigurationException).
@@ -1243,14 +1850,17 @@ def table1(cql, test_keyspace):
 # Cassandra doesn't shut down in this test, but it still fails uncleanly and
 # leaves the table in a partly-existing state so it fails this test and the
 # test is marked a cassandra_bug.
-def test_create_materialized_view_oversized_name(cql, test_keyspace, table1, cassandra_bug):
-    stmt = f'CREATE MATERIALIZED VIEW {test_keyspace}.%s AS SELECT * FROM {table1} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (p,c)'
+def test_create_materialized_view_oversized_name(
+    cql, test_keyspace, table1, cassandra_bug
+):
+    stmt = f"CREATE MATERIALIZED VIEW {test_keyspace}.%s AS SELECT * FROM {table1} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (p,c)"
     try:
         with pytest.raises((InvalidRequest, ConfigurationException)):
-            cql.execute(stmt % ('x'*500))
+            cql.execute(stmt % ("x" * 500))
     finally:
         # We shouldn't reach here, but if we did, let the test fail cleanly
-        cql.execute(f'DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{"x"*500}')
+        cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{'x' * 500}")
+
 
 # Verify that invalid characters (like, for example, "!") in materialized
 # view names are cleanly rejected, as InvalidRequest or ConfigurationException.
@@ -1259,7 +1869,7 @@ def test_create_materialized_view_oversized_name(cql, test_keyspace, table1, cas
 # The test below (test_create_materialized_view_slash_name) checks the one
 # character - slash - that it is critical to not allow.
 def test_create_materialized_view_invalid_char_name(cql, test_keyspace, table1):
-    stmt = f'CREATE MATERIALIZED VIEW {test_keyspace}.%s AS SELECT * FROM {table1} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (p,c)'
+    stmt = f"CREATE MATERIALIZED VIEW {test_keyspace}.%s AS SELECT * FROM {table1} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (p,c)"
     try:
         with pytest.raises((InvalidRequest, ConfigurationException)):
             cql.execute(stmt % ('"xyz!123"'))
@@ -1267,19 +1877,21 @@ def test_create_materialized_view_invalid_char_name(cql, test_keyspace, table1):
         # We shouldn't reach here, but if we did, let the test fail cleanly
         cql.execute(f'DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}."xyz!123"')
 
+
 # Verify that zero-sized materialized view names are cleanly rejected,
 # as SyntaxException
 def test_create_materialized_view_with_empty_name(cql, test_keyspace, table1):
-    stmt = f'CREATE MATERIALIZED VIEW {test_keyspace}.%s AS SELECT * FROM {table1} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (p,c)'
+    stmt = f"CREATE MATERIALIZED VIEW {test_keyspace}.%s AS SELECT * FROM {table1} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (p,c)"
     with pytest.raises(SyntaxException):
         cql.execute(stmt % ('""'))
+
 
 # Thanks to commit f76f6dbccb2, a slash in the name failed even when other
 # characters are not enforced (see "!" in the previous test). However, it
 # still fails with an "unclean" internal error instead of the expected
 # exception.
 def test_create_materialized_view_slash_name(cql, test_keyspace, table1):
-    stmt = f'CREATE MATERIALIZED VIEW {test_keyspace}.%s AS SELECT * FROM {table1} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (p,c)'
+    stmt = f"CREATE MATERIALIZED VIEW {test_keyspace}.%s AS SELECT * FROM {table1} WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (p,c)"
     try:
         with pytest.raises((InvalidRequest, ConfigurationException)):
             cql.execute(stmt % ('"/xyz/"'))
@@ -1287,43 +1899,61 @@ def test_create_materialized_view_slash_name(cql, test_keyspace, table1):
         # We shouldn't reach here, but if we did, let the test fail cleanly
         cql.execute(f'DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}."/xyz/"')
 
+
 @pytest.fixture(scope="module")
 def mv1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, primary key (p)') as table:
-        with new_materialized_view(cql, table, '*', 'c, p', 'p is not null and c is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, primary key (p)"
+    ) as table:
+        with new_materialized_view(
+            cql, table, "*", "c, p", "p is not null and c is not null"
+        ) as mv:
             yield mv
+
 
 # A materialized view cannot be written to directly - it can only be written
 # through its base table. This test verifies that all CQL operations that can
 # write to a table - INSERT, UPDATE, BATCH, DELETE, and TRUNCATE - are
 # rejected on a view table.
 def test_view_forbids_write(cql, mv1):
-    with pytest.raises(InvalidRequest, match='Cannot directly modify a materialized view'):
-        cql.execute(f'INSERT INTO {mv1} (c,p) VALUES (1,2)')
-    with pytest.raises(InvalidRequest, match=f'Cannot directly modify a materialized view'):
-        cql.execute(f'UPDATE {mv1} SET x=1 WHERE c=1 AND p=2')
-    with pytest.raises(InvalidRequest, match='Cannot directly modify a materialized view'):
-        cql.execute(f'BEGIN BATCH UPDATE {mv1} SET x=1 WHERE c=1 AND p=2; APPLY BATCH')
-    with pytest.raises(InvalidRequest, match='Cannot directly modify a materialized view'):
-        cql.execute(f'DELETE FROM {mv1} WHERE c=1 AND p=2')
-    with pytest.raises(InvalidRequest, match='Cannot TRUNCATE materialized view directly'):
-        cql.execute(f'TRUNCATE {mv1}')
+    with pytest.raises(
+        InvalidRequest, match="Cannot directly modify a materialized view"
+    ):
+        cql.execute(f"INSERT INTO {mv1} (c,p) VALUES (1,2)")
+    with pytest.raises(
+        InvalidRequest, match=f"Cannot directly modify a materialized view"
+    ):
+        cql.execute(f"UPDATE {mv1} SET x=1 WHERE c=1 AND p=2")
+    with pytest.raises(
+        InvalidRequest, match="Cannot directly modify a materialized view"
+    ):
+        cql.execute(f"BEGIN BATCH UPDATE {mv1} SET x=1 WHERE c=1 AND p=2; APPLY BATCH")
+    with pytest.raises(
+        InvalidRequest, match="Cannot directly modify a materialized view"
+    ):
+        cql.execute(f"DELETE FROM {mv1} WHERE c=1 AND p=2")
+    with pytest.raises(
+        InvalidRequest, match="Cannot TRUNCATE materialized view directly"
+    ):
+        cql.execute(f"TRUNCATE {mv1}")
+
 
 # A materialized view should not be operated on with operations that have
 # "TABLE" in their name - DROP TABLE, ALTER TABLE, and DESC TABLE. There
 # are identical operations with "MATERIALIZED VIEW" in their name, which
 # should be used instead.
 def test_view_forbids_table_ops(cql, mv1):
-    with pytest.raises(InvalidRequest, match='Cannot use'):
-        cql.execute(f'DROP TABLE {mv1}')
-    with pytest.raises(InvalidRequest, match='Cannot use'):
+    with pytest.raises(InvalidRequest, match="Cannot use"):
+        cql.execute(f"DROP TABLE {mv1}")
+    with pytest.raises(InvalidRequest, match="Cannot use"):
         cql.execute(f"ALTER TABLE {mv1} WITH comment='hello'")
     # Unlike the previous operations, in DESC TABLE cassandra doesn't explain
     # that DESC TABLE cannot be used on a view and that DESC MATERIALIZED VIEW
     # should be used instead - it just reports that the table is "not found".
     # Reproduces #21026 (DESC TABLE was allowed on a view):
-    with pytest.raises(InvalidRequest, match='Cannot use|not found'):
-        cql.execute(f'DESC TABLE {mv1}')
+    with pytest.raises(InvalidRequest, match="Cannot use|not found"):
+        cql.execute(f"DESC TABLE {mv1}")
+
 
 # A materialized view cannot have its own materialized views, nor secondary
 # indexes. Verify that.
@@ -1332,45 +1962,56 @@ def test_view_forbids_view_or_index(cql, mv1):
     # just claims that "Base table '{mv1}' doesn't exist" (it exists, but it's
     # not a base table). Scylla says "Materialized views cannot be created
     # against other materialized views". Let's allow both:
-    with pytest.raises(InvalidRequest, match='Base table|materialized views'):
-        with new_materialized_view(cql, mv1, '*', 'v, p', 'v is not null and p is not null'):
+    with pytest.raises(InvalidRequest, match="Base table|materialized views"):
+        with new_materialized_view(
+            cql, mv1, "*", "v, p", "v is not null and p is not null"
+        ):
             pass
-    with pytest.raises(InvalidRequest, match='materialized views'):
-        with new_secondary_index(cql, mv1, 'x'):
+    with pytest.raises(InvalidRequest, match="materialized views"):
+        with new_secondary_index(cql, mv1, "x"):
             pass
+
+
 # Test that TRUNCATE on a base table also truncates its views. This test
 # doesn't try to exercise the inconsistency created by non-atomic deletion of a
 # base and views (see #17635) - it just tries to check the basic functionality,
 # that TRUNCATE on a base actually performs a TRUNCATE also on the views.
 def test_truncate_base(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, a int, b int') as table:
-        with new_materialized_view(cql, table, '*', 'a,p', 'a is not null and p is not null') as mv1:
-            with new_materialized_view(cql, table, '*', 'b,p', 'b is not null and p is not null') as mv2:
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, a int, b int") as table:
+        with new_materialized_view(
+            cql, table, "*", "a,p", "a is not null and p is not null"
+        ) as mv1:
+            with new_materialized_view(
+                cql, table, "*", "b,p", "b is not null and p is not null"
+            ) as mv2:
                 # Wait for the view building to end on both views - so we
                 # won't run into issue #17635 in this test (where a view
                 # building in parallel with TRUNCATE results in untruncated
                 # data in the view).
                 for mv in [mv1, mv2]:
                     wait_for_view_built(cql, mv)
-                cql.execute(f'INSERT INTO {table} (p,a,b) VALUES (0,1,2)')
+                cql.execute(f"INSERT INTO {table} (p,a,b) VALUES (0,1,2)")
                 # Check the data reached the base and both views. On a single-
                 # node cluster, this insertion is synchronous so no need to
                 # retry the reads.
-                assert [(0,1,2)] == list(cql.execute(f"SELECT p,a,b FROM {table}"))
-                assert [(0,1,2)] == list(cql.execute(f"SELECT p,a,b FROM {mv1}"))
-                assert [(0,1,2)] == list(cql.execute(f"SELECT p,a,b FROM {mv2}"))
+                assert [(0, 1, 2)] == list(cql.execute(f"SELECT p,a,b FROM {table}"))
+                assert [(0, 1, 2)] == list(cql.execute(f"SELECT p,a,b FROM {mv1}"))
+                assert [(0, 1, 2)] == list(cql.execute(f"SELECT p,a,b FROM {mv2}"))
                 # Check that after a TRUNCATE, the data is gone from the base
                 # table, but also from both views:
-                cql.execute(f'TRUNCATE {table}')
+                cql.execute(f"TRUNCATE {table}")
                 assert [] == list(cql.execute(f"SELECT p,a,b FROM {table}"))
                 assert [] == list(cql.execute(f"SELECT p,a,b FROM {mv1}"))
                 assert [] == list(cql.execute(f"SELECT p,a,b FROM {mv2}"))
 
+
 # Test that DROP TABLE on a base table which has a view is *not* allowed
 # (it's necessary to explicitly DROP MATERIALIZED VIEW the view first):
 def test_drop_table_with_view(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, a int') as table:
-        with new_materialized_view(cql, table, '*', 'a,p', 'a is not null and p is not null') as mv:
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, a int") as table:
+        with new_materialized_view(
+            cql, table, "*", "a,p", "a is not null and p is not null"
+        ) as mv:
             # Interestingly, the error message in Scylla and Cassandra have
             # the same text ("Cannot drop a table when materialized views
             # still depend on it") but Cassandra adds in parentheses the name
@@ -1378,28 +2019,38 @@ def test_drop_table_with_view(cql, test_keyspace):
             # prevented the deletion. I think Scylla's message is better,
             # but let's not insist and just look for a phrase that will
             # probably appear in the error message even if it's changed:
-            with pytest.raises(InvalidRequest, match='materialized view'):
-                cql.execute(f'DROP TABLE {table}')
+            with pytest.raises(InvalidRequest, match="materialized view"):
+                cql.execute(f"DROP TABLE {table}")
+
 
 # Although the previous test checked that DROP TABLE is not allowed on a
 # table that still has views, a DROP KEYSPACE is allowed and deletes all
 # the tables and views in that keyspace.
 def test_drop_keyspace_with_view(cql, this_dc):
     ks = unique_name()
-    cql.execute("CREATE KEYSPACE " + ks + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
+    cql.execute(
+        "CREATE KEYSPACE "
+        + ks
+        + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '"
+        + this_dc
+        + "' : 1 }"
+    )
     try:
-        table = ks + '.' + unique_name()
-        cql.execute(f'CREATE TABLE {table} (p int PRIMARY KEY, a int)')
-        mv = ks + '.' + unique_name()
-        cql.execute(f'CREATE MATERIALIZED VIEW {mv} AS SELECT * FROM {table} WHERE a IS NOT NULL AND p IS NOT NULL PRIMARY KEY (a, p)')
+        table = ks + "." + unique_name()
+        cql.execute(f"CREATE TABLE {table} (p int PRIMARY KEY, a int)")
+        mv = ks + "." + unique_name()
+        cql.execute(
+            f"CREATE MATERIALIZED VIEW {mv} AS SELECT * FROM {table} WHERE a IS NOT NULL AND p IS NOT NULL PRIMARY KEY (a, p)"
+        )
         # Check that DROP KEYSPACE is allowed, despite the existance of a view
-        cql.execute(f'DROP KEYSPACE {ks}')
+        cql.execute(f"DROP KEYSPACE {ks}")
         # It's obvious that if the keyspace no longer exists a view in it
         # can't possibly exist, but let's verify anyway:
-        with pytest.raises(InvalidRequest, match='does not exist'):
-            cql.execute(f'SELECT * FROM {mv}')
+        with pytest.raises(InvalidRequest, match="does not exist"):
+            cql.execute(f"SELECT * FROM {mv}")
     finally:
-        cql.execute(f'DROP KEYSPACE IF EXISTS {ks}')
+        cql.execute(f"DROP KEYSPACE IF EXISTS {ks}")
+
 
 # Test that in many cases, the existance of a materialized view prevents
 # dropping columns from a base table. Scylla does allow dropping *some*
@@ -1408,19 +2059,24 @@ def test_drop_keyspace_with_view(cql, this_dc):
 # which checks the same scenarios, but as a C++ test cannot be compared to
 # Cassandra.
 def test_alter_table_drop_forbidden(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, a int, b int, c int') as base:
-        with new_materialized_view(cql, base, '*', 'a,p', 'a is not null and p is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int PRIMARY KEY, a int, b int, c int"
+    ) as base:
+        with new_materialized_view(
+            cql, base, "*", "a,p", "a is not null and p is not null"
+        ) as mv:
             # Base column base column b is selected, and can't be dropped.
-            with pytest.raises(InvalidRequest, match='materialized view'):
-                cql.execute(f'ALTER TABLE {base} DROP b')
+            with pytest.raises(InvalidRequest, match="materialized view"):
+                cql.execute(f"ALTER TABLE {base} DROP b")
             # A view key column is also selected and can't be dropped
-            with pytest.raises(InvalidRequest, match='materialized view'):
-                cql.execute(f'ALTER TABLE {base} DROP a')
-        with new_materialized_view(cql, base, 'p,a', 'p', 'p is not null') as mv:
+            with pytest.raises(InvalidRequest, match="materialized view"):
+                cql.execute(f"ALTER TABLE {base} DROP a")
+        with new_materialized_view(cql, base, "p,a", "p", "p is not null") as mv:
             # Base column base column b is unselected but this view has
             # virtual columns, so b is a virtual column and can't be dropped.
-            with pytest.raises(InvalidRequest, match='materialized view'):
-                cql.execute(f'ALTER TABLE {base} DROP b')
+            with pytest.raises(InvalidRequest, match="materialized view"):
+                cql.execute(f"ALTER TABLE {base} DROP b")
+
 
 # Cassandra starting in version 3.11 (see Cassandra commit
 # e6fb8302848bc43888b0a742a9b0abce09872c45doesn't) doesn't allow dropping
@@ -1431,36 +2087,51 @@ def test_alter_table_drop_forbidden(cql, test_keyspace):
 # aren't allowed in both Scylla or Cassandra).
 # The test is marked scylla_only because only Scylla allows these column drops.
 def test_alter_table_drop_allowed(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, a int, b int, c int') as base:
-        with new_materialized_view(cql, base, 'p,a,b', 'a,p', 'a is not null and p is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int PRIMARY KEY, a int, b int, c int"
+    ) as base:
+        with new_materialized_view(
+            cql, base, "p,a,b", "a,p", "a is not null and p is not null"
+        ) as mv:
             # base column c is not selected, and because the view's key has
             # a column not in the base's (a) there are no virtual columns, so
             # Scylla allows to drop column c.
-            cql.execute(f'ALTER TABLE {base} DROP c')
+            cql.execute(f"ALTER TABLE {base} DROP c")
+
 
 # Test that if a view uses "SELECT *" and a new column is added to the base
 # table, it is also added to the view and selected.
 # See also test_mv_prepared_statement_with_altered_base() above
 def test_alter_table_add_select_star(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, a int, b int') as base:
-        with new_materialized_view(cql, base, '*', 'a,p', 'a is not null and p is not null') as mv:
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, a int, b int") as base:
+        with new_materialized_view(
+            cql, base, "*", "a,p", "a is not null and p is not null"
+        ) as mv:
             # We can add a new column "c" to the base table, and it will be
             # automatically selected in the view because "SELECT *" expands
             # to contain it.
-            cql.execute(f'INSERT INTO {base} (p,a,b) VALUES (1,2,3)')
-            cql.execute(f'ALTER TABLE {base} ADD c int')
-            cql.execute(f'INSERT INTO {base} (p,a,b,c) VALUES (0,1,2,3)')
-            assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {base}"))
-            assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {mv}"))
-            
+            cql.execute(f"INSERT INTO {base} (p,a,b) VALUES (1,2,3)")
+            cql.execute(f"ALTER TABLE {base} ADD c int")
+            cql.execute(f"INSERT INTO {base} (p,a,b,c) VALUES (0,1,2,3)")
+            assert {(0, 1, 2, 3), (1, 2, 3, None)} == set(
+                cql.execute(f"SELECT p,a,b,c FROM {base}")
+            )
+            assert {(0, 1, 2, 3), (1, 2, 3, None)} == set(
+                cql.execute(f"SELECT p,a,b,c FROM {mv}")
+            )
+
+
 # Test that if a view is created with "SELECT *", DESC MATERIALIZED VIEW operation shows it
 # as "SELECT *" instead of expanding it (explicitly showing each column).
 # Reproduces issue #21154
 def test_desc_mv_with_select_star(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, a int, b int') as base:
-        with new_materialized_view(cql, base, '*', 'a,p', 'a is not null and p is not null') as mv:
-                mv_desc_result = cql.execute(f"DESC MATERIALIZED VIEW {mv};").one()
-                assert 'SELECT *' in mv_desc_result.create_statement
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, a int, b int") as base:
+        with new_materialized_view(
+            cql, base, "*", "a,p", "a is not null and p is not null"
+        ) as mv:
+            mv_desc_result = cql.execute(f"DESC MATERIALIZED VIEW {mv};").one()
+            assert "SELECT *" in mv_desc_result.create_statement
+
 
 # Test that tombstones with future timestamps work correctly
 # when a write with lower timestamp arrives - in such case,
@@ -1468,44 +2139,75 @@ def test_desc_mv_with_select_star(cql, test_keyspace):
 # needs to take it into account.
 # Reproduces issue #5793
 def test_views_with_future_tombstones(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'a int, b int, c int, d int, e int, primary key (a, b, c)') as table:
-        with new_materialized_view(cql, table, '*', 'b, a, c', 'a is not null and b is not null and c is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "a int, b int, c int, d int, e int, primary key (a, b, c)"
+    ) as table:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "b, a, c",
+            "a is not null and b is not null and c is not null",
+        ) as mv:
             # Partition tombstone
-            cql.execute(f'delete from {table} using timestamp 10 where a=1')
-            assert [] == list(cql.execute(f'select * from {table}'))
-            cql.execute(f'insert into {table} (a,b,c,d,e) values (1,2,3,4,5) using timestamp 8')
-            assert [] == list(cql.execute(f'select * from {table}'))
+            cql.execute(f"delete from {table} using timestamp 10 where a=1")
+            assert [] == list(cql.execute(f"select * from {table}"))
+            cql.execute(
+                f"insert into {table} (a,b,c,d,e) values (1,2,3,4,5) using timestamp 8"
+            )
+            assert [] == list(cql.execute(f"select * from {table}"))
             # On a single-node test, the update will be synchronous so no
             # need for retry.
-            assert [] == list(cql.execute(f'select * from {mv}'))
+            assert [] == list(cql.execute(f"select * from {mv}"))
 
             # Range tombstone
-            cql.execute(f'delete from {table} using timestamp 16 where a=2 and b > 1 and b < 4')
-            assert [] == list(cql.execute(f'select * from {table}'))
-            cql.execute(f'insert into {table} (a,b,c,d,e) values (2,3,4,5,6) using timestamp 12')
-            assert [] == list(cql.execute(f'select * from {table}'))
-            assert [] == list(cql.execute(f'select * from {mv}'))
+            cql.execute(
+                f"delete from {table} using timestamp 16 where a=2 and b > 1 and b < 4"
+            )
+            assert [] == list(cql.execute(f"select * from {table}"))
+            cql.execute(
+                f"insert into {table} (a,b,c,d,e) values (2,3,4,5,6) using timestamp 12"
+            )
+            assert [] == list(cql.execute(f"select * from {table}"))
+            assert [] == list(cql.execute(f"select * from {mv}"))
 
             # Row tombstone
-            cql.execute(f'delete from {table} using timestamp 24 where a=3 and b=4 and c=5')
-            assert [] == list(cql.execute(f'select * from {table}'))
-            cql.execute(f'insert into {table} (a,b,c,d,e) values (3,4,5,6,7) using timestamp 18')
-            assert [] == list(cql.execute(f'select * from {table}'))
-            assert [] == list(cql.execute(f'select * from {mv}'))
+            cql.execute(
+                f"delete from {table} using timestamp 24 where a=3 and b=4 and c=5"
+            )
+            assert [] == list(cql.execute(f"select * from {table}"))
+            cql.execute(
+                f"insert into {table} (a,b,c,d,e) values (3,4,5,6,7) using timestamp 18"
+            )
+            assert [] == list(cql.execute(f"select * from {table}"))
+            assert [] == list(cql.execute(f"select * from {mv}"))
+
 
 # Test view representation in system.* tables
 def test_view_in_system_tables(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as base:
-        with new_materialized_view(cql, base, '*', 'v,p', 'v is not null and p is not null') as view:
+        with new_materialized_view(
+            cql, base, "*", "v,p", "v is not null and p is not null"
+        ) as view:
             deadline = time.time() + 60
             while time.time() < deadline:
-                if view in [ f'{r.keyspace_name}.{r.view_name}' for r in cql.execute('select * from system.built_views')]:
+                if view in [
+                    f"{r.keyspace_name}.{r.view_name}"
+                    for r in cql.execute("select * from system.built_views")
+                ]:
                     break
                 time.sleep(0.1)
-            res = [ f'{r.keyspace_name}.{r.view_name}' for r in cql.execute('select * from system.built_views')]
+            res = [
+                f"{r.keyspace_name}.{r.view_name}"
+                for r in cql.execute("select * from system.built_views")
+            ]
             assert view in res
-            res = [ f'{r.table_name}.{r.index_name}' for r in cql.execute('select * from system."IndexInfo"')]
+            res = [
+                f"{r.table_name}.{r.index_name}"
+                for r in cql.execute('select * from system."IndexInfo"')
+            ]
             assert view not in res
+
 
 # This test indirectly verifies that a shadowable tombstone goes beyond
 # hiding data older than its timestamp - it actually hides an *entire* row -
@@ -1514,57 +2216,85 @@ def test_view_in_system_tables(cql, test_keyspace):
 # in this area if the newer call was a map element, but it turns out we
 # didn't have such a bug - and this test passes.
 def test_shadowable_tombstone_and_newer_collection_cells(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, m map<int, int>, primary key (p, c)') as table:
-        with new_materialized_view(cql, table, '*', 'x, p, c', 'x is not null and p is not null and c is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, m map<int, int>, primary key (p, c)"
+    ) as table:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "x, p, c",
+            "x is not null and p is not null and c is not null",
+        ) as mv:
             # Insert into the base table a row p=1 c=2 with x=3. This will
             # create an empty view row x=3
-            cql.execute(f'insert into {table} (p,c,x) values (1,2,3)')
+            cql.execute(f"insert into {table} (p,c,x) values (1,2,3)")
             # We should see this new row when reading the view partition x=1.
             # We assume that on a single-node test, the view updates are
             # synchronous so don't need to retry.
-            assert [(1,2,3)] == list(cql.execute(f'select p,c,x from {mv} where x=3'))
+            assert [(1, 2, 3)] == list(cql.execute(f"select p,c,x from {mv} where x=3"))
             # Now, in the base row p=1 c=2 leave x unmodified (3), but add
             # an element to the map m. The view row will remain with its old
             # timestamp, but will get a new cell - the new map element - with
             # a *newer* timestamp.
-            cql.execute(f'update {table} set m = m + {{7: 8}} where p=1 and c=2')
-            assert [(1,2,3,{7:8})] == list(cql.execute(f'select p,c,x,m from {mv} where x=3'))
+            cql.execute(f"update {table} set m = m + {{7: 8}} where p=1 and c=2")
+            assert [(1, 2, 3, {7: 8})] == list(
+                cql.execute(f"select p,c,x,m from {mv} where x=3")
+            )
             # Finally, in the base row p=1 c=2, set x to 4. This should
             # create a new view rew with x=5, but more importantly for this
             # test - should delete the entirety of the old view row x=3.
             # Even the map item that was added with a later timestamp, should
             # be gone.
-            cql.execute(f'update {table} set x = 4 where p=1 and c=2')
-            assert [(1,2,4,{7:8})] == list(cql.execute(f'select p,c,x,m from {mv} where x=4'))
-            assert [] == list(cql.execute(f'select p,c,x,m from {mv} where x=3'))
+            cql.execute(f"update {table} set x = 4 where p=1 and c=2")
+            assert [(1, 2, 4, {7: 8})] == list(
+                cql.execute(f"select p,c,x,m from {mv} where x=4")
+            )
+            assert [] == list(cql.execute(f"select p,c,x,m from {mv} where x=3"))
+
 
 # Same as the previous test checking shadowable tombstones and newer calls,
 # but here we use ordinary atomic (not collection) cells, and also use INSERT
 # instead of UPDATE.
 def test_shadowable_tombstone_and_newer_atomic_cells(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p, c)') as table:
-        with new_materialized_view(cql, table, '*', 'x, p, c', 'x is not null and p is not null and c is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, y int, primary key (p, c)"
+    ) as table:
+        with new_materialized_view(
+            cql,
+            table,
+            "*",
+            "x, p, c",
+            "x is not null and p is not null and c is not null",
+        ) as mv:
             # Insert into the base table a row p=1 c=2 with x=3. This will
             # create an empty view row x=3
-            cql.execute(f'insert into {table} (p,c,x) values (1,2,3)')
+            cql.execute(f"insert into {table} (p,c,x) values (1,2,3)")
             # We should see this new row when reading the view partition x=1.
             # We assume that on a single-node test, the view updates are
             # synchronous so don't need to retry.
-            assert [(1,2,3,None)] == list(cql.execute(f'select p,c,x,y from {mv} where x=3'))
+            assert [(1, 2, 3, None)] == list(
+                cql.execute(f"select p,c,x,y from {mv} where x=3")
+            )
             # Now, in the base row p=1 c=2 leave x unmodified (3), but set
             # a value for column y. The new cell y will get a new timestamp,
             # but because we use INSERT instead of UPDATE - the base row
             # marker will also get a new row timestamp, but it doesn't
             # affect the row marker of the view (which only depends on the
             # timestamp of x).
-            cql.execute(f'insert into {table} (p,c,y) values (1,2,7)')
-            assert [(1,2,3,7)] == list(cql.execute(f'select p,c,x,y from {mv} where x=3'))
+            cql.execute(f"insert into {table} (p,c,y) values (1,2,7)")
+            assert [(1, 2, 3, 7)] == list(
+                cql.execute(f"select p,c,x,y from {mv} where x=3")
+            )
             # Finally, in the base row p=1 c=2, set x to 4. This should
             # create a new view rew with x=5, but more importantly for this
             # test - should delete the entirety of the old view row x=3.
-            cql.execute(f'insert into {table} (p,c,x) values (1,2,4)')
-            assert [(1,2,4,7)] == list(cql.execute(f'select p,c,x,y from {mv} where x=4'))
-            assert [] == list(cql.execute(f'select p,c,x,y from {mv} where x=3'))
+            cql.execute(f"insert into {table} (p,c,x) values (1,2,4)")
+            assert [(1, 2, 4, 7)] == list(
+                cql.execute(f"select p,c,x,y from {mv} where x=4")
+            )
+            assert [] == list(cql.execute(f"select p,c,x,y from {mv} where x=3"))
+
 
 # Test that setting a TTL on a base-regular column which is a view key
 # column, correctly applies this TTL to the view row. In other words,
@@ -1576,8 +2306,12 @@ def test_shadowable_tombstone_and_newer_atomic_cells(cql, test_keyspace):
 def test_view_update_with_ttl(cql, test_keyspace):
     # To be able to set a TTL on a view key column x, obviously it needs to
     # be a *regular* column in the base (key columns do not have TTLs).
-    with new_test_table(cql, test_keyspace, 'p int, x int, y int, primary key (p)') as table:
-        with new_materialized_view(cql, table, '*', 'x, p', 'x is not null and p is not null') as mv:
+    with new_test_table(
+        cql, test_keyspace, "p int, x int, y int, primary key (p)"
+    ) as table:
+        with new_materialized_view(
+            cql, table, "*", "x, p", "x is not null and p is not null"
+        ) as mv:
             # Unfortunately, because we can't read the TTL of a row marker
             # (issue #14019) we can't verify that the correct TTL was set
             # on the view row marker - such that it would cause it to
@@ -1586,53 +2320,77 @@ def test_view_update_with_ttl(cql, test_keyspace):
             # A wrong TTL on the row marker would have left an empty row,
             # and a wrong TTL on the cell y would have left that in the view.
             # This means this test takes two seconds :-(
-            cql.execute(f'insert into {table} (p,x,y) values (1,2,3) using ttl 1')
+            cql.execute(f"insert into {table} (p,x,y) values (1,2,3) using ttl 1")
             time.sleep(1.1)
-            assert [] == list(cql.execute(f'select * from {mv}'))
+            assert [] == list(cql.execute(f"select * from {mv}"))
             # Updating x without a TTL will make this row appear again
             # We assume that on a single node, view updates are synchronous
             # so we don't need to loop the read.
-            cql.execute(f'update {table} set x=4, y=5 where p=1')
-            assert [(4,1,5)] == list(cql.execute(f'select * from {mv}'))
+            cql.execute(f"update {table} set x=4, y=5 where p=1")
+            assert [(4, 1, 5)] == list(cql.execute(f"select * from {mv}"))
             # Update x again with a TTL of 1 and sleep. The view row should
             # disappear completely (including the row marker and y)
-            cql.execute(f'update {table} using ttl 1 set x=5 where p=1')
+            cql.execute(f"update {table} using ttl 1 set x=5 where p=1")
             time.sleep(1.1)
-            assert [] == list(cql.execute(f'select * from {mv}'))
+            assert [] == list(cql.execute(f"select * from {mv}"))
+
 
 # Test view representation in REST API
 def test_view_in_API(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as base:
-        with new_materialized_view(cql, base, '*', 'v,p', 'v is not null and p is not null') as view:
-            view_name = view.split('.')[1]
-            res = rest_api.get_request(cql, f"storage_service/view_build_statuses/{test_keyspace}/{view_name}")
-            assert len(res) == 1 and 'value' in res[0] and res[0]['value'] in [ 'UNKNOWN', 'STARTED', 'SUCCESS' ]
+        with new_materialized_view(
+            cql, base, "*", "v,p", "v is not null and p is not null"
+        ) as view:
+            view_name = view.split(".")[1]
+            res = rest_api.get_request(
+                cql, f"storage_service/view_build_statuses/{test_keyspace}/{view_name}"
+            )
+            assert (
+                len(res) == 1
+                and "value" in res[0]
+                and res[0]["value"] in ["UNKNOWN", "STARTED", "SUCCESS"]
+            )
             # Indexes are implemented on top of materialized-views, but even then no MVs
             # should appear in the output of built_indexes API. And since this API only
             # reports views that are built, check that view is built first.
             wait_for_view_built(cql, view)
-            res = rest_api.get_request(cql, f"column_family/built_indexes/{base.replace('.',':')}")
+            res = rest_api.get_request(
+                cql, f"column_family/built_indexes/{base.replace('.', ':')}"
+            )
             assert view_name not in res
+
 
 # Test that we can perform reads from the view in reverse order without crashing.
 # Reproduces issue https://github.com/scylladb/scylladb/issues/21354
 def test_reverse_read_from_view(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'a int PRIMARY KEY, b int') as table:
-        with new_materialized_view(cql, table, '*', 'b, a', 'a is not null and b is not null') as mv:
-            cql.execute(f'insert into {table} (a, b) values (1, 1)')
-            cql.execute(f'insert into {table} (a, b) values (2, 1)')
-            assert {(1,),(2,)} == set(cql.execute(f'select a from {mv} where b=1'))
-            assert [(1,),(2,)] == list(cql.execute(f'select a from {mv} where b=1 order by a asc'))
-            assert [(2,),(1,)] == list(cql.execute(f'select a from {mv} where b=1 order by a desc'))
+    with new_test_table(cql, test_keyspace, "a int PRIMARY KEY, b int") as table:
+        with new_materialized_view(
+            cql, table, "*", "b, a", "a is not null and b is not null"
+        ) as mv:
+            cql.execute(f"insert into {table} (a, b) values (1, 1)")
+            cql.execute(f"insert into {table} (a, b) values (2, 1)")
+            assert {(1,), (2,)} == set(cql.execute(f"select a from {mv} where b=1"))
+            assert [(1,), (2,)] == list(
+                cql.execute(f"select a from {mv} where b=1 order by a asc")
+            )
+            assert [(2,), (1,)] == list(
+                cql.execute(f"select a from {mv} where b=1 order by a desc")
+            )
+
 
 # Test that we can rename multiple columns in the base table at the same time
 # without causing any issues for view updates.
 # Reproduces issue https://github.com/scylladb/scylladb/issues/22194
 def test_rename_multiple_columns(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'pk int, ck int, PRIMARY KEY (pk, ck)') as table:
-        with new_materialized_view(cql, table, '*', 'ck, pk', 'pk IS NOT NULL AND ck IS NOT NULL'):
-            cql.execute(f'ALTER TABLE {table} RENAME pk TO pk2 AND ck TO ck2')
-            cql.execute(f'INSERT INTO {table} (pk2, ck2) VALUES (0,0)')
+    with new_test_table(
+        cql, test_keyspace, "pk int, ck int, PRIMARY KEY (pk, ck)"
+    ) as table:
+        with new_materialized_view(
+            cql, table, "*", "ck, pk", "pk IS NOT NULL AND ck IS NOT NULL"
+        ):
+            cql.execute(f"ALTER TABLE {table} RENAME pk TO pk2 AND ck TO ck2")
+            cql.execute(f"INSERT INTO {table} (pk2, ck2) VALUES (0,0)")
+
 
 # Datastax's documentation for CREATE MATERIALIZED VIEW's SELECT clause states
 # that "All primary key columns are automatically included.". Scylla's
@@ -1647,14 +2405,24 @@ def test_rename_multiple_columns(cql, test_keyspace):
 # Cassandra bug (CASSANDRA-20701) so the test has the cassandra_bug tag
 # (remove this tag to verify it passes on Cassandra 3 but not 4 or 5).
 def test_mv_select_key_columns(cql, test_keyspace, cassandra_bug):
-    with new_test_table(cql, test_keyspace, 'p int, c int, v1 int, v2 int, v3 int, primary key (p, c)') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, v1 int, v2 int, v3 int, primary key (p, c)"
+    ) as table:
         # Create a view with primary key (v1, p, c) and additionally select v2
         # (but not v3). We want to check that it's fine to only mention v2 in
         # the SELECT clause - without v1,p,c.
-        with new_materialized_view(cql, table, 'v2', 'v1, p, c', 'v1 is not null and p is not null and c is not null') as mv:
+        with new_materialized_view(
+            cql,
+            table,
+            "v2",
+            "v1, p, c",
+            "v1 is not null and p is not null and c is not null",
+        ) as mv:
             # Verify that the view actually contains the expected columns,
             # v1, p, c, v2 (but not v3). This is more-or-less obvious if the
             # CREATE MATERIALIZED VIEW statement above succeeded, but it can't
             # hurt to make sure.
-            cql.execute(f'insert into {table} (p, c, v1, v2, v3) values (1, 2, 3, 4, 5)')
-            assert [(3,1,2,4)] == list(cql.execute(f'select * from {mv} where v1=3'))
+            cql.execute(
+                f"insert into {table} (p, c, v1, v2, v3) values (1, 2, 3, 4, 5)"
+            )
+            assert [(3, 1, 2, 4)] == list(cql.execute(f"select * from {mv} where v1=3"))

--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -14,17 +14,27 @@ from .util import new_test_table, unique_key_int
 from datetime import datetime
 from cassandra.protocol import InvalidRequest
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int, i int, g bigint, b blob, s text, t timestamp, u timeuuid, d date, PRIMARY KEY (p)") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int, i int, g bigint, b blob, s text, t timestamp, u timeuuid, d date, PRIMARY KEY (p)",
+    ) as table:
         yield table
+
 
 @pytest.fixture(scope="module")
 def tbl_set(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace,
-                        "p int PRIMARY KEY, s1 set<int>, s2 set<int>,"
-                        "s3 set<tinyint>, m map<int, int>, s4 frozen<set<int>>") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int PRIMARY KEY, s1 set<int>, s2 set<int>,"
+        "s3 set<tinyint>, m map<int, int>, s4 frozen<set<int>>",
+    ) as table:
         yield table
+
 
 # Check that a function that can take a column name as a parameter, can also
 # take a constant. This feature is barely useful for WHERE clauses, and
@@ -33,8 +43,15 @@ def tbl_set(cql, test_keyspace):
 def test_constant_function_parameter(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, b) VALUES ({p}, 0x03)")
-    assert [(p,)] == list(cql.execute(f"SELECT p FROM {table1} WHERE p={p} AND b=tinyintAsBlob(3) ALLOW FILTERING"))
-    assert [(b'\x04',)] == list(cql.execute(f"SELECT tinyintAsBlob(4) FROM {table1} WHERE p={p}"))
+    assert [(p,)] == list(
+        cql.execute(
+            f"SELECT p FROM {table1} WHERE p={p} AND b=tinyintAsBlob(3) ALLOW FILTERING"
+        )
+    )
+    assert [(b"\x04",)] == list(
+        cql.execute(f"SELECT tinyintAsBlob(4) FROM {table1} WHERE p={p}")
+    )
+
 
 # According to the documentation, "The `minTimeuuid` function takes a
 # `timestamp` value t, either a timestamp or a date string.". But although
@@ -45,28 +62,34 @@ def test_constant_function_parameter(cql, table1):
 # correct.
 def test_selector_mintimeuuid(cql, table1):
     p = unique_key_int()
-    cql.execute(f"INSERT INTO {table1} (p, s, t, i) VALUES ({p}, '2013-02-02 10:00+0000', 123, 456)")
+    cql.execute(
+        f"INSERT INTO {table1} (p, s, t, i) VALUES ({p}, '2013-02-02 10:00+0000', 123, 456)"
+    )
     # We just check this works, not what the value is:
     cql.execute(f"SELECT mintimeuuid(t) FROM {table1} WHERE p={p}")
     # This doesn't work - despite the documentation, in a selector a
     # date string is not supported by mintimeuuid.
-    with pytest.raises(InvalidRequest, match='of type timestamp'):
+    with pytest.raises(InvalidRequest, match="of type timestamp"):
         cql.execute(f"SELECT mintimeuuid(s) FROM {table1} WHERE p={p}")
     # Other integer types also don't work, it must be a timestamp:
-    with pytest.raises(InvalidRequest, match='of type timestamp'):
+    with pytest.raises(InvalidRequest, match="of type timestamp"):
         cql.execute(f"SELECT mintimeuuid(i) FROM {table1} WHERE p={p}")
+
 
 # Cassandra allows the implicit (and wrong!) casting of a bigint returned
 # by writetime() to the timestamp type required by mintimeuuid(). Scylla
 # doesn't. I'm not sure which behavior we should consider correct, but it's
 # useful to have a test that demonstrates this incompatibility.
 # Reproduces #14319.
-@pytest.mark.xfail(reason="issue #14319")
+@pytest.mark.xfail(
+    reason="Maybe inconsistent handling of implicit timestamp<->bigint conversion #14319"
+)
 def test_selector_mintimeuuid_64bit(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, g) VALUES ({p}, 123)")
     cql.execute(f"SELECT mintimeuuid(g) FROM {table1} WHERE p={p}")
     cql.execute(f"SELECT mintimeuuid(writetime(g)) FROM {table1} WHERE p={p}")
+
 
 # blobasbigint() must insist to receive a properly-sized (8-byte) blob.
 # If it accepts a shorter blob (e.g., 4 bytes) and returns that to the driver,
@@ -77,8 +100,9 @@ def test_blobas_wrong_size(cql, table1):
     cql.execute(f"INSERT INTO {table1} (p, i) VALUES ({p}, 123)")
     # Cassandra and Scylla print: "In call to function system.blobasbigint,
     # value 0x0000007b is not a valid binary representation for type bigint".
-    with pytest.raises(InvalidRequest, match='blobasbigint'):
+    with pytest.raises(InvalidRequest, match="blobasbigint"):
         cql.execute(f"SELECT blobasbigint(intasblob(i)) FROM {table1} WHERE p={p}")
+
 
 # The mintimeuuid() function works with valid "timestamp"-type values, which
 # are 64-bit *signed* integers representing milliseconds since the epoch.
@@ -92,7 +116,10 @@ def test_blobas_wrong_size(cql, table1):
 def test_mintimeuuid_reasonable(cql, table1, timestamp):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, {timestamp})")
-    assert [(timestamp,)] == list(cql.execute(f"SELECT tounixtimestamp(mintimeuuid(t)) FROM {table1} WHERE p={p}"))
+    assert [(timestamp,)] == list(
+        cql.execute(f"SELECT tounixtimestamp(mintimeuuid(t)) FROM {table1} WHERE p={p}")
+    )
+
 
 # The "timestamp" column type stores a 64-bit number of milliseconds, but
 # Scylla's and Cassandra's implementation of timeuuids cannot store this
@@ -101,12 +128,18 @@ def test_mintimeuuid_reasonable(cql, table1, timestamp):
 # or to throw an exception. Crashing is not acceptable (reproduces #17035),
 # and so is returning a value, but it having the wrong timestamp (this
 # happens in Cassandra, so this test is marked a cassandra_bug)
-@pytest.mark.parametrize("timestamp", [-2**63+123, -2**62, -2**58, 2**62, 2**63-123])
+@pytest.mark.parametrize(
+    "timestamp", [-(2**63) + 123, -(2**62), -(2**58), 2**62, 2**63 - 123]
+)
 def test_mintimeuuid_extreme(cql, table1, timestamp, cassandra_bug):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, {timestamp})")
     try:
-        res = list(cql.execute(f"SELECT tounixtimestamp(mintimeuuid(t)) FROM {table1} WHERE p={p}"))
+        res = list(
+            cql.execute(
+                f"SELECT tounixtimestamp(mintimeuuid(t)) FROM {table1} WHERE p={p}"
+            )
+        )
     except:
         # If mintimeuuid() refuses these extreme values, it's fine.
         # The real bug is to return something, which is wrong (the
@@ -114,6 +147,7 @@ def test_mintimeuuid_extreme(cql, table1, timestamp, cassandra_bug):
         pass
     else:
         assert [(timestamp,)] == res
+
 
 # An example of an extreme negative timestamp is what totimestamp(123)
 # returns: As shown in test_type_date.py, the number "123" is converted to
@@ -125,9 +159,12 @@ def test_mintimeuuid_extreme(cql, table1, timestamp, cassandra_bug):
 def test_mintimeuuid_extreme_from_totimestamp(cql, table1):
     p = unique_key_int()
     try:
-        cql.execute(f"SELECT * FROM {table1} WHERE p={p} and u < mintimeuuid(totimestamp(123)) ALLOW FILTERING")
+        cql.execute(
+            f"SELECT * FROM {table1} WHERE p={p} and u < mintimeuuid(totimestamp(123)) ALLOW FILTERING"
+        )
     except:
         pass
+
 
 # According to the documentation, the toTimestamp() function can take either
 # a "timeuuid" or a "date" value and convert it to a "timestamp" type
@@ -140,12 +177,17 @@ def test_totimestamp_date(cql, table1):
     p = unique_key_int()
     # The date 2**31 is the day of the epoch, so 2**31+1 is one day later,
     # Midnight January 2nd, 1970:
-    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {2**31+1})")
-    assert [(datetime(1970,1,2,0,0),)] == list(cql.execute(f"SELECT totimestamp(d) FROM {table1} WHERE p={p}"))
+    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {2**31 + 1})")
+    assert [(datetime(1970, 1, 2, 0, 0),)] == list(
+        cql.execute(f"SELECT totimestamp(d) FROM {table1} WHERE p={p}")
+    )
     # The day 2**31-1 is one day before the epoch, and this (negative
     # timestamps) is allowed:
-    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {2**31-1})")
-    assert [(datetime(1969,12,31,0,0),)] == list(cql.execute(f"SELECT totimestamp(d) FROM {table1} WHERE p={p}"))
+    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {2**31 - 1})")
+    assert [(datetime(1969, 12, 31, 0, 0),)] == list(
+        cql.execute(f"SELECT totimestamp(d) FROM {table1} WHERE p={p}")
+    )
+
 
 # Same as above test test_totimestame_date(), but use extreme dates
 # millions of years in the past. These tests cannot be run with the
@@ -159,7 +201,7 @@ def test_totimestamp_date_extreme(cql, table1):
     # (more than a million years before our time), but at 4e16 milliseconds
     # before the epoch, it should still fit nicely into 63 bits (9e18
     # milliseconds), and should work fine.
-    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {2**31-2**29})")
+    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {2**31 - 2**29})")
     cql.execute(f"SELECT totimestamp(d) FROM {table1} WHERE p={p}")
     # The day 2**30 is 2**30 days before the epoch - it's a useless date
     # (almost 3 million years before our time), but at 10^17 milliseconds
@@ -168,26 +210,41 @@ def test_totimestamp_date_extreme(cql, table1):
     cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {2**30})")
     cql.execute(f"SELECT totimestamp(d) FROM {table1} WHERE p={p}")
 
+
 # Test set_intersection() function. Not supported in Cassandra.
 def test_set_intersection_fn(cql, tbl_set, scylla_only):
     p1 = unique_key_int()
     p2 = unique_key_int()
-    cql.execute(f"INSERT INTO {tbl_set} (p, s1, s2, s3, m, s4) VALUES ({p1}, {{1,2,3}}, {{2,3,4}}, {{1}}, {{1:2, 2:3}}, {{-1,2}})")
-    cql.execute(f"INSERT INTO {tbl_set} (p, s1, s2, s3, m, s4) VALUES ({p2}, {{1,2,3}}, NULL, {{1}}, {{1:2, 2:3}}, {{-1,2}})")
+    cql.execute(
+        f"INSERT INTO {tbl_set} (p, s1, s2, s3, m, s4) VALUES ({p1}, {{1,2,3}}, {{2,3,4}}, {{1}}, {{1:2, 2:3}}, {{-1,2}})"
+    )
+    cql.execute(
+        f"INSERT INTO {tbl_set} (p, s1, s2, s3, m, s4) VALUES ({p2}, {{1,2,3}}, NULL, {{1}}, {{1:2, 2:3}}, {{-1,2}})"
+    )
     # Normal intersection.
-    assert [(set([2,3]),)] == list(cql.execute(f"SELECT set_intersection(s1, s2) FROM {tbl_set} WHERE p={p1}"))
+    assert [(set([2, 3]),)] == list(
+        cql.execute(f"SELECT set_intersection(s1, s2) FROM {tbl_set} WHERE p={p1}")
+    )
     # Intersecting with NULL.
-    assert [(None,)] == list(cql.execute(f"SELECT set_intersection(s1, s2) FROM {tbl_set} WHERE p={p2}"))
+    assert [(None,)] == list(
+        cql.execute(f"SELECT set_intersection(s1, s2) FROM {tbl_set} WHERE p={p2}")
+    )
     # Frozen and non-frozen.
-    assert [(set([2]),)] == list(cql.execute(f"SELECT set_intersection(s1, s4) FROM {tbl_set} WHERE p={p1}"))
+    assert [(set([2]),)] == list(
+        cql.execute(f"SELECT set_intersection(s1, s4) FROM {tbl_set} WHERE p={p1}")
+    )
     # Nesting
-    assert [(set([2]),)] == list(cql.execute(f"SELECT set_intersection(s1, set_intersection(s2, s4)) FROM {tbl_set} WHERE p={p1}"))
+    assert [(set([2]),)] == list(
+        cql.execute(
+            f"SELECT set_intersection(s1, set_intersection(s2, s4)) FROM {tbl_set} WHERE p={p1}"
+        )
+    )
     # Some error cases
-    with pytest.raises(InvalidRequest, match='accepts 2 arguments'):
+    with pytest.raises(InvalidRequest, match="accepts 2 arguments"):
         cql.execute(f"SELECT set_intersection(s1, s2, s3) FROM {tbl_set} WHERE p={p1}")
-    with pytest.raises(InvalidRequest, match='accepts 2 arguments'):
+    with pytest.raises(InvalidRequest, match="accepts 2 arguments"):
         cql.execute(f"SELECT set_intersection(s1) FROM {tbl_set} WHERE p={p1}")
-    with pytest.raises(InvalidRequest, match='both arguments are of set type'):
+    with pytest.raises(InvalidRequest, match="both arguments are of set type"):
         cql.execute(f"SELECT set_intersection(s1, p) FROM {tbl_set} WHERE p={p1}")
-    with pytest.raises(InvalidRequest, match='both arguments are of the same set type'):
+    with pytest.raises(InvalidRequest, match="both arguments are of the same set type"):
         cql.execute(f"SELECT set_intersection(s1, s3) FROM {tbl_set} WHERE p={p1}")

--- a/test/cqlpy/test_scan.py
+++ b/test/cqlpy/test_scan.py
@@ -23,7 +23,7 @@ from cassandra.query import SimpleStatement
 # This test focuses on cases which do not need ALLOW FILTERING. The next
 # test will focus on those that do.
 # Reproduces issue #64 and #4244
-@pytest.mark.xfail(reason="issues #64 and #4244")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix #64, Add support for mixing token, multi- and single-column restrictions #4244")
 def test_multi_column_restrictions_ck(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, c3 int, PRIMARY KEY (p, c1, c2, c3)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c1, c2, c3) VALUES (1, ?, ?, ?)")
@@ -99,7 +99,7 @@ def test_multi_column_range_restrictions_and_filtering(cql, test_keyspace):
 # We add another clustering key column to ensure that filtering *in*
 # a long partition is really needed - not just filtering on the partitions
 # (these are two different code paths).
-@pytest.mark.xfail(reason="issue #64")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix. #64")
 def test_multi_column_restrictions_ck_filtering(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c0 int, c1 int, c2 int, c3 int, PRIMARY KEY (p, c0, c1, c2, c3)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c0, c1, c2, c3) VALUES (1, 1, ?, ?, ?)")
@@ -128,7 +128,7 @@ def test_multi_column_restrictions_ck_filtering(cql, test_keyspace):
 # Reproduces #4244. Contrasting with the other reproducers for #4244 above,
 # in this test the single-column restriction is on the same column as the
 # multi-column restriction, not a different column.
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def test_multi_column_and_single_column_restriction_same_ck(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, PRIMARY KEY (p, c1, c2)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c1, c2) VALUES (1, ?, ?)")
@@ -149,7 +149,7 @@ def test_multi_column_and_single_column_restriction_same_ck(cql, test_keyspace):
 # on the same column and on a different column..
 # Reproduces issue #4244 (note that this is a different aspect of #4244 than
 # the multi-column restriction problems reproduced by other tests above).
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def test_restriction_token_and_nontoken(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c) VALUES (?, ?)")

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -14,9 +14,21 @@ from contextlib import ExitStack
 from . import rest_api
 from cassandra.protocol import InvalidRequest, ConfigurationException, ReadFailure
 from cassandra.query import SimpleStatement
-from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order
+from .cassandra_tests.porting import (
+    assert_rows,
+    assert_row_count,
+    assert_rows_ignoring_order,
+)
 
-from .util import new_test_table, unique_name, unique_key_int, is_scylla, ScyllaMetrics, config_value_context
+from .util import (
+    new_test_table,
+    unique_name,
+    unique_key_int,
+    is_scylla,
+    ScyllaMetrics,
+    config_value_context,
+)
+
 
 # A reproducer for issue #7443: Normally, when the entire table is SELECTed,
 # the partitions are returned sorted by the partitions' token. When there
@@ -24,41 +36,54 @@ from .util import new_test_table, unique_name, unique_key_int, is_scylla, Scylla
 # filtering happens to use a secondary index, again the order is not expected
 # to change.
 def test_partition_order_with_si(cql, test_keyspace):
-    schema = 'pk int, x int, PRIMARY KEY ((pk))'
+    schema = "pk int, x int, PRIMARY KEY ((pk))"
     with new_test_table(cql, test_keyspace, schema) as table:
         # Insert 20 partitions, all of them with x=1 so that filtering by x=1
         # will yield the same 20 partitions:
         N = 20
-        stmt = cql.prepare('INSERT INTO '+table+' (pk, x) VALUES (?, ?)')
+        stmt = cql.prepare("INSERT INTO " + table + " (pk, x) VALUES (?, ?)")
         for i in range(N):
             cql.execute(stmt, [i, 1])
         # SELECT all the rows, and verify they are returned in increasing
         # partition token order (note that the token is a *signed* number):
-        tokens = [row.system_token_pk for row in cql.execute('SELECT token(pk) FROM '+table)]
+        tokens = [
+            row.system_token_pk for row in cql.execute("SELECT token(pk) FROM " + table)
+        ]
         assert len(tokens) == N
         assert sorted(tokens) == tokens
         # Now select all the partitions with filtering of x=1. Since all
         # rows have x=1, this shouldn't change the list of matching rows, and
         # also shouldn't check their order:
-        tokens1 = [row.system_token_pk for row in cql.execute('SELECT token(pk) FROM '+table+' WHERE x=1 ALLOW FILTERING')]
+        tokens1 = [
+            row.system_token_pk
+            for row in cql.execute(
+                "SELECT token(pk) FROM " + table + " WHERE x=1 ALLOW FILTERING"
+            )
+        ]
         assert tokens1 == tokens
         # Now add an index on x, which allows implementing the "x=1"
         # restriction differently. With the index, "ALLOW FILTERING" is
         # no longer necessary. But the order of the results should
         # still not change. Issue #7443 is about the order changing here.
-        cql.execute('CREATE INDEX ON '+table+'(x)')
+        cql.execute("CREATE INDEX ON " + table + "(x)")
         # "CREATE INDEX" does not wait until the index is actually available
         # for use. Reads immediately after the CREATE INDEX may fail or return
         # partial results. So let's retry until reads resume working:
         for i in range(100):
             try:
-                tokens2 = [row.system_token_pk for row in cql.execute('SELECT token(pk) FROM '+table+' WHERE x=1')]
+                tokens2 = [
+                    row.system_token_pk
+                    for row in cql.execute(
+                        "SELECT token(pk) FROM " + table + " WHERE x=1"
+                    )
+                ]
                 if len(tokens2) == N:
                     break
             except ReadFailure:
                 pass
             time.sleep(0.1)
         assert tokens2 == tokens
+
 
 # Test which ensures that indexes for a query are picked by the order in which
 # they appear in restrictions. That way, users can deterministically pick
@@ -72,11 +97,12 @@ def test_partition_order_with_si(cql, test_keyspace):
 # (and upgrades...) to allow paged queries that use an index to continue.
 # Ref: #7969
 def test_order_of_indexes(scylla_only, cql, test_keyspace):
-    schema = 'p int primary key, v1 int, v2 int, v3 int'
+    schema = "p int primary key, v1 int, v2 int, v3 int"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX my_v3_idx ON {table}(v3)")
         cql.execute(f"CREATE INDEX my_v1_idx ON {table}(v1)")
         cql.execute(f"CREATE INDEX my_v2_idx ON {table}((p),v2)")
+
         # All queries below should use the first index they find in the list
         # of restrictions. Tracing information will be consulted to ensure
         # it's true. Currently some of the cases below succeed, because the
@@ -84,42 +110,78 @@ def test_order_of_indexes(scylla_only, cql, test_keyspace):
         # server restart), but some of them fail. Once a proper ordering
         # is implemented, all cases below should succeed.
         def index_used(query, index_name):
-            assert any([index_name in event.description for event in cql.execute(query, trace=True).get_query_trace().events])
+            assert any(
+                [
+                    index_name in event.description
+                    for event in cql.execute(query, trace=True).get_query_trace().events
+                ]
+            )
+
         index_used(f"SELECT * FROM {table} WHERE v3 = 1", "my_v3_idx")
-        index_used(f"SELECT * FROM {table} WHERE v3 = 1 and v1 = 2 allow filtering", "my_v3_idx")
-        index_used(f"SELECT * FROM {table} WHERE p = 1 and v1 = 1 and v3 = 2 allow filtering", "my_v1_idx")
-        index_used(f"SELECT * FROM {table} WHERE p = 1 and v3 = 1 and v1 = 2 allow filtering", "my_v3_idx")
+        index_used(
+            f"SELECT * FROM {table} WHERE v3 = 1 and v1 = 2 allow filtering",
+            "my_v3_idx",
+        )
+        index_used(
+            f"SELECT * FROM {table} WHERE p = 1 and v1 = 1 and v3 = 2 allow filtering",
+            "my_v1_idx",
+        )
+        index_used(
+            f"SELECT * FROM {table} WHERE p = 1 and v3 = 1 and v1 = 2 allow filtering",
+            "my_v3_idx",
+        )
         # Local indexes are still skipped if they cannot be used
-        index_used(f"SELECT * FROM {table} WHERE v2 = 1 and v1 = 2 allow filtering", "my_v1_idx")
-        index_used(f"SELECT * FROM {table} WHERE v2 = 1 and v3 = 2 and v1 = 3 allow filtering", "my_v3_idx")
-        index_used(f"SELECT * FROM {table} WHERE v1 = 1 and v2 = 2 and v3 = 3 allow filtering", "my_v1_idx")
+        index_used(
+            f"SELECT * FROM {table} WHERE v2 = 1 and v1 = 2 allow filtering",
+            "my_v1_idx",
+        )
+        index_used(
+            f"SELECT * FROM {table} WHERE v2 = 1 and v3 = 2 and v1 = 3 allow filtering",
+            "my_v3_idx",
+        )
+        index_used(
+            f"SELECT * FROM {table} WHERE v1 = 1 and v2 = 2 and v3 = 3 allow filtering",
+            "my_v1_idx",
+        )
         # Local indexes are still preferred over global ones, if they can be used
-        index_used(f"SELECT * FROM {table} WHERE p = 1 and v1 = 1 and v3 = 2 and v2 = 2 allow filtering", "my_v2_idx")
-        index_used(f"SELECT * FROM {table} WHERE p = 1 and v2 = 1 and v1 = 2 allow filtering", "my_v2_idx")
+        index_used(
+            f"SELECT * FROM {table} WHERE p = 1 and v1 = 1 and v3 = 2 and v2 = 2 allow filtering",
+            "my_v2_idx",
+        )
+        index_used(
+            f"SELECT * FROM {table} WHERE p = 1 and v2 = 1 and v1 = 2 allow filtering",
+            "my_v2_idx",
+        )
+
 
 # Indexes can be created without an explicit name, in which case a default name is chosen.
 # However, due to #8620 it was possible to break the index creation mechanism by creating
 # a properly named regular table, which conflicts with the generated index name.
 def test_create_unnamed_index_when_its_name_is_taken(cql, test_keyspace):
-    schema = 'p int primary key, v int'
+    schema = "p int primary key, v int"
     with new_test_table(cql, test_keyspace, schema) as table:
         try:
-            cql.execute(f"CREATE TABLE {table}_v_idx_index (i_do_not_exist_in_the_base_table int primary key)")
+            cql.execute(
+                f"CREATE TABLE {table}_v_idx_index (i_do_not_exist_in_the_base_table int primary key)"
+            )
             # Creating an index should succeed, even though its default name is taken
             # by the table above
             cql.execute(f"CREATE INDEX ON {table}(v)")
         finally:
             cql.execute(f"DROP TABLE {table}_v_idx_index")
 
+
 # Indexed created with an explicit name cause a materialized view to be created,
 # and this view has a specific name - <index-name>_index. If there happens to be
 # a regular table (or another view) named just like that, index creation should fail.
 def test_create_named_index_when_its_name_is_taken(scylla_only, cql, test_keyspace):
-    schema = 'p int primary key, v int'
+    schema = "p int primary key, v int"
     with new_test_table(cql, test_keyspace, schema) as table:
         index_name = unique_name()
         try:
-            cql.execute(f"CREATE TABLE {test_keyspace}.{index_name}_index (i_do_not_exist_in_the_base_table int primary key)")
+            cql.execute(
+                f"CREATE TABLE {test_keyspace}.{index_name}_index (i_do_not_exist_in_the_base_table int primary key)"
+            )
             # Creating an index should fail, because it's impossible to create
             # its underlying materialized view, because its name is taken by a regular table
             with pytest.raises(InvalidRequest, match="already exists"):
@@ -127,10 +189,11 @@ def test_create_named_index_when_its_name_is_taken(scylla_only, cql, test_keyspa
         finally:
             cql.execute(f"DROP TABLE {test_keyspace}.{index_name}_index")
 
+
 # Tests for CREATE INDEX IF NOT EXISTS
 # Reproduces issue #8717.
 def test_create_index_if_not_exists(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int primary key, v int') as table:
+    with new_test_table(cql, test_keyspace, "p int primary key, v int") as table:
         cql.execute(f"CREATE INDEX ON {table}(v)")
         # Can't create the same index again without "IF NOT EXISTS", but can
         # do it with "IF NOT EXISTS":
@@ -165,6 +228,7 @@ def test_create_index_if_not_exists(cql, test_keyspace):
             cql.execute(f"DROP INDEX {test_keyspace}.abc")
         cql.execute(f"DROP INDEX {test_keyspace}.xyz")
 
+
 # Another test for CREATE INDEX IF NOT EXISTS: Checks what happens if an index
 # with the given *name* already exists, but it's a different index than the
 # one requested, i.e.,
@@ -183,7 +247,9 @@ def test_create_index_if_not_exists(cql, test_keyspace):
 # Cassandra.
 # Reproduces issue #9182
 def test_create_index_if_not_exists2(cql, test_keyspace, cassandra_bug):
-    with new_test_table(cql, test_keyspace, 'p int primary key, v1 int, v2 int') as table:
+    with new_test_table(
+        cql, test_keyspace, "p int primary key, v1 int, v2 int"
+    ) as table:
         index_name = unique_name()
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v1)")
         # Obviously can't create a different index with the same name:
@@ -194,13 +260,15 @@ def test_create_index_if_not_exists2(cql, test_keyspace, cassandra_bug):
         with pytest.raises(InvalidRequest, match="already exists"):
             cql.execute(f"CREATE INDEX IF NOT EXISTS {index_name} ON {table}(v2)")
 
+
 # Verify that oversized index names are cleanly rejected  as InvalidRequest
 # Reproduces issue #20755
 def test_create_index_oversized_name(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int primary key, v int') as table:
-        index_name = 'x'*500
+    with new_test_table(cql, test_keyspace, "p int primary key, v int") as table:
+        index_name = "x" * 500
         with pytest.raises((InvalidRequest, ConfigurationException)):
             cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+
 
 # Test that the paging state works properly for indexes on tables
 # with descending clustering order. There was a problem with indexes
@@ -209,8 +277,8 @@ def test_create_index_oversized_name(cql, test_keyspace):
 # is different from the underlying view type, even though, from the perspective
 # of deserialization, they're equal. Issue #8666
 def test_paging_with_desc_clustering_order(cql, test_keyspace):
-    schema = 'p int, c int, primary key (p,c)'
-    extra = 'with clustering order by (c desc)'
+    schema = "p int, c int, primary key (p,c)"
+    extra = "with clustering order by (c desc)"
     with new_test_table(cql, test_keyspace, schema, extra) as table:
         cql.execute(f"CREATE INDEX ON {table}(c)")
         for i in range(3):
@@ -218,14 +286,15 @@ def test_paging_with_desc_clustering_order(cql, test_keyspace):
         stmt = SimpleStatement(f"SELECT * FROM {table} WHERE c = 42", fetch_size=1)
         assert len([row for row in cql.execute(stmt)]) == 3
 
+
 # The following test is similar to the above, except that the reversed type
 # is not of the indexed column itself - but it's still part of the index's
 # materialized view (because it's part of the key), and we use SELECT DISTINCT
 # instead of SELECT. This reproduces Scylla Enterprise issue #2449,
 # and is a regression test for commit c8653d1321ca9ff5963f9e5479372a6000a0f096.
 def test_paging_with_desc_clustering_order2(cql, test_keyspace):
-    schema = 'p1 int, p2 int, c int, primary key ((p1,p2),c)'
-    extra = 'with clustering order by (c desc)'
+    schema = "p1 int, p2 int, c int, primary key ((p1,p2),c)"
+    extra = "with clustering order by (c desc)"
     with new_test_table(cql, test_keyspace, schema, extra) as table:
         cql.execute(f"CREATE INDEX ON {table}(p1)")
         for i in range(3):
@@ -233,8 +302,11 @@ def test_paging_with_desc_clustering_order2(cql, test_keyspace):
         stmt = SimpleStatement(f"SELECT p1,p2 FROM {table} WHERE p1 = 7", fetch_size=1)
         assert len(list(cql.execute(stmt))) == 3
         # Reproduces Scylla Enterprise issue #2449:
-        stmt = SimpleStatement(f"SELECT DISTINCT p1,p2 FROM {table} WHERE p1 = 7", fetch_size=1)
+        stmt = SimpleStatement(
+            f"SELECT DISTINCT p1,p2 FROM {table} WHERE p1 = 7", fetch_size=1
+        )
         assert len(list(cql.execute(stmt))) == 3
+
 
 # Test that deleting a base partition works fine, even if it produces a large batch
 # of individual view updates. Refs #8852 - view updates used to be applied with
@@ -242,7 +314,7 @@ def test_paging_with_desc_clustering_order2(cql, test_keyspace):
 # so a regression test is necessary. Scylla-only - relies on the underlying
 # representation of the index table.
 def test_partition_deletion(cql, test_keyspace, scylla_only):
-    schema = 'p int, c1 int, c2 int, v int, primary key (p,c1,c2)'
+    schema = "p int, c1 int, c2 int, v int, primary key (p,c1,c2)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(c1)")
         prep = cql.prepare(f"INSERT INTO {table}(p,c1,c2) VALUES (1, ?, 1)")
@@ -252,13 +324,14 @@ def test_partition_deletion(cql, test_keyspace, scylla_only):
         res = [row for row in cql.execute(f"SELECT * FROM {table}_c1_idx_index")]
         assert len(res) == 0
 
+
 # Test that deleting a clustering range works fine, even if it produces a large batch
 # of individual view updates. Refs #8852 - view updates used to be applied with
 # per-partition granularity, but after fixing the issue it's no longer the case,
 # so a regression test is necessary. Scylla-only - relies on the underlying
 # representation of the index table.
 def test_range_deletion(cql, test_keyspace, scylla_only):
-    schema = 'p int, c1 int, c2 int, v int, primary key (p,c1,c2)'
+    schema = "p int, c1 int, c2 int, v int, primary key (p,c1,c2)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(c1)")
         prep = cql.prepare(f"INSERT INTO {table}(p,c1,c2) VALUES (1, ?, 1)")
@@ -268,17 +341,21 @@ def test_range_deletion(cql, test_keyspace, scylla_only):
         res = [row.c1 for row in cql.execute(f"SELECT * FROM {table}_c1_idx_index")]
         assert sorted(res) == [x for x in range(1342) if x <= 5 or x >= 846]
 
+
 # Reproduces #8627:
 # Test that trying to insert a value for an indexed column that exceeds 64KiB fails,
 # because this value is too large to be written as a key in the underlying index
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627"
+)
 def test_too_large_indexed_value(cql, test_keyspace):
-    schema = 'p int, c int, v text, primary key (p,c)'
+    schema = "p int, c int, v text, primary key (p,c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(v)")
-        big = 'x'*66536
-        with pytest.raises(InvalidRequest, match='size'):
+        big = "x" * 66536
+        with pytest.raises(InvalidRequest, match="size"):
             cql.execute(f"INSERT INTO {table}(p,c,v) VALUES (0,1,'{big}')")
+
 
 # Similar to the above test (test_too_large_indexed_value) but when indexing
 # keys of collection. Modern Cassandra, and Scylla, allow collection keys
@@ -286,33 +363,38 @@ def test_too_large_indexed_value(cql, test_keyspace):
 # to 64 KB. When a collection is indexed, the insertion of oversized elements
 # should fail cleanly at the time of write.
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627"
+)
 def test_too_large_indexed_collection_value(cql, test_keyspace):
-    schema = 'p int, c int, m map<text,text>, primary key (p,c)'
+    schema = "p int, c int, m map<text,text>, primary key (p,c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(values(m))")
         cql.execute(f"CREATE INDEX ON {table}(keys(m))")
-        big = 'x'*66536
-        with pytest.raises(InvalidRequest, match='size'):
+        big = "x" * 66536
+        with pytest.raises(InvalidRequest, match="size"):
             cql.execute(f"INSERT INTO {table}(p,c,m) VALUES (0,1,{{'hi': '{big}'}})")
-        with pytest.raises(InvalidRequest, match='size'):
+        with pytest.raises(InvalidRequest, match="size"):
             cql.execute(f"INSERT INTO {table}(p,c,m) VALUES (0,1,{{'{big}': 'hi'}})")
+
 
 # Reproduces #8627:
 # Same as test_too_large_indexed_value above, just check adding an index
 # to a table with pre-existing data. The background index-building process
 # cannot return an error to the user, but we do expect it to skip the
 # problematic row and continue to complete the rest of the index build.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(
+    reason="Cleanly reject updates with indexed values where value > 64k #8627"
+)
 def test_too_large_indexed_value_build(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
+    with new_test_table(cql, test_keyspace, "p int primary key, v text") as table:
         # No index yet - a "big" value in v is perfectly fine:
-        stmt = cql.prepare(f'INSERT INTO {table} (p,v) VALUES (?, ?)')
+        stmt = cql.prepare(f"INSERT INTO {table} (p,v) VALUES (?, ?)")
         for i in range(30):
             cql.execute(stmt, [i, str(i)])
-        big = 'x'*66536
+        big = "x" * 66536
         cql.execute(stmt, [30, big])
-        assert [(30,big)] == list(cql.execute(f'SELECT * FROM {table} WHERE p=30'))
+        assert [(30, big)] == list(cql.execute(f"SELECT * FROM {table} WHERE p=30"))
         # Create an index on v as the new key. The background index-building
         # process should start promptly.
         cql.execute(f"CREATE INDEX ON {table}(v)")
@@ -323,7 +405,7 @@ def test_too_large_indexed_value_build(cql, test_keyspace):
         # it needs to wait for a timeout.
         # However, today we are lucky (?) that the cql.execute(read, [big])
         # test also fails immediately on Scylla, so this test fails quickly.
-        read = cql.prepare(f'SELECT * FROM {table} WHERE v = ?')
+        read = cql.prepare(f"SELECT * FROM {table} WHERE v = ?")
         start_time = time.time()
         while time.time() < start_time + 30:
             # The oversized "big" cannot be a key in the view, and
@@ -343,18 +425,22 @@ def test_too_large_indexed_value_build(cql, test_keyspace):
         for i in range(30):
             assert list(cql.execute(read, [str(i)]))
 
+
 # Selecting values using only clustering key should require filtering, but work correctly
 # Reproduces issue #8991
 def test_filter_cluster_key(cql, test_keyspace):
-    schema = 'p int, c1 int, c2 int, primary key (p, c1, c2)'
+    schema = "p int, c1 int, c2 int, primary key (p, c1, c2)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(c2)")
         cql.execute(f"INSERT INTO {table} (p, c1, c2) VALUES (0, 1, 1)")
         cql.execute(f"INSERT INTO {table} (p, c1, c2) VALUES (0, 0, 1)")
-        
-        stmt = SimpleStatement(f"SELECT c1, c2 FROM {table} WHERE c1 = 1 and c2 = 1 ALLOW FILTERING")
+
+        stmt = SimpleStatement(
+            f"SELECT c1, c2 FROM {table} WHERE c1 = 1 and c2 = 1 ALLOW FILTERING"
+        )
         rows = cql.execute(stmt)
         assert_rows(rows, [1, 1])
+
 
 # Reproduces #8627:
 # Reproduced #13548:
@@ -365,62 +451,85 @@ def test_filter_cluster_key(cql, test_keyspace):
 # an "old" table's object in memory won't get deallocated before the "new" table's object is created,
 # which raised a seastar::metrics::double_registration exception
 def test_instant_table_recreation(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
-        insert_statement = cql.prepare(f'INSERT INTO {table} (p,v) VALUES (?, ?)')
-        big_string = 'x'*66536
+    with new_test_table(cql, test_keyspace, "p int primary key, v text") as table:
+        insert_statement = cql.prepare(f"INSERT INTO {table} (p,v) VALUES (?, ?)")
+        big_string = "x" * 66536
         cql.execute(insert_statement, [0, big_string])
         cql.execute(f"CREATE INDEX ON {table}(v)")
     # going out of scope DROPs the above table. Create another table with the same name:
-    with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
+    with new_test_table(cql, test_keyspace, "p int primary key, v text") as table:
         pass
+
 
 # Selecting *only* an indexed clustering key does not require filtering, it's
 # a full-index scan (the amount of output is proportional to the read).
 # Additionally, with unnecessary parentheses the query also works, and isn't
 # handled like a multi-column restriction (reproduces #13250).
-@pytest.mark.xfail(reason="issue #13250")
+@pytest.mark.xfail(
+    reason="one-element multi-column restriction should be handled like a single-column restriction #13250"
+)
 def test_index_scan_multicolumn_syntax(cql, test_keyspace):
-    schema = 'p int, c1 int, c2 int, primary key (p, c1, c2)'
+    schema = "p int, c1 int, c2 int, primary key (p, c1, c2)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(c1)")
         cql.execute(f"CREATE INDEX ON {table}(c2)")
         cql.execute(f"INSERT INTO {table} (p, c1, c2) VALUES (0, 1, 1)")
         cql.execute(f"INSERT INTO {table} (p, c1, c2) VALUES (0, 0, 1)")
         cql.execute(f"INSERT INTO {table} (p, c1, c2) VALUES (0, 1, 0)")
-        assert [(0,), (1,)] == list(cql.execute(f'SELECT c2 FROM {table} WHERE c1 = 1'))
-        assert [(0,), (1,)] == list(cql.execute(f'SELECT c1 FROM {table} WHERE c2 = 1'))
+        assert [(0,), (1,)] == list(cql.execute(f"SELECT c2 FROM {table} WHERE c1 = 1"))
+        assert [(0,), (1,)] == list(cql.execute(f"SELECT c1 FROM {table} WHERE c2 = 1"))
         # The query (c1) = (1) isn't a real multi-column restriction (it
         # should mean the same as c1=1) so it can use the index - and work
         # without ALLOW FILTERING. Reproduces #13250:
-        assert [(0,), (1,)] == list(cql.execute(f'SELECT c2 FROM {table} WHERE (c1) = (1)'))
+        assert [(0,), (1,)] == list(
+            cql.execute(f"SELECT c2 FROM {table} WHERE (c1) = (1)")
+        )
         # The query (c2) = (1) isn't a real multi-column restriction (it
         # should mean the same as c2=1) so it should be allowed despite
         # missing a restriction on c1. In our case c2=1 is allowed because
         # c2 is indexed. Reproduces #13250:
-        assert [(0,), (1,)] == list(cql.execute(f'SELECT c1 FROM {table} WHERE (c2) = (1)'))
+        assert [(0,), (1,)] == list(
+            cql.execute(f"SELECT c1 FROM {table} WHERE (c2) = (1)")
+        )
+
 
 def test_multi_column_with_regular_index(cql, test_keyspace):
     """Reproduces #9085."""
-    with new_test_table(cql, test_keyspace, 'p int, c1 int, c2 int, r int, primary key(p,c1,c2)') as tbl:
-        cql.execute(f'CREATE INDEX ON {tbl}(r)')
-        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 1, 1, 0)')
-        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 1, 2, 1)')
-        cql.execute(f'INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 2, 1, 0)')
-        assert_rows(cql.execute(f'SELECT c1 FROM {tbl} WHERE (c1,c2)<(2,0) AND r=0 ALLOW FILTERING'), [1])
-        assert_rows(cql.execute(f'SELECT c1 FROM {tbl} WHERE p=1 AND (c1,c2)<(2,0) AND r=0 ALLOW FILTERING'), [1])
+    with new_test_table(
+        cql, test_keyspace, "p int, c1 int, c2 int, r int, primary key(p,c1,c2)"
+    ) as tbl:
+        cql.execute(f"CREATE INDEX ON {tbl}(r)")
+        cql.execute(f"INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 1, 1, 0)")
+        cql.execute(f"INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 1, 2, 1)")
+        cql.execute(f"INSERT INTO {tbl}(p, c1, c2, r) VALUES (1, 2, 1, 0)")
+        assert_rows(
+            cql.execute(
+                f"SELECT c1 FROM {tbl} WHERE (c1,c2)<(2,0) AND r=0 ALLOW FILTERING"
+            ),
+            [1],
+        )
+        assert_rows(
+            cql.execute(
+                f"SELECT c1 FROM {tbl} WHERE p=1 AND (c1,c2)<(2,0) AND r=0 ALLOW FILTERING"
+            ),
+            [1],
+        )
+
 
 # Test that indexing an *empty string* works as expected. There is nothing
 # wrong or unusual about an empty string, and it should be supported just
 # like any other string.
 # Reproduces issue #9364
 def test_index_empty_string(cql, test_keyspace):
-    schema = 'p int, v text, primary key (p)'
+    schema = "p int, v text, primary key (p)"
     # Searching for v='' without an index (with ALLOW FILTERING), works
     # as expected:
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"INSERT INTO {table} (p, v) VALUES (1, 'hello')")
         cql.execute(f"INSERT INTO {table} (p, v) VALUES (2, '')")
-        assert_rows(cql.execute(f"SELECT p FROM {table} WHERE v='' ALLOW FILTERING"), [2])
+        assert_rows(
+            cql.execute(f"SELECT p FROM {table} WHERE v='' ALLOW FILTERING"), [2]
+        )
     # Now try the same thing with an index on v. ALLOW FILTERING should
     # no longer be needed, and the correct row should be found (in #9364
     # it wasn't). We create here a new table instead of adding an index to
@@ -435,10 +544,11 @@ def test_index_empty_string(cql, test_keyspace):
         # synchronous so we don't have to retry the SELECT.
         assert_rows(cql.execute(f"SELECT p FROM {table} WHERE v=''"), [2])
 
+
 # Test that trying to delete an entry based on an indexed column
 # does not cause the whole partition to be wiped. Refs #9495
 def test_try_deleting_based_on_index_column(cql, test_keyspace):
-    schema = 'p int, c1 int, c2 int, v int, primary key (p, c1, c2)'
+    schema = "p int, c1 int, c2 int, v int, primary key (p, c1, c2)"
     with new_test_table(cql, test_keyspace, schema) as table:
         for i in range(10):
             cql.execute(f"INSERT INTO {table} (p,c1,c2,v) VALUES (0,{i},{i},{i})")
@@ -451,6 +561,7 @@ def test_try_deleting_based_on_index_column(cql, test_keyspace):
         with pytest.raises(InvalidRequest):
             cql.execute(f"DELETE FROM {table} WHERE p = 0 AND c2 = 1500")
         assert_row_count(cql.execute(f"SELECT v FROM {table}"), 10)
+
 
 # Reproducer for issue #3403: A column name may contain all sorts of
 # non-alphanumeric characters, including even "/". When an index is created,
@@ -465,7 +576,7 @@ def test_index_weird_chars_in_col_name(cql, test_keyspace):
         # directories anywhere in the file system - or to crash if the
         # directory creation fails - e.g., if magic_path ends in
         # /dev/null/hello, and /dev/null is not a directory
-        magic_path='/..'*20 + tmpdir + '/x_yz'
+        magic_path = "/.." * 20 + tmpdir + "/x_yz"
         schema = f'pk int PRIMARY KEY, "{magic_path}" int'
         with new_test_table(cql, test_keyspace, schema) as table:
             cql.execute(f'CREATE INDEX ON {table}("{magic_path}")')
@@ -474,11 +585,16 @@ def test_index_weird_chars_in_col_name(cql, test_keyspace):
             assert os.listdir(tmpdir) == []
             # Check that the expected index name was chosen - based on
             # only the alphanumeric/underscore characters of the column name.
-            ks, cf = table.split('.')
-            index_name = list(cql.execute(f"SELECT index_name FROM system_schema.indexes WHERE keyspace_name = '{ks}' AND table_name = '{cf}'"))[0].index_name
-            iswordchar = lambda x: str.isalnum(x) or x == '_'
-            cleaned_up_column_name = ''.join(filter(iswordchar, magic_path))
-            assert index_name == cf + '_' + cleaned_up_column_name + '_idx'
+            ks, cf = table.split(".")
+            index_name = list(
+                cql.execute(
+                    f"SELECT index_name FROM system_schema.indexes WHERE keyspace_name = '{ks}' AND table_name = '{cf}'"
+                )
+            )[0].index_name
+            iswordchar = lambda x: str.isalnum(x) or x == "_"
+            cleaned_up_column_name = "".join(filter(iswordchar, magic_path))
+            assert index_name == cf + "_" + cleaned_up_column_name + "_idx"
+
 
 # Cassandra does not allow IN restrictions on non-primary-key columns,
 # and Scylla does (see test_filtering.py::test_filter_in_restriction).
@@ -490,15 +606,18 @@ def test_index_weird_chars_in_col_name(cql, test_keyspace):
 # supported" suggesting it may be fixed in the future).
 @pytest.mark.xfail
 def test_index_in_restriction(cql, test_keyspace, cassandra_bug):
-    schema = 'pk int, ck int, x int, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, x int, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(x)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck, x) VALUES (?, ?, ?)')
+        cql.execute(f"CREATE INDEX ON {table}(x)")
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, ck, x) VALUES (?, ?, ?)")
         for i in range(3):
-            cql.execute(stmt, [1, i, i*2])
-        assert [(1,), (2,)] == list(cql.execute(f'SELECT ck FROM {table} WHERE x IN (2, 4)'))
-        assert [(1,)] == list(cql.execute(f'SELECT ck FROM {table} WHERE x IN (2, 7)'))
-        assert [] == list(cql.execute(f'SELECT ck FROM {table} WHERE x IN (3, 7)'))
+            cql.execute(stmt, [1, i, i * 2])
+        assert [(1,), (2,)] == list(
+            cql.execute(f"SELECT ck FROM {table} WHERE x IN (2, 4)")
+        )
+        assert [(1,)] == list(cql.execute(f"SELECT ck FROM {table} WHERE x IN (2, 7)"))
+        assert [] == list(cql.execute(f"SELECT ck FROM {table} WHERE x IN (3, 7)"))
+
 
 # Test that a LIMIT works correctly in conjunction filtering - with an
 # without a secondary index. The LIMIT is supposed to control the number
@@ -506,13 +625,25 @@ def test_index_in_restriction(cql, test_keyspace, cassandra_bug):
 # rows before filtering.
 # Reproduces #10649 - when use_index=True the test failed because LIMIT
 # returned fewer than the requested number of rows.
-@pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
+@pytest.mark.parametrize(
+    "use_index",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Combination of secondary index and LIMIT can produce too few results #10649"
+            ),
+        ),
+        False,
+    ],
+)
 def test_filter_and_limit(cql, test_keyspace, use_index, driver_bug_1):
-    with new_test_table(cql, test_keyspace, 'pk int primary key, x int, y int') as table:
+    with new_test_table(
+        cql, test_keyspace, "pk int primary key, x int, y int"
+    ) as table:
         if use_index:
-            cql.execute(f'CREATE INDEX ON {table}(x)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, x, y) VALUES (?, ?, ?)')
+            cql.execute(f"CREATE INDEX ON {table}(x)")
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, x, y) VALUES (?, ?, ?)")
         cql.execute(stmt, [0, 1, 0])
         cql.execute(stmt, [1, 1, 1])
         cql.execute(stmt, [2, 1, 0])
@@ -521,17 +652,26 @@ def test_filter_and_limit(cql, test_keyspace, use_index, driver_bug_1):
         cql.execute(stmt, [5, 1, 1])
         cql.execute(stmt, [6, 1, 0])
         cql.execute(stmt, [7, 1, 1])
-        results = list(cql.execute(f'SELECT pk FROM {table} WHERE x = 1 AND y = 0 ALLOW FILTERING'))
+        results = list(
+            cql.execute(f"SELECT pk FROM {table} WHERE x = 1 AND y = 0 ALLOW FILTERING")
+        )
         assert sorted(results) == [(0,), (2,), (4,), (6,)]
         # Make sure that with LIMIT 3 we get back exactly 3 results - not
         # less and also not more.
-        results = list(cql.execute(f'SELECT pk FROM {table} WHERE x = 1 AND y = 0 LIMIT 3 ALLOW FILTERING'))
+        results = list(
+            cql.execute(
+                f"SELECT pk FROM {table} WHERE x = 1 AND y = 0 LIMIT 3 ALLOW FILTERING"
+            )
+        )
         assert sorted(results) == [(0,), (2,), (4,)]
         # Make the test even harder (exercising more code paths) by asking
         # to fetch the 3 results in tiny one-result pages instead of one page.
-        s = cql.prepare(f'SELECT pk FROM {table} WHERE x = 1 AND y = 0 LIMIT 3 ALLOW FILTERING')
+        s = cql.prepare(
+            f"SELECT pk FROM {table} WHERE x = 1 AND y = 0 LIMIT 3 ALLOW FILTERING"
+        )
         s.fetch_size = 1
         assert sorted(cql.execute(s)) == [(0,), (2,), (4,)]
+
 
 # The following test is similar to the previous one (test_filter_and_limit)
 # with one main difference: Whereas in the previous test the table's schema
@@ -542,13 +682,25 @@ def test_filter_and_limit(cql, test_keyspace, use_index, driver_bug_1):
 # list of matching rows (this test).
 # Reproduces #10649 - when use_index=True the test failed because LIMIT
 # returned fewer than the requested number of rows.
-@pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
+@pytest.mark.parametrize(
+    "use_index",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Combination of secondary index and LIMIT can produce too few results #10649"
+            ),
+        ),
+        False,
+    ],
+)
 def test_filter_and_limit_clustering(cql, test_keyspace, use_index):
-    with new_test_table(cql, test_keyspace, 'pk int, ck int, x int, PRIMARY KEY(pk, ck)') as table:
+    with new_test_table(
+        cql, test_keyspace, "pk int, ck int, x int, PRIMARY KEY(pk, ck)"
+    ) as table:
         if use_index:
-            cql.execute(f'CREATE INDEX ON {table}(x)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck, x) VALUES (?, ?, ?)')
+            cql.execute(f"CREATE INDEX ON {table}(x)")
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, ck, x) VALUES (?, ?, ?)")
         cql.execute(stmt, [0, 0, 1])
         cql.execute(stmt, [1, 1, 1])
         cql.execute(stmt, [2, 0, 1])
@@ -557,17 +709,28 @@ def test_filter_and_limit_clustering(cql, test_keyspace, use_index):
         cql.execute(stmt, [5, 1, 1])
         cql.execute(stmt, [6, 0, 1])
         cql.execute(stmt, [7, 1, 1])
-        results = list(cql.execute(f'SELECT pk FROM {table} WHERE x = 1 AND ck = 0 ALLOW FILTERING'))
+        results = list(
+            cql.execute(
+                f"SELECT pk FROM {table} WHERE x = 1 AND ck = 0 ALLOW FILTERING"
+            )
+        )
         assert sorted(results) == [(0,), (2,), (4,), (6,)]
         # Make sure that with LIMIT 3 we get back exactly 3 results - not
         # less and also not more.
-        results = list(cql.execute(f'SELECT pk FROM {table} WHERE x = 1 AND ck = 0 LIMIT 3 ALLOW FILTERING'))
+        results = list(
+            cql.execute(
+                f"SELECT pk FROM {table} WHERE x = 1 AND ck = 0 LIMIT 3 ALLOW FILTERING"
+            )
+        )
         assert sorted(results) == [(0,), (2,), (4,)]
         # Make the test even harder (exercising more code paths) by asking
         # to fetch the 3 results in tiny one-result pages instead of one page.
-        s = cql.prepare(f'SELECT pk FROM {table} WHERE x = 1 AND ck = 0 LIMIT 3 ALLOW FILTERING')
+        s = cql.prepare(
+            f"SELECT pk FROM {table} WHERE x = 1 AND ck = 0 LIMIT 3 ALLOW FILTERING"
+        )
         s.fetch_size = 1
         assert sorted(cql.execute(s)) == [(0,), (2,), (4,)]
+
 
 # Another reproducer for #10649, similar to the previous test
 # (test_filter_and_limit_clustering) but indexes the clustering
@@ -575,40 +738,69 @@ def test_filter_and_limit_clustering(cql, test_keyspace, use_index):
 # who discovered #10649, and involves slightly different code paths in
 # Scylla (the index-driver query needs to read individual rows, not
 # entire partitions, from the base table).
-@pytest.mark.xfail(reason="#10649")
+@pytest.mark.xfail(
+    reason="Combination of secondary index and LIMIT can produce too few results #10649"
+)
 def test_filter_and_limit_2(cql, test_keyspace):
-    schema = 'pk int, ck1 int, ck2 int, x int, PRIMARY KEY (pk, ck1, ck2)'
+    schema = "pk int, ck1 int, ck2 int, x int, PRIMARY KEY (pk, ck1, ck2)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(ck2)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck1, ck2, x) VALUES (?, ?, ?, ?)')
+        cql.execute(f"CREATE INDEX ON {table}(ck2)")
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, ck1, ck2, x) VALUES (?, ?, ?, ?)")
         N = 10
         J = 3
         for i in range(N):
             for j in range(J):
-                cql.execute(stmt, [1, i, j, j+i%2])
-        results = list(cql.execute(f'SELECT ck1 FROM {table} WHERE ck2 = 2 AND x = 3 ALLOW FILTERING'))
+                cql.execute(stmt, [1, i, j, j + i % 2])
+        results = list(
+            cql.execute(
+                f"SELECT ck1 FROM {table} WHERE ck2 = 2 AND x = 3 ALLOW FILTERING"
+            )
+        )
         # Note in the data-adding loop above, all rows match our pk=1, and
         # when ck=2 it means j=2 and at that point - x=3 if i%2==1. So the
         # expected results are:
-        assert results == [(i,) for i in range(N) if i%2==1]
+        assert results == [(i,) for i in range(N) if i % 2 == 1]
         for i in [3, 1, N]:
-            assert results[0:i] == list(cql.execute(f'SELECT ck1 FROM {table} WHERE ck2 = 2 AND x = 3 LIMIT {i} ALLOW FILTERING'))
+            assert results[0:i] == list(
+                cql.execute(
+                    f"SELECT ck1 FROM {table} WHERE ck2 = 2 AND x = 3 LIMIT {i} ALLOW FILTERING"
+                )
+            )
         # Try exactly the same with adding pk=1, which shouldn't change
         # anything in the result (because all our rows have pk=1).
         for i in [3, 1, N]:
-            assert results[0:i] == list(cql.execute(f'SELECT ck1 FROM {table} WHERE pk = 1 AND ck2 = 2 AND x = 3 LIMIT {i} ALLOW FILTERING'))
+            assert results[0:i] == list(
+                cql.execute(
+                    f"SELECT ck1 FROM {table} WHERE pk = 1 AND ck2 = 2 AND x = 3 LIMIT {i} ALLOW FILTERING"
+                )
+            )
+
 
 # Yet another reproducer for #10649, this time using a local index instead
 # of a global index. As before, test that a LIMIT works correctly in
 # conjunction filtering. A user tried this variant in issue #12766.
 # This is a scylla_only test because local index is a Scylla-only feature.
-@pytest.mark.parametrize("use_local_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
-def test_filter_and_limit_local_index(cql, test_keyspace, use_local_index, driver_bug_1, scylla_only):
-    with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p, c)') as table:
+@pytest.mark.parametrize(
+    "use_local_index",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Combination of secondary index and LIMIT can produce too few results #10649"
+            ),
+        ),
+        False,
+    ],
+)
+def test_filter_and_limit_local_index(
+    cql, test_keyspace, use_local_index, driver_bug_1, scylla_only
+):
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, x int, y int, primary key (p, c)"
+    ) as table:
         if use_local_index:
-            cql.execute(f'CREATE INDEX ON {table}((p), x)')
-        stmt = cql.prepare(f'INSERT INTO {table} (p, c, x, y) VALUES (?, ?, ?, ?)')
+            cql.execute(f"CREATE INDEX ON {table}((p), x)")
+        stmt = cql.prepare(f"INSERT INTO {table} (p, c, x, y) VALUES (?, ?, ?, ?)")
         cql.execute(stmt, [0, 0, 1, 0])
         cql.execute(stmt, [0, 1, 1, 1])
         cql.execute(stmt, [0, 2, 1, 0])
@@ -617,17 +809,36 @@ def test_filter_and_limit_local_index(cql, test_keyspace, use_local_index, drive
         cql.execute(stmt, [0, 5, 1, 1])
         cql.execute(stmt, [0, 6, 1, 0])
         cql.execute(stmt, [0, 7, 1, 1])
-        results = list(cql.execute(f'SELECT c FROM {table} WHERE p = 0 AND x = 1 AND y = 1 ALLOW FILTERING'))
+        results = list(
+            cql.execute(
+                f"SELECT c FROM {table} WHERE p = 0 AND x = 1 AND y = 1 ALLOW FILTERING"
+            )
+        )
         assert sorted(results) == [(1,), (3,), (5,), (7,)]
         # Make sure that with LIMIT N we get back exactly N results - not
         # less and also not more.
-        assert [(1,)] == sorted(list(cql.execute(f'SELECT c FROM {table} WHERE p = 0 AND x = 1 AND y = 1 LIMIT 1 ALLOW FILTERING')))
-        assert [(1,), (3,), (5,)] == sorted(list(cql.execute(f'SELECT c FROM {table} WHERE p = 0 AND x = 1 AND y = 1 LIMIT 3 ALLOW FILTERING')))
+        assert [(1,)] == sorted(
+            list(
+                cql.execute(
+                    f"SELECT c FROM {table} WHERE p = 0 AND x = 1 AND y = 1 LIMIT 1 ALLOW FILTERING"
+                )
+            )
+        )
+        assert [(1,), (3,), (5,)] == sorted(
+            list(
+                cql.execute(
+                    f"SELECT c FROM {table} WHERE p = 0 AND x = 1 AND y = 1 LIMIT 3 ALLOW FILTERING"
+                )
+            )
+        )
         # Make the test even harder (exercising more code paths) by asking
         # to fetch the 3 results in tiny one-result pages instead of one page.
-        s = cql.prepare(f'SELECT c FROM {table} WHERE p = 0 AND x = 1 AND y = 1 LIMIT 3 ALLOW FILTERING')
+        s = cql.prepare(
+            f"SELECT c FROM {table} WHERE p = 0 AND x = 1 AND y = 1 LIMIT 3 ALLOW FILTERING"
+        )
         s.fetch_size = 1
         assert sorted(cql.execute(s)) == [(1,), (3,), (5,)]
+
 
 # Tests for issue #2962 - different type of indexing on collection columns.
 # Note that we also have a randomized test for this feature as a C++ unit
@@ -639,170 +850,244 @@ def test_filter_and_limit_local_index(cql, test_keyspace, use_local_index, drive
 # (and therefore index) updates are synchronous, so none of these tests need
 # loops to wait for a change to be indexed.
 
+
 def test_index_list(cql, test_keyspace):
-    schema = 'pk int, ck int, l list<int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, l list<int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # Without an index, the "CONTAINS" restriction requires filtering
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 3')
-        cql.execute(f'CREATE INDEX ON {table}(l)')
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 3")
+        cql.execute(f"CREATE INDEX ON {table}(l)")
         # The list is still empty, nothing should match
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 3'))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 3"))
         # Add a values to the list, check they can be found
-        cql.execute(f'UPDATE {table} set l = l + [7] WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 7'))
-        cql.execute(f'UPDATE {table} set l = l + [8] WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 7'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 8'))
+        cql.execute(f"UPDATE {table} set l = l + [7] WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 7")
+        )
+        cql.execute(f"UPDATE {table} set l = l + [8] WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 7")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 8")
+        )
         # Remove values from the list, check they can no longer be found
-        cql.execute(f'UPDATE {table} set l = l - [7] WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 7'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 8'))
-        cql.execute(f'UPDATE {table} set l = l - [8] WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 8'))
+        cql.execute(f"UPDATE {table} set l = l - [7] WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 7"))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 8")
+        )
+        cql.execute(f"UPDATE {table} set l = l - [8] WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 8"))
         # Replace entire value of list, everything in it should be indexed
-        cql.execute(f'INSERT INTO {table} (pk, ck, l) VALUES (1, 2, [4, 5])')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 4'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 5'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 8'))
-        cql.execute(f'UPDATE {table} set l = [2, 5] WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 2'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 5'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 4'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 8'))
+        cql.execute(f"INSERT INTO {table} (pk, ck, l) VALUES (1, 2, [4, 5])")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 4")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 5")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 8"))
+        cql.execute(f"UPDATE {table} set l = [2, 5] WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 2")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 5")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 4"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 8"))
         # A list can have the same value more than once, here we append
         # another 2 to the list which will now contain [2, 5, 2]. Searching
         # for 2, we should find this row, but only once.
-        cql.execute(f'UPDATE {table} set l = l + [2] WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 2'))
+        cql.execute(f"UPDATE {table} set l = l + [2] WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 2")
+        )
         # If we remove the first element from the list [2, 5, 2], there is
         # still a 2 remaining, so it should still be found:
-        cql.execute(f'DELETE l[0] FROM {table} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 2'))
+        cql.execute(f"DELETE l[0] FROM {table} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 2")
+        )
         # Removing the other 2 (now l=[5,2]) should leaving a search for 2
         # returning nothing:
-        cql.execute(f'DELETE l[1] FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 2'))
+        cql.execute(f"DELETE l[1] FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 2"))
         # The list is now [5]. Replace the 5 with 2 and see 2 is found, 5 not:
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 5'))
-        cql.execute(f'UPDATE {table} set l[0] = 2 WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 2'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 5'))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 5")
+        )
+        cql.execute(f"UPDATE {table} set l[0] = 2 WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 2")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 5"))
         # Replacing the list [2] with an empty list works as expected:
-        cql.execute(f'UPDATE {table} SET l = [] WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE l CONTAINS 2'))
+        cql.execute(f"UPDATE {table} SET l = [] WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE l CONTAINS 2"))
+
 
 def test_index_set(cql, test_keyspace):
-    schema = 'pk int, ck int, s set<int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, s set<int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # Without an index, the "CONTAINS" restriction requires filtering
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 3')
-        cql.execute(f'CREATE INDEX ON {table}(s)')
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 3")
+        cql.execute(f"CREATE INDEX ON {table}(s)")
         # The set is still empty, nothing should match
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 3'))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 3"))
         # Add a values to the set, check they can be found
-        cql.execute(f'UPDATE {table} set s = s + {{7}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 7'))
-        cql.execute(f'UPDATE {table} set s = s + {{8}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 7'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 8'))
+        cql.execute(f"UPDATE {table} set s = s + {{7}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 7")
+        )
+        cql.execute(f"UPDATE {table} set s = s + {{8}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 7")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 8")
+        )
         # Remove values from the set, check they can no longer be found
-        cql.execute(f'UPDATE {table} set s = s - {{7}} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 7'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 8'))
-        cql.execute(f'UPDATE {table} set s = s - {{8}} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 8'))
+        cql.execute(f"UPDATE {table} set s = s - {{7}} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 7"))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 8")
+        )
+        cql.execute(f"UPDATE {table} set s = s - {{8}} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 8"))
         # Replace entire value of set, everything in it should be indexed
-        cql.execute(f'INSERT INTO {table} (pk, ck, s) VALUES (1, 2, {{4, 5}})')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 4'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 5'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 8'))
-        cql.execute(f'UPDATE {table} set s = {{2, 5}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 2'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 5'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 4'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 8'))
+        cql.execute(f"INSERT INTO {table} (pk, ck, s) VALUES (1, 2, {{4, 5}})")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 4")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 5")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 8"))
+        cql.execute(f"UPDATE {table} set s = {{2, 5}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 2")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 5")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 4"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 8"))
         # A set can only have the same value once. The set is now {2,5},
         # trying to add 2 again makes no difference - and removing it just once
         # will remove this value:
-        cql.execute(f'UPDATE {table} set s = s + {{2}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 2'))
-        cql.execute(f'UPDATE {table} set s = s - {{2}} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 2'))
+        cql.execute(f"UPDATE {table} set s = s + {{2}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 2")
+        )
+        cql.execute(f"UPDATE {table} set s = s - {{2}} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 2"))
         # The set is now {5}. Replacing it with an empty set works as expected:
-        cql.execute(f'UPDATE {table} SET s = {{}} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 5'))
+        cql.execute(f"UPDATE {table} SET s = {{}} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 5"))
         # The DELETE operation does the same thing:
-        cql.execute(f'UPDATE {table} SET s = {{17,18}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 17'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 18'))
-        cql.execute(f'DELETE s FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 17'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE s CONTAINS 18'))
+        cql.execute(f"UPDATE {table} SET s = {{17,18}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 17")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 18")
+        )
+        cql.execute(f"DELETE s FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 17"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE s CONTAINS 18"))
+
 
 def test_index_map_values(cql, test_keyspace):
-    schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # Without an index, the "CONTAINS" restriction requires filtering
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 3')
-        cql.execute(f'CREATE INDEX ON {table}(m)')
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 3")
+        cql.execute(f"CREATE INDEX ON {table}(m)")
         # indexing m (same as values(m)) will allow CONTAINS but not CONTAINS KEY
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3')
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3")
         # The map is still empty, nothing should match
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 3'))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 3"))
         # Add a elements to the map, check their values can be found
-        cql.execute(f'UPDATE {table} set m = m + {{10: 7}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 7'))
-        cql.execute(f'UPDATE {table} set m = m + {{11: 8}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 7'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 8'))
+        cql.execute(f"UPDATE {table} set m = m + {{10: 7}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 7")
+        )
+        cql.execute(f"UPDATE {table} set m = m + {{11: 8}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 7")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 8")
+        )
         # Remove elements from the map, check they can no longer be found
-        cql.execute(f'DELETE m[10] FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 7'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 8'))
-        cql.execute(f'DELETE m[11] FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 8'))
+        cql.execute(f"DELETE m[10] FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 7"))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 8")
+        )
+        cql.execute(f"DELETE m[11] FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 8"))
         # Replace entire value of map, everything in it should be indexed
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{17: 4, 18: 5}})')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 4'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 5'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 8'))
-        cql.execute(f'UPDATE {table} set m = {{3: 2, 4: 5}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 2'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 5'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 4'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 8'))
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{17: 4, 18: 5}})")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 4")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 5")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 8"))
+        cql.execute(f"UPDATE {table} set m = {{3: 2, 4: 5}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 2")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 5")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 4"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 8"))
         # A map can have multiple elements with the same *value*. The list is now
         # {3:2, 4:5}, if we add another element of value 2, searching for value 2
         # will return the item only once. But we'll need to delete both elements
         # to no longer find the value 2:
-        cql.execute(f'UPDATE {table} set m = m + {{14: 2}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 2'))
-        cql.execute(f'DELETE m[3] FROM {table} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 2'))
-        cql.execute(f'DELETE m[14] FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 2'))
+        cql.execute(f"UPDATE {table} set m = m + {{14: 2}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 2")
+        )
+        cql.execute(f"DELETE m[3] FROM {table} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 2")
+        )
+        cql.execute(f"DELETE m[14] FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 2"))
         # The map is now {4:5}. Change the value of 4 and see it take effect:
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 5'))
-        cql.execute(f'UPDATE {table} set m[4] = 6 WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 5'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 6'))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 5")
+        )
+        cql.execute(f"UPDATE {table} set m[4] = 6 WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 5"))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 6")
+        )
         # The "-" operation also works as expected (it removes specific *key*,
         # not *values*, depsite what some confused documentation claims):
-        cql.execute(f'UPDATE {table} set m = m - {{4}} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 6'))
+        cql.execute(f"UPDATE {table} set m = m - {{4}} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 6"))
+
 
 # In the previous test (test_index_map_values) we noted that if one map has
 # several keys with the same value, then the "values(m)" index must store
@@ -815,29 +1100,36 @@ def test_index_map_values(cql, test_keyspace):
 # *paging*. So the purpose of this test is to check that paging does not
 # cause the same row to be returned more than once.
 def test_index_map_values_paging(cql, test_keyspace):
-    schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # index m (same as values(m)). Will allow "CONTAINS".
-        cql.execute(f'CREATE INDEX ON {table}(m)')
+        cql.execute(f"CREATE INDEX ON {table}(m)")
         # Insert a map where 10 out of the 12 elements have the same value 3
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{0:4, 1:3, 2:3, 3:3, 4:3, 5:3, 6:3, 7:3, 8:3, 9:3, 10:3, 11:7}})')
+        cql.execute(
+            f"INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{0:4, 1:3, 2:3, 3:3, 4:3, 5:3, 6:3, 7:3, 8:3, 9:3, 10:3, 11:7}})"
+        )
         # But looking for "m CONTAINS 3" should return the row (1,2) only once:
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 3'))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 3")
+        )
         # Try exactly the same with paging with small page sizes. If Scylla
         # doesn't de-duplicate the results between pages, the same row will
         # be returned multiple times.
         for page_size in [1, 2, 3, 7]:
-            stmt = SimpleStatement(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 3', fetch_size=page_size)
-            assert [(1,2)] == list(cql.execute(stmt))
+            stmt = SimpleStatement(
+                f"SELECT pk,ck FROM {table} WHERE m CONTAINS 3", fetch_size=page_size
+            )
+            assert [(1, 2)] == list(cql.execute(stmt))
+
 
 # In the previous test (test_index_map_values*) all tests involved a single
 # row, which could match a search, or not. In this test we verify that the
 # case of multiple matching rows also works.
 def test_index_map_values_multiple_matching_rows(cql, test_keyspace, driver_bug_1):
-    schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # index m (same as values(m)). Will allow "CONTAINS".
-        cql.execute(f'CREATE INDEX ON {table}(m)')
+        cql.execute(f"CREATE INDEX ON {table}(m)")
         # Insert several rows with several different maps, some of them have
         # the value 3 in them somewhere, others don't. One of the maps has
         # multiple occurrences of the value 3, so we also reproduce here the
@@ -845,322 +1137,430 @@ def test_index_map_values_multiple_matching_rows(cql, test_keyspace, driver_bug_
         # Note: Scylla needs to skip a duplicate 3 value in (2,4) which
         # results in an empty page in the result set when page_size=1. We
         # need the driver to correctly support this, hence the "driver_bug_1".
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{1:2, 3:4}})')
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (1, 3, {{1:3, 3:4}})')
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (1, 4, {{7:3}})')
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (2, 2, {{1:3, 2:3, 3:4}})')
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (2, 4, {{}})')
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (2, 5, {{7:3}})')
-        assert [(1,3),(1,4),(2,2),(2,5)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 3'))
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{1:2, 3:4}})")
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (1, 3, {{1:3, 3:4}})")
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (1, 4, {{7:3}})")
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (2, 2, {{1:3, 2:3, 3:4}})")
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (2, 4, {{}})")
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (2, 5, {{7:3}})")
+        assert [(1, 3), (1, 4), (2, 2), (2, 5)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 3")
+        )
         for page_size in [1, 2, 3, 7]:
-            stmt = SimpleStatement(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 3', fetch_size=page_size)
-            assert [(1,3),(1,4),(2,2),(2,5)] == list(cql.execute(stmt))
+            stmt = SimpleStatement(
+                f"SELECT pk,ck FROM {table} WHERE m CONTAINS 3", fetch_size=page_size
+            )
+            assert [(1, 3), (1, 4), (2, 2), (2, 5)] == list(cql.execute(stmt))
+
 
 # In the previous tests (test_index_map_values*) all tests involved a base
 # table with both partition keys and clustering keys. Because some of the
 # implementation is different depending the schema has clustering keys,
 # let's also write a similar test with just a partition key:
 def test_index_map_values_partition_key_only(cql, test_keyspace, driver_bug_1):
-    schema = 'pk int, m map<int,int>, PRIMARY KEY (pk)'
+    schema = "pk int, m map<int,int>, PRIMARY KEY (pk)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # index m (same as values(m)). Will allow "CONTAINS".
-        cql.execute(f'CREATE INDEX ON {table}(m)')
+        cql.execute(f"CREATE INDEX ON {table}(m)")
         # Insert several rows with several different maps, some of them have
         # the value 3 in them somewhere, others don't. One of the maps has
         # multiple occurrences of the value 3, so we also reproduce here the
         # same bug that test_index_map_values_paging() reproduces (and here
         # test its intersection with the case of no clustering key).
-        cql.execute(f'INSERT INTO {table} (pk, m) VALUES (1, {{1:2, 3:4}})')
-        cql.execute(f'INSERT INTO {table} (pk, m) VALUES (2, {{1:3, 3:4}})')
-        cql.execute(f'INSERT INTO {table} (pk, m) VALUES (3, {{7:3}})')
-        cql.execute(f'INSERT INTO {table} (pk, m) VALUES (4, {{1:3, 2:3, 3:4}})')
-        cql.execute(f'INSERT INTO {table} (pk, m) VALUES (5, {{}})')
-        assert [(2,), (3,), (4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE m CONTAINS 3'))
+        cql.execute(f"INSERT INTO {table} (pk, m) VALUES (1, {{1:2, 3:4}})")
+        cql.execute(f"INSERT INTO {table} (pk, m) VALUES (2, {{1:3, 3:4}})")
+        cql.execute(f"INSERT INTO {table} (pk, m) VALUES (3, {{7:3}})")
+        cql.execute(f"INSERT INTO {table} (pk, m) VALUES (4, {{1:3, 2:3, 3:4}})")
+        cql.execute(f"INSERT INTO {table} (pk, m) VALUES (5, {{}})")
+        assert [(2,), (3,), (4,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE m CONTAINS 3")
+        )
         for page_size in [1, 2, 3, 7]:
-            stmt = SimpleStatement(f'SELECT pk FROM {table} WHERE m CONTAINS 3', fetch_size=page_size)
+            stmt = SimpleStatement(
+                f"SELECT pk FROM {table} WHERE m CONTAINS 3", fetch_size=page_size
+            )
             assert [(2,), (3,), (4,)] == sorted(cql.execute(stmt))
             # I wanted to check here that page_size is actually obeyed,
             # but we can't - when Scylla skips one of the duplicate values
             # it can result in a smaller page, and while not great (Cassandra
             # doesn't do it, all its pages are full size), it's legal.
 
+
 def test_index_map_keys(cql, test_keyspace):
-    schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
         # Without an index, the "CONTAINS KEY" restriction requires filtering
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3')
-        cql.execute(f'CREATE INDEX ON {table}(keys(m))')
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3")
+        cql.execute(f"CREATE INDEX ON {table}(keys(m))")
         # indexing keys(m) will allow CONTAINS KEY but not CONTAINS
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 3')
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 3")
         # The map is still empty, nothing should match
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3'))
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3")
+        )
         # Add a elements to the map, check their keys can be found
-        cql.execute(f'UPDATE {table} set m = m + {{10: 7}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10'))
-        cql.execute(f'UPDATE {table} set m = m + {{11: 8}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 11'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10'))
+        cql.execute(f"UPDATE {table} set m = m + {{10: 7}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10")
+        )
+        cql.execute(f"UPDATE {table} set m = m + {{11: 8}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 11")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10")
+        )
         # Remove elements from the map, check they can no longer be found
-        cql.execute(f'DELETE m[10] FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 11'))
-        cql.execute(f'DELETE m[11] FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 11'))
+        cql.execute(f"DELETE m[10] FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 11")
+        )
+        cql.execute(f"DELETE m[11] FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10")
+        )
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 11")
+        )
         # Replace entire value of map, everything in it should be indexed
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{17: 4, 18: 5}})')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 17'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 18'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 11'))
-        cql.execute(f'UPDATE {table} set m = {{3: 2, 4: 5}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 4'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 17'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 18'))
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{17: 4, 18: 5}})")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 17")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 18")
+        )
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 10")
+        )
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 11")
+        )
+        cql.execute(f"UPDATE {table} set m = {{3: 2, 4: 5}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 4")
+        )
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 17")
+        )
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 18")
+        )
         # The map is now {3:2, 4:5}. Change the value of 4 and see see it has
         # no effect on keys:
-        cql.execute(f'UPDATE {table} set m[4] = 6 WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 4'))
+        cql.execute(f"UPDATE {table} set m[4] = 6 WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 4")
+        )
         # The "-" operation also works as expected (it removes specific *key*,
         # not *values*, depsite what some confused documentation claims):
-        cql.execute(f'UPDATE {table} set m = m - {{4}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 4'))
+        cql.execute(f"UPDATE {table} set m = m - {{4}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3")
+        )
+        assert [] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 4")
+        )
+
 
 def test_index_map_entries(cql, test_keyspace):
-    schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(entries(m))')
+        cql.execute(f"CREATE INDEX ON {table}(entries(m))")
         # indexing entries(m) will allow neither CONTAINS KEY nor CONTAINS
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 3')
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 3")
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3')
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 3")
         # The map is still empty, nothing should match
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[1] = 2'))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[1] = 2"))
         # Add a elements to the map, check their keys can be found
-        cql.execute(f'UPDATE {table} set m = m + {{10: 7}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[10] = 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[10] = 8'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[11] = 7'))
-        cql.execute(f'UPDATE {table} set m = m + {{11: 8}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[10] = 7'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[11] = 8'))
+        cql.execute(f"UPDATE {table} set m = m + {{10: 7}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[10] = 7")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[10] = 8"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[11] = 7"))
+        cql.execute(f"UPDATE {table} set m = m + {{11: 8}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[10] = 7")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[11] = 8")
+        )
         # Remove elements from the map, check they can no longer be found
-        cql.execute(f'DELETE m[10] FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[10] = 7'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[11] = 8'))
-        cql.execute(f'DELETE m[11] FROM {table} WHERE pk=1 AND ck=2')
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[10] = 7'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[11] = 8'))
+        cql.execute(f"DELETE m[10] FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[10] = 7"))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[11] = 8")
+        )
+        cql.execute(f"DELETE m[11] FROM {table} WHERE pk=1 AND ck=2")
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[10] = 7"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[11] = 8"))
         # Replace entire value of map, everything in it should be indexed
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{17: 4, 18: 5}})')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[17] = 4'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[18] = 5'))
-        cql.execute(f'UPDATE {table} set m = {{3: 2, 4: 5}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[3] = 2'))
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[4] = 5'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[17] = 4'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[18] = 5'))
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{17: 4, 18: 5}})")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[17] = 4")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[18] = 5")
+        )
+        cql.execute(f"UPDATE {table} set m = {{3: 2, 4: 5}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[3] = 2")
+        )
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[4] = 5")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[17] = 4"))
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[18] = 5"))
         # The map is now {3:2, 4:5}. Change the value of 4 and see see it has
         # the expected effect
-        cql.execute(f'UPDATE {table} set m[4] = 6 WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[4] = 6'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[4] = 5'))
+        cql.execute(f"UPDATE {table} set m[4] = 6 WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[4] = 6")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[4] = 5"))
         # The "-" operation also works as expected (it removes specific *key*,
         # not *values*, depsite what some confused documentation claims):
-        cql.execute(f'UPDATE {table} set m = m - {{4}} WHERE pk=1 AND ck=2')
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[3] = 2'))
-        assert [] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[4] = 6'))
+        cql.execute(f"UPDATE {table} set m = m - {{4}} WHERE pk=1 AND ck=2")
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[3] = 2")
+        )
+        assert [] == list(cql.execute(f"SELECT pk,ck FROM {table} WHERE m[4] = 6"))
+
 
 # Check that it is possible to index the same map column in different ways
 # (values, keys and entries) at the same time:
 def test_index_map_multiple(cql, test_keyspace):
-    schema = 'pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, m map<int,int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(values(m))')
-        cql.execute(f'CREATE INDEX ON {table}(keys(m))')
-        cql.execute(f'CREATE INDEX ON {table}(entries(m))')
-        cql.execute(f'INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{17: 4, 18: 5}})')
+        cql.execute(f"CREATE INDEX ON {table}(values(m))")
+        cql.execute(f"CREATE INDEX ON {table}(keys(m))")
+        cql.execute(f"CREATE INDEX ON {table}(entries(m))")
+        cql.execute(f"INSERT INTO {table} (pk, ck, m) VALUES (1, 2, {{17: 4, 18: 5}})")
         # values(m) can do this:
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS 4'))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS 4")
+        )
         # keys(m) can do this:
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 18'))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m CONTAINS KEY 18")
+        )
         # entries(m) can do this:
-        assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE m[18] = 5'))
+        assert [(1, 2)] == list(
+            cql.execute(f"SELECT pk,ck FROM {table} WHERE m[18] = 5")
+        )
+
 
 # Test that indexing keys(x), values(x) or entries(x) is only allowed for
 # specific column types (namely, specific kinds of collections).
 def test_index_collection_wrong_type(cql, test_keyspace):
-    schema = 'pk int primary key, x int, l list<int>, s set<int>, m map<int,int>, t tuple<int,int>'
+    schema = "pk int primary key, x int, l list<int>, s set<int>, m map<int,int>, t tuple<int,int>"
     with new_test_table(cql, test_keyspace, schema) as table:
         # scalar type: only the bare column name is allowed:
-        cql.execute(f'CREATE INDEX ON {table}(x)')
+        cql.execute(f"CREATE INDEX ON {table}(x)")
         with pytest.raises(InvalidRequest, match="keys()"):
-            cql.execute(f'CREATE INDEX ON {table}(keys(x))')
+            cql.execute(f"CREATE INDEX ON {table}(keys(x))")
         with pytest.raises(InvalidRequest, match="entries()"):
-            cql.execute(f'CREATE INDEX ON {table}(entries(x))')
+            cql.execute(f"CREATE INDEX ON {table}(entries(x))")
         with pytest.raises(InvalidRequest, match="values()"):
-            cql.execute(f'CREATE INDEX ON {table}(values(x))')
+            cql.execute(f"CREATE INDEX ON {table}(values(x))")
         # list: bare column name and values() is allowed. Both of these
         # refer to the same index - so you can't have both at the same time.
-        cql.execute(f'CREATE INDEX ON {table}(l)')
+        cql.execute(f"CREATE INDEX ON {table}(l)")
         with pytest.raises(InvalidRequest, match="keys()"):
-            cql.execute(f'CREATE INDEX ON {table}(keys(l))')
+            cql.execute(f"CREATE INDEX ON {table}(keys(l))")
         with pytest.raises(InvalidRequest, match="entries()"):
-            cql.execute(f'CREATE INDEX ON {table}(entries(l))')
+            cql.execute(f"CREATE INDEX ON {table}(entries(l))")
         with pytest.raises(InvalidRequest, match="duplicate"):
-            cql.execute(f'CREATE INDEX ON {table}(values(l))')
+            cql.execute(f"CREATE INDEX ON {table}(values(l))")
         cql.execute(f"DROP INDEX {test_keyspace}.{table.split('.')[1]}_l_idx")
-        cql.execute(f'CREATE INDEX ON {table}(values(l))')
+        cql.execute(f"CREATE INDEX ON {table}(values(l))")
         # set: bare column name and values() is allowed. Both of these
         # refer to the same index - so you can't have both at the same time.
-        cql.execute(f'CREATE INDEX ON {table}(s)')
+        cql.execute(f"CREATE INDEX ON {table}(s)")
         with pytest.raises(InvalidRequest, match="keys()"):
-            cql.execute(f'CREATE INDEX ON {table}(keys(s))')
+            cql.execute(f"CREATE INDEX ON {table}(keys(s))")
         with pytest.raises(InvalidRequest, match="entries()"):
-            cql.execute(f'CREATE INDEX ON {table}(entries(s))')
+            cql.execute(f"CREATE INDEX ON {table}(entries(s))")
         with pytest.raises(InvalidRequest, match="duplicate"):
-            cql.execute(f'CREATE INDEX ON {table}(values(s))')
+            cql.execute(f"CREATE INDEX ON {table}(values(s))")
         cql.execute(f"DROP INDEX {test_keyspace}.{table.split('.')[1]}_s_idx")
-        cql.execute(f'CREATE INDEX ON {table}(values(s))')
+        cql.execute(f"CREATE INDEX ON {table}(values(s))")
         # map: bare column name, values(), keys() and entries() are all
         # allowed. The first tworefer to the same index - so you can't have
         # both at the same time.
-        cql.execute(f'CREATE INDEX ON {table}(m)')
-        cql.execute(f'CREATE INDEX ON {table}(keys(m))')
-        cql.execute(f'CREATE INDEX ON {table}(entries(m))')
+        cql.execute(f"CREATE INDEX ON {table}(m)")
+        cql.execute(f"CREATE INDEX ON {table}(keys(m))")
+        cql.execute(f"CREATE INDEX ON {table}(entries(m))")
         with pytest.raises(InvalidRequest, match="duplicate"):
-            cql.execute(f'CREATE INDEX ON {table}(values(m))')
+            cql.execute(f"CREATE INDEX ON {table}(values(m))")
         cql.execute(f"DROP INDEX {test_keyspace}.{table.split('.')[1]}_m_idx")
-        cql.execute(f'CREATE INDEX ON {table}(values(m))')
+        cql.execute(f"CREATE INDEX ON {table}(values(m))")
         # A tuple is not a collection, and doesn't support indexing its
         # elements separately (this would not have been possible, by the way,
         # because it can have elements of different types).
-        cql.execute(f'CREATE INDEX ON {table}(t)')
+        cql.execute(f"CREATE INDEX ON {table}(t)")
         with pytest.raises(InvalidRequest, match="keys()"):
-            cql.execute(f'CREATE INDEX ON {table}(keys(t))')
+            cql.execute(f"CREATE INDEX ON {table}(keys(t))")
         with pytest.raises(InvalidRequest, match="entries()"):
-            cql.execute(f'CREATE INDEX ON {table}(entries(t))')
+            cql.execute(f"CREATE INDEX ON {table}(entries(t))")
         with pytest.raises(InvalidRequest, match="values()"):
-            cql.execute(f'CREATE INDEX ON {table}(values(t))')
+            cql.execute(f"CREATE INDEX ON {table}(values(t))")
         # None of the above types allow a FULL index - it is only
         # allowed for *frozen* collections.
         with pytest.raises(InvalidRequest, match="full()"):
-            cql.execute(f'CREATE INDEX ON {table}(full(t))')
+            cql.execute(f"CREATE INDEX ON {table}(full(t))")
         with pytest.raises(InvalidRequest, match="full()"):
-            cql.execute(f'CREATE INDEX ON {table}(full(l))')
+            cql.execute(f"CREATE INDEX ON {table}(full(l))")
         with pytest.raises(InvalidRequest, match="full()"):
-            cql.execute(f'CREATE INDEX ON {table}(full(m))')
+            cql.execute(f"CREATE INDEX ON {table}(full(m))")
         with pytest.raises(InvalidRequest, match="full()"):
-            cql.execute(f'CREATE INDEX ON {table}(full(s))')
+            cql.execute(f"CREATE INDEX ON {table}(full(s))")
         with pytest.raises(InvalidRequest, match="full()"):
-            cql.execute(f'CREATE INDEX ON {table}(full(t))')
+            cql.execute(f"CREATE INDEX ON {table}(full(t))")
+
 
 # Check the default name of collection indexes. This "default name" is
 # needed to drop an index which was created without explicitly specifying
 # a name for it. We want the default name to be identical to Cassandra,
 # because an application may assume it is so.
 def test_index_collection_default_name(cql, test_keyspace):
-    schema = 'pk int primary key, m map<int,int>'
+    schema = "pk int primary key, m map<int,int>"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(m)')
+        cql.execute(f"CREATE INDEX ON {table}(m)")
         cql.execute(f"DROP INDEX {table}_m_idx")
         # values(m) and m refer to the same thing so must have the same
         # default name.
-        cql.execute(f'CREATE INDEX ON {table}(values(m))')
+        cql.execute(f"CREATE INDEX ON {table}(values(m))")
         cql.execute(f"DROP INDEX {table}_m_idx")
         # key(m) and entries(m) are different indexes than just m, but
         # their default index name turns out to be exactly the same one:
-        cql.execute(f'CREATE INDEX ON {table}(keys(m))')
+        cql.execute(f"CREATE INDEX ON {table}(keys(m))")
         cql.execute(f"DROP INDEX {table}_m_idx")
-        cql.execute(f'CREATE INDEX ON {table}(entries(m))')
+        cql.execute(f"CREATE INDEX ON {table}(entries(m))")
         cql.execute(f"DROP INDEX {table}_m_idx")
         # We can create multiple types of the above indexes at the same
         # time (see also test_index_map_multiple() above), so they will
         # get different default names using the standard default index
         # name mechanism (adding _1, etc.)
-        cql.execute(f'CREATE INDEX ON {table}(m)')
-        cql.execute(f'CREATE INDEX ON {table}(keys(m))')
-        cql.execute(f'CREATE INDEX ON {table}(entries(m))')
+        cql.execute(f"CREATE INDEX ON {table}(m)")
+        cql.execute(f"CREATE INDEX ON {table}(keys(m))")
+        cql.execute(f"CREATE INDEX ON {table}(entries(m))")
         cql.execute(f"DROP INDEX {table}_m_idx")
         cql.execute(f"DROP INDEX {table}_m_idx_1")
         cql.execute(f"DROP INDEX {table}_m_idx_2")
+
 
 # Reproducer for issue #10707 - indexing a column whose name is a quoted
 # string should work fine. Even if the quoted string happens to look like
 # an instruction to index a collection, e.g., "keys(m)".
 def test_index_quoted_names(cql, test_keyspace):
-    quoted_names = ['"hEllo"', '"x y"', '"hi""hello""yo"', '"""hi"""', '"keys(m)"', '"values(m)"', '"entries(m)"']
-    schema = 'pk int, ck int, m int, ' + ','.join([name + " int" for name in quoted_names]) + ', PRIMARY KEY (pk, ck)'
+    quoted_names = [
+        '"hEllo"',
+        '"x y"',
+        '"hi""hello""yo"',
+        '"""hi"""',
+        '"keys(m)"',
+        '"values(m)"',
+        '"entries(m)"',
+    ]
+    schema = (
+        "pk int, ck int, m int, "
+        + ",".join([name + " int" for name in quoted_names])
+        + ", PRIMARY KEY (pk, ck)"
+    )
     with new_test_table(cql, test_keyspace, schema) as table:
         for name in quoted_names:
-            cql.execute(f'CREATE INDEX ON {table}({name})')
-        names = ','.join(quoted_names)
-        values = ','.join(['3' for name in quoted_names])
-        cql.execute(f'INSERT INTO {table} (pk, ck, {names}) VALUES (1, 2, {values})')
+            cql.execute(f"CREATE INDEX ON {table}({name})")
+        names = ",".join(quoted_names)
+        values = ",".join(["3" for name in quoted_names])
+        cql.execute(f"INSERT INTO {table} (pk, ck, {names}) VALUES (1, 2, {values})")
         for name in quoted_names:
-            assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE {name} = 3'))
+            assert [(1, 2)] == list(
+                cql.execute(f"SELECT pk,ck FROM {table} WHERE {name} = 3")
+            )
 
     # Moreover, we can have a collection with a quoted name, and can then
     # ask to index something strange-looking like keys("keys(m)").
-    schema = 'pk int, ck int, m int, ' + ','.join([name + " map<int,int>" for name in quoted_names]) + ', PRIMARY KEY (pk, ck)'
+    schema = (
+        "pk int, ck int, m int, "
+        + ",".join([name + " map<int,int>" for name in quoted_names])
+        + ", PRIMARY KEY (pk, ck)"
+    )
     with new_test_table(cql, test_keyspace, schema) as table:
         for name in quoted_names:
-            cql.execute(f'CREATE INDEX ON {table}(keys({name}))')
-        names = ','.join(quoted_names)
-        values = ','.join(['{3:4}' for name in quoted_names])
-        cql.execute(f'INSERT INTO {table} (pk, ck, {names}) VALUES (1, 2, {values})')
+            cql.execute(f"CREATE INDEX ON {table}(keys({name}))")
+        names = ",".join(quoted_names)
+        values = ",".join(["{3:4}" for name in quoted_names])
+        cql.execute(f"INSERT INTO {table} (pk, ck, {names}) VALUES (1, 2, {values})")
         for name in quoted_names:
-            assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE {name} CONTAINS KEY 3'))
+            assert [(1, 2)] == list(
+                cql.execute(f"SELECT pk,ck FROM {table} WHERE {name} CONTAINS KEY 3")
+            )
 
-@pytest.mark.xfail(reason="#10713 - local collection indexing is not implemented yet")
+
+@pytest.mark.xfail(reason="Local secondary indexing for collections #10713")
 def test_local_secondary_index_on_collection(cql, test_keyspace):
-    schema = 'pk int, ck int, l list<int>, PRIMARY KEY (pk, ck)'
+    schema = "pk int, ck int, l list<int>, PRIMARY KEY (pk, ck)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}((pk), l)')
+        cql.execute(f"CREATE INDEX ON {table}((pk), l)")
+
 
 # Test that queries with the index over collection provide the same answer as it
 # would be without index, but with ALLOW FILTERING.
 # The operations on collections here are picked up randomly.
 def test_secondary_collection_index(cql, test_keyspace):
 
-    seed = int(time.time()*1e8)
+    seed = int(time.time() * 1e8)
     print(f"Seed for collection index test: {seed}")
     rand = random.Random(seed)
 
-    schema = f'id int, m map<int, text>, primary key (id)'
+    schema = f"id int, m map<int, text>, primary key (id)"
 
     possible_ids = [100, 101]
     possible_keys = [1, 2, 3]
-    possible_values = ['abc', 'def', 'ghi']
+    possible_values = ["abc", "def", "ghi"]
 
     def insert(table, id, map, **kwargs):
-        a = (f'insert into {table}(id, m) values (%s, %s)', (id, map))
+        a = (f"insert into {table}(id, m) values (%s, %s)", (id, map))
         print(a)
         cql.execute(*a)
+
     def update_cell(table, id, key, value, **kwargs):
-        a = (f'update {table} set m[%s] = %s where id = %s', (key, value, id))
+        a = (f"update {table} set m[%s] = %s where id = %s", (key, value, id))
         print(a)
         cql.execute(*a)
+
     def update_delete(table, id, keys, **kwargs):
-        a = (f'update {table} set m = m - %s where id = %s', (keys, id))
+        a = (f"update {table} set m = m - %s where id = %s", (keys, id))
         print(a)
         cql.execute(*a)
+
     def update_add(table, id, map, **kwargs):
-        a = (f'update {table} set m = m + %s where id = %s', (map, id))
+        a = (f"update {table} set m = m + %s where id = %s", (map, id))
         print(a)
         cql.execute(*a)
+
     def delete(table, id, **kwargs):
-        a = (f'delete m from {table} where id = %s', (id,))
+        a = (f"delete m from {table} where id = %s", (id,))
         print(a)
         cql.execute(*a)
+
     def delete_cell(table, id, key, **kwargs):
-        a = (f'delete m[%s] from {table} where id = %s', (key, id))
+        a = (f"delete m[%s] from {table} where id = %s", (key, id))
         print(a)
         cql.execute(*a)
 
@@ -1169,58 +1569,69 @@ def test_secondary_collection_index(cql, test_keyspace):
         keys = rand.sample(possible_keys, k=size)
         values = rand.choices(possible_values, k=size)
         return dict(zip(keys, values))
+
     def random_keys():
         return set(random_map())
+
     def random_key():
         return random.choice(possible_keys)
+
     def random_value():
         return random.choice(possible_values)
+
     def random_id():
         return random.choice(possible_ids)
 
     def random_operation():
-        return random.choice([insert, update_cell, update_delete, update_add, delete, delete_cell])
+        return random.choice(
+            [insert, update_cell, update_delete, update_add, delete, delete_cell]
+        )
+
     def random_args():
         return {
-            'map': random_map(),
-            'key': random_key(),
-            'value': random_value(),
-            'keys': random_keys(),
-            'id': random_id(),
+            "map": random_map(),
+            "key": random_key(),
+            "value": random_value(),
+            "keys": random_keys(),
+            "id": random_id(),
         }
 
-    with new_test_table(cql, test_keyspace, schema) as tab1, new_test_table(cql, test_keyspace, schema) as tab2:
+    with (
+        new_test_table(cql, test_keyspace, schema) as tab1,
+        new_test_table(cql, test_keyspace, schema) as tab2,
+    ):
+
         def select(cql, table, where, *args):
-            query = f'select id from {table} where {where}'
+            query = f"select id from {table} where {where}"
             if table is tab2:
-                query += ' allow filtering'
+                query += " allow filtering"
             try:
                 return cql.execute(query, *args)
             except:
-                print('args=', args, table, where)
+                print("args=", args, table, where)
                 raise
+
         def test_all_possible_selects():
             # Choose something that is not possible.
             possible_ids_ = possible_ids + [10000]
             possible_keys_ = possible_keys + [10000]
-            possible_values_ = possible_values + ['aaaaa']
+            possible_values_ = possible_values + ["aaaaa"]
             for k, v in itertools.product(possible_keys_, possible_values_):
-                r1 = select(cql, tab1, 'm[%s] = %s', (k, v))
-                r2 = select(cql, tab2, 'm[%s] = %s', (k, v))
+                r1 = select(cql, tab1, "m[%s] = %s", (k, v))
+                r2 = select(cql, tab2, "m[%s] = %s", (k, v))
                 assert_rows_ignoring_order(r1, *list(r2))
             for k in possible_keys_:
-                r1 = select(cql, tab1, 'm contains key %s', (k,))
-                r2 = select(cql, tab2, 'm contains key %s', (k,))
+                r1 = select(cql, tab1, "m contains key %s", (k,))
+                r2 = select(cql, tab2, "m contains key %s", (k,))
                 assert_rows_ignoring_order(r1, *list(r2))
             for v in possible_values_:
-                r1 = select(cql, tab1, 'm contains %s', (v,))
-                r2 = select(cql, tab2, 'm contains %s', (v,))
+                r1 = select(cql, tab1, "m contains %s", (v,))
+                r2 = select(cql, tab2, "m contains %s", (v,))
                 assert_rows_ignoring_order(r1, *list(r2))
 
-
-        cql.execute(f'create index on {tab1}(keys(m))')
-        cql.execute(f'create index on {tab1}(values(m))')
-        cql.execute(f'create index on {tab1}(entries(m))')
+        cql.execute(f"create index on {tab1}(keys(m))")
+        cql.execute(f"create index on {tab1}(values(m))")
+        cql.execute(f"create index on {tab1}(entries(m))")
 
         for _ in range(50):
             op = random_operation()
@@ -1230,13 +1641,15 @@ def test_secondary_collection_index(cql, test_keyspace):
                 op(tab, **args)
             test_all_possible_selects()
 
+
 # Test that paging through a select using a secondary index works as
 # expected, returning pages of the requested size.
 # We have several tests here, for different schemas, that exercises
 # different code paths and may expose different bugs.
 
+
 def test_index_paging_pk_ck(cql, test_keyspace):
-    schema = 'p int, c int, x int, primary key (p,c)'
+    schema = "p int, c int, x int, primary key (p,c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(x)")
         insert = cql.prepare(f"INSERT INTO {table}(p,c,x) VALUES (?,?,?)")
@@ -1244,7 +1657,9 @@ def test_index_paging_pk_ck(cql, test_keyspace):
             cql.execute(insert, [i, i, 3])
         cql.execute(insert, [17, 17, 2])
         for page_size in [1, 2, 3, 100]:
-            stmt = SimpleStatement(f"SELECT p FROM {table} WHERE x = 3", fetch_size=page_size)
+            stmt = SimpleStatement(
+                f"SELECT p FROM {table} WHERE x = 3", fetch_size=page_size
+            )
             # Check that:
             # 1. Each page of results has the expected page_size, or less in
             #    the last page. Although partial pages are theoretically
@@ -1263,8 +1678,9 @@ def test_index_paging_pk_ck(cql, test_keyspace):
             # Finally check that altogether, we read the right rows.
             assert sorted(all_rows) == [(i,) for i in range(10)]
 
+
 def test_index_paging_pk_only(cql, test_keyspace):
-    schema = 'p int, x int, primary key (p)'
+    schema = "p int, x int, primary key (p)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(x)")
         insert = cql.prepare(f"INSERT INTO {table}(p,x) VALUES (?,?)")
@@ -1272,7 +1688,9 @@ def test_index_paging_pk_only(cql, test_keyspace):
             cql.execute(insert, [i, 3])
         cql.execute(insert, [17, 2])
         for page_size in [1, 2, 3, 100]:
-            stmt = SimpleStatement(f"SELECT p FROM {table} WHERE x = 3", fetch_size=page_size)
+            stmt = SimpleStatement(
+                f"SELECT p FROM {table} WHERE x = 3", fetch_size=page_size
+            )
             all_rows = []
             results = cql.execute(stmt)
             while len(results.current_rows) == page_size:
@@ -1282,14 +1700,17 @@ def test_index_paging_pk_only(cql, test_keyspace):
             all_rows.extend(results.current_rows)
             assert sorted(all_rows) == [(i,) for i in range(10)]
 
+
 # When a partition key is indexed (it is redundant to index the entire
 # partition key, so this test has a compound partition key and indexes only
 # one component), the restriction can match the entire partition, but paging
 # still needs to page through it - and not return the entire partition as one
 # page! Reproduces #7432.
-@pytest.mark.xfail(reason="issue #7432")
+@pytest.mark.xfail(
+    reason="Some queries with secondary indexes return too large pages #7432"
+)
 def test_index_paging_match_partition(cql, test_keyspace):
-    schema = 'p1 int, p2 int, c int, primary key (p1,p2,c)'
+    schema = "p1 int, p2 int, c int, primary key (p1,p2,c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(p2)")
         insert = cql.prepare(f"INSERT INTO {table}(p1,p2,c) VALUES (?,?,?)")
@@ -1298,7 +1719,9 @@ def test_index_paging_match_partition(cql, test_keyspace):
             cql.execute(insert, [1, 1, i])
         cql.execute(insert, [17, 17, 2])
         for page_size in [1, 2, 3, 100]:
-            stmt = SimpleStatement(f"SELECT c FROM {table} WHERE p2 = 1", fetch_size=page_size)
+            stmt = SimpleStatement(
+                f"SELECT c FROM {table} WHERE p2 = 1", fetch_size=page_size
+            )
             # Check that:
             # 1. Each page of results has the expected page_size, or less in
             #    the last page. Although partial pages are theoretically
@@ -1317,20 +1740,25 @@ def test_index_paging_match_partition(cql, test_keyspace):
             # Finally check that altogether, we read the right rows.
             assert sorted(all_rows) == [(i,) for i in range(10)]
 
+
 # Currently, paging of queries that uses secondary indexes on static columns
 # is unable to page through partitions of the base table and must return them
 # in whole. Related to #7432.
-@pytest.mark.xfail(reason="issue #7432")
+@pytest.mark.xfail(
+    reason="Some queries with secondary indexes return too large pages #7432"
+)
 def test_index_paging_static_column(cql, test_keyspace):
-    schema = 'p int, c int, s int static, PRIMARY KEY(p, c)'
+    schema = "p int, c int, s int static, PRIMARY KEY(p, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(s)')
+        cql.execute(f"CREATE INDEX ON {table}(s)")
         insert = cql.prepare(f"INSERT INTO {table}(p,c,s) VALUES (?,?,?)")
         for p in range(5):
             for c in range(5):
                 cql.execute(insert, [p, c, 42])
         for page_size in [1, 2, 3, 4, 100]:
-            stmt = SimpleStatement(f"SELECT p, c FROM {table} WHERE s = 42", fetch_size=page_size)
+            stmt = SimpleStatement(
+                f"SELECT p, c FROM {table} WHERE s = 42", fetch_size=page_size
+            )
 
             all_rows = []
             results = cql.execute(stmt)
@@ -1341,7 +1769,8 @@ def test_index_paging_static_column(cql, test_keyspace):
             assert len(results.current_rows) < page_size
             all_rows.extend(results.current_rows)
             # Finally check that altogether, we read the right rows.
-            assert sorted(all_rows) == [(p,c) for p in range(5) for c in range(5)]
+            assert sorted(all_rows) == [(p, c) for p in range(5) for c in range(5)]
+
 
 # If, in contrast with test_index_paging_match_partition above which indexed
 # a partition key column, we index a clustering key column, paging does work
@@ -1349,10 +1778,20 @@ def test_index_paging_static_column(cql, test_keyspace):
 # issue #7432, if we add "GROUP BY p" to the query, Scylla now mistakenly
 # returns all the results in one page instead of stopping. So the following
 # test passes with use_group_by = False but failed with use_group_by = True.
-@pytest.mark.parametrize("use_group_by", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#7432")), False])
+@pytest.mark.parametrize(
+    "use_group_by",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Some queries with secondary indexes return too large pages #7432"
+            ),
+        ),
+        False,
+    ],
+)
 def test_index_paging_group_by(cql, test_keyspace, use_group_by):
-    schema = 'p int, c1 int, c2 int, primary key (p,c1,c2)'
+    schema = "p int, c1 int, c2 int, primary key (p,c1,c2)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(c1)")
         insert = cql.prepare(f"INSERT INTO {table}(p,c1,c2) VALUES (?,?,?)")
@@ -1361,8 +1800,10 @@ def test_index_paging_group_by(cql, test_keyspace, use_group_by):
             cql.execute(insert, [i, 1, i])
         cql.execute(insert, [17, 17, 2])
         for page_size in [1, 2, 3, 100]:
-            group_by = 'GROUP BY p' if use_group_by else ''
-            stmt = SimpleStatement(f"SELECT p FROM {table} WHERE c1 = 1 {group_by}", fetch_size=page_size)
+            group_by = "GROUP BY p" if use_group_by else ""
+            stmt = SimpleStatement(
+                f"SELECT p FROM {table} WHERE c1 = 1 {group_by}", fetch_size=page_size
+            )
             # Check that:
             # 1. Each page of results has the expected page_size, or less in
             #    the last page. Although partial pages are theoretically
@@ -1381,40 +1822,46 @@ def test_index_paging_group_by(cql, test_keyspace, use_group_by):
             # Finally check that altogether, we read the right rows.
             assert sorted(all_rows) == [(i,) for i in range(10)]
 
+
 # Tests basic operations on a static column index.
 def test_static_column_index(cql, test_keyspace):
-    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    schema = "pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(s)')
+        cql.execute(f"CREATE INDEX ON {table}(s)")
 
         # Insert
-        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (0, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (1, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (2, 1)')
+        cql.execute(f"INSERT INTO {table} (pk, s) VALUES (0, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, s) VALUES (1, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, s) VALUES (2, 1)")
 
-        assert [(0,),(1,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
-        assert [(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+        assert [(0,), (1,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s = 0")
+        )
+        assert [(2,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 1"))
 
         # Update
-        cql.execute(f'UPDATE {table} SET s = 1 WHERE pk = 1')
+        cql.execute(f"UPDATE {table} SET s = 1 WHERE pk = 1")
 
-        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
-        assert [(1,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+        assert [(0,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 0"))
+        assert [(1,), (2,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s = 1")
+        )
 
         # Partition delete
-        cql.execute(f'DELETE FROM {table} WHERE pk = 2')
+        cql.execute(f"DELETE FROM {table} WHERE pk = 2")
 
-        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
-        assert [(1,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
+        assert [(0,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 0"))
+        assert [(1,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 1"))
+
 
 # Tests that building static indexes from a non-empty state works.
 def test_static_column_index_build(cql, test_keyspace):
-    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    schema = "pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (0, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (1, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, s) VALUES (2, 0)')
-        cql.execute(f'CREATE INDEX ON {table}(s)')
+        cql.execute(f"INSERT INTO {table} (pk, s) VALUES (0, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, s) VALUES (1, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, s) VALUES (2, 0)")
+        cql.execute(f"CREATE INDEX ON {table}(s)")
 
         # Indexes are created in the background, so we should wait here.
         # I don't know how to get information about secondary index build
@@ -1424,7 +1871,7 @@ def test_static_column_index_build(cql, test_keyspace):
         rows = None
         while time.time() < start_time + 30:
             try:
-                rows = sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
+                rows = sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 0"))
                 if len(rows) == 3:
                     break
             except:
@@ -1435,184 +1882,249 @@ def test_static_column_index_build(cql, test_keyspace):
                 pass
             time.sleep(0.1)
 
-        assert [(0,),(1,),(2,)] == rows
+        assert [(0,), (1,), (2,)] == rows
+
 
 # Tests combinations of lookup in an index of static column with other
 # restrictions. Reproduces #12829.
 # NOTE: currently marked with skip instead of xfail because
 # on_internal_error() crashes Scylla.
-@pytest.mark.skip(reason="issue #12829")
+@pytest.mark.skip(
+    reason="DB error when querying by primary key, clustering key and index on static column #12829"
+)
 def test_static_column_index_restrictions(cql, test_keyspace):
-    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    schema = "pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(s)')
-        cql.execute(f'INSERT INTO {table} (pk, c, s) VALUES (0, 3, 1)')
-        cql.execute(f'INSERT INTO {table} (pk, c, s) VALUES (0, 4, 1)')
-        cql.execute(f'INSERT INTO {table} (pk, c, s) VALUES (1, 4, 2)')
+        cql.execute(f"CREATE INDEX ON {table}(s)")
+        cql.execute(f"INSERT INTO {table} (pk, c, s) VALUES (0, 3, 1)")
+        cql.execute(f"INSERT INTO {table} (pk, c, s) VALUES (0, 4, 1)")
+        cql.execute(f"INSERT INTO {table} (pk, c, s) VALUES (1, 4, 2)")
 
-        assert [(0,3),(0,4)] == sorted(cql.execute(f'SELECT pk,c FROM {table} WHERE s = 1'))
-        assert [(0,3),(0,4)] == sorted(cql.execute(f'SELECT pk,c FROM {table} WHERE pk = 0 AND s = 1'))
+        assert [(0, 3), (0, 4)] == sorted(
+            cql.execute(f"SELECT pk,c FROM {table} WHERE s = 1")
+        )
+        assert [(0, 3), (0, 4)] == sorted(
+            cql.execute(f"SELECT pk,c FROM {table} WHERE pk = 0 AND s = 1")
+        )
         # Reproduces #12829:
-        assert [(0,3)] == sorted(cql.execute(f'SELECT pk,c FROM {table} WHERE pk = 0 AND s = 1 AND c = 3'))
+        assert [(0, 3)] == sorted(
+            cql.execute(f"SELECT pk,c FROM {table} WHERE pk = 0 AND s = 1 AND c = 3")
+        )
+
 
 # Checks that clustering row deletions do not affect static columns.
 def test_static_column_index_unaffected_by_clustering_row_ops(cql, test_keyspace):
-    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    schema = "pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(s)')
+        cql.execute(f"CREATE INDEX ON {table}(s)")
 
-        cql.execute(f'INSERT INTO {table} (pk, c, s, v) VALUES (0, 0, 42, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (0, 1, 10)')
-        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (0, 2, 20)')
-        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (0, 3, 30)')
-        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (0, 4, 40)')
+        cql.execute(f"INSERT INTO {table} (pk, c, s, v) VALUES (0, 0, 42, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, c, v) VALUES (0, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (pk, c, v) VALUES (0, 2, 20)")
+        cql.execute(f"INSERT INTO {table} (pk, c, v) VALUES (0, 3, 30)")
+        cql.execute(f"INSERT INTO {table} (pk, c, v) VALUES (0, 4, 40)")
 
         # We are not using SELECT DISTINCT because it is not implemented yet
         # for queries that restrict a non-pk column. Therefore, `pk` appears
         # multiple times in the result.
 
-        assert [(0,)]*5 == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+        assert [(0,)] * 5 == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 42"))
 
         # Row delete
-        cql.execute(f'DELETE FROM {table} WHERE pk = 0 AND c = 4')
-        assert [(0,)]*4 == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+        cql.execute(f"DELETE FROM {table} WHERE pk = 0 AND c = 4")
+        assert [(0,)] * 4 == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 42"))
 
         # Range delete
-        cql.execute(f'DELETE FROM {table} WHERE pk = 0 AND c >= 1 AND c < 3')
-        assert [(0,)]*2 == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+        cql.execute(f"DELETE FROM {table} WHERE pk = 0 AND c >= 1 AND c < 3")
+        assert [(0,)] * 2 == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 42"))
 
         # Range delete, but this time get rid of all rows (static row should stay)
-        cql.execute(f'DELETE FROM {table} WHERE pk = 0 AND c >= 0 AND c <= 4')
-        assert [(0,)]*1 == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+        cql.execute(f"DELETE FROM {table} WHERE pk = 0 AND c >= 0 AND c <= 4")
+        assert [(0,)] * 1 == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 42"))
 
         # Finally, perform a partition delete and get rid of the row
-        cql.execute(f'DELETE FROM {table} WHERE pk = 0')
-        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 42'))
+        cql.execute(f"DELETE FROM {table} WHERE pk = 0")
+        assert [] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 42"))
+
 
 # Checks that changing a static column's value is correctly reflected by queries
 # accelerated by a secondary index.
-def test_static_column_index_all_clustering_rows_moved_by_static_column_update(cql, test_keyspace):
-    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+def test_static_column_index_all_clustering_rows_moved_by_static_column_update(
+    cql, test_keyspace
+):
+    schema = "pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         rows_for_pk = [
             [(0, 0, 0), (0, 1, 10), (0, 2, 20)],
             [(1, 0, 0), (1, 1, 10), (1, 2, 20)],
         ]
 
-        cql.execute(f'CREATE INDEX ON {table}(s)')
+        cql.execute(f"CREATE INDEX ON {table}(s)")
 
         for pk in range(2):
-            cql.execute(f'INSERT INTO {table} (pk, c, s, v) VALUES ({pk}, 0, 0, 0)')
-            cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES ({pk}, 1, 10)')
-            cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES ({pk}, 2, 20)')
+            cql.execute(f"INSERT INTO {table} (pk, c, s, v) VALUES ({pk}, 0, 0, 0)")
+            cql.execute(f"INSERT INTO {table} (pk, c, v) VALUES ({pk}, 1, 10)")
+            cql.execute(f"INSERT INTO {table} (pk, c, v) VALUES ({pk}, 2, 20)")
 
-        assert rows_for_pk[0] + rows_for_pk[1] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 0'))
-        assert [] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 1'))
+        assert rows_for_pk[0] + rows_for_pk[1] == sorted(
+            cql.execute(f"SELECT pk, c, v FROM {table} WHERE s = 0")
+        )
+        assert [] == sorted(cql.execute(f"SELECT pk, c, v FROM {table} WHERE s = 1"))
 
         cql.execute(f"UPDATE {table} SET s = 1 WHERE pk = 1")
 
-        assert rows_for_pk[0] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 0'))
-        assert rows_for_pk[1] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 1'))
+        assert rows_for_pk[0] == sorted(
+            cql.execute(f"SELECT pk, c, v FROM {table} WHERE s = 0")
+        )
+        assert rows_for_pk[1] == sorted(
+            cql.execute(f"SELECT pk, c, v FROM {table} WHERE s = 1")
+        )
 
         cql.execute(f"UPDATE {table} SET s = 1 WHERE pk = 0")
 
-        assert [] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 0'))
-        assert rows_for_pk[0] + rows_for_pk[1] == sorted(cql.execute(f'SELECT pk, c, v FROM {table} WHERE s = 1'))
+        assert [] == sorted(cql.execute(f"SELECT pk, c, v FROM {table} WHERE s = 0"))
+        assert rows_for_pk[0] + rows_for_pk[1] == sorted(
+            cql.execute(f"SELECT pk, c, v FROM {table} WHERE s = 1")
+        )
 
 
 # Tests operations on tables which have both static column and regular column indexes.
 # Checks that one does not interfere with the other.
 def test_static_and_regular_index_operations(cql, test_keyspace):
-    schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
+    schema = "pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(s)')
-        cql.execute(f'CREATE INDEX ON {table}(v)')
+        cql.execute(f"CREATE INDEX ON {table}(s)")
+        cql.execute(f"CREATE INDEX ON {table}(v)")
 
-        cql.execute(f'INSERT INTO {table} (pk, s, c, v) VALUES (0, 0, 0, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, s, c, v) VALUES (1, 0, 0, 1)')
-        cql.execute(f'INSERT INTO {table} (pk, s, c, v) VALUES (2, 1, 0, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, s, c, v) VALUES (3, 1, 0, 1)')
+        cql.execute(f"INSERT INTO {table} (pk, s, c, v) VALUES (0, 0, 0, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, s, c, v) VALUES (1, 0, 0, 1)")
+        cql.execute(f"INSERT INTO {table} (pk, s, c, v) VALUES (2, 1, 0, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, s, c, v) VALUES (3, 1, 0, 1)")
 
-        assert [(0,),(1,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
-        assert [(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
-        assert [(0,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 0'))
-        assert [(1,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 1'))
+        assert [(0,), (1,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s = 0")
+        )
+        assert [(2,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s = 1")
+        )
+        assert [(0,), (2,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE v = 0")
+        )
+        assert [(1,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE v = 1")
+        )
 
-        cql.execute(f'UPDATE {table} SET s = 1 WHERE pk = 1')
+        cql.execute(f"UPDATE {table} SET s = 1 WHERE pk = 1")
 
-        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
-        assert [(1,),(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
-        assert [(0,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 0'))
-        assert [(1,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 1'))
+        assert [(0,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 0"))
+        assert [(1,), (2,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s = 1")
+        )
+        assert [(0,), (2,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE v = 0")
+        )
+        assert [(1,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE v = 1")
+        )
 
-        cql.execute(f'UPDATE {table} SET v = 0 WHERE pk = 1 AND c = 0')
+        cql.execute(f"UPDATE {table} SET v = 0 WHERE pk = 1 AND c = 0")
 
-        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 0'))
-        assert [(1,),(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 1'))
-        assert [(0,),(1,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 0'))
-        assert [(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 1'))
+        assert [(0,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 0"))
+        assert [(1,), (2,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s = 1")
+        )
+        assert [(0,), (1,), (2,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE v = 0")
+        )
+        assert [(3,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE v = 1"))
 
         # There are separate codepaths for processing static column addition/removal
         # in case the static row isn't the last element of the mutation.
         # The operations below allow us to test those cases
 
-        cql.execute(f'INSERT INTO {table} (pk, c, v) VALUES (4, 0, 4)')
-        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 2'))
-        assert [(4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 4'))
+        cql.execute(f"INSERT INTO {table} (pk, c, v) VALUES (4, 0, 4)")
+        assert [] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 2"))
+        assert [(4,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE v = 4"))
 
         # Static column is set on a partition which didn't have a static row yet
-        cql.execute(f'BEGIN BATCH \
+        cql.execute(
+            f"BEGIN BATCH \
                       UPDATE {table} SET s = 2 WHERE pk = 4; \
                       UPDATE {table} SET v = 5 WHERE pk = 4 AND c = 0; \
-                      APPLY BATCH')
-        assert [(4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 2'))
-        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 4'))
-        assert [(4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 5'))
+                      APPLY BATCH"
+        )
+        assert [(4,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 2"))
+        assert [] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE v = 4"))
+        assert [(4,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE v = 5"))
 
         # Static column is removed from a partition
         # In order to construct the batch, we need the write timestamp
-        timestamp = list(cql.execute(f'SELECT writetime(v) FROM {table} WHERE pk = 4 AND c = 0'))[0][0]
-        cql.execute(f'BEGIN BATCH \
+        timestamp = list(
+            cql.execute(f"SELECT writetime(v) FROM {table} WHERE pk = 4 AND c = 0")
+        )[0][0]
+        cql.execute(
+            f"BEGIN BATCH \
                       DELETE FROM {table} USING TIMESTAMP {timestamp} WHERE pk = 4; \
-                      UPDATE {table} USING TIMESTAMP {timestamp+1} SET v = 6 WHERE pk = 4 AND c = 0; \
-                      APPLY BATCH')
-        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s = 2'))
-        assert [] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 5'))
-        assert [(4,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE v = 6'))
+                      UPDATE {table} USING TIMESTAMP {timestamp + 1} SET v = 6 WHERE pk = 4 AND c = 0; \
+                      APPLY BATCH"
+        )
+        assert [] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s = 2"))
+        assert [] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE v = 5"))
+        assert [(4,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE v = 6"))
+
 
 # Make sure that, when there are multiple static column indexes and only one
 # column is modified, only the index relevant to that column is modified.
 def test_multiple_static_column_indexes(cql, test_keyspace):
-    schema = 'pk int, c int, s1 int STATIC, s2 int STATIC, PRIMARY KEY(pk, c)'
+    schema = "pk int, c int, s1 int STATIC, s2 int STATIC, PRIMARY KEY(pk, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        cql.execute(f'CREATE INDEX ON {table}(s1)')
-        cql.execute(f'CREATE INDEX ON {table}(s2)')
+        cql.execute(f"CREATE INDEX ON {table}(s1)")
+        cql.execute(f"CREATE INDEX ON {table}(s2)")
 
-        cql.execute(f'INSERT INTO {table} (pk, s1, s2) VALUES (0, 0, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, s1, s2) VALUES (1, 0, 1)')
-        cql.execute(f'INSERT INTO {table} (pk, s1, s2) VALUES (2, 1, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, s1, s2) VALUES (3, 1, 1)')
+        cql.execute(f"INSERT INTO {table} (pk, s1, s2) VALUES (0, 0, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, s1, s2) VALUES (1, 0, 1)")
+        cql.execute(f"INSERT INTO {table} (pk, s1, s2) VALUES (2, 1, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, s1, s2) VALUES (3, 1, 1)")
 
-        assert [(0,),(1,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s1 = 0'))
-        assert [(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s1 = 1'))
-        assert [(0,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s2 = 0'))
-        assert [(1,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s2 = 1'))
+        assert [(0,), (1,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s1 = 0")
+        )
+        assert [(2,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s1 = 1")
+        )
+        assert [(0,), (2,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s2 = 0")
+        )
+        assert [(1,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s2 = 1")
+        )
 
-        cql.execute(f'UPDATE {table} SET s1 = 1 WHERE pk = 1')
+        cql.execute(f"UPDATE {table} SET s1 = 1 WHERE pk = 1")
 
-        assert [(0,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s1 = 0'))
-        assert [(1,),(2,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s1 = 1'))
-        assert [(0,),(2,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s2 = 0'))
-        assert [(1,),(3,)] == sorted(cql.execute(f'SELECT pk FROM {table} WHERE s2 = 1'))
+        assert [(0,)] == sorted(cql.execute(f"SELECT pk FROM {table} WHERE s1 = 0"))
+        assert [(1,), (2,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s1 = 1")
+        )
+        assert [(0,), (2,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s2 = 0")
+        )
+        assert [(1,), (3,)] == sorted(
+            cql.execute(f"SELECT pk FROM {table} WHERE s2 = 1")
+        )
+
 
 # Test that creating a local index on a static column is disallowed.
 # Local static indexes are not useful because there is only one value
 # of a static column allowed for a given partition.
 def test_disallow_local_indexes_on_static_columns(scylla_only, cql, test_keyspace):
-    schema = 'pk int, c int, s int static, PRIMARY KEY(pk, c)'
+    schema = "pk int, c int, s int static, PRIMARY KEY(pk, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
-        with pytest.raises(InvalidRequest, match="Local indexes containing static columns are not supported"):
-            cql.execute(f'CREATE INDEX ON {table}((pk), s)')
+        with pytest.raises(
+            InvalidRequest,
+            match="Local indexes containing static columns are not supported",
+        ):
+            cql.execute(f"CREATE INDEX ON {table}((pk), s)")
+
 
 # Check that a "SELECT p FROM table WHERE v = 1 AND token(p) > ..."
 # works where p is a base table's partition key and  v is an indexed
@@ -1622,7 +2134,7 @@ def test_disallow_local_indexes_on_static_columns(scylla_only, cql, test_keyspac
 # Reproduces issue #7043. See also C++ tests
 # test_select_with_token_range_*() in test/boost/secondary_index_test.cc
 def test_index_filter_by_token(cql, test_keyspace):
-    schema = 'p int, v int, primary key (p)'
+    schema = "p int, v int, primary key (p)"
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE INDEX ON {table}(v)")
         insert = cql.prepare(f"INSERT INTO {table}(p,v) VALUES (?,?)")
@@ -1640,33 +2152,49 @@ def test_index_filter_by_token(cql, test_keyspace):
         # a subset of base_results) and also the v = ... works together
         # (v=1 yields the data, v=0 yields nothing).
         token3 = base_results[3].system_token_p
-        assert base_results[4:] == list(cql.execute(f"SELECT token(p), p FROM {table} WHERE v = 1 AND token(p) > {token3}"))
-        assert [] == list(cql.execute(f"SELECT token(p), p FROM {table} WHERE v = 0 AND token(p) > {token3}"))
+        assert base_results[4:] == list(
+            cql.execute(
+                f"SELECT token(p), p FROM {table} WHERE v = 1 AND token(p) > {token3}"
+            )
+        )
+        assert [] == list(
+            cql.execute(
+                f"SELECT token(p), p FROM {table} WHERE v = 0 AND token(p) > {token3}"
+            )
+        )
+
 
 # Looking up a null value in a secondary index should match nothing (in
 # general in Scylla, "= null" matches nothing - not even a null value).
 # The "= null" expression is disallowed in Cassandra, so these tests are
 # Scylla-only.
 def test_global_secondary_index_null_lookup(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, v int') as table:
-        cql.execute(f'CREATE INDEX ON {table}(v)')
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
+        cql.execute(f"CREATE INDEX ON {table}(v)")
         p = unique_key_int()
-        cql.execute(f'INSERT INTO {table}(p,v) VALUES ({p},1)')
-        assert [] == list(cql.execute(f'SELECT p FROM {table} WHERE v=null'))
+        cql.execute(f"INSERT INTO {table}(p,v) VALUES ({p},1)")
+        assert [] == list(cql.execute(f"SELECT p FROM {table} WHERE v=null"))
+
 
 def test_local_secondary_index_null_lookup(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, v int') as table:
-        cql.execute(f'CREATE INDEX ON {table}((p), v)')
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
+        cql.execute(f"CREATE INDEX ON {table}((p), v)")
         p = unique_key_int()
-        cql.execute(f'INSERT INTO {table}(p,v) VALUES ({p},1)')
-        assert [] == list(cql.execute(f'SELECT * FROM {table} WHERE p={p} AND v=null'))
+        cql.execute(f"INSERT INTO {table}(p,v) VALUES ({p},1)")
+        assert [] == list(cql.execute(f"SELECT * FROM {table} WHERE p={p} AND v=null"))
+
 
 def test_local_secondary_index_null_lookup2(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, 'p int, c int, PRIMARY KEY (p, c), v int') as table:
-        cql.execute(f'CREATE INDEX ON {table}((p), v)')
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c), v int"
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}((p), v)")
         p = unique_key_int()
-        cql.execute(f'INSERT INTO {table}(p,c,v) VALUES ({p},0,1)')
-        assert [] == list(cql.execute(f'SELECT * FROM {table} WHERE p={p} AND c=0 AND v=null'))
+        cql.execute(f"INSERT INTO {table}(p,c,v) VALUES ({p},0,1)")
+        assert [] == list(
+            cql.execute(f"SELECT * FROM {table} WHERE p={p} AND c=0 AND v=null")
+        )
+
 
 # Reproducers for issue #7659, which involves a query with multiple indexes
 # which wrongly tries to use an index for a non-EQ restriction (whereas an
@@ -1675,44 +2203,78 @@ def test_local_secondary_index_null_lookup2(cql, test_keyspace, scylla_only):
 # with two different symptoms (one used to assert, the other "just" threw an
 # exception), and for both global and local indexes.
 
+
 def test_7659_global(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'a int, d int, f int, PRIMARY KEY (a, d)') as table:
-        cql.execute(f'CREATE INDEX ON {table}(d)')
-        cql.execute(f'CREATE INDEX ON {table}(f)')
-        cql.execute(f'INSERT INTO {table}(a,d,f) VALUES (1, 0, 1)')
-        cql.execute(f'INSERT INTO {table}(a,d,f) VALUES (2, 0, 2)')
-        cql.execute(f'INSERT INTO {table}(a,d,f) VALUES (3, 0, 3)')
-        cql.execute(f'INSERT INTO {table}(a,d,f) VALUES (4, 0, 0)')
-        cql.execute(f'INSERT INTO {table}(a,d,f) VALUES (5, 1, 1)')
+    with new_test_table(
+        cql, test_keyspace, "a int, d int, f int, PRIMARY KEY (a, d)"
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}(d)")
+        cql.execute(f"CREATE INDEX ON {table}(f)")
+        cql.execute(f"INSERT INTO {table}(a,d,f) VALUES (1, 0, 1)")
+        cql.execute(f"INSERT INTO {table}(a,d,f) VALUES (2, 0, 2)")
+        cql.execute(f"INSERT INTO {table}(a,d,f) VALUES (3, 0, 3)")
+        cql.execute(f"INSERT INTO {table}(a,d,f) VALUES (4, 0, 0)")
+        cql.execute(f"INSERT INTO {table}(a,d,f) VALUES (5, 1, 1)")
         # With issue #7659, this generated an assertion failure:
-        assert [(1,),(2,)] == sorted(list(cql.execute(f"SELECT a FROM {table} WHERE d=0 AND f in (1,2) ALLOW FILTERING")))
+        assert [(1,), (2,)] == sorted(
+            list(
+                cql.execute(
+                    f"SELECT a FROM {table} WHERE d=0 AND f in (1,2) ALLOW FILTERING"
+                )
+            )
+        )
         # With issue #7659, this generated an exception and failed request:
-        assert [(1,),(2,),(3,)] == sorted(list(cql.execute(f"SELECT a FROM {table} WHERE d=0 AND f>0 ALLOW FILTERING")))
+        assert [(1,), (2,), (3,)] == sorted(
+            list(
+                cql.execute(f"SELECT a FROM {table} WHERE d=0 AND f>0 ALLOW FILTERING")
+            )
+        )
+
 
 # the version of this test for local index is scylla_only, because LSI is
 # a Scylla extension that doesn't exist in Cassandra.
 def test_7659_local(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, 'a int, b int, c int, d int, e int, f int, PRIMARY KEY ((a, b), c, d)') as table:
-        cql.execute(f'CREATE INDEX ON {table}((a, b), f)')
-        cql.execute(f'CREATE INDEX ON {table}(d)')
-        cql.execute(f'INSERT INTO {table}(a,b,c,d,e,f) VALUES (0,0,0,0,0,1)')
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "a int, b int, c int, d int, e int, f int, PRIMARY KEY ((a, b), c, d)",
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}((a, b), f)")
+        cql.execute(f"CREATE INDEX ON {table}(d)")
+        cql.execute(f"INSERT INTO {table}(a,b,c,d,e,f) VALUES (0,0,0,0,0,1)")
         # With issue #7659, this generated an assertion failure:
-        assert [(0,)] == list(cql.execute(f"SELECT a FROM {table} WHERE a=0 and b=0 AND d=0 AND f in (1,2) ALLOW FILTERING"))
+        assert [(0,)] == list(
+            cql.execute(
+                f"SELECT a FROM {table} WHERE a=0 and b=0 AND d=0 AND f in (1,2) ALLOW FILTERING"
+            )
+        )
         # With issue #7659, this generated an exception and failed request:
-        assert [(0,)] == list(cql.execute(f"SELECT a FROM {table} WHERE a=0 and b=0 AND d=0 AND f>0 ALLOW FILTERING"))
+        assert [(0,)] == list(
+            cql.execute(
+                f"SELECT a FROM {table} WHERE a=0 and b=0 AND d=0 AND f>0 ALLOW FILTERING"
+            )
+        )
+
 
 # An index can be used to satisfy equality relations (a=2) but not
 # inequality (e.g., a>=2). If those are present, Scylla needs to ignore
 # the index and just do filtering normally.
 # Reproduces #5823
 def test_index_non_eq_relation(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'a bigint, b bigint, c bigint, PRIMARY KEY ((a, b))') as table:
-        cql.execute(f'CREATE INDEX ON {table}(a)')
-        cql.execute(f'INSERT INTO {table} (a,b,c) VALUES (0,2,1)')
-        cql.execute(f'INSERT INTO {table} (a,b,c) VALUES (1,2,3)')
-        cql.execute(f'INSERT INTO {table} (a,b,c) VALUES (2,2,4)')
-        assert [(3,),(4,)] == sorted(cql.execute(f"SELECT c FROM {table} WHERE a>0 and b=2 ALLOW FILTERING"))
-        assert [(4,)] == sorted(cql.execute(f"SELECT c FROM {table} WHERE a>=2 ALLOW FILTERING"))
+    with new_test_table(
+        cql, test_keyspace, "a bigint, b bigint, c bigint, PRIMARY KEY ((a, b))"
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}(a)")
+        cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (0,2,1)")
+        cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (1,2,3)")
+        cql.execute(f"INSERT INTO {table} (a,b,c) VALUES (2,2,4)")
+        assert [(3,), (4,)] == sorted(
+            cql.execute(f"SELECT c FROM {table} WHERE a>0 and b=2 ALLOW FILTERING")
+        )
+        assert [(4,)] == sorted(
+            cql.execute(f"SELECT c FROM {table} WHERE a>=2 ALLOW FILTERING")
+        )
+
 
 # A reproducer for issue #12762: When scan with a PER PARTITION LIMIT uses
 # a secondary index for its filtering, it still needs apply the PER PARTITION
@@ -1721,13 +2283,25 @@ def test_index_non_eq_relation(cql, test_keyspace):
 # With issue #12762, this test used to pass without an index (use_index=False)
 # but failed with an index (use_index=True) - it seems the PER PARTITION LIMIT
 # request was just ignored.
-@pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12762")), False])
+@pytest.mark.parametrize(
+    "use_index",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Strange result on select query with partition limit and index #12762"
+            ),
+        ),
+        False,
+    ],
+)
 def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_index):
-    with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)"
+    ) as table:
         if use_index:
             cql.execute(f"CREATE INDEX ON {table}(v)")
-        stmt = cql.prepare(f'INSERT INTO {table} (p, c, v) VALUES (?, ?, ?)')
+        stmt = cql.prepare(f"INSERT INTO {table} (p, c, v) VALUES (?, ?, ?)")
         cql.execute(stmt, [0, 0, 0])
         cql.execute(stmt, [0, 1, 0])
         cql.execute(stmt, [1, 0, 0])
@@ -1735,8 +2309,13 @@ def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_in
         # ALLOW FILTERING isn't needed if there's an index. Scylla must
         # use the index when it's available (otherwise the query v=0 won't
         # be efficient), but shouldn't forget also the PER PARTITION LIMIT.
-        allow_filtering = '' if use_index else 'ALLOW FILTERING'
-        assert {(0,0,0), (1, 0, 0)} == set(cql.execute(f'SELECT * FROM {table} WHERE v=0 PER PARTITION LIMIT 1 {allow_filtering}'))
+        allow_filtering = "" if use_index else "ALLOW FILTERING"
+        assert {(0, 0, 0), (1, 0, 0)} == set(
+            cql.execute(
+                f"SELECT * FROM {table} WHERE v=0 PER PARTITION LIMIT 1 {allow_filtering}"
+            )
+        )
+
 
 # Similar to above test with PER PARTITION LIMIT, but also adds further
 # filtering which eliminates some result candidates retrieved by the index.
@@ -1745,20 +2324,37 @@ def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_in
 # first result happens not to match the filter it needs to continue trying
 # the second result, and so on, and not skip to the next partition until
 # we have one post-filtered result.
-@pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12762")), False])
+@pytest.mark.parametrize(
+    "use_index",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="Strange result on select query with partition limit and index #12762"
+            ),
+        ),
+        False,
+    ],
+)
 def test_index_filtering2_scan_and_per_partition_limit(cql, test_keyspace, use_index):
-    with new_test_table(cql, test_keyspace, "p int, c int, v int, z int, PRIMARY KEY (p, c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, v int, z int, PRIMARY KEY (p, c)"
+    ) as table:
         if use_index:
             cql.execute(f"CREATE INDEX ON {table}(v)")
-        stmt = cql.prepare(f'INSERT INTO {table} (p, c, v, z) VALUES (?, ?, ?, ?)')
+        stmt = cql.prepare(f"INSERT INTO {table} (p, c, v, z) VALUES (?, ?, ?, ?)")
         cql.execute(stmt, [0, 0, 0, 0])
         cql.execute(stmt, [0, 1, 0, 1])
         cql.execute(stmt, [0, 2, 0, 1])
         cql.execute(stmt, [1, 0, 0, 0])
         cql.execute(stmt, [1, 1, 0, 1])
         cql.execute(stmt, [1, 2, 0, 1])
-        assert {(0, 1, 0, 1), (1, 1, 0, 1)} == set(cql.execute(f'SELECT * FROM {table} WHERE v=0 AND z=1 PER PARTITION LIMIT 1 ALLOW FILTERING'))
+        assert {(0, 1, 0, 1), (1, 1, 0, 1)} == set(
+            cql.execute(
+                f"SELECT * FROM {table} WHERE v=0 AND z=1 PER PARTITION LIMIT 1 ALLOW FILTERING"
+            )
+        )
+
 
 # Test that when adding an index to a table, queries should not begin to
 # use it before it's fully built - otherwise we would get wrong query
@@ -1767,18 +2363,21 @@ def test_index_filtering2_scan_and_per_partition_limit(cql, test_keyspace, use_i
 # the ALLOW FILTERING request right after the CREATE INDEX causes an
 # exception in SecondaryIndexManagement and a failed read. This is despite
 # CASSANDRA-8505 claiming that this issue was already fixed in 2015.
-@pytest.mark.xfail(reason="issue #7963")
+@pytest.mark.xfail(reason="Secondary index shouldn't be used before fully built #7963")
 def test_unbuilt_index_not_used(cql, test_keyspace, cassandra_bug):
     # The bigger "count" is the slower the test and the higher the chance
     # of reproducing the bug #7963. With dev build on my laptop, count=100
     # is enough for reproducing the failure in 90% of the runs.
     count = 100
-    with new_test_table(cql, test_keyspace,
-            "p int, c int, v int, PRIMARY KEY (p, c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)"
+    ) as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c, v) VALUES (?, ?, ?)")
         for i in range(count):
-            cql.execute(stmt, [i, i*10, i*100])
-        assert list(cql.execute(f"SELECT p FROM {table} WHERE v=100 ALLOW FILTERING")) == [(1,)]
+            cql.execute(stmt, [i, i * 10, i * 100])
+        assert list(
+            cql.execute(f"SELECT p FROM {table} WHERE v=100 ALLOW FILTERING")
+        ) == [(1,)]
         # Before we add an index, the same query without ALLOW FILTERING is
         # not allowed:
         with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
@@ -1789,7 +2388,9 @@ def test_unbuilt_index_not_used(cql, test_keyspace, cassandra_bug):
         cql.execute(f"CREATE INDEX ON {table} (v)")
         # Failure here reproduces #7963: (note that depending on timing, it
         # might not fail every time even before the bug is fixed)
-        assert list(cql.execute(f"SELECT p FROM {table} WHERE v=100 ALLOW FILTERING")) == [(1,)]
+        assert list(
+            cql.execute(f"SELECT p FROM {table} WHERE v=100 ALLOW FILTERING")
+        ) == [(1,)]
         # If we retry the same query *without* the ALLOW FILTERING phrase,
         # this should either be allowed and produce correct results (if the
         # index has finished building) - or, should complain that ALLOW
@@ -1803,32 +2404,43 @@ def test_unbuilt_index_not_used(cql, test_keyspace, cassandra_bug):
             # FILTERING, if the index wasn't yet built.
             assert "ALLOW FILTERING" in str(e)
 
+
 # Utility function waiting (up to a timeout) for the given index to be built.
 # Uses the "IndexInfo" system table, supported by both Scylla and Cassandra.
 def wait_for_index(cql, keyspace, index_name, timeout_sec=60):
     start_time = time.time()
     while time.time() < start_time + timeout_sec:
-        if list(cql.execute(f"SELECT index_name FROM system.\"IndexInfo\" WHERE table_name = '{keyspace}' and index_name = '{index_name}'")):
+        if list(
+            cql.execute(
+                f"SELECT index_name FROM system.\"IndexInfo\" WHERE table_name = '{keyspace}' and index_name = '{index_name}'"
+            )
+        ):
             return
         time.sleep(0.1)
-    pytest.fail(f"Timeout ({timeout_sec} seconds) waiting for index {keyspace}.{index_name}")
+    pytest.fail(
+        f"Timeout ({timeout_sec} seconds) waiting for index {keyspace}.{index_name}"
+    )
+
 
 # The following test starts a filtering request (with ALLOW FILTERING),
 # pages through the results, and between two pages adds a secondary-index
 # that could be used - or not - for continuing the request, but certainly
 # shouldn't break the request. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(
+    reason="Adding a secondary index can break an ongoing paged read using another index #18992"
+)
 def test_paging_and_create_index(cql, test_keyspace):
     count = 20
-    with new_test_table(cql, test_keyspace,
-            "p int, v int, PRIMARY KEY (p)") as table:
+    with new_test_table(cql, test_keyspace, "p int, v int, PRIMARY KEY (p)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
         # Add 'count' partitions with v=17 in all of them, so the filter
         # "WHERE v=17" will return all rows.
         for i in range(count):
             cql.execute(stmt, [i, 17])
         page_size = 7
-        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING", fetch_size=page_size)
+        stmt = SimpleStatement(
+            f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING", fetch_size=page_size
+        )
         # Save the result of a full query (this would be count rows ordered
         # by token(p) order) so we can later compare this to what we get
         # when we insert a CREATE INDEX between pages.
@@ -1846,25 +2458,32 @@ def test_paging_and_create_index(cql, test_keyspace):
         wait_for_index(cql, test_keyspace, index_name)
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
-            assert len(r.current_rows) <= page_size # sanity check
+            assert len(r.current_rows) <= page_size  # sanity check
             got.extend(r.current_rows)
         assert expected == got
+
 
 # This test is the same as the previous one, but in this test the request
 # filters on both v1 and v2 is already using an index for column v2, and
 # now between the pages we add an index for v1. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(
+    reason="Adding a secondary index can break an ongoing paged read using another index #18992"
+)
 def test_paging_and_create_index2(cql, test_keyspace):
     count = 20
-    with new_test_table(cql, test_keyspace,
-            "p int, v1 text, v2 int, PRIMARY KEY (p)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, v1 text, v2 int, PRIMARY KEY (p)"
+    ) as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, v1, v2) VALUES (?, ?, ?)")
         # Add 'count' partitions with v1="dog", v2=3 in all of them, so the
         # filter "WHERE v1='dog' AND v2=3" will return all rows.
         for i in range(count):
             cql.execute(stmt, [i, "dog", 3])
         page_size = 7
-        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v1='dog' AND v2=3 ALLOW FILTERING", fetch_size=page_size)
+        stmt = SimpleStatement(
+            f"SELECT p FROM {table} WHERE v1='dog' AND v2=3 ALLOW FILTERING",
+            fetch_size=page_size,
+        )
         expected = list(cql.execute(stmt))
         # Create the index on v2, and run the query again, should get the same
         # results.
@@ -1890,6 +2509,7 @@ def test_paging_and_create_index2(cql, test_keyspace):
             got.extend(r.current_rows)
         assert expected == got
 
+
 # Similar to the previous tests, but here a secondary index which is used
 # for the original request is suddenly deleted between pages. In this test,
 # the query has "ALLOW FILTERING" so the query can continue to work -
@@ -1897,18 +2517,21 @@ def test_paging_and_create_index2(cql, test_keyspace):
 # will do the same without ALLOW FILTERING in the query - and we'll see the
 # query can't be resumed after the index is dropped.
 # Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(
+    reason="Adding a secondary index can break an ongoing paged read using another index #18992"
+)
 def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
     count = 20
-    with new_test_table(cql, test_keyspace,
-            "p int, v int, PRIMARY KEY (p)") as table:
+    with new_test_table(cql, test_keyspace, "p int, v int, PRIMARY KEY (p)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
         # Add 'count' partitions with v=17 in all of them, so the filter v=17
         # will return all rows.
         for i in range(count):
             cql.execute(stmt, [i, 17])
         page_size = 7
-        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING", fetch_size=page_size)
+        stmt = SimpleStatement(
+            f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING", fetch_size=page_size
+        )
         expected = list(cql.execute(stmt))
         # Create the index on v, and run the query again with the index,
         # should get the same results.
@@ -1927,9 +2550,10 @@ def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
         cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
-            assert len(r.current_rows) <= page_size # sanity check
+            assert len(r.current_rows) <= page_size  # sanity check
             got.extend(r.current_rows)
         assert expected == got
+
 
 # This test is the same as the previous one, except that it uses a query
 # *without* ALLOW FILTERING while an index existed, and when it attempts
@@ -1937,8 +2561,7 @@ def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
 # message about ALLOW FILTERING being necessary.
 def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
     count = 20
-    with new_test_table(cql, test_keyspace,
-            "p int, v int, PRIMARY KEY (p)") as table:
+    with new_test_table(cql, test_keyspace, "p int, v int, PRIMARY KEY (p)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
         for i in range(count):
             cql.execute(stmt, [i, 17])
@@ -1947,7 +2570,9 @@ def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
         wait_for_index(cql, test_keyspace, index_name)
 
         page_size = 7
-        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17", fetch_size=page_size)
+        stmt = SimpleStatement(
+            f"SELECT p FROM {table} WHERE v=17", fetch_size=page_size
+        )
         expected = list(cql.execute(stmt))
         # Run the same paged query again but this time use the page-by-page
         # API, and do a DROP INDEX between the first and second page.
@@ -1975,12 +2600,21 @@ def test_index_in_system_tables(cql, test_keyspace):
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
         wait_for_index(cql, test_keyspace, index_name)
         if is_scylla(cql):
-            res = [ f'{r.keyspace_name}.{r.view_name}' for r in cql.execute('select * from system.built_views')]
-            assert f'{test_keyspace}.{index_name}_index' in res
-        res = [ f'{r.table_name}::{r.index_name}' for r in cql.execute('select * from system."IndexInfo"')]
-        assert f'{test_keyspace}::{index_name}' in res
-        res = cql.execute(f'select * from system."IndexInfo" where table_name = \'{test_keyspace}\' AND index_name = \'{index_name}\'').one()
+            res = [
+                f"{r.keyspace_name}.{r.view_name}"
+                for r in cql.execute("select * from system.built_views")
+            ]
+            assert f"{test_keyspace}.{index_name}_index" in res
+        res = [
+            f"{r.table_name}::{r.index_name}"
+            for r in cql.execute('select * from system."IndexInfo"')
+        ]
+        assert f"{test_keyspace}::{index_name}" in res
+        res = cql.execute(
+            f"select * from system.\"IndexInfo\" where table_name = '{test_keyspace}' AND index_name = '{index_name}'"
+        ).one()
         assert (test_keyspace, index_name) == (res.table_name, res.index_name)
+
 
 # The following test needs an index that we know is already built. We
 # create here an index on an empty table, so it should be built almost
@@ -1995,17 +2629,22 @@ def built_index(cql, test_keyspace):
         wait_for_index(cql, test_keyspace, index_name)
         yield (table, index_name)
 
+
 # Check that a built index is listed in system."IndexInfo". This system
 # table was first introduced in Cassandra 2.1.
 # This test does not check that a created but not-yet-built index is not
 # in IndexInfo.
 def test_built_index_in_system_indexinfo(cql, built_index):
     table, index_name = built_index
-    keyspace_name, table_name = table.split('.')
-    index_info = [ (r.table_name, r.index_name) for r in cql.execute('select * from system."IndexInfo"')]
+    keyspace_name, table_name = table.split(".")
+    index_info = [
+        (r.table_name, r.index_name)
+        for r in cql.execute('select * from system."IndexInfo"')
+    ]
     # Note that confusingly, the "table_name"  column in IndexInfo is
     # NOT the table's name - it's the keyspace name!
     assert (keyspace_name, index_name) in index_info
+
 
 # Check that an index is listed in system_schema.indexes. This system
 # table was first introduced in Cassandra 3.0, and we also test the
@@ -2015,8 +2654,12 @@ def test_built_index_in_system_indexinfo(cql, built_index):
 # already built.
 def test_index_in_system_schema_indexes(cql, built_index):
     table, index_name = built_index
-    keyspace_name, table_name = table.split('.')
-    res = [r for r in cql.execute('select * from system_schema.indexes') if r.index_name == index_name ]
+    keyspace_name, table_name = table.split(".")
+    res = [
+        r
+        for r in cql.execute("select * from system_schema.indexes")
+        if r.index_name == index_name
+    ]
     assert len(res) == 1
     assert res[0].index_name == index_name
     assert res[0].keyspace_name == keyspace_name
@@ -2028,8 +2671,9 @@ def test_index_in_system_schema_indexes(cql, built_index):
     # a "target" which (in the case of a global index of a single column)
     # contains just the column name, here "v". Let's check that this continues
     # to be the true, and doesn't accidentally regress.
-    assert res[0].kind == 'COMPOSITES'
-    assert res[0].options == {'target': 'v'}
+    assert res[0].kind == "COMPOSITES"
+    assert res[0].options == {"target": "v"}
+
 
 # Test index representation in REST API
 def test_index_in_API(cql, test_keyspace):
@@ -2037,7 +2681,9 @@ def test_index_in_API(cql, test_keyspace):
         index_name = unique_name()
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
         wait_for_index(cql, test_keyspace, index_name)
-        res = rest_api.get_request(cql, f"column_family/built_indexes/{table.replace('.',':')}")
+        res = rest_api.get_request(
+            cql, f"column_family/built_indexes/{table.replace('.', ':')}"
+        )
         assert index_name in res
 
 
@@ -2062,44 +2708,48 @@ def test_index_in_API(cql, test_keyspace):
 # from the index view (where the LIMIT is correctly applied). A mismatch is
 # always interpreted as more pages being available, which in this case is incorrect.
 # See `generate_view_paging_state_from_base_query_results()` for more details.
-@pytest.mark.xfail(reason="issue #22158")
+@pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #22158")
 def test_limit_partition(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'pk1 int, pk2 int, ck int, primary key ((pk1, pk2), ck)') as table:
-        cql.execute(f'CREATE INDEX ON {table}(pk2)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk1, pk2, ck) VALUES (?, ?, ?)')
+    with new_test_table(
+        cql, test_keyspace, "pk1 int, pk2 int, ck int, primary key ((pk1, pk2), ck)"
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}(pk2)")
+        stmt = cql.prepare(f"INSERT INTO {table} (pk1, pk2, ck) VALUES (?, ?, ?)")
         cql.execute(stmt, [1, 1, 1])
         cql.execute(stmt, [1, 1, 2])
         cql.execute(stmt, [2, 1, 1])
         cql.execute(stmt, [2, 1, 2])
         # Test LIMIT within a single partition - succeeds.
-        rs = cql.execute(f'SELECT pk1, ck FROM {table} WHERE pk2 = 1 LIMIT 1')
-        assert sorted(list(rs)) == [(2,1)]
+        rs = cql.execute(f"SELECT pk1, ck FROM {table} WHERE pk2 = 1 LIMIT 1")
+        assert sorted(list(rs)) == [(2, 1)]
         assert rs.has_more_pages == False
         # Test LIMIT across partitions - reproduces #22158.
-        rs = cql.execute(f'SELECT pk1, ck FROM {table} WHERE pk2 = 1 LIMIT 3')
-        assert sorted(list(rs)) == [(1,1), (2,1), (2,2)]
+        rs = cql.execute(f"SELECT pk1, ck FROM {table} WHERE pk2 = 1 LIMIT 3")
+        assert sorted(list(rs)) == [(1, 1), (2, 1), (2, 2)]
         assert rs.has_more_pages == False
 
 
 # Same as test_limit_partition above, except that it uses partition slices
 # instead of whole partitions. This is achieved by indexing the first clustering
 # key column.
-@pytest.mark.xfail(reason="issue #22158")
+@pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #22158")
 def test_limit_partition_slice(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'pk int, ck1 int, ck2 int, primary key (pk, ck1, ck2)') as table:
-        cql.execute(f'CREATE INDEX ON {table}(ck1)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck1, ck2) VALUES (?, ?, ?)')
+    with new_test_table(
+        cql, test_keyspace, "pk int, ck1 int, ck2 int, primary key (pk, ck1, ck2)"
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}(ck1)")
+        stmt = cql.prepare(f"INSERT INTO {table} (pk, ck1, ck2) VALUES (?, ?, ?)")
         cql.execute(stmt, [1, 1, 1])
         cql.execute(stmt, [1, 1, 2])
         cql.execute(stmt, [2, 1, 1])
         cql.execute(stmt, [2, 1, 2])
         # Test LIMIT within a single partition slice - succeeds.
-        rs = cql.execute(f'SELECT pk, ck2 FROM {table} WHERE ck1 = 1 LIMIT 1')
-        assert sorted(list(rs)) == [(1,1)]
+        rs = cql.execute(f"SELECT pk, ck2 FROM {table} WHERE ck1 = 1 LIMIT 1")
+        assert sorted(list(rs)) == [(1, 1)]
         assert rs.has_more_pages == False
         # Test LIMIT across partition slices - reproduces #22158.
-        rs = cql.execute(f'SELECT pk, ck2 FROM {table} WHERE ck1 = 1 LIMIT 3')
-        assert sorted(list(rs)) == [(1,1), (1,2), (2,1)]
+        rs = cql.execute(f"SELECT pk, ck2 FROM {table} WHERE ck1 = 1 LIMIT 3")
+        assert sorted(list(rs)) == [(1, 1), (1, 2), (2, 1)]
         assert rs.has_more_pages == False
 
 
@@ -2116,52 +2766,88 @@ def test_limit_partition_slice(cql, test_keyspace):
 # assumes that the last partition of the previous page was fully read, so it
 # completely ignores it when preparing the second page. This logic is
 # implemented in `find_index_partition_ranges()`.
-@pytest.mark.xfail(reason="issue #25839")
+@pytest.mark.xfail(
+    reason="Secondary index: large rows + paging cause incomplete results #25839"
+)
 def test_short_read(cql, test_keyspace):
-    page_memory_limit = 1024 if is_scylla(cql) else 1024 * 1024  # 1MiB in Cassandra, 1KiB in Scylla (for faster execution)
+    page_memory_limit = (
+        1024 if is_scylla(cql) else 1024 * 1024
+    )  # 1MiB in Cassandra, 1KiB in Scylla (for faster execution)
     row_size = page_memory_limit // 2  # will cause short read after 2 rows
     with ExitStack() as stack:
-        table = stack.enter_context(new_test_table(cql, test_keyspace, 'pk int, ck1 int, ck2 int, data text, primary key (pk, ck1, ck2)'))
+        table = stack.enter_context(
+            new_test_table(
+                cql,
+                test_keyspace,
+                "pk int, ck1 int, ck2 int, data text, primary key (pk, ck1, ck2)",
+            )
+        )
         if is_scylla(cql):
-            stack.enter_context(config_value_context(cql, 'query_page_size_in_bytes', str(page_memory_limit)))
-        cql.execute(f'CREATE INDEX ON {table}(ck1)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck1, ck2, data) VALUES (?, ?, ?, ?)')
-        cql.execute(stmt, [1, 1, 1, 'A' * row_size])
-        cql.execute(stmt, [1, 1, 2, 'B' * row_size])
-        cql.execute(stmt, [1, 1, 3, 'C' * row_size])
-        cql.execute(stmt, [2, 1, 1, 'D' * row_size])
-        rs = cql.execute(f'SELECT pk, ck2, data FROM {table} WHERE ck1 = 1')
+            stack.enter_context(
+                config_value_context(
+                    cql, "query_page_size_in_bytes", str(page_memory_limit)
+                )
+            )
+        cql.execute(f"CREATE INDEX ON {table}(ck1)")
+        stmt = cql.prepare(
+            f"INSERT INTO {table} (pk, ck1, ck2, data) VALUES (?, ?, ?, ?)"
+        )
+        cql.execute(stmt, [1, 1, 1, "A" * row_size])
+        cql.execute(stmt, [1, 1, 2, "B" * row_size])
+        cql.execute(stmt, [1, 1, 3, "C" * row_size])
+        cql.execute(stmt, [2, 1, 1, "D" * row_size])
+        rs = cql.execute(f"SELECT pk, ck2, data FROM {table} WHERE ck1 = 1")
         rows = [(col[0], col[1]) for col in list(rs)]
-        assert sorted(rows) == [(1,1), (1,2), (1,3), (2,1)]
+        assert sorted(rows) == [(1, 1), (1, 2), (1, 3), (2, 1)]
+
 
 # Another reproducer for issue #25839, this time asking for a count() as
 # a user tried in #28026 and noticing that adding an additional column
 # to the selection causes the count to become smaller.
-@pytest.mark.xfail(reason="issue #25839")
+@pytest.mark.xfail(
+    reason="Secondary index: large rows + paging cause incomplete results #25839"
+)
 def test_short_count(cql, test_keyspace):
     # Newer Scylla have configurable query_page_size_in_bytes so we can set
     # it low to have a faster test. Older Scylla and Cassandra have hard-coded
     # 1MB setting for this so we need to use larger data in this test.
-    config = 'query_page_size_in_bytes'
-    configurable = is_scylla(cql) and list(cql.execute(f"SELECT value FROM system.config WHERE name='{config}'")) != []
+    config = "query_page_size_in_bytes"
+    configurable = (
+        is_scylla(cql)
+        and list(cql.execute(f"SELECT value FROM system.config WHERE name='{config}'"))
+        != []
+    )
     page_memory_limit = 1024 if configurable else 1024 * 1024
     row_size = page_memory_limit // 2  # will cause short read after 2 rows
     with ExitStack() as stack:
-        table = stack.enter_context(new_test_table(cql, test_keyspace, 'pk int, ck1 int, ck2 int, data text, primary key (pk, ck1, ck2)'))
+        table = stack.enter_context(
+            new_test_table(
+                cql,
+                test_keyspace,
+                "pk int, ck1 int, ck2 int, data text, primary key (pk, ck1, ck2)",
+            )
+        )
         if configurable:
-            stack.enter_context(config_value_context(cql, 'query_page_size_in_bytes', str(page_memory_limit)))
-        cql.execute(f'CREATE INDEX ON {table}(ck1)')
-        stmt = cql.prepare(f'INSERT INTO {table} (pk, ck1, ck2, data) VALUES (?, ?, ?, ?)')
-        cql.execute(stmt, [1, 1, 1, 'A' * row_size])
-        cql.execute(stmt, [1, 1, 2, 'B' * row_size])
-        cql.execute(stmt, [1, 1, 3, 'C' * row_size])
-        cql.execute(stmt, [2, 1, 1, 'D' * row_size])
-        rs = list(cql.execute(f'SELECT count(*) FROM {table} WHERE ck1 = 1'))
+            stack.enter_context(
+                config_value_context(
+                    cql, "query_page_size_in_bytes", str(page_memory_limit)
+                )
+            )
+        cql.execute(f"CREATE INDEX ON {table}(ck1)")
+        stmt = cql.prepare(
+            f"INSERT INTO {table} (pk, ck1, ck2, data) VALUES (?, ?, ?, ?)"
+        )
+        cql.execute(stmt, [1, 1, 1, "A" * row_size])
+        cql.execute(stmt, [1, 1, 2, "B" * row_size])
+        cql.execute(stmt, [1, 1, 3, "C" * row_size])
+        cql.execute(stmt, [2, 1, 1, "D" * row_size])
+        rs = list(cql.execute(f"SELECT count(*) FROM {table} WHERE ck1 = 1"))
         assert len(rs) == 1
         assert rs[0].count == 4
-        rs = list(cql.execute(f'SELECT count(*), pk, data FROM {table} WHERE ck1 = 1'))
+        rs = list(cql.execute(f"SELECT count(*), pk, data FROM {table} WHERE ck1 = 1"))
         assert len(rs) == 1
         assert rs[0].count == 4
+
 
 def test_index_metrics(cql, test_keyspace, scylla_only):
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
@@ -2169,13 +2855,20 @@ def test_index_metrics(cql, test_keyspace, scylla_only):
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
         wait_for_index(cql, test_keyspace, index_name)
         initial_metrics = ScyllaMetrics.query(cql)
-        initial_count = initial_metrics.get(f'scylla_index_query_latencies_count', {"idx": index_name, "ks": test_keyspace})
+        initial_count = initial_metrics.get(
+            f"scylla_index_query_latencies_count",
+            {"idx": index_name, "ks": test_keyspace},
+        )
         if initial_count is None:
             initial_count = 0
         cql.execute(f"SELECT * FROM {table} WHERE v=1")
         current_metrics = ScyllaMetrics.query(cql)
-        current_count = current_metrics.get(f'scylla_index_query_latencies_count', {"idx": index_name, "ks": test_keyspace})
+        current_count = current_metrics.get(
+            f"scylla_index_query_latencies_count",
+            {"idx": index_name, "ks": test_keyspace},
+        )
         assert current_count - initial_count == 1
+
 
 # An aggregation (such as sum()) returns only one row, but needs to use some
 # paging when it is reads data internally. select_internal_page_size controls
@@ -2192,25 +2885,30 @@ def small_select_internal_page_size(cql, test_keyspace):
     if not is_scylla(cql):
         yield select_internal_page_size
     else:
-        with config_value_context(cql, 'select_internal_page_size', str(select_internal_page_size)):
+        with config_value_context(
+            cql, "select_internal_page_size", str(select_internal_page_size)
+        ):
             yield select_internal_page_size
+
 
 # Test combination of indexing, paging and aggregation.
 # Indexed queries used to erroneously return partial per-page results
 # for aggregation queries, as described in issue #4540. This test
 # (originally written in C++ in commit 3d9a37f28fe) reproduced that bug.
-def test_indexing_paging_and_aggregation(cql, test_keyspace, small_select_internal_page_size):
+def test_indexing_paging_and_aggregation(
+    cql, test_keyspace, small_select_internal_page_size
+):
     row_count = 2 * small_select_internal_page_size + 42
-    with new_test_table(cql, test_keyspace, 'id int primary key, v int') as table:
-        cql.execute(f'CREATE INDEX ON {table}(v)')
-        stmt = cql.prepare(f'INSERT INTO {table} (id, v) VALUES (?, ?)')
+    with new_test_table(cql, test_keyspace, "id int primary key, v int") as table:
+        cql.execute(f"CREATE INDEX ON {table}(v)")
+        stmt = cql.prepare(f"INSERT INTO {table} (id, v) VALUES (?, ?)")
         for i in range(row_count):
             cql.execute(stmt, [i + 1, i % 2])
         # In Scylla, in a single-node test materialized views and therefore
         # secondary indexes have synchronous updates, so we can read the
         # indexed data immediately. In Cassandra, secondary indexes are
         # always synchronously updated (they don't use materialized views).
-        res = list(cql.execute(f'SELECT sum(id) FROM {table} WHERE v = 1'))
+        res = list(cql.execute(f"SELECT sum(id) FROM {table} WHERE v = 1"))
         # Aggregation (like sum(id)) internally pages through the data
         # select_internal_page_size rows at a time, but even though
         # we have more rows than that in the table, it must only return a
@@ -2234,25 +2932,32 @@ def test_indexing_paging_and_aggregation(cql, test_keyspace, small_select_intern
         # internal paging through the data instead of using
         # select_internal_page_size. This test doesn't actually check
         # which of those are used, but that whatever is used, should work.
-        stmt = SimpleStatement(f'SELECT sum(id) FROM {table} WHERE v = 0', fetch_size=2)
+        stmt = SimpleStatement(f"SELECT sum(id) FROM {table} WHERE v = 0", fetch_size=2)
         assert list(cql.execute(stmt)) == [(row_count * row_count // 4,)]
         # Same check as we did for sum(), but for avg()
-        res = list(cql.execute(f'SELECT avg(id) FROM {table} WHERE v = 1'))
+        res = list(cql.execute(f"SELECT avg(id) FROM {table} WHERE v = 1"))
         assert res == [(row_count // 2 + 1,)]
 
     # Test the same thing again, but this time the indexed column is a
     # clustering key column, not the first one. After issue #3405 we
     # have a special code path for indexing composite non-prefix clustering
     # keys, so we want to exercise it too.
-    with new_test_table(cql, test_keyspace, 'id int, c1 int, c2 int, primary key(id, c1, c2)') as table:
-        cql.execute(f'CREATE INDEX ON {table}(c2)')
-        stmt = cql.prepare(f'INSERT INTO {table} (id, c1, c2) VALUES (?, ?, ?)')
+    with new_test_table(
+        cql, test_keyspace, "id int, c1 int, c2 int, primary key(id, c1, c2)"
+    ) as table:
+        cql.execute(f"CREATE INDEX ON {table}(c2)")
+        stmt = cql.prepare(f"INSERT INTO {table} (id, c1, c2) VALUES (?, ?, ?)")
         for i in range(row_count):
             cql.execute(stmt, [i + 1, i + 1, i % 2])
-        stmt = SimpleStatement(f'SELECT sum(id) FROM {table} WHERE c2 = 0', fetch_size=2)
+        stmt = SimpleStatement(
+            f"SELECT sum(id) FROM {table} WHERE c2 = 0", fetch_size=2
+        )
         assert list(cql.execute(stmt)) == [(row_count * row_count // 4,)]
-        stmt = SimpleStatement(f'SELECT avg(id) FROM {table} WHERE c2 = 1', fetch_size=3)
+        stmt = SimpleStatement(
+            f"SELECT avg(id) FROM {table} WHERE c2 = 1", fetch_size=3
+        )
         assert list(cql.execute(stmt)) == [(row_count / 2 + 1,)]
+
 
 # Verify that a newly created secondary index has
 # the property `tombstone_gc` set to some value.
@@ -2263,8 +2968,11 @@ def test_tombstone_gc_property(cql, test_keyspace, scylla_only):
         index_name = unique_name()
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
 
-        desc_row = cql.execute(f"DESCRIBE MATERIALIZED VIEW {test_keyspace}.{index_name}_index").one()
+        desc_row = cql.execute(
+            f"DESCRIBE MATERIALIZED VIEW {test_keyspace}.{index_name}_index"
+        ).one()
         assert "tombstone_gc = {" in desc_row.create_statement
+
 
 # Verify that a newly created unnamed secondary index has
 # the property `tombstone_gc` set to some value.

--- a/test/cqlpy/test_select_collection_element.py
+++ b/test/cqlpy/test_select_collection_element.py
@@ -18,6 +18,7 @@ def table1(cql, test_keyspace):
     yield table
     cql.execute("DROP TABLE " + table)
 
+
 def test_basic_int_key_selection(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1}(p,m) VALUES ({p}, " + "{1:10,2:20})")
@@ -25,14 +26,18 @@ def test_basic_int_key_selection(cql, table1):
     assert list(cql.execute(f"SELECT m[2] FROM {table1} WHERE p={p}")) == [(20,)]
     assert list(cql.execute(f"SELECT m[3] FROM {table1} WHERE p={p}")) == [(None,)]
 
+
 def test_basic_string_key_selection(cql, test_keyspace):
-    schema = 'p int PRIMARY KEY, m map<text, int>'
+    schema = "p int PRIMARY KEY, m map<text, int>"
     with new_test_table(cql, test_keyspace, schema) as table:
         p = unique_key_int()
         cql.execute(f"INSERT INTO {table}(p,m) VALUES ({p}, " + "{'aa':10,'ab':20})")
         assert list(cql.execute(f"SELECT m['aa'] FROM {table} WHERE p={p}")) == [(10,)]
         assert list(cql.execute(f"SELECT m['ab'] FROM {table} WHERE p={p}")) == [(20,)]
-        assert list(cql.execute(f"SELECT m['ac'] FROM {table} WHERE p={p}")) == [(None,)]
+        assert list(cql.execute(f"SELECT m['ac'] FROM {table} WHERE p={p}")) == [
+            (None,)
+        ]
+
 
 def test_subscript_type_mismatch(cql, table1):
     p = unique_key_int()
@@ -40,13 +45,18 @@ def test_subscript_type_mismatch(cql, table1):
     with pytest.raises(InvalidRequest):
         cql.execute(f"SELECT m['x'] FROM {table1} WHERE p={p}")
 
+
 def test_subscript_with_alias(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1}(p,m) VALUES ({p}, " + "{1:10,2:20})")
-    assert [(r.m1, r.m2) for r in cql.execute(f"SELECT m[1] as m1, m[2] as m2 FROM {table1} WHERE p={p}")] == [(10, 20)]
+    assert [
+        (r.m1, r.m2)
+        for r in cql.execute(f"SELECT m[1] as m1, m[2] as m2 FROM {table1} WHERE p={p}")
+    ] == [(10, 20)]
+
 
 def test_frozen_map_subscript(cql, test_keyspace):
-    schema = 'p int PRIMARY KEY, m frozen<map<int, int>>'
+    schema = "p int PRIMARY KEY, m frozen<map<int, int>>"
     with new_test_table(cql, test_keyspace, schema) as table:
         p = unique_key_int()
         cql.execute(f"INSERT INTO {table}(p,m) VALUES ({p}, " + "{1:10,2:20})")
@@ -54,15 +64,28 @@ def test_frozen_map_subscript(cql, test_keyspace):
         assert list(cql.execute(f"SELECT m[2] FROM {table} WHERE p={p}")) == [(20,)]
         assert list(cql.execute(f"SELECT m[3] FROM {table} WHERE p={p}")) == [(None,)]
 
+
 def test_nested_key_selection(cql, test_keyspace):
-    schema = 'p int PRIMARY KEY, m map<text, frozen<map<text, int>>>'
+    schema = "p int PRIMARY KEY, m map<text, frozen<map<text, int>>>"
     with new_test_table(cql, test_keyspace, schema) as table:
         p = unique_key_int()
-        cql.execute(f"INSERT INTO {table}(p, m) VALUES ({p}, " + "{'1': {'a': 10, 'b': 11}, '2': {'a': 12}})")
-        assert list(cql.execute(f"SELECT m['1']['a'] FROM {table} WHERE p={p}")) == [(10,)]
-        assert list(cql.execute(f"SELECT m['1']['b'] FROM {table} WHERE p={p}")) == [(11,)]
-        assert list(cql.execute(f"SELECT m['2']['a'] FROM {table} WHERE p={p}")) == [(12,)]
-        assert list(cql.execute(f"SELECT m['2']['b'] FROM {table} WHERE p={p}")) == [(None,)]
+        cql.execute(
+            f"INSERT INTO {table}(p, m) VALUES ({p}, "
+            + "{'1': {'a': 10, 'b': 11}, '2': {'a': 12}})"
+        )
+        assert list(cql.execute(f"SELECT m['1']['a'] FROM {table} WHERE p={p}")) == [
+            (10,)
+        ]
+        assert list(cql.execute(f"SELECT m['1']['b'] FROM {table} WHERE p={p}")) == [
+            (11,)
+        ]
+        assert list(cql.execute(f"SELECT m['2']['a'] FROM {table} WHERE p={p}")) == [
+            (12,)
+        ]
+        assert list(cql.execute(f"SELECT m['2']['b'] FROM {table} WHERE p={p}")) == [
+            (None,)
+        ]
+
 
 def test_prepare_key(cql, table1):
     p = unique_key_int()
@@ -74,12 +97,14 @@ def test_prepare_key(cql, table1):
     assert list(cql.execute(lookup1, [3, p])) == [(None,)]
 
     lookup2 = cql.prepare(f"SELECT m[:x1], m[:x2] FROM {table1} WHERE p = :key")
-    assert list(cql.execute(lookup2, {'x1':2, 'x2':1, 'key':p})) == [(20,10)]
+    assert list(cql.execute(lookup2, {"x1": 2, "x2": 1, "key": p})) == [(20, 10)]
+
 
 def test_null_map(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1}(p) VALUES ({p})")
     assert list(cql.execute(f"SELECT m[1] FROM {table1} WHERE p={p}")) == [(None,)]
+
 
 # scylla only because scylla returns null while cassandra returns error
 def test_null_subscript(scylla_only, cql, table1):
@@ -87,47 +112,63 @@ def test_null_subscript(scylla_only, cql, table1):
     cql.execute(f"INSERT INTO {table1}(p,m) VALUES ({p}, " + "{1:10,2:20})")
     assert list(cql.execute(f"SELECT m[null] FROM {table1} WHERE p={p}")) == [(None,)]
 
+
 def test_subscript_and_field(cql, test_keyspace):
-    with new_type(cql, test_keyspace, '(a int)') as typ:
+    with new_type(cql, test_keyspace, "(a int)") as typ:
         schema = f"p int PRIMARY KEY, m map<int, frozen<{typ}>>"
         with new_test_table(cql, test_keyspace, schema) as table:
             p = unique_key_int()
             cql.execute(f"INSERT INTO {table}(p,m) VALUES ({p}, " + "{1:{a:10}})")
-            assert list(cql.execute(f"SELECT m[1].a FROM {table} WHERE p={p}")) == [(10,)]
+            assert list(cql.execute(f"SELECT m[1].a FROM {table} WHERE p={p}")) == [
+                (10,)
+            ]
+
 
 def test_field_and_subscript(cql, test_keyspace):
-    with new_type(cql, test_keyspace, '(a frozen<map<int,int>>)') as typ:
+    with new_type(cql, test_keyspace, "(a frozen<map<int,int>>)") as typ:
         schema = f"p int PRIMARY KEY, t {typ}"
         with new_test_table(cql, test_keyspace, schema) as table:
             p = unique_key_int()
             cql.execute(f"INSERT INTO {table}(p,t) VALUES ({p}, " + "{a:{1:10}})")
-            assert list(cql.execute(f"SELECT t.a[1] FROM {table} WHERE p={p}")) == [(10,)]
+            assert list(cql.execute(f"SELECT t.a[1] FROM {table} WHERE p={p}")) == [
+                (10,)
+            ]
+
 
 def test_field_and_subscript_and_field(cql, test_keyspace):
-    with new_type(cql, test_keyspace, '(b int)') as typ1, \
-         new_type(cql, test_keyspace, f"(a frozen<map<int,{typ1}>>)") as typ2:
-            schema = f"p int PRIMARY KEY, t {typ2}"
-            with new_test_table(cql, test_keyspace, schema) as table:
-                p = unique_key_int()
-                cql.execute(f"INSERT INTO {table}(p,t) VALUES ({p}, " + "{a:{1:{b:10}}})")
-                assert list(cql.execute(f"SELECT t.a[1].b FROM {table} WHERE p={p}")) == [(10,)]
+    with (
+        new_type(cql, test_keyspace, "(b int)") as typ1,
+        new_type(cql, test_keyspace, f"(a frozen<map<int,{typ1}>>)") as typ2,
+    ):
+        schema = f"p int PRIMARY KEY, t {typ2}"
+        with new_test_table(cql, test_keyspace, schema) as table:
+            p = unique_key_int()
+            cql.execute(f"INSERT INTO {table}(p,t) VALUES ({p}, " + "{a:{1:{b:10}}})")
+            assert list(cql.execute(f"SELECT t.a[1].b FROM {table} WHERE p={p}")) == [
+                (10,)
+            ]
+
 
 def test_other_types_cannot_be_subscripted(cql, table1):
-    with pytest.raises(InvalidRequest, match='not a'):
+    with pytest.raises(InvalidRequest, match="not a"):
         cql.execute(f"SELECT p[2] FROM {table1}")
-    with pytest.raises(InvalidRequest, match='not a'):
+    with pytest.raises(InvalidRequest, match="not a"):
         cql.execute(f"SELECT token(p)[2] FROM {table1}")
+
 
 def test_udf_subscript(scylla_only, cql, test_keyspace, table1):
     fn = "(k int) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return k+1'"
-    with new_function(cql, test_keyspace, fn, 'add_one'):
+    with new_function(cql, test_keyspace, fn, "add_one"):
         p = unique_key_int()
         cql.execute(f"INSERT INTO {table1}(p,m) VALUES ({p}, " + "{1:10,2:20})")
-        assert list(cql.execute(f"SELECT m[add_one(1)] FROM {table1} WHERE p={p}")) == [(20,)]
+        assert list(cql.execute(f"SELECT m[add_one(1)] FROM {table1} WHERE p={p}")) == [
+            (20,)
+        ]
+
 
 # cassandra doesn't support subscript on a list
 def test_list_subscript(scylla_only, cql, test_keyspace):
-    schema = 'p int PRIMARY KEY, l list<int>'
+    schema = "p int PRIMARY KEY, l list<int>"
     with new_test_table(cql, test_keyspace, schema) as table:
         p = unique_key_int()
         cql.execute(f"INSERT INTO {table}(p,l) VALUES ({p}, " + "[10,20])")
@@ -136,8 +177,9 @@ def test_list_subscript(scylla_only, cql, test_keyspace):
         assert list(cql.execute(f"SELECT l[2] FROM {table} WHERE p={p}")) == [(None,)]
         assert list(cql.execute(f"SELECT l[10] FROM {table} WHERE p={p}")) == [(None,)]
 
+
 def test_set_subscript(cql, test_keyspace):
-    schema = 'p int PRIMARY KEY, s set<int>'
+    schema = "p int PRIMARY KEY, s set<int>"
     with new_test_table(cql, test_keyspace, schema) as table:
         p = unique_key_int()
         cql.execute(f"INSERT INTO {table}(p,s) VALUES ({p}, " + "{10,20})")
@@ -146,11 +188,16 @@ def test_set_subscript(cql, test_keyspace):
         assert list(cql.execute(f"SELECT s[11] FROM {table} WHERE p={p}")) == [(None,)]
         assert list(cql.execute(f"SELECT s[20] FROM {table} WHERE p={p}")) == [(20,)]
 
+
 # scylla only because cassandra doesn't support lua language
-@pytest.mark.xfail(reason="#22075")
+@pytest.mark.xfail(
+    reason="Selecting collection elements with slice syntax and remaining Cassandra compatibility #22075"
+)
 def test_subscript_function_arg(scylla_only, cql, test_keyspace, table1):
     fn = "(k int) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return k+1'"
-    with new_function(cql, test_keyspace, fn, 'add_one'):
+    with new_function(cql, test_keyspace, fn, "add_one"):
         p = unique_key_int()
         cql.execute(f"INSERT INTO {table1}(p,m) VALUES ({p}, " + "{1:10,2:20})")
-        assert list(cql.execute(f"SELECT add_one(m[1]) FROM {table1} WHERE p={p}")) == [(11,)]
+        assert list(cql.execute(f"SELECT add_one(m[1]) FROM {table1} WHERE p={p}")) == [
+            (11,)
+        ]

--- a/test/cqlpy/test_select_from_mutation_fragments.py
+++ b/test/cqlpy/test_select_from_mutation_fragments.py
@@ -22,37 +22,58 @@ import time
 
 @pytest.fixture(scope="module")
 def test_table(cql, test_keyspace):
-    """ Prepares a table for the mutation dump tests to work with."""
-    with util.new_test_table(cql, test_keyspace, 'pk1 int, pk2 int, ck1 int, ck2 int, v text, s text static, PRIMARY KEY ((pk1, pk2), ck1, ck2)',
-                             "WITH compaction = {'class':'NullCompactionStrategy'}") as table:
+    """Prepares a table for the mutation dump tests to work with."""
+    with util.new_test_table(
+        cql,
+        test_keyspace,
+        "pk1 int, pk2 int, ck1 int, ck2 int, v text, s text static, PRIMARY KEY ((pk1, pk2), ck1, ck2)",
+        "WITH compaction = {'class':'NullCompactionStrategy'}",
+    ) as table:
         yield table
 
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_smoke(cql, test_table, scylla_only):
-    """ Simple smoke tests, this should fail first if something is very wrong. """
+    """Simple smoke tests, this should fail first if something is very wrong."""
     partitions = {}
     for i in range(0, 1):
         pk1 = util.unique_key_int()
         pk2 = 0
         cql.execute(f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2}")
-        cql.execute(f"UPDATE {test_table} SET s = 'static val' WHERE pk1 = {pk1} AND pk2 = {pk2}")
-        cql.execute(f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = 0 AND ck2 > 0 AND ck2 < 3")
-        cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 1, 'regular val')")
-        cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 2, 'regular val')")
+        cql.execute(
+            f"UPDATE {test_table} SET s = 'static val' WHERE pk1 = {pk1} AND pk2 = {pk2}"
+        )
+        cql.execute(
+            f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = 0 AND ck2 > 0 AND ck2 < 3"
+        )
+        cql.execute(
+            f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 1, 'regular val')"
+        )
+        cql.execute(
+            f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 2, 'regular val')"
+        )
         partitions[(pk1, pk2)] = [
-                (pk1, pk2, 'sstable:', 0, None, None, None, 'partition start'),
-                (pk1, pk2, 'sstable:', 1, None, None, None, 'static row'),
-                (pk1, pk2, 'sstable:', 2, 0   , 0   , 1   , 'range tombstone change'),
-                (pk1, pk2, 'sstable:', 2, 0   , 1   , 0   , 'clustering row'),
-                (pk1, pk2, 'sstable:', 2, 0   , 2   , 0   , 'clustering row'),
-                (pk1, pk2, 'sstable:', 2, 0   , 3   , -1  , 'range tombstone change'),
-                (pk1, pk2, 'sstable:', 3, None, None, None, 'partition end'),
+            (pk1, pk2, "sstable:", 0, None, None, None, "partition start"),
+            (pk1, pk2, "sstable:", 1, None, None, None, "static row"),
+            (pk1, pk2, "sstable:", 2, 0, 0, 1, "range tombstone change"),
+            (pk1, pk2, "sstable:", 2, 0, 1, 0, "clustering row"),
+            (pk1, pk2, "sstable:", 2, 0, 2, 0, "clustering row"),
+            (pk1, pk2, "sstable:", 2, 0, 3, -1, "range tombstone change"),
+            (pk1, pk2, "sstable:", 3, None, None, None, "partition end"),
         ]
 
     nodetool.flush(cql, f"{test_table}")
 
-    col_names = ('pk1', 'pk2', 'mutation_source', 'partition_region', 'ck1', 'ck2', 'position_weight', 'mutation_fragment_kind')
+    col_names = (
+        "pk1",
+        "pk2",
+        "mutation_source",
+        "partition_region",
+        "ck1",
+        "ck2",
+        "position_weight",
+        "mutation_fragment_kind",
+    )
 
     def check_partition_rows(rows, expected_rows):
         assert len(rows) == len(expected_rows)
@@ -60,18 +81,26 @@ def test_smoke(cql, test_table, scylla_only):
         for expected_col_values, row in zip(expected_rows, rows):
             for col_name, col_value in zip(col_names, expected_col_values):
                 assert hasattr(row, col_name)
-                if col_name == 'mutation_source':
+                if col_name == "mutation_source":
                     assert getattr(row, col_name).startswith(col_value)
                 else:
                     assert getattr(row, col_name) == col_value
 
     # Point queries
     for (pk1, pk2), expected_rows in partitions.items():
-        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} AND mutation_source > 'sstable:'"))
+        rows = list(
+            cql.execute(
+                f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} AND mutation_source > 'sstable:'"
+            )
+        )
         check_partition_rows(rows, expected_rows)
 
     # Range scan
-    all_rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE mutation_source > 'sstable:' ALLOW FILTERING"))
+    all_rows = list(
+        cql.execute(
+            f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE mutation_source > 'sstable:' ALLOW FILTERING"
+        )
+    )
     for (pk1, pk2), expected_rows in partitions.items():
         rows = [r for r in all_rows if r.pk1 == pk1 and r.pk2 == pk2]
         check_partition_rows(rows, expected_rows)
@@ -79,49 +108,76 @@ def test_smoke(cql, test_table, scylla_only):
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_order_by(cql, test_table, scylla_only):
-    """ ORDER BY is not allowed """
+    """ORDER BY is not allowed"""
     pk1 = util.unique_key_int()
     pk2 = 0
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')")
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')"
+    )
 
-    with pytest.raises(cassandra.protocol.InvalidRequest, match="ORDER BY is not supported in SELECT FROM MUTATION_FRAGMENTS\\(\\) statements"):
-        cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} ORDER BY mutation_source DESC")
+    with pytest.raises(
+        cassandra.protocol.InvalidRequest,
+        match="ORDER BY is not supported in SELECT FROM MUTATION_FRAGMENTS\\(\\) statements",
+    ):
+        cql.execute(
+            f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} ORDER BY mutation_source DESC"
+        )
 
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_mutation_source(cql, test_table, scylla_only):
-    """ Manipulate where the data is located in the node, and check that the corred mutation source is reported. """
+    """Manipulate where the data is located in the node, and check that the corred mutation source is reported."""
     pk1 = util.unique_key_int()
     pk2 = util.unique_key_int()
 
     def expect_sources(*expected_sources):
-        for src in ('memtable', 'row-cache', 'sstable'):
-            rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} AND mutation_source >= '{src}' AND mutation_source < '{src};'"))
+        for src in ("memtable", "row-cache", "sstable"):
+            rows = list(
+                cql.execute(
+                    f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} AND mutation_source >= '{src}' AND mutation_source < '{src};'"
+                )
+            )
             if src in expected_sources:
-                assert len(rows) == 3 # partition-start, clustering-row, partition-end
+                assert len(rows) == 3  # partition-start, clustering-row, partition-end
             else:
                 assert len(rows) == 0
 
     # Start with an empty memtable.
     nodetool.flush(cql, f"{test_table}")
 
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')")
-    expect_sources('memtable')
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')"
+    )
+    expect_sources("memtable")
 
     nodetool.flush(cql, f"{test_table}")
-    expect_sources('row-cache', 'sstable')
+    expect_sources("row-cache", "sstable")
 
-    requests.post(f'{nodetool.rest_api_url(cql)}/system/drop_sstable_caches')
-    expect_sources('sstable')
+    requests.post(f"{nodetool.rest_api_url(cql)}/system/drop_sstable_caches")
+    expect_sources("sstable")
 
-    assert list(cql.execute(f"SELECT v FROM {test_table} WHERE pk1={pk1} AND pk2={pk2} BYPASS CACHE"))[0].v == 'vv'
-    expect_sources('sstable')
+    assert (
+        list(
+            cql.execute(
+                f"SELECT v FROM {test_table} WHERE pk1={pk1} AND pk2={pk2} BYPASS CACHE"
+            )
+        )[0].v
+        == "vv"
+    )
+    expect_sources("sstable")
 
-    assert list(cql.execute(f"SELECT v FROM {test_table} WHERE pk1={pk1} AND pk2={pk2}"))[0].v == 'vv'
-    expect_sources('row-cache', 'sstable')
+    assert (
+        list(cql.execute(f"SELECT v FROM {test_table} WHERE pk1={pk1} AND pk2={pk2}"))[
+            0
+        ].v
+        == "vv"
+    )
+    expect_sources("row-cache", "sstable")
 
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')")
-    expect_sources('memtable', 'row-cache', 'sstable')
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')"
+    )
+    expect_sources("memtable", "row-cache", "sstable")
 
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
@@ -133,42 +189,60 @@ def test_mutation_dump_range_tombstone_changes(cql, test_table, scylla_only):
     """
     pk1 = util.unique_key_int()
     pk2 = util.unique_key_int()
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')")
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')"
+    )
 
     rts = 4
 
     for ck in range(44, 44 - rts, -1):
-        cql.execute(f"DELETE FROM {test_table} WHERE pk1={pk1} AND pk2={pk2} AND ck1=0 AND ck2>30 AND ck2<{ck}")
+        cql.execute(
+            f"DELETE FROM {test_table} WHERE pk1={pk1} AND pk2={pk2} AND ck1=0 AND ck2>30 AND ck2<{ck}"
+        )
         nodetool.flush(cql, f"{test_table}")
 
-    res = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} AND mutation_source > 'sstable' AND mutation_source < 'sstable;' AND partition_region = 2 ALLOW FILTERING"))
+    res = list(
+        cql.execute(
+            f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} AND mutation_source > 'sstable' AND mutation_source < 'sstable;' AND partition_region = 2 ALLOW FILTERING"
+        )
+    )
     # row + 2 * range-tombstone-change
     assert len(res) == 2 * rts + 1
 
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_count(cql, test_table, scylla_only):
-    """ Test aggregation (COUNT). """
+    """Test aggregation (COUNT)."""
     pk1 = util.unique_key_int()
     pk2 = util.unique_key_int()
 
-    cql.execute(f"UPDATE {test_table} SET s = 'static val' WHERE pk1 = {pk1} AND pk2 = {pk2}")
+    cql.execute(
+        f"UPDATE {test_table} SET s = 'static val' WHERE pk1 = {pk1} AND pk2 = {pk2}"
+    )
 
     for ck in range(0, 10):
-        cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, {ck}, 'vv')")
+        cql.execute(
+            f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, {ck}, 'vv')"
+        )
 
     for ck in range(10, 20):
-        cql.execute(f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = 1 AND ck2 > {ck} AND ck2 < 100")
+        cql.execute(
+            f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = 1 AND ck2 > {ck} AND ck2 < 100"
+        )
 
     def check_count(kind, expected_count):
-        res = list(cql.execute(f"SELECT COUNT(*) FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} AND mutation_fragment_kind = '{kind}' ALLOW FILTERING"))
+        res = list(
+            cql.execute(
+                f"SELECT COUNT(*) FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2} AND mutation_fragment_kind = '{kind}' ALLOW FILTERING"
+            )
+        )
         assert res[0].count == expected_count
 
-    check_count('partition start', 1)
-    check_count('static row', 1)
-    check_count('clustering row', 10)
-    check_count('range tombstone change', 11)
-    check_count('partition end', 1)
+    check_count("partition start", 1)
+    check_count("static row", 1)
+    check_count("clustering row", 10)
+    check_count("range tombstone change", 11)
+    check_count("partition end", 1)
 
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
@@ -179,14 +253,19 @@ def test_many_partition_scan(cql, test_keyspace, scylla_only):
     The former uses paging, reading 1000 partition keys in a page. Stress this
     logic a bit.
     """
-    with util.new_test_table(cql, test_keyspace, 'pk int PRIMARY KEY, v text', " WITH tombstone_gc = {'mode': 'disabled'}") as test_table:
+    with util.new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v text",
+        " WITH tombstone_gc = {'mode': 'disabled'}",
+    ) as test_table:
         insert_stmt = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
         delete_stmt = cql.prepare(f"DELETE FROM {test_table} WHERE pk = ?")
         partitions = []
         # the scan algorithm reads 1000 partition / page, so have enough partitions for at least 2 pages
         partition_count = 1312
         for pk in range(0, partition_count):
-            cql.execute(insert_stmt, (pk, 'v'))
+            cql.execute(insert_stmt, (pk, "v"))
             if pk % 3 == 0:
                 cql.execute(delete_stmt, (pk,))
                 partitions.append((pk, False))
@@ -194,19 +273,27 @@ def test_many_partition_scan(cql, test_keyspace, scylla_only):
                 partitions.append((pk, True))
 
         nodetool.flush(cql, f"{test_table}")
-        requests.post(f'{nodetool.rest_api_url(cql)}/system/drop_sstable_caches')
+        requests.post(f"{nodetool.rest_api_url(cql)}/system/drop_sstable_caches")
 
         # the real test here is that this scan completes without problems
         # since this scan is very slow, we create an extra patient cql connection,
         # with an abundant 10 minutes timeout
         ep = cql.hosts[0].endpoint
-        with util.cql_session(ep.address, ep.port, False, 'cassandra', 'cassandra', 600) as patient_cql:
-            res_all = list(patient_cql.execute(f"SELECT pk, mutation_source, mutation_fragment_kind, metadata FROM MUTATION_FRAGMENTS({test_table});"))
+        with util.cql_session(
+            ep.address, ep.port, False, "cassandra", "cassandra", 600
+        ) as patient_cql:
+            res_all = list(
+                patient_cql.execute(
+                    f"SELECT pk, mutation_source, mutation_fragment_kind, metadata FROM MUTATION_FRAGMENTS({test_table});"
+                )
+            )
 
         actual_partitions = []
         for r in res_all:
             if r.mutation_fragment_kind == "partition start":
-                actual_partitions.append((r.pk, len(json.loads(r.metadata)["tombstone"]) == 0))
+                actual_partitions.append(
+                    (r.pk, len(json.loads(r.metadata)["tombstone"]) == 0)
+                )
 
         actual_partitions = sorted(actual_partitions)
 
@@ -215,34 +302,60 @@ def test_many_partition_scan(cql, test_keyspace, scylla_only):
 
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
-def test_metadata_and_value(cql, test_keyspace, scylla_path, scylla_data_dir, scylla_only):
+def test_metadata_and_value(
+    cql, test_keyspace, scylla_path, scylla_data_dir, scylla_only
+):
     """
     Test that metadata + value columns allow reconstructing a full sstable dump.
     Meaning that their json representation of metadata and value is the same.
     """
-    with util.new_test_table(cql, test_keyspace, 'pk int, ck int, v1 text, v2 map<int, text>, v3 tuple<int, text, boolean>, s text static, PRIMARY KEY (pk, ck)') as test_table:
-        insert_stmt = cql.prepare(f"INSERT INTO {test_table} (pk, ck, v1, v2, v3, s) VALUES (?, ?, ?, ?, ?, ?)")
-        delete_row_stmt = cql.prepare(f"DELETE FROM {test_table} WHERE pk = ? AND ck = ?")
-        delete_row_range_stmt = cql.prepare(f"DELETE FROM {test_table} WHERE pk = ? AND ck > ? AND CK < ?")
+    with util.new_test_table(
+        cql,
+        test_keyspace,
+        "pk int, ck int, v1 text, v2 map<int, text>, v3 tuple<int, text, boolean>, s text static, PRIMARY KEY (pk, ck)",
+    ) as test_table:
+        insert_stmt = cql.prepare(
+            f"INSERT INTO {test_table} (pk, ck, v1, v2, v3, s) VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        delete_row_stmt = cql.prepare(
+            f"DELETE FROM {test_table} WHERE pk = ? AND ck = ?"
+        )
+        delete_row_range_stmt = cql.prepare(
+            f"DELETE FROM {test_table} WHERE pk = ? AND ck > ? AND CK < ?"
+        )
         delete_partition_stmt = cql.prepare(f"DELETE FROM {test_table} WHERE pk = ?")
         for pk in range(0, 2):
             for ck in range(0, 10):
                 if ck % 4:
                     cql.execute(delete_row_stmt, (pk, ck))
                 else:
-                    cql.execute(insert_stmt, (pk, ck, 'v1_val', {0: '0_val', 1: '1_val'}, (4, 'tuple_val', ck % 2), 'static_val'))
+                    cql.execute(
+                        insert_stmt,
+                        (
+                            pk,
+                            ck,
+                            "v1_val",
+                            {0: "0_val", 1: "1_val"},
+                            (4, "tuple_val", ck % 2),
+                            "static_val",
+                        ),
+                    )
             cql.execute(delete_row_range_stmt, (pk, 100, 200))
         cql.execute(delete_partition_stmt, (100,))
 
         nodetool.flush(cql, f"{test_table}")
         nodetool.flush_keyspace(cql, "system_schema")
-        requests.post(f'{nodetool.rest_api_url(cql)}/system/drop_sstable_caches')
+        requests.post(f"{nodetool.rest_api_url(cql)}/system/drop_sstable_caches")
 
-        table_name = test_table.split('.')[1]
-        sstables = glob.glob(os.path.join(scylla_data_dir, test_keyspace, f"{table_name}-*", "*-Data.db"))
+        table_name = test_table.split(".")[1]
+        sstables = glob.glob(
+            os.path.join(scylla_data_dir, test_keyspace, f"{table_name}-*", "*-Data.db")
+        )
 
         with nodetool.no_autocompaction_context(cql, "system", "system_schema"):
-            res = subprocess.check_output([scylla_path, "sstable", "dump-data", "--merge"] + sstables)
+            res = subprocess.check_output(
+                [scylla_path, "sstable", "dump-data", "--merge"] + sstables
+            )
 
         reference_dump = json.loads(res)["sstables"]["anonymous"]
 
@@ -285,7 +398,11 @@ def test_metadata_and_value(cql, test_keyspace, scylla_path, scylla_data_dir, sc
                 else:
                     partition["clustering_elements"] = [cr]
             elif kind == "range tombstone change":
-                rtc = {"type": "range-tombstone-change", "key": {"value": str(row.ck)}, "weight": row.position_weight}
+                rtc = {
+                    "type": "range-tombstone-change",
+                    "key": {"value": str(row.ck)},
+                    "weight": row.position_weight,
+                }
                 rtc.update(json.loads(row.metadata))
                 if "clustering_elements" in partition:
                     partition["clustering_elements"].append(rtc)
@@ -296,33 +413,38 @@ def test_metadata_and_value(cql, test_keyspace, scylla_path, scylla_data_dir, sc
                 reconstructed_dump.append(partition)
 
         reference_dump_json = json.dumps(reference_dump, indent=4, sort_keys=True)
-        reconstructed_dump_json = json.dumps(reconstructed_dump, indent=4, sort_keys=True)
+        reconstructed_dump_json = json.dumps(
+            reconstructed_dump, indent=4, sort_keys=True
+        )
 
         assert reference_dump_json == reconstructed_dump_json
 
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_paging(cql, test_table, scylla_only):
-    """ Test that paging works properly. """
+    """Test that paging works properly."""
     pk1 = util.unique_key_int()
     pk2 = util.unique_key_int()
 
-    insert_stmt = cql.prepare(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES (?, ?, ?, ?, ?)")
+    insert_stmt = cql.prepare(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES (?, ?, ?, ?, ?)"
+    )
     num_rows = 43
     expected_mutation_fragments = num_rows + 2
     page_size = 10
     for ck in range(0, num_rows):
-        cql.execute(insert_stmt, (pk1, pk2, 0, ck, 'asdasd'))
+        cql.execute(insert_stmt, (pk1, pk2, 0, ck, "asdasd"))
 
     nodetool.flush(cql, f"{test_table}")
 
     read_stmt = cassandra.query.SimpleStatement(
-            f"""SELECT * FROM mutation_fragments({test_table})
+        f"""SELECT * FROM mutation_fragments({test_table})
             WHERE
                 pk1 = {pk1} AND
                 pk2 = {pk2} AND
                 mutation_source > 'sstable:'""",
-            fetch_size=page_size)
+        fetch_size=page_size,
+    )
     result = cql.execute(read_stmt)
 
     remaining = expected_mutation_fragments
@@ -339,25 +461,34 @@ def test_paging(cql, test_table, scylla_only):
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_slicing_rows(cql, test_table, scylla_only):
-    """ Test that slicing rows from underlying works. """
+    """Test that slicing rows from underlying works."""
     pk1 = util.unique_key_int()
     pk2 = util.unique_key_int()
 
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')")
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 20, 'vv')")
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 1, 20, 'vv')")
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')"
+    )
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 20, 'vv')"
+    )
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 1, 20, 'vv')"
+    )
 
     nodetool.flush(cql, f"{test_table}")
 
-    all_rows = list(cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
+    all_rows = list(
+        cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
             WHERE
                 pk1 = {pk1} AND
                 pk2 = {pk2} AND
-                mutation_source > 'sstable:'"""))
+                mutation_source > 'sstable:'""")
+    )
     mutation_source = all_rows[0].mutation_source
 
     def check_slice(ck1, ck2_start_inclusive, ck2_end_exclusive):
-        res = list(cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
+        res = list(
+            cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
             WHERE
                 pk1 = {pk1} AND
                 pk2 = {pk2} AND
@@ -366,8 +497,15 @@ def test_slicing_rows(cql, test_table, scylla_only):
                 ck1 = {ck1} AND
                 ck2 >= {ck2_start_inclusive} AND
                 ck2 < {ck2_end_exclusive}
-            """))
-        expected_rows = [r for r in all_rows if r.ck1 == ck1 and r.ck2 >= ck2_start_inclusive and r.ck2 < ck2_end_exclusive]
+            """)
+        )
+        expected_rows = [
+            r
+            for r in all_rows
+            if r.ck1 == ck1
+            and r.ck2 >= ck2_start_inclusive
+            and r.ck2 < ck2_end_exclusive
+        ]
         assert res == expected_rows
 
     check_slice(0, 0, 1)
@@ -384,27 +522,36 @@ def test_slicing_rows(cql, test_table, scylla_only):
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_slicing_range_tombstone_changes(cql, test_table, scylla_only):
-    """ Test that slicing range-tombstone-changes from underlying works. """
+    """Test that slicing range-tombstone-changes from underlying works."""
     pk1 = util.unique_key_int()
     pk2 = util.unique_key_int()
     ck1 = 0
 
-    cql.execute(f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = {ck1}")
-    cql.execute(f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = {ck1} AND ck2 > 10 AND ck2 < 20")
-    cql.execute(f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = {ck1} AND ck2 > 20 AND ck2 < 30")
+    cql.execute(
+        f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = {ck1}"
+    )
+    cql.execute(
+        f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = {ck1} AND ck2 > 10 AND ck2 < 20"
+    )
+    cql.execute(
+        f"DELETE FROM {test_table} WHERE pk1 = {pk1} AND pk2 = {pk2} AND ck1 = {ck1} AND ck2 > 20 AND ck2 < 30"
+    )
 
     nodetool.flush(cql, f"{test_table}")
 
-    sample_row = list(cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
+    sample_row = list(
+        cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
         WHERE
             pk1 = {pk1} AND
             pk2 = {pk2} AND
             mutation_source > 'sstable:'
-        LIMIT 1"""))
+        LIMIT 1""")
+    )
     mutation_source = sample_row[0].mutation_source
 
     def check_slice_ck1_fixed(ck2_start_inclusive, ck2_end_exclusive, expected_rtcs):
-        res = list(cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
+        res = list(
+            cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
             WHERE
                 pk1 = {pk1} AND
                 pk2 = {pk2} AND
@@ -413,7 +560,8 @@ def test_slicing_range_tombstone_changes(cql, test_table, scylla_only):
                 ck1 = {ck1} AND
                 ck2 >= {ck2_start_inclusive} AND
                 ck2 < {ck2_end_exclusive}
-            """))
+            """)
+        )
         assert len(res) == len(expected_rtcs)
         for row, rtc in zip(res, expected_rtcs):
             assert row.ck1 == ck1
@@ -430,12 +578,22 @@ def test_ck_in_query(cql, test_table, scylla_only):
     pk1 = util.unique_key_int()
     pk2 = util.unique_key_int()
 
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')")
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 1, 1, 'vv')")
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')"
+    )
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 1, 1, 'vv')"
+    )
     nodetool.flush(cql, f"{test_table}")
-    cql.execute(f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')")
+    cql.execute(
+        f"INSERT INTO {test_table} (pk1, pk2, ck1, ck2, v) VALUES ({pk1}, {pk2}, 0, 0, 'vv')"
+    )
 
-    sources_res = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2}"))
+    sources_res = list(
+        cql.execute(
+            f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2}"
+        )
+    )
 
     sources = {r.mutation_source.split(":")[0]: r.mutation_source for r in sources_res}
     assert len(sources) == 3
@@ -443,7 +601,8 @@ def test_ck_in_query(cql, test_table, scylla_only):
     assert "row-cache" in sources
     assert "sstable" in sources
 
-    res = list(cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
+    res = list(
+        cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
         WHERE
             pk1 = {pk1} AND
             pk2 = {pk2} AND
@@ -452,14 +611,15 @@ def test_ck_in_query(cql, test_table, scylla_only):
                 ('{sources["row-cache"]}', 2, 0, 0, 0),
                 ('{sources["sstable"]}', 2, 0, 0, 0),
                 ('{sources["sstable"]}', 2, 1, 1, 0))
-        """))
+        """)
+    )
 
     columns = ("mutation_source", "partition_region", "ck1", "ck2", "position_weight")
     expected_results = [
-            (sources["memtable"], 2, 0, 0, 0),
-            (sources["row-cache"], 2, 0, 0, 0),
-            (sources["sstable"], 2, 0, 0, 0),
-            (sources["sstable"], 2, 1, 1, 0),
+        (sources["memtable"], 2, 0, 0, 0),
+        (sources["row-cache"], 2, 0, 0, 0),
+        (sources["sstable"], 2, 0, 0, 0),
+        (sources["sstable"], 2, 1, 1, 0),
     ]
 
     assert len(res) == len(expected_results)
@@ -472,7 +632,12 @@ def test_ck_in_query(cql, test_table, scylla_only):
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_many_partitions(cql, test_keyspace, scylla_only):
     num_partitions = 5000
-    with util.new_test_table(cql, test_keyspace, 'pk int PRIMARY KEY, v int', " WITH tombstone_gc = {'mode': 'disabled'}") as table:
+    with util.new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v int",
+        " WITH tombstone_gc = {'mode': 'disabled'}",
+    ) as table:
         delete_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ?")
         for pk in range(num_partitions):
             cql.execute(delete_id, (pk,))
@@ -482,9 +647,14 @@ def test_many_partitions(cql, test_keyspace, scylla_only):
         # since this scan is very slow, we create an extra patient cql connection,
         # with an abundant 10 minutes timeout
         ep = cql.hosts[0].endpoint
-        with util.cql_session(ep.address, ep.port, False, 'cassandra', 'cassandra', 600) as patient_cql:
-            res = list(patient_cql.execute(
-                f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE mutation_source > 'sstable:' ALLOW FILTERING"))
+        with util.cql_session(
+            ep.address, ep.port, False, "cassandra", "cassandra", 600
+        ) as patient_cql:
+            res = list(
+                patient_cql.execute(
+                    f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE mutation_source > 'sstable:' ALLOW FILTERING"
+                )
+            )
         pks = set()
         partition_starts = 0
         partition_ends = 0
@@ -497,34 +667,44 @@ def test_many_partitions(cql, test_keyspace, scylla_only):
                 partition_ends += 1
                 assert row.pk in pks
             else:
-                pytest.fail(f"Unexpected mutation fragment kind: {row.mutation_fragment_kind}")
+                pytest.fail(
+                    f"Unexpected mutation fragment kind: {row.mutation_fragment_kind}"
+                )
 
         assert partition_starts == num_partitions
         assert partition_ends == num_partitions
         assert len(pks) == num_partitions
 
 
-@pytest.mark.xfail(reason="issue #18768; token() filtering doesn't work with MUTATION_FRAGMENTS")
+@pytest.mark.xfail(
+    reason="token() filtering doesn't work with mutation_fragments #18768"
+)
 def test_mutation_fragments_vs_token(cql, test_keyspace, scylla_only):
-    with util.new_test_table(cql, test_keyspace, 'pk int PRIMARY KEY, c int') as table:
-        print(f'INSERT INFO {table} (pk, c) VALUES (0, 0)')
-        cql.execute(f'INSERT INTO {table} (pk, c) VALUES (0, 0)')
+    with util.new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, c int") as table:
+        print(f"INSERT INFO {table} (pk, c) VALUES (0, 0)")
+        cql.execute(f"INSERT INTO {table} (pk, c) VALUES (0, 0)")
         # FIXME add some reasonable validation of selected keys vs tokens
-        cql.execute(f'SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE token(pk) <= -1')
+        cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE token(pk) <= -1")
 
 
-def test_mutation_fragments_scan_includes_dead_partitions(cql, test_keyspace, scylla_only):
-    with util.new_test_table(cql, test_keyspace, 'pk int PRIMARY KEY, c int',
-                             " WITH compaction = {'class':'NullCompactionStrategy'}"
-                             " AND tombstone_gc = {'mode': 'immediate', 'propagation_delay_in_seconds': 0}") as table:
-        cql.execute(f'DELETE FROM {table} WHERE pk = 0')
-        time.sleep(1) # need one second sleep to make the above tombstone gc-eligible
-        res = list(cql.execute(f'SELECT * FROM MUTATION_FRAGMENTS({table})'))
-        assert len(res) == 2 # partition start and end fragments
+def test_mutation_fragments_scan_includes_dead_partitions(
+    cql, test_keyspace, scylla_only
+):
+    with util.new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, c int",
+        " WITH compaction = {'class':'NullCompactionStrategy'}"
+        " AND tombstone_gc = {'mode': 'immediate', 'propagation_delay_in_seconds': 0}",
+    ) as table:
+        cql.execute(f"DELETE FROM {table} WHERE pk = 0")
+        time.sleep(1)  # need one second sleep to make the above tombstone gc-eligible
+        res = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table})"))
+        assert len(res) == 2  # partition start and end fragments
 
 
 def test_virtual_table(cql):
-    clients = list(cql.execute('SELECT * FROM MUTATION_FRAGMENTS(system.clients)'))
+    clients = list(cql.execute("SELECT * FROM MUTATION_FRAGMENTS(system.clients)"))
 
     # There should be at least one client -- 'cql'
     assert len(clients) > 0

--- a/test/cqlpy/test_sstable_compression.py
+++ b/test/cqlpy/test_sstable_compression.py
@@ -12,66 +12,130 @@ from . import nodetool
 from .util import new_test_table, new_materialized_view, is_scylla
 from cassandra.protocol import ConfigurationException, SyntaxException
 
+
 # In older Cassandra and Scylla, the name of the compression algorithm was
 # given as a "sstable_compression" attribute, but newer Cassandra switched
 # to "class". Check that we support this new name class.
 # Reproduces #8948.
-@pytest.mark.xfail(reason="#8948")
+@pytest.mark.xfail(
+    reason='Cassandra 3.11.10 uses "class" instead of "sstable_compression" for compression settings by default #8948'
+)
 def test_compression_class(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int primary key, v int", "with compression = { 'class': 'LZ4Compressor' }") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int primary key, v int",
+        "with compression = { 'class': 'LZ4Compressor' }",
+    ) as table:
         pass
+
 
 # In the following tests, we use the older "sstable_compression" option name
 # (instead of the new "class") so we can have passing tests despite #8948.
 # When both Scylla and Cassandra support "class", we should modify this variable
 # to use it:
-sstable_compression = 'sstable_compression'
+sstable_compression = "sstable_compression"
+
 
 @pytest.fixture(scope="module")
 def table_lz4(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int primary key, v int", "with compression = { '" + sstable_compression + "': 'LZ4Compressor' }") as table:
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "p int primary key, v int",
+        "with compression = { '" + sstable_compression + "': 'LZ4Compressor' }",
+    ) as table:
         yield table
+
 
 # Test that if we have a table with lz4 compression, it has the expected
 # compression "class" in its schema table. Note that even if the older
 # "sstable_compression" attribute was used to set the compression class,
 # when reading the schema we should see "class".
 # Reproduces #8948.
-@pytest.mark.xfail(reason="#8948")
+@pytest.mark.xfail(
+    reason='Cassandra 3.11.10 uses "class" instead of "sstable_compression" for compression settings by default #8948'
+)
 def test_read_compression_class(cql, table_lz4):
-    [ks, cf] = table_lz4.split('.')
-    opts = cql.execute(f"SELECT compression FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='{cf}'").one().compression
-    assert 'class' in opts
-    assert opts['class'] == 'org.apache.cassandra.io.compress.LZ4Compressor'
+    [ks, cf] = table_lz4.split(".")
+    opts = (
+        cql.execute(
+            f"SELECT compression FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='{cf}'"
+        )
+        .one()
+        .compression
+    )
+    assert "class" in opts
+    assert opts["class"] == "org.apache.cassandra.io.compress.LZ4Compressor"
+
 
 # When creating a compressed table without specifying chunk_length_in_kb
 # explicitly, some default value is nevertheless used, and its value should
 # be readable from the schema.
 # Reproduces #6442.
-@pytest.mark.xfail(reason="#6442")
+@pytest.mark.xfail(
+    reason="Always print all schema parameters (including default values) #6442"
+)
 def test_read_chunk_length(cql, table_lz4):
-    [ks, cf] = table_lz4.split('.')
-    opts = cql.execute(f"SELECT compression FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='{cf}'").one().compression
-    assert 'chunk_length_in_kb' in opts
+    [ks, cf] = table_lz4.split(".")
+    opts = (
+        cql.execute(
+            f"SELECT compression FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='{cf}'"
+        )
+        .one()
+        .compression
+    )
+    assert "chunk_length_in_kb" in opts
+
 
 # Both Cassandra and Scylla only allow chunk_length_in_kb to be set a power
 # of two.
 def test_chunk_length_must_be_power_of_two(cql, test_keyspace):
-    with pytest.raises(ConfigurationException, match='power of 2'):
-        with new_test_table(cql, test_keyspace, "p int primary key, v int", "with compression = { '" + sstable_compression + "': 'LZ4Compressor', 'chunk_length_in_kb': 100 }") as table:
+    with pytest.raises(ConfigurationException, match="power of 2"):
+        with new_test_table(
+            cql,
+            test_keyspace,
+            "p int primary key, v int",
+            "with compression = { '"
+            + sstable_compression
+            + "': 'LZ4Compressor', 'chunk_length_in_kb': 100 }",
+        ) as table:
             pass
+
 
 # chunk_length_in_kb cannot be zero, negative, null, or non-integer.
 # Surprisingly, Scylla allows floating-point numbers (and truncates them).
 # It shouldn't, and Cassandra doesn't, so this case is "xfail" below.
-@pytest.mark.parametrize("garbage", ["0", "-1", "null", "'dog'",
-        pytest.param("1.1", marks=pytest.mark.xfail(reason='Scylla truncates float chunk length'))])
+@pytest.mark.parametrize(
+    "garbage",
+    [
+        "0",
+        "-1",
+        "null",
+        "'dog'",
+        pytest.param(
+            "1.1", marks=pytest.mark.xfail(reason="Scylla truncates float chunk length")
+        ),
+    ],
+)
 def test_chunk_length_invalid(cql, test_keyspace, garbage):
     # The error should usually be ConfigurationException, but strangely
     # Cassandra throws a SyntaxException in the "null" case.
-    with pytest.raises((ConfigurationException, SyntaxException), match='chunk_length_in_kb'):
-        with new_test_table(cql, test_keyspace, "p int primary key, v int", "with compression = { '" + sstable_compression + "': 'LZ4Compressor', 'chunk_length_in_kb': " + garbage + " }") as table:
+    with pytest.raises(
+        (ConfigurationException, SyntaxException), match="chunk_length_in_kb"
+    ):
+        with new_test_table(
+            cql,
+            test_keyspace,
+            "p int primary key, v int",
+            "with compression = { '"
+            + sstable_compression
+            + "': 'LZ4Compressor', 'chunk_length_in_kb': "
+            + garbage
+            + " }",
+        ) as table:
             pass
+
 
 # If a user is allowed to specify a huge number for chunk_length_in_kb, it can
 # result in unbounded allocations and potentially crashing Scylla. Therefore,
@@ -81,19 +145,33 @@ def test_chunk_length_invalid(cql, test_keyspace, garbage):
 # chunk sizes, so the test is marked a "cassandra_bug".
 # Reproduces #9933.
 def test_huge_chunk_length(cql, test_keyspace, cassandra_bug):
-    with pytest.raises(ConfigurationException, match='chunk_length_in_kb'):
-        with new_test_table(cql, test_keyspace, "p int primary key, v int", "with compression = { '" + sstable_compression + "': 'LZ4Compressor', 'chunk_length_in_kb': 1048576 }") as table:
+    with pytest.raises(ConfigurationException, match="chunk_length_in_kb"):
+        with new_test_table(
+            cql,
+            test_keyspace,
+            "p int primary key, v int",
+            "with compression = { '"
+            + sstable_compression
+            + "': 'LZ4Compressor', 'chunk_length_in_kb': 1048576 }",
+        ) as table:
             # At this point, the test already failed, as we expected the table
             # creation to have failed with ConfigurationException. But if we
             # reached here, let's really demonstrate the bug - write
             # something and flush it, to have sstable compression actually
             # be used.
-            cql.execute(f'INSERT INTO {table} (p, v) VALUES (1, 2)')
+            cql.execute(f"INSERT INTO {table} (p, v) VALUES (1, 2)")
             nodetool.flush(cql, table)
     # Also check the same for ALTER TABLE
     with new_test_table(cql, test_keyspace, "p int primary key, v int") as table:
-        with pytest.raises(ConfigurationException, match='chunk_length_in_kb'):
-            cql.execute("ALTER TABLE " + table + " with compression = { '" + sstable_compression + "': 'LZ4Compressor', 'chunk_length_in_kb': 1048576 }")
+        with pytest.raises(ConfigurationException, match="chunk_length_in_kb"):
+            cql.execute(
+                "ALTER TABLE "
+                + table
+                + " with compression = { '"
+                + sstable_compression
+                + "': 'LZ4Compressor', 'chunk_length_in_kb': 1048576 }"
+            )
+
 
 # Check that whatever is currently the default sstable compression algorithm
 # (for a long time it was LZ4Compressor but issue #26610 changed it to
@@ -110,26 +188,44 @@ def test_huge_chunk_length(cql, test_keyspace, cassandra_bug):
 def test_aux_tables_compression_parity(cql, test_keyspace):
     extra = "with cdc = {'enabled': true}" if is_scylla(cql) else ""
     with new_test_table(cql, test_keyspace, "p int primary key, v int", extra) as table:
-        with new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as mv:
-            cql.execute(f'CREATE INDEX ON {table}(v)')
+        with new_materialized_view(
+            cql, table, "*", "v, p", "v is not null and p is not null"
+        ) as mv:
+            cql.execute(f"CREATE INDEX ON {table}(v)")
             # base table's compression setting:
-            ks, cf = table.split('.')
-            r = list(cql.execute(f"SELECT compression FROM system_schema.tables WHERE  keyspace_name='{ks}' and table_name='{cf}'"))
+            ks, cf = table.split(".")
+            r = list(
+                cql.execute(
+                    f"SELECT compression FROM system_schema.tables WHERE  keyspace_name='{ks}' and table_name='{cf}'"
+                )
+            )
             assert len(r) == 1
             base_compression = r[0].compression
             # view table's compression setting:
-            _, view = mv.split('.')
-            r = list(cql.execute(f"SELECT compression FROM system_schema.views WHERE  keyspace_name='{ks}' and view_name='{view}'"))
+            _, view = mv.split(".")
+            r = list(
+                cql.execute(
+                    f"SELECT compression FROM system_schema.views WHERE  keyspace_name='{ks}' and view_name='{view}'"
+                )
+            )
             assert len(r) == 1
             view_compression = r[0].compression
-            if extra: # Scylla-only part
+            if extra:  # Scylla-only part
                 # secondary index's backing view's compression setting:
-                r = list(cql.execute(f"SELECT compression FROM system_schema.views WHERE  keyspace_name='{ks}' and view_name='{cf}_v_idx_index'"))
+                r = list(
+                    cql.execute(
+                        f"SELECT compression FROM system_schema.views WHERE  keyspace_name='{ks}' and view_name='{cf}_v_idx_index'"
+                    )
+                )
                 assert len(r) == 1
                 index_compression = r[0].compression
                 assert view_compression == index_compression
                 # CDC log table's compression setting:
-                r = list(cql.execute(f"SELECT compression FROM system_schema.tables WHERE  keyspace_name='{ks}' and table_name='{cf}_scylla_cdc_log'"))
+                r = list(
+                    cql.execute(
+                        f"SELECT compression FROM system_schema.tables WHERE  keyspace_name='{ks}' and table_name='{cf}_scylla_cdc_log'"
+                    )
+                )
                 assert len(r) == 1
                 cdc_compression = r[0].compression
                 assert view_compression == cdc_compression

--- a/test/cqlpy/test_static.py
+++ b/test/cqlpy/test_static.py
@@ -13,11 +13,13 @@ import pytest
 from cassandra.protocol import SyntaxException, InvalidRequest
 from .util import new_test_table, unique_key_int
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    schema='p int, c int, r int, s int static, PRIMARY KEY(p, c)'
+    schema = "p int, c int, r int, s int static, PRIMARY KEY(p, c)"
     with new_test_table(cql, test_keyspace, schema) as table:
         yield table
+
 
 # Test what happens when we SELECT a partition which has a static column
 # set but no clustering row, but the static column is *not* selected.
@@ -27,29 +29,34 @@ def table1(cql, test_keyspace):
 # and we have no good explanation why Scylla's behavior is more correct than
 # Cassandra. If we later decide that we consider *both* behaviors equally
 # correct, we can change the test to accept both and make it pass.
-@pytest.mark.xfail(reason="issue #10091")
+@pytest.mark.xfail(
+    reason="because of static column, a of SELECT of partition no clustering rows can return a row anyway #10091"
+)
 def test_static_not_selected(cql, table1):
     p = unique_key_int()
     # The partition p doesn't exist, so the following select yields nothing:
-    assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == []
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p={p}")) == []
     # Insert just the static column, and no clustering row:
-    cql.execute(f'INSERT INTO {table1} (p, s) values ({p}, 1)')
+    cql.execute(f"INSERT INTO {table1} (p, s) values ({p}, 1)")
     # If we select all the columns, including the static column s, SELECTing
     # the partition gives us one "row" with the static column set and all
     # other columns set to null - otherwise the static column cannot be
     # returned.
-    assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == [(p,None,1,None)]
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p={p}")) == [
+        (p, None, 1, None)
+    ]
     # But what happens if we SELECT just regular (non-static) columns?
     # Should the SELECT return nothing (since there is no clustering row),
     # or return one "row" with null columns (basically just like in the
     # previous SELECT, just intersected with the desired column)?
     # Currently, Cassandra does the former, Scylla does the latter,
     # so the following assert fails on Scylla:
-    assert list(cql.execute(f'SELECT r FROM {table1} WHERE p={p}')) == []
+    assert list(cql.execute(f"SELECT r FROM {table1} WHERE p={p}")) == []
+
 
 # Verify that if a partition has a static column set, reading an *existing*
 # clustering row will return it, but reading a *non-existing* row will not
-# return anything - not even the static column. 
+# return anything - not even the static column.
 #
 # Contrast this with issue #10081 (test_lwt.py::test_lwt_missing_row_with_static)
 # where we suggested that in an UPDATE with IF condition (LWT), the static
@@ -58,12 +65,17 @@ def test_static_not_selected(cql, table1):
 def test_missing_row_with_static(cql, table1):
     p = unique_key_int()
     # Insert into partition p just static column and once clustering row c=2
-    cql.execute(f'INSERT INTO {table1}(p, s, c, r) values ({p}, 1, 2, 3)')
+    cql.execute(f"INSERT INTO {table1}(p, s, c, r) values ({p}, 1, 2, 3)")
     # If we SELECT row c=2, we get it and the static column:
-    assert list(cql.execute(f'SELECT p, s, c, r FROM {table1} WHERE p={p} AND c=2')) == [(p, 1, 2, 3)]
+    assert list(
+        cql.execute(f"SELECT p, s, c, r FROM {table1} WHERE p={p} AND c=2")
+    ) == [(p, 1, 2, 3)]
     # If we SELECT row c=1 (which doesn't exist), we get nothing - not even
     # the static column
-    assert list(cql.execute(f'SELECT p, s, c, r FROM {table1} WHERE p={p} AND c=1')) == []
+    assert (
+        list(cql.execute(f"SELECT p, s, c, r FROM {table1} WHERE p={p} AND c=1")) == []
+    )
+
 
 # Verify that if a partition has a static column set, filtering it (with
 # ALLOW FILTERING) based on regular columns will need to find clustering
@@ -75,14 +87,26 @@ def test_filter_with_static(cql, table1):
     p = unique_key_int()
     # Insert into partition p just static column and one clustering row
     # with its regular column r set to 3:
-    cql.execute(f'INSERT INTO {table1}(p, s, c, r) values ({p}, 1, 2, 3)')
+    cql.execute(f"INSERT INTO {table1}(p, s, c, r) values ({p}, 1, 2, 3)")
     # If we filter for r=3, we expect to get the clustering row and the
     # static column:
-    assert list(cql.execute(f'SELECT p, s, c, r FROM {table1} WHERE p={p} AND r=3 ALLOW FILTERING')) == [(p, 1, 2, 3)]
+    assert list(
+        cql.execute(
+            f"SELECT p, s, c, r FROM {table1} WHERE p={p} AND r=3 ALLOW FILTERING"
+        )
+    ) == [(p, 1, 2, 3)]
     # If we filter for r=4, we expect to get nothing - not even the static
     # column. Getting back just the static row, with r=null, would be wrong
     # because it does *not* match the filter r=4.
-    assert list(cql.execute(f'SELECT p, s, c, r FROM {table1} WHERE p={p} AND r=4 ALLOW FILTERING')) == []
+    assert (
+        list(
+            cql.execute(
+                f"SELECT p, s, c, r FROM {table1} WHERE p={p} AND r=4 ALLOW FILTERING"
+            )
+        )
+        == []
+    )
+
 
 # Reproduce issue #10357. The query is identical to the one in the above
 # test (test_filter_with_static), but here the partition has only a static
@@ -90,11 +114,19 @@ def test_filter_with_static(cql, table1):
 # when using a filtering on a regular column.
 def test_filter_with_only_static(cql, table1):
     p = unique_key_int()
-    cql.execute(f'INSERT INTO {table1}(p, s) values ({p}, 1)')
+    cql.execute(f"INSERT INTO {table1}(p, s) values ({p}, 1)")
     # There are no clustering rows or r column set for anything, so filtering
     # for r=4 should return nothing. But issue #10357 caused Scylla to wrongly
     # return a row with only the static value - which doesn't match the filter.
-    assert list(cql.execute(f'SELECT p, s, c, r FROM {table1} WHERE p={p} AND r=4 ALLOW FILTERING')) == []
+    assert (
+        list(
+            cql.execute(
+                f"SELECT p, s, c, r FROM {table1} WHERE p={p} AND r=4 ALLOW FILTERING"
+            )
+        )
+        == []
+    )
+
 
 # The CREATE TABLE syntax allows either "PRIMARY KEY" or "STATIC" to follow
 # a column's definition, but it's forbidden to use both at once!
@@ -106,8 +138,12 @@ def test_syntax_primary_key_and_static(cql, test_keyspace):
     # on this bizarre distinction, and allow both types of errors for both
     # cases.
     with pytest.raises((SyntaxException, InvalidRequest)):
-        with new_test_table(cql, test_keyspace, 'p int STATIC PRIMARY KEY, v int') as table:
+        with new_test_table(
+            cql, test_keyspace, "p int STATIC PRIMARY KEY, v int"
+        ) as table:
             pass
     with pytest.raises((SyntaxException, InvalidRequest)):
-        with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY STATIC, v int') as table:
+        with new_test_table(
+            cql, test_keyspace, "p int PRIMARY KEY STATIC, v int"
+        ) as table:
             pass

--- a/test/cqlpy/test_system_tables.py
+++ b/test/cqlpy/test_system_tables.py
@@ -30,11 +30,12 @@ from cassandra.protocol import Unauthorized
 # simplest case: we write N different partitions to a table, and look at how
 # close the partition count estimate is to the truth.
 
+
 # Utility function creating a temporary table, writing N partitions into
 # it and then returning the total size_estimates.partitions_count for this
 # table:
 def write_table_and_estimate_partitions(cql, test_keyspace, N):
-    with new_test_table(cql, test_keyspace, 'k int PRIMARY KEY') as table:
+    with new_test_table(cql, test_keyspace, "k int PRIMARY KEY") as table:
         write = cql.prepare(f"INSERT INTO {table} (k) VALUES (?)")
         for i in range(N):
             cql.execute(write, [i])
@@ -46,13 +47,18 @@ def write_table_and_estimate_partitions(cql, test_keyspace, N):
         nodetool.refreshsizeestimates(cql)
         # The size_estimates table has, for a keyspace/table partition, a
         # separate row for separate token ranges. We need to sum those up.
-        table_name = table[len(test_keyspace)+1:]
-        counts = [x.partitions_count for x in cql.execute(
-            f"SELECT partitions_count FROM system.size_estimates WHERE keyspace_name = '{test_keyspace}' AND table_name = '{table_name}'")]
+        table_name = table[len(test_keyspace) + 1 :]
+        counts = [
+            x.partitions_count
+            for x in cql.execute(
+                f"SELECT partitions_count FROM system.size_estimates WHERE keyspace_name = '{test_keyspace}' AND table_name = '{table_name}'"
+            )
+        ]
         count = sum(counts)
         print(counts)
         print(count)
         return count
+
 
 # We expect that when write_table_and_estimate_partitions writes N partitions
 # and returns Scylla's or Cassandra's estimate on the number of partitions,
@@ -64,11 +70,14 @@ def write_table_and_estimate_partitions(cql, test_keyspace, N):
 # up to 14%. So just to be generous let's allow a 25% inaccuracy for this
 # small test. In issue #9083 we noted that Scylla had much larger errors -
 # reporting as much as 10880 (!) partitions when we have just 1000.
-@pytest.mark.xfail(reason="issue #9083")
+@pytest.mark.xfail(
+    reason="system.size_estimates.partitions_count cannot reflect the number of partitions in the table #9083"
+)
 def test_partitions_estimate_simple_small(cql, test_keyspace):
     N = 1000
     count = write_table_and_estimate_partitions(cql, test_keyspace, N)
-    assert count > N/1.25 and count < N*1.25
+    assert count > N / 1.25 and count < N * 1.25
+
 
 # For a larger test, the estimation accuracy should be better:
 # Experimentally, for 10,000 rows, Cassandra's estimation error goes
@@ -76,12 +85,15 @@ def test_partitions_estimate_simple_small(cql, test_keyspace):
 # This is a relatively long test (takes around 2 seconds), and isn't
 # needed to reproduce #9083 (the previous shorter test does it too),
 # so we skip this test.
-@pytest.mark.xfail(reason="issue #9083")
+@pytest.mark.xfail(
+    reason="system.size_estimates.partitions_count cannot reflect the number of partitions in the table #9083"
+)
 @pytest.mark.skip(reason="slow test, remove skip to try it anyway")
 def test_partitions_estimate_simple_large(cql, test_keyspace):
     N = 10000
     count = write_table_and_estimate_partitions(cql, test_keyspace, N)
-    assert count > N/1.05 and count < N*1.05
+    assert count > N / 1.05 and count < N * 1.05
+
 
 # If we write the *same* 1000 partitions to two sstables (by flushing twice,
 # and assuming that 1000 tiny partitions easily fit a memtable), and check
@@ -91,10 +103,12 @@ def test_partitions_estimate_simple_large(cql, test_keyspace):
 # Currently both Cassandra and Scylla fail this test. They are simply not
 # meant to provide accurate partition-count estimates when faced with high
 # space amplification.
-@pytest.mark.xfail(reason="partition count estimator does not use cardinality estimator")
+@pytest.mark.xfail(
+    reason="partition count estimator does not use cardinality estimator"
+)
 def test_partitions_estimate_full_overlap(cassandra_bug, cql, test_keyspace):
     N = 500
-    with new_test_table(cql, test_keyspace, 'k int PRIMARY KEY') as table:
+    with new_test_table(cql, test_keyspace, "k int PRIMARY KEY") as table:
         write = cql.prepare(f"INSERT INTO {table} (k) VALUES (?)")
         for i in range(N):
             cql.execute(write, [i])
@@ -106,13 +120,18 @@ def test_partitions_estimate_full_overlap(cassandra_bug, cql, test_keyspace):
         # TODO: In Scylla we should use NullCompactionStrategy to avoid the two
         # sstables from immediately being compacted together.
         nodetool.refreshsizeestimates(cql)
-        table_name = table[len(test_keyspace)+1:]
-        counts = [x.partitions_count for x in cql.execute(
-            f"SELECT partitions_count FROM system.size_estimates WHERE keyspace_name = '{test_keyspace}' AND table_name = '{table_name}'")]
+        table_name = table[len(test_keyspace) + 1 :]
+        counts = [
+            x.partitions_count
+            for x in cql.execute(
+                f"SELECT partitions_count FROM system.size_estimates WHERE keyspace_name = '{test_keyspace}' AND table_name = '{table_name}'"
+            )
+        ]
         count = sum(counts)
         print(counts)
         print(count)
-        assert count > N/1.5 and count < N*1.5
+        assert count > N / 1.5 and count < N * 1.5
+
 
 # Test that deleted partitions should not be counted by the estimated
 # partitions count. Unfortunately, the current state of both Cassandra
@@ -124,20 +143,25 @@ def test_partitions_estimate_full_overlap(cassandra_bug, cql, test_keyspace):
 @pytest.mark.xfail(reason="partition count estimator doesn't handle deletions")
 def test_partitions_estimate_only_deletions(cassandra_bug, cql, test_keyspace):
     N = 1000
-    with new_test_table(cql, test_keyspace, 'k int PRIMARY KEY') as table:
+    with new_test_table(cql, test_keyspace, "k int PRIMARY KEY") as table:
         delete = cql.prepare(f"DELETE FROM {table} WHERE k=?")
         for i in range(N):
             cql.execute(delete, [i])
         nodetool.flush(cql, table)
         nodetool.refreshsizeestimates(cql)
-        table_name = table[len(test_keyspace)+1:]
-        counts = [x.partitions_count for x in cql.execute(
-            f"SELECT partitions_count FROM system.size_estimates WHERE keyspace_name = '{test_keyspace}' AND table_name = '{table_name}'")]
+        table_name = table[len(test_keyspace) + 1 :]
+        counts = [
+            x.partitions_count
+            for x in cql.execute(
+                f"SELECT partitions_count FROM system.size_estimates WHERE keyspace_name = '{test_keyspace}' AND table_name = '{table_name}'"
+            )
+        ]
         count = sum(counts)
         print(counts)
         print(count)
         # Count should be close to 0, not to N
-        assert count < N/1.25
+        assert count < N / 1.25
+
 
 # See issue #21223
 # Test possibility to set 'memtable_flush_period_in_ms' option for system tables
@@ -147,6 +171,10 @@ def test_alter_system_table_properties(cql, test_keyspace):
         cql.execute("ALTER TABLE system.compaction_history WITH comment = ''")
 
     with pytest.raises(Unauthorized):
-        cql.execute("ALTER TABLE system.compaction_history WITH memtable_flush_period_in_ms = 80000 AND comment = ''")
+        cql.execute(
+            "ALTER TABLE system.compaction_history WITH memtable_flush_period_in_ms = 80000 AND comment = ''"
+        )
 
-    cql.execute("ALTER TABLE system.compaction_history WITH memtable_flush_period_in_ms = 80000")
+    cql.execute(
+        "ALTER TABLE system.compaction_history WITH memtable_flush_period_in_ms = 80000"
+    )

--- a/test/cqlpy/test_type_duration.py
+++ b/test/cqlpy/test_type_duration.py
@@ -23,6 +23,7 @@ s = 1000000000  # nanoseconds per second
 m = 60 * s
 h = 60 * m
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
@@ -30,53 +31,60 @@ def table1(cql, test_keyspace):
     yield table
     cql.execute("DROP TABLE " + table)
 
+
 # The Cassandra documentation
 # https://cassandra.apache.org/doc/latest/cql/types.html#durations
-# or our copy 
+# or our copy
 # https://docs.scylladb.com/getting-started/types/#working-with-durations
 # Specify three ways in which a duration can be input in CQL syntax:
 # a human-readable combination of units (e.g., 12h30m17us), or two ISO 8601
 # formats. Let's begin by testing the human-readable format:
 
+
 # Test each of the units which are supposed to be allowed, separately -
 # y, mo, w, d, h, m, s, ms, us *or* µs, ns:
 # Reproduces issue #8001
-@pytest.mark.xfail(reason="issue #8001")
+@pytest.mark.xfail(
+    reason='Documented unit "µs" not supported for assigning a "duration" type #8001'
+)
 def test_type_duration_human_readable_input_units(cql, table1):
     # Map of allowed units and their expected meaning.
     units = {
-        'y': Duration(12, 0, 0),
-        'mo': Duration(1, 0, 0),
-        'w': Duration(0, 7, 0),
-        'd': Duration(0, 1, 0),
-        'h': Duration(0, 0, 1*h),
-        'm': Duration(0, 0, 1*m),
-        's': Duration(0, 0, 1*s),
-        'ms': Duration(0, 0, 1000000),
-        'us': Duration(0, 0, 1000),
-        'ns': Duration(0, 0, 1),
+        "y": Duration(12, 0, 0),
+        "mo": Duration(1, 0, 0),
+        "w": Duration(0, 7, 0),
+        "d": Duration(0, 1, 0),
+        "h": Duration(0, 0, 1 * h),
+        "m": Duration(0, 0, 1 * m),
+        "s": Duration(0, 0, 1 * s),
+        "ms": Duration(0, 0, 1000000),
+        "us": Duration(0, 0, 1000),
+        "ns": Duration(0, 0, 1),
         # An alias for "us" which should be supported, but wasn't (issue #8001)
-        'µs': Duration(0, 0, 1000),
+        "µs": Duration(0, 0, 1000),
     }
     p = unique_key_int()
-    for (unit, duration) in units.items():
+    for unit, duration in units.items():
         print(unit)
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, 1{unit})")
-        assert list(cql.execute(f"SELECT d FROM {table1} where p = {p}")) == [(duration,)]
+        assert list(cql.execute(f"SELECT d FROM {table1} where p = {p}")) == [
+            (duration,)
+        ]
+
 
 # Test that various combinations of units (e.g., 1d12h30m) work
 def test_type_duration_combine_units(cql, table1):
     # Map of example duration strings and their expected meaning.
     examples = {
-        '1d12h30m': Duration(0, 1, 12*h + 30*m),
-        '1y2mo': Duration(14, 0, 0),
+        "1d12h30m": Duration(0, 1, 12 * h + 30 * m),
+        "1y2mo": Duration(14, 0, 0),
         # A negative duration - with a prefix "-", is supported. We'll have
         # a separate test below showing you can't put the "-" anywhere else.
-        '-1y2mo': Duration(-14, 0, 0),
-        '-1y2h': Duration(-12, 0, -2*h),
+        "-1y2mo": Duration(-14, 0, 0),
+        "-1y2h": Duration(-12, 0, -2 * h),
         # Unit names are case insensitive
-        '1Y2mO': Duration(14, 0, 0),
-        '2d10h': Duration(0, 2, 10*h),
+        "1Y2mO": Duration(14, 0, 0),
+        "2d10h": Duration(0, 2, 10 * h),
         # Units of months, days and nanoseconds are inherently separate and
         # do not "overflow" into larger units: 40 days is 40 days, not one
         # month and 10 (or 9 or 12?) days. 30 hours is 30 hours, not
@@ -84,16 +92,19 @@ def test_type_duration_combine_units(cql, table1):
         # how many days make a month (it can be 28, 30 or 31), and don't even
         # know how many hours make a day - when daylight saving time starts
         # or stops in a certain day.
-        '40d': Duration(0, 40, 0),
-        '30h': Duration(0, 0, 30*h),
+        "40d": Duration(0, 40, 0),
+        "30h": Duration(0, 0, 30 * h),
         # The "human readable" format allows to mix weeks and other units.
         # We'll see below that the ISO 8601 format doesn't.
-        '2y3w': Duration(24, 21, 0),
+        "2y3w": Duration(24, 21, 0),
     }
     p = unique_key_int()
-    for (string, duration) in examples.items():
+    for string, duration in examples.items():
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {string})")
-        assert list(cql.execute(f"SELECT d FROM {table1} where p = {p}")) == [(duration,)]
+        assert list(cql.execute(f"SELECT d FROM {table1} where p = {p}")) == [
+            (duration,)
+        ]
+
 
 # We tested above that the duration "-1y2mo" is supported, meaning a negative
 # duration of one year and two months (i.e., a negative 14 months). In this
@@ -104,12 +115,14 @@ def test_type_duration_negative_part(cql, table1):
     with pytest.raises(SyntaxException, match="-2mo"):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, 1y-2mo)")
 
+
 # While 1y means "one year", you can't just write "y" without a multiplier.
 # In math or physics lingo, "y" is a dimension, not a unit vector.
 def test_type_duration_missing_multiplier(cql, table1):
     p = unique_key_int()
     with pytest.raises(SyntaxException):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, y)")
+
 
 # Only integer multipliers of each units is allowed. If you want half a year,
 # you'll need to ask for six months, not half a year.
@@ -120,48 +133,55 @@ def test_type_duration_integer_only(cql, table1):
     with pytest.raises(SyntaxException):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, 2m12.5s)")
 
+
 # You cannot specify the same unit twice: 2m3m is not allowed for 5m.
 # The error here is InvalidRequest, not SyntaxException as more obvious
 # format errors in the duration.
 def test_type_duration_twice_same_unit(cql, table1):
     p = unique_key_int()
-    with pytest.raises(InvalidRequest, match='multiple times'):
+    with pytest.raises(InvalidRequest, match="multiple times"):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, 2m3m)")
+
 
 # The order of the size of the units should be decreasing - 12s3m is not
 # allowed.
 def test_type_duration_wrong_unit_order(cql, table1):
     p = unique_key_int()
-    with pytest.raises(InvalidRequest, match='The seconds should be after minutes'):
+    with pytest.raises(InvalidRequest, match="The seconds should be after minutes"):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, 12s3m)")
-    with pytest.raises(InvalidRequest, match='The minutes should be after days'):
+    with pytest.raises(InvalidRequest, match="The minutes should be after days"):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, 1y3m4d)")
+
 
 # Now tests for the ISO 8601 format, starting with the letter "P":
 # There are two variants of this format:
 # 1. P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W
 # 2. P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]
 
+
 # Test the "regular" ISO 8601 format,
 # P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W
 def test_type_duration_iso_8601(cql, table1):
     examples = {
-        'P1Y2D': Duration(12, 2, 0),
-        'P1Y2M': Duration(14, 0, 0),
-        'P2W': Duration(0, 14, 0),
-        'P1YT2H': Duration(12, 0, 2*h),
-        '-P1YT2H': Duration(-12, 0, -2*h),
-        'P2D': Duration(0, 2, 0),
-        'PT30H': Duration(0, 0, 30*h),
-        'PT30H20M': Duration(0, 0, 30*h + 20*m),
-        'PT20M': Duration(0, 0, 20*m),
-        'PT56S': Duration(0, 0, 56*s),
-        'P1Y3MT2H10M': Duration(15, 0, 130*m),
+        "P1Y2D": Duration(12, 2, 0),
+        "P1Y2M": Duration(14, 0, 0),
+        "P2W": Duration(0, 14, 0),
+        "P1YT2H": Duration(12, 0, 2 * h),
+        "-P1YT2H": Duration(-12, 0, -2 * h),
+        "P2D": Duration(0, 2, 0),
+        "PT30H": Duration(0, 0, 30 * h),
+        "PT30H20M": Duration(0, 0, 30 * h + 20 * m),
+        "PT20M": Duration(0, 0, 20 * m),
+        "PT56S": Duration(0, 0, 56 * s),
+        "P1Y3MT2H10M": Duration(15, 0, 130 * m),
     }
     p = unique_key_int()
-    for (string, duration) in examples.items():
+    for string, duration in examples.items():
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {string})")
-        assert list(cql.execute(f"SELECT d FROM {table1} where p = {p}")) == [(duration,)]
+        assert list(cql.execute(f"SELECT d FROM {table1} where p = {p}")) == [
+            (duration,)
+        ]
+
 
 # The ISO 8601 format can specify either only weeks, or no weeks. It cannot
 # mix weeks and other units: We saw above that '2y3w' is a valid human-format
@@ -171,25 +191,29 @@ def test_type_duration_iso_8601_mix_w(cql, table1):
     with pytest.raises(SyntaxException):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, P2Y3W)")
 
+
 # Test the "alternative" ISO 8601 format,
 # P[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]
 def test_type_duration_iso_8601_alternative(cql, table1):
     examples = {
-        'P0001-00-02T00:00:00': Duration(12, 2, 0),
-        'P0001-02-00T00:00:00': Duration(14, 0, 0),
-        'P0001-00-00T02:00:00': Duration(12, 0, 2*h),
-        '-P0001-02-00T00:00:00': Duration(-14, 0, 0),
-        'P0000-00-02T00:00:00': Duration(0, 2, 0),
-        'P0000-00-00T30:00:00': Duration(0, 0, 30*h),
-        'P0000-00-00T30:20:00': Duration(0, 0, 30*h + 20*m),
-        'P0000-00-00T00:20:00': Duration(0, 0, 20*m),
-        'P0000-00-00T00:00:56': Duration(0, 0, 56*s),
-        'P0001-03-00T02:10:00': Duration(15, 0, 130*m),
+        "P0001-00-02T00:00:00": Duration(12, 2, 0),
+        "P0001-02-00T00:00:00": Duration(14, 0, 0),
+        "P0001-00-00T02:00:00": Duration(12, 0, 2 * h),
+        "-P0001-02-00T00:00:00": Duration(-14, 0, 0),
+        "P0000-00-02T00:00:00": Duration(0, 2, 0),
+        "P0000-00-00T30:00:00": Duration(0, 0, 30 * h),
+        "P0000-00-00T30:20:00": Duration(0, 0, 30 * h + 20 * m),
+        "P0000-00-00T00:20:00": Duration(0, 0, 20 * m),
+        "P0000-00-00T00:00:56": Duration(0, 0, 56 * s),
+        "P0001-03-00T02:10:00": Duration(15, 0, 130 * m),
     }
     p = unique_key_int()
-    for (string, duration) in examples.items():
+    for string, duration in examples.items():
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, {string})")
-        assert list(cql.execute(f"SELECT d FROM {table1} where p = {p}")) == [(duration,)]
+        assert list(cql.execute(f"SELECT d FROM {table1} where p = {p}")) == [
+            (duration,)
+        ]
+
 
 # In the ISO 8601 alternative format, you cannot just drop parts like the "T"
 def test_type_duration_iso_8601_alternative_missing_t(cql, table1):
@@ -197,11 +221,12 @@ def test_type_duration_iso_8601_alternative_missing_t(cql, table1):
     with pytest.raises(SyntaxException):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, P0002-00-20)")
 
+
 # Unlike the "human readable" formats, the ISO 8601 formats are case
 # sensitive, and lowercase letters won't work:
 def test_type_duration_iso_8601_case_sensitive(cql, table1):
     p = unique_key_int()
-    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, P1Y2D)") # works
+    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, P1Y2D)")  # works
     with pytest.raises(SyntaxException):
         cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, P1y2D)")
     with pytest.raises(SyntaxException):

--- a/test/cqlpy/test_type_time.py
+++ b/test/cqlpy/test_type_time.py
@@ -12,6 +12,7 @@ import pytest
 
 from cassandra.util import Time
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
@@ -19,17 +20,21 @@ def table1(cql, test_keyspace):
     yield table
     cql.execute("DROP TABLE " + table)
 
+
 # According to the Cassandra documentation, a time "can be input either as an
 # integer or using a string representing the time. In the later case, the
 # format should be hh:mm:ss[.fffffffff] (where the sub-second precision is
 # optional and if provided, can be less than the nanosecond). The following
 # tests verify that these different initialization options actually work.
 # Reproduces issue #7987
-@pytest.mark.xfail(reason="issue #7987")
+@pytest.mark.xfail(
+    reason="Unprepared statement fails to set time column from an integer #7987"
+)
 def test_type_time_from_int_unprepared(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, 123)")
     assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(Time(123),)]
+
 
 def test_type_time_from_int_prepared(cql, table1):
     p = unique_key_int()
@@ -37,15 +42,21 @@ def test_type_time_from_int_prepared(cql, table1):
     cql.execute(stmt, [p, 123])
     assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(Time(123),)]
 
+
 def test_type_time_from_string_unprepared(cql, table1):
     p = unique_key_int()
     for t in ["08:12:54", "08:12:54.123", "08:12:54.123456", "08:12:54.123456789"]:
         cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '{t}')")
-        assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(Time(t),)]
+        assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+            (Time(t),)
+        ]
+
 
 def test_type_time_from_string_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, t) VALUES (?, ?)")
     for t in ["08:12:54", "08:12:54.123", "08:12:54.123456", "08:12:54.123456789"]:
         cql.execute(stmt, [p, t])
-        assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(Time(t),)]
+        assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+            (Time(t),)
+        ]

--- a/test/cqlpy/test_type_timestamp.py
+++ b/test/cqlpy/test_type_timestamp.py
@@ -15,15 +15,20 @@ from datetime import datetime
 from cassandra.protocol import InvalidRequest
 import pytest
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int primary key, t timestamp") as table:
         yield table
 
+
 @pytest.fixture(scope="module")
 def table2(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int, c int, t timestamp, primary key (p,c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, t timestamp, primary key (p,c)"
+    ) as table:
         yield table
+
 
 # According to the Cassandra documentation, a timestamp is a 64-bit integer
 # "representing a number of milliseconds since the standard base time known
@@ -39,7 +44,9 @@ def table2(cql, test_keyspace):
 # and then read - so that is the Cassandra-compatible approach - but
 # arguably a more correct and useful behavior would be to fail the write
 # up-front, even before reaching the read.
-@pytest.mark.xfail(reason="issue #11588")
+@pytest.mark.xfail(
+    reason="Timestamp validation happens during read, instead of during write #11588"
+)
 def test_type_timestamp_overflow(cql, table1):
     p = unique_key_int()
     t = 1667215862 * 1000000
@@ -50,7 +57,10 @@ def test_type_timestamp_overflow(cql, table1):
     # be marked scylla_only), but passing the write and failing the read
     # (as in #11588) is a bug.
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, {t})")
-    assert list(cql.execute(f"SELECT tounixtimestamp(t) from {table1} where p = {p}")) == [(t,)]
+    assert list(
+        cql.execute(f"SELECT tounixtimestamp(t) from {table1} where p = {p}")
+    ) == [(t,)]
+
 
 # Check that setting a timestamp to a reasonable number of milliseconds
 # since the epoch, we can read it back properly: We can read the same
@@ -60,8 +70,13 @@ def test_type_timestamp_select(cql, table1):
     p = unique_key_int()
     t = 1667215862123
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, {t})")
-    assert list(cql.execute(f"SELECT tounixtimestamp(t) from {table1} where p = {p}")) == [(t,)]
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2022, 10, 31, 11, 31, 2, 123000),)]
+    assert list(
+        cql.execute(f"SELECT tounixtimestamp(t) from {table1} where p = {p}")
+    ) == [(t,)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2022, 10, 31, 11, 31, 2, 123000),)
+    ]
+
 
 # Above we created a timestamp value from an integer. The documentation also
 # says that it can be assigned a string, and that this string uses a ISO 8601
@@ -72,27 +87,51 @@ def test_type_timestamp_from_string(cql, table1):
     # Some example valid timestamp formats, taken from the documentation
     # https://docs.scylladb.com/stable/cql/types.html#timestamps:
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03 04:05+0000')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 4, 5, 0, 0),)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 4, 5, 0, 0),)
+    ]
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03 04:05:12+0000')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 4, 5, 12, 0),)]
-    cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03 04:05:12.345+0000')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 4, 5, 12, 345000),)]
-    cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03T05:06:17.123+0000')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 5, 6, 17, 123000),)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 4, 5, 12, 0),)
+    ]
+    cql.execute(
+        f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03 04:05:12.345+0000')"
+    )
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 4, 5, 12, 345000),)
+    ]
+    cql.execute(
+        f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03T05:06:17.123+0000')"
+    )
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 5, 6, 17, 123000),)
+    ]
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03+0000')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 0, 0, 0, 0),)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 0, 0, 0, 0),)
+    ]
     # As noticed in issue #20501, Instead of +0000 the strings "UTC", "GMT" and "z" are also allowed timezones.
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03 UTC')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 0, 0, 0, 0),)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 0, 0, 0, 0),)
+    ]
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03 GMT')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 0, 0, 0, 0),)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 0, 0, 0, 0),)
+    ]
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03z')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 0, 0, 0, 0),)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 0, 0, 0, 0),)
+    ]
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03Z')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 0, 0, 0, 0),)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 0, 0, 0, 0),)
+    ]
     # Cassandra doesn't allow extra spaces in timezone names but Scylla does.
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03  Z ')")
-    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 0, 0, 0, 0),)]
+    assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+        (datetime(2011, 2, 3, 0, 0, 0, 0),)
+    ]
     # Dropping the timezone string +0000 is allowed, but results in an unknown
     # timezone (the on the machine running Scylla), so we don't know how to
     # check the correctness of the result. But at least the insert should
@@ -101,6 +140,7 @@ def test_type_timestamp_from_string(cql, table1):
     # An invalid format for the timestamp should result in InvalidRequest:
     with pytest.raises(InvalidRequest):
         cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, 'an invalid timestamp')")
+
 
 # The timestamp column type has millisecond resolution. What happens if we
 # assign a string to a timestamp column which attempts to specify a time
@@ -113,31 +153,106 @@ def test_type_timestamp_from_string(cql, table1):
 def test_type_timestamp_from_string_overprecise(cql, table1, cassandra_bug):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
-        cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03 04:05:12.345678+0000')")
-        assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [(datetime(2011, 2, 3, 4, 5, 12, 345000),)]
+        cql.execute(
+            f"INSERT INTO {table1} (p, t) VALUES ({p}, '2011-02-03 04:05:12.345678+0000')"
+        )
+        assert list(cql.execute(f"SELECT t from {table1} where p = {p}")) == [
+            (datetime(2011, 2, 3, 4, 5, 12, 345000),)
+        ]
+
 
 # Check that filtering expressions of timestamps - equality and inequality
 # checks - work as expected
 def test_type_timestamp_comparison(cql, table2):
     p = unique_key_int()
-    cql.execute(f"INSERT INTO {table2} (p, c, t) VALUES ({p}, 1, '2011-02-03 04:05:12.345+0000')")
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t = '2011-02-03 04:05:12.345+0000' ALLOW FILTERING")) == [(1,)]
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t = '2012-02-03 04:05:12.345+0000' ALLOW FILTERING")) == []
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t < '2011-02-04+0000' ALLOW FILTERING")) == [(1,)]
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t < '2011-02-03+0000' ALLOW FILTERING")) == []
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t > '2011-02-03+0000' ALLOW FILTERING")) == [(1,)]
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t > '2011-02-04+0000' ALLOW FILTERING")) == []
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t <= '2011-02-03 04:05:12.345+0000' ALLOW FILTERING")) == [(1,)]
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t < '2011-02-03 04:05:12.345+0000' ALLOW FILTERING")) == []
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t >= '2011-02-03 04:05:12.345+0000' ALLOW FILTERING")) == [(1,)]
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t > '2011-02-03 04:05:12.345+0000' ALLOW FILTERING")) == []
+    cql.execute(
+        f"INSERT INTO {table2} (p, c, t) VALUES ({p}, 1, '2011-02-03 04:05:12.345+0000')"
+    )
+    assert list(
+        cql.execute(
+            f"SELECT c from {table2} where p = {p} and t = '2011-02-03 04:05:12.345+0000' ALLOW FILTERING"
+        )
+    ) == [(1,)]
+    assert (
+        list(
+            cql.execute(
+                f"SELECT c from {table2} where p = {p} and t = '2012-02-03 04:05:12.345+0000' ALLOW FILTERING"
+            )
+        )
+        == []
+    )
+    assert list(
+        cql.execute(
+            f"SELECT c from {table2} where p = {p} and t < '2011-02-04+0000' ALLOW FILTERING"
+        )
+    ) == [(1,)]
+    assert (
+        list(
+            cql.execute(
+                f"SELECT c from {table2} where p = {p} and t < '2011-02-03+0000' ALLOW FILTERING"
+            )
+        )
+        == []
+    )
+    assert list(
+        cql.execute(
+            f"SELECT c from {table2} where p = {p} and t > '2011-02-03+0000' ALLOW FILTERING"
+        )
+    ) == [(1,)]
+    assert (
+        list(
+            cql.execute(
+                f"SELECT c from {table2} where p = {p} and t > '2011-02-04+0000' ALLOW FILTERING"
+            )
+        )
+        == []
+    )
+    assert list(
+        cql.execute(
+            f"SELECT c from {table2} where p = {p} and t <= '2011-02-03 04:05:12.345+0000' ALLOW FILTERING"
+        )
+    ) == [(1,)]
+    assert (
+        list(
+            cql.execute(
+                f"SELECT c from {table2} where p = {p} and t < '2011-02-03 04:05:12.345+0000' ALLOW FILTERING"
+            )
+        )
+        == []
+    )
+    assert list(
+        cql.execute(
+            f"SELECT c from {table2} where p = {p} and t >= '2011-02-03 04:05:12.345+0000' ALLOW FILTERING"
+        )
+    ) == [(1,)]
+    assert (
+        list(
+            cql.execute(
+                f"SELECT c from {table2} where p = {p} and t > '2011-02-03 04:05:12.345+0000' ALLOW FILTERING"
+            )
+        )
+        == []
+    )
+
 
 # Cassandra 4 added the feature of arithmetic between values in general, and
 # timestamps in particular (to which durations can be added). Scylla used to
 # be missing this feature - see #2693, #2694 and their many duplicates.
-@pytest.mark.xfail(reason="issue #2693, #2694")
+@pytest.mark.xfail(
+    reason="Support arithmetic operators #2693, Support operators on date-times #2694"
+)
 def test_type_timestamp_arithmetic(cql, table2):
     p = unique_key_int()
-    cql.execute(f"INSERT INTO {table2} (p, c, t) VALUES ({p}, 1, '2011-02-03 04:05:12.345+0000')")
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t > '2011-02-03 04:05:12.345+0000' - 1d ALLOW FILTERING")) == [(1,)]
-    assert list(cql.execute(f"SELECT c from {table2} where p = {p} and t = '2011-02-03 05:05:12.345+0000' - 1h ALLOW FILTERING")) == [(1,)]
+    cql.execute(
+        f"INSERT INTO {table2} (p, c, t) VALUES ({p}, 1, '2011-02-03 04:05:12.345+0000')"
+    )
+    assert list(
+        cql.execute(
+            f"SELECT c from {table2} where p = {p} and t > '2011-02-03 04:05:12.345+0000' - 1d ALLOW FILTERING"
+        )
+    ) == [(1,)]
+    assert list(
+        cql.execute(
+            f"SELECT c from {table2} where p = {p} and t = '2011-02-03 05:05:12.345+0000' - 1h ALLOW FILTERING"
+        )
+    ) == [(1,)]

--- a/test/cqlpy/test_unset.py
+++ b/test/cqlpy/test_unset.py
@@ -14,20 +14,30 @@ from .util import new_test_table, unique_key_int
 from cassandra.query import UNSET_VALUE
 from cassandra.protocol import InvalidRequest
 
+
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, a int, b int, c int, li list<int>") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int PRIMARY KEY, a int, b int, c int, li list<int>"
+    ) as table:
         yield table
+
 
 @pytest.fixture(scope="module")
 def table2(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)"
+    ) as table:
         yield table
+
 
 @pytest.fixture(scope="module")
 def table3(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, "p int, c int, r int, PRIMARY KEY (p, c)") as table:
+    with new_test_table(
+        cql, test_keyspace, "p int, c int, r int, PRIMARY KEY (p, c)"
+    ) as table:
         yield table
+
 
 # A basic test that in a prepared statement with three assignments, one
 # bound by an UNSET_VALUE is simply not done, but the other ones are.
@@ -35,12 +45,12 @@ def table3(cql, test_keyspace):
 # a real value or an UNSET_VALUE.
 def test_update_unset_value_basic(cql, table1):
     p = unique_key_int()
-    stmt = cql.prepare(f'UPDATE {table1} SET a=?, b=?, c=? WHERE p={p}')
+    stmt = cql.prepare(f"UPDATE {table1} SET a=?, b=?, c=? WHERE p={p}")
     a = 1
     b = 2
     c = 3
     cql.execute(stmt, [a, b, c])
-    assert [(a, b, c)] == list(cql.execute(f'SELECT a,b,c FROM {table1} WHERE p = {p}'))
+    assert [(a, b, c)] == list(cql.execute(f"SELECT a,b,c FROM {table1} WHERE p = {p}"))
     i = 4
     for unset_a in [False, True]:
         for unset_b in [False, True]:
@@ -64,7 +74,10 @@ def test_update_unset_value_basic(cql, table1):
                     c = i
                     i += 1
                 cql.execute(stmt, [newa, newb, newc])
-                assert [(a, b, c)] == list(cql.execute(f'SELECT a,b,c FROM {table1} WHERE p = {p}'))
+                assert [(a, b, c)] == list(
+                    cql.execute(f"SELECT a,b,c FROM {table1} WHERE p = {p}")
+                )
+
 
 # The expression "SET a=?" is skipped if the bound value is UNSET_VALUE.
 # But what if it is part of a more complex expression like "SET a=(int)?+1"
@@ -74,14 +87,16 @@ def test_update_unset_value_basic(cql, table1):
 # such case the whole write request will fail instead of parts of it being
 # skipped. See discussion in pull request #12517.
 
-@pytest.mark.xfail(reason="issue #2693 - Scylla doesn't yet support arithmetic expressions")
+
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def test_update_unset_value_expr_arithmetic(cql, table1):
     p = unique_key_int()
-    stmt = cql.prepare(f'UPDATE {table1} SET a=(int)?+1 WHERE p={p}')
+    stmt = cql.prepare(f"UPDATE {table1} SET a=(int)?+1 WHERE p={p}")
     cql.execute(stmt, [7])
-    assert [(8,)] == list(cql.execute(f'SELECT a FROM {table1} WHERE p = {p}'))
+    assert [(8,)] == list(cql.execute(f"SELECT a FROM {table1} WHERE p = {p}"))
     with pytest.raises(InvalidRequest):
         cql.execute(stmt, [UNSET_VALUE])
+
 
 # Despite the decision that expressions will not allow UNSET_VALUE, Cassandra
 # decided that (quoting its NEWS.txt) "an unset bind counter operation does
@@ -93,11 +108,12 @@ def test_update_unset_value_expr_arithmetic(cql, table1):
 def test_unset_counter_increment(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, c counter") as table:
         p = unique_key_int()
-        stmt = cql.prepare(f'UPDATE {table} SET c=c+? WHERE p={p}')
+        stmt = cql.prepare(f"UPDATE {table} SET c=c+? WHERE p={p}")
         cql.execute(stmt, [3])
-        assert [(3,)] == list(cql.execute(f'SELECT c FROM {table} WHERE p = {p}'))
+        assert [(3,)] == list(cql.execute(f"SELECT c FROM {table} WHERE p = {p}"))
         cql.execute(stmt, [UNSET_VALUE])
-        assert [(3,)] == list(cql.execute(f'SELECT c FROM {table} WHERE p = {p}'))
+        assert [(3,)] == list(cql.execute(f"SELECT c FROM {table} WHERE p = {p}"))
+
 
 # Like the counter increment, a list append operation (li=li+?) is a primitive
 # operation and not expression, so we believe UNSET_VALUE should be able
@@ -106,11 +122,12 @@ def test_unset_counter_increment(cql, test_keyspace):
 # this a Cassandra bug and hence the cassandra_bug tag.
 def test_unset_list_append(cql, table1, cassandra_bug):
     p = unique_key_int()
-    stmt = cql.prepare(f'UPDATE {table1} SET li=li+? WHERE p={p}')
+    stmt = cql.prepare(f"UPDATE {table1} SET li=li+? WHERE p={p}")
     cql.execute(stmt, [[7]])
-    assert [([7],)] == list(cql.execute(f'SELECT li FROM {table1} WHERE p = {p}'))
+    assert [([7],)] == list(cql.execute(f"SELECT li FROM {table1} WHERE p = {p}"))
     cql.execute(stmt, [UNSET_VALUE])
-    assert [([7],)] == list(cql.execute(f'SELECT li FROM {table1} WHERE p = {p}'))
+    assert [([7],)] == list(cql.execute(f"SELECT li FROM {table1} WHERE p = {p}"))
+
 
 # According to Cassandra's NEWS.txt, "an unset bind ttl is treated as
 # 'unlimited'". It shouldn't skip the write.
@@ -121,36 +138,41 @@ def test_unset_list_append(cql, table1, cassandra_bug):
 def test_unset_ttl(cql, table1):
     p = unique_key_int()
     # First write using a normal TTL:
-    stmt = cql.prepare(f'UPDATE {table1} USING TTL ? SET a=? WHERE p={p}')
+    stmt = cql.prepare(f"UPDATE {table1} USING TTL ? SET a=? WHERE p={p}")
     cql.execute(stmt, [20000, 3])
-    res = list(cql.execute(f'SELECT a, ttl(a) FROM {table1} WHERE p = {p}'))
+    res = list(cql.execute(f"SELECT a, ttl(a) FROM {table1} WHERE p = {p}"))
     assert res[0].a == 3
     assert res[0].ttl_a > 10000
     # Check that an UNSET_VALUE ttl didn't skip the write but reset the TTL
     # to unlimited (None)
     cql.execute(stmt, [UNSET_VALUE, 4])
-    assert [(4, None)] == list(cql.execute(f'SELECT a, ttl(a) FROM {table1} WHERE p = {p}'))
+    assert [(4, None)] == list(
+        cql.execute(f"SELECT a, ttl(a) FROM {table1} WHERE p = {p}")
+    )
+
 
 # According to Cassadra's NEWS.txt, "an unset bind timestamp is treated
 # as 'now'". It shouldn't skip the write.
 def test_unset_timestamp(cql, table1):
     p = unique_key_int()
-    stmt = cql.prepare(f'UPDATE {table1} USING TIMESTAMP ? SET a=? WHERE p={p}')
+    stmt = cql.prepare(f"UPDATE {table1} USING TIMESTAMP ? SET a=? WHERE p={p}")
     cql.execute(stmt, [UNSET_VALUE, 3])
-    assert [(3,)] == list(cql.execute(f'SELECT a FROM {table1} WHERE p = {p}'))
+    assert [(3,)] == list(cql.execute(f"SELECT a FROM {table1} WHERE p = {p}"))
+
 
 # According to Cassandra's NEWS.txt, "In a QUERY request an unset limit
 # is treated as 'unlimited'.". It mustn't cause the query to fail (let alone
 # be skipped somehow).
 def test_unset_limit(cql, table2):
     p = unique_key_int()
-    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 1)')
-    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 2)')
-    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 3)')
-    cql.execute(f'INSERT INTO {table2} (p, c) VALUES ({p}, 4)')
-    stmt = cql.prepare(f'SELECT c FROM {table2} WHERE p={p} limit ?')
-    assert [(1,),(2,)] == list(cql.execute(stmt, [2]))
-    assert [(1,),(2,),(3,),(4,)] == list(cql.execute(stmt, [UNSET_VALUE]))
+    cql.execute(f"INSERT INTO {table2} (p, c) VALUES ({p}, 1)")
+    cql.execute(f"INSERT INTO {table2} (p, c) VALUES ({p}, 2)")
+    cql.execute(f"INSERT INTO {table2} (p, c) VALUES ({p}, 3)")
+    cql.execute(f"INSERT INTO {table2} (p, c) VALUES ({p}, 4)")
+    stmt = cql.prepare(f"SELECT c FROM {table2} WHERE p={p} limit ?")
+    assert [(1,), (2,)] == list(cql.execute(stmt, [2]))
+    assert [(1,), (2,), (3,), (4,)] == list(cql.execute(stmt, [UNSET_VALUE]))
+
 
 # According Cassandra's NEWS.txt, "Unset WHERE clauses with unset
 # partition column, clustering column or index column are not allowed.".
@@ -160,9 +182,10 @@ def test_unset_limit(cql, table2):
 # Reproduces #10358
 def test_unset_where_clustering(cql, table2):
     p = unique_key_int()
-    stmt = cql.prepare(f'SELECT * FROM {table2} WHERE p = {p} and c = ?')
+    stmt = cql.prepare(f"SELECT * FROM {table2} WHERE p = {p} and c = ?")
     with pytest.raises(InvalidRequest, match="unset"):
         cql.execute(stmt, [UNSET_VALUE])
+
 
 # ... but the NEWS.txt doesn't say what happens in other WHERE restrictions
 # that involve a non-key column. In practice, those should be an error as
@@ -174,13 +197,17 @@ def test_unset_where_regular(cql, table1):
     # expression never gets evaluated and the UNSET_VALUE error is never
     # detected. Cassandra does detect this error even if there is no data,
     # but we don't care about reproducing that specific error case.
-    cql.execute(f'INSERT INTO {table1} (p, a) VALUES ({p}, 1)')
-    stmt = cql.prepare(f'SELECT * FROM {table1} WHERE p = {p} and a = ? ALLOW FILTERING')
+    cql.execute(f"INSERT INTO {table1} (p, a) VALUES ({p}, 1)")
+    stmt = cql.prepare(
+        f"SELECT * FROM {table1} WHERE p = {p} and a = ? ALLOW FILTERING"
+    )
     with pytest.raises(InvalidRequest, match="unset"):
         cql.execute(stmt, [UNSET_VALUE])
 
+
 # TODO: check that (according to NEWS.txt documentation): "Unset tuple field,
 # UDT field and map key are not allowed.".
+
 
 # Although UNSET_VALUE is designed to skip part of a SET, it is not designed
 # to skip an entire write which uses a an UNSET_VALUE in its WHERE clause -
@@ -193,21 +220,21 @@ def test_unset_where_regular(cql, table1):
 # the request).
 def test_unset_insert_where(cql, table2):
     p = unique_key_int()
-    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?)')
+    stmt = cql.prepare(f"INSERT INTO {table2} (p, c) VALUES ({p}, ?)")
     with pytest.raises(InvalidRequest, match="unset"):
         cql.execute(stmt, [UNSET_VALUE])
+
 
 # Similar to test_unset_insert_where() above, just use an LWT write ("IF
 # NOT EXISTS"). Test that using an UNSET_VALUE in an LWT condition causes
 # a clear error, not silent skip and not a crash as in issue #13001.
-@pytest.mark.parametrize("test_keyspace",
-                         ["tablets", "vnodes"],
-                         indirect=True)
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_unset_insert_where_lwt(cql, table2):
     p = unique_key_int()
-    stmt = cql.prepare(f'INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS')
+    stmt = cql.prepare(f"INSERT INTO {table2} (p, c) VALUES ({p}, ?) IF NOT EXISTS")
     with pytest.raises(InvalidRequest, match="unset"):
         cql.execute(stmt, [UNSET_VALUE])
+
 
 # Like test_unset_insert_where, but using UPDATE
 # Python driver doesn't allow sending an UNSET_VALUE for the partition key,
@@ -218,12 +245,11 @@ def test_unset_update_where(cql, table3):
     with pytest.raises(InvalidRequest, match="unset"):
         cql.execute(stmt, [UNSET_VALUE])
 
+
 # Like test_unset_insert_where_lwt, but using UPDATE
 # Python driver doesn't allow sending an UNSET_VALUE for the partition key,
 # so only the clustering key is tested.
-@pytest.mark.parametrize("test_keyspace",
-                         ["tablets", "vnodes"],
-                         indirect=True)
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_unset_update_where_lwt(cql, table3):
     stmt = cql.prepare(f"UPDATE {table3} SET r = 42 WHERE p = 0 AND c = ? IF r = ?")
 


### PR DESCRIPTION
…ue titles

Replace short, uninformative reason= strings in pytest.mark.xfail and pytest.mark.skip decorators with descriptive strings that include the actual GitHub issue title. For example:

  Before: reason="issue #10347"
  After:  reason="Alternator doesn't limit partition and sort key lengths #10347"

  Before: reason="#5064 - transactions not yet supported"
  After:  reason='Alternator: support "transactions" feature #5064'

This makes it immediately clear why a test is expected to fail or is skipped, without requiring a GitHub lookup. The format used is:
  "<GitHub issue title> #<number>"
When multiple issues are referenced:
  "<Title one> #1234, <Title two> #5678"

Reason strings that already contained meaningful descriptions (e.g., "Cassandra 3.10's += syntax not yet supported. Issue #7735") were left unchanged.

No xfail/skip marker types were changed - this is purely a reason string clarification patch. In particular, compact_storage_test.py and test_empty.py retain their original xfail/skip marker types (unrelated to PR #28681 which changes marker types in those files).

The one exception is testJsonOrdering in json_test.py, which was changed from xfail to skip because the test crashes the debug build (use-after-free detected by sanitizer).

Scope: 55 files across test/alternator/ (12 files) and test/cqlpy/ (43 files), covering ~75 distinct GitHub issues.

Note: the large diff is due to Python code reformatting (Black formatter) that was applied alongside the reason string changes. The actual reason= string modifications are a small subset of the total diff.

No need to backport.