### PR TITLE
test.py: fix strict-config argument.

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,8 +1,7 @@
 [pytest]
-strict_config = true
 xfail_strict = true
 
-addopts = --strict-markers
+addopts = --strict-markers  --strict-config
 
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session


### PR DESCRIPTION
The ini-level strict_config was removed/never existed as a config key in pytest 8 — it's only a command-line flag(and  back in pytest 9) In pytest 8.3.5, the equivalent is the --strict-config CLI flag, not an ini option

Fixes SCYLLADB-955


local testing:

```
artsiom@fedora:~/codebase/scylladb$ ./tools/toolchain/dbuild pytest --test-py-init test/alternator/test_123.py 
Test session starts (platform: linux, Python 3.14.3, pytest 8.3.5, pytest-sugar 1.1.1)
rootdir: /home/artsiom/codebase/scylladb/test
configfile: pytest.ini
plugins: allure-pytest-2.15.3, xdist-3.8.0, asyncio-1.1.0, sugar-1.1.1, timeout-2.4.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collected 3 items                                                                                                                                                                                                                                                                                                            

 alternator/test_123.py ✓✓✓                                                                                                                                                                                                                                                                                    100% ██████████

Results (7.10s):
       3 passed

```

no warning messages