### PR TITLE
test: remove xfail_strict option

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 strict_config = true
-xfail_strict = true
 
 addopts = --strict-markers
 


### PR DESCRIPTION
A few days ago, in commit 7b30a3981ba52ea6de9b7ce3f2c15c43c459e019 we added to pytest.ini the option xfail_strict. This option causes every time a test XPASSes, i.e., an XFAIL test actually passes, to be considered an error and fail the test.

This was a mistake. Although it's good to know about XFAILing tests which started to consistently pass, and *eventually* do something about them (like remove the xfail marker or close an issue that we didn't notice got solved), we can't just decide that an xfailing test must never ever pass. Some tests do not reproduce a bug with 100% certainty. For example, consider the cqlpy test

     test_secondary_index.py::test_unbuilt_index_not_used

This test reproduces a timing-related bug (if you read from a secondary index "too quickly" you can get wrong results), but only about 90% of the time, not 100% of the time. It is marked xfail, but it doesn't mean it always fails. For the xfailing test to be a useful reproducer for a bug it just needs to fail often - not every sigle time.

So this patch removes the strict_xfail option.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-956