### PR TITLE
test: replace uninformative xfail/skip reason strings with GitHub iss…

### DIFF
--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -1021,7 +1021,7 @@ def test_rbac_streams(dynamodb, cql):
 # with streams enabled up-front during creation - and enabling the stream
 # later in an already existing table.
 # Reproduces issue #19798
-@pytest.mark.xfail(reason="#19798")
+@pytest.mark.xfail(reason="Auto-grant and auto-revoke missing for CDC log table #19798")
 @pytest.mark.parametrize("during_creation", [True, False])
 def test_rbac_streams_autogrant(dynamodb, cql, during_creation):
     schema = {

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -282,7 +282,7 @@ def test_gsi_describe_indexstatus(test_table_gsi_1):
 # In addition to the basic listing of an GSI in DescribeTable tested above,
 # in this test we check additional fields that should appear in each GSI's
 # description.
-@pytest.mark.xfail(reason="issues #7550, #11466")
+@pytest.mark.xfail(reason="Alternator: missing ItemCount field in return of DescribeTable #7550, Alternator: missing IndexSizeBytes field in return of DescribeTable #11466")
 def test_gsi_describe_fields(test_table_gsi_1):
     desc = test_table_gsi_1.meta.client.describe_table(TableName=test_table_gsi_1.name)
     gsis = desc['Table']['GlobalSecondaryIndexes']
@@ -625,7 +625,7 @@ def test_gsi_wrong_type_attribute_batch(test_table_gsi_2):
 # a pre-existing table. In that case we can't reject the base-table update
 # because the oversized attribute is already there - but can just drop this
 # item from the GSI.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_gsi_limit_partition_key_len_2048(test_table_gsi_2):
     # A value for 'x' (the GSI's partition key) of length 2048 is fine:
     p = random_string()
@@ -651,7 +651,7 @@ def test_gsi_limit_partition_key_len_2048(test_table_gsi_2):
 # should pass even if Alternator decides to adopt a different key length
 # limits from DynamoDB. We do have to adopt *some* limit because the
 # internal Scylla implementation has a 64 KB limit on key lengths.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_gsi_limit_partition_key_len(test_table_gsi_2):
     # A value for 'x' (the GSI's partition key) of length 2048 is fine:
     p = random_string()
@@ -681,7 +681,7 @@ def test_gsi_limit_partition_key_len(test_table_gsi_2):
 # a pre-existing table. In that case we can't reject the base-table update
 # because the oversized attribute is already there - but can just drop this
 # item from the GSI.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_gsi_limit_sort_key_len_1024(test_table_gsi_5):
     # A value for 'x' (the GSI's partition key) of length 1024 is fine:
     p = random_string()
@@ -709,7 +709,7 @@ def test_gsi_limit_sort_key_len_1024(test_table_gsi_5):
 # should pass even if Alternator decides to adopt a different key length
 # limits from DynamoDB. We do have to adopt *some* limit because the
 # internal Scylla implementation has a 64 KB limit on key lengths.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_gsi_limit_sort_key_len(test_table_gsi_5):
     # A value for 'x' (the GSI's partition key) of length 1024 is fine:
     p = random_string()
@@ -2133,7 +2133,7 @@ def test_gsi_invalid_key_types(dynamodb):
 # implement this GSI needs to add "p" as an extra clustering key, but it
 # doesn't mean that "p" should be allowed in a KeyConditions or
 # KeyConditionExpression - it shouldn't because it's not a real range key.
-@pytest.mark.xfail(reason="Issue #26103")
+@pytest.mark.xfail(reason="Alternator streams may generate event even if item did not really change #26103")
 def test_faux_range_key_in_keyconditions(test_table_gsi_2):
     p = random_string()
     x = random_string()
@@ -2158,7 +2158,7 @@ def test_faux_range_key_in_keyconditions(test_table_gsi_2):
             KeyConditions={'z': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
                            'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
 
-@pytest.mark.xfail(reason="Issue #26103")
+@pytest.mark.xfail(reason="Alternator streams may generate event even if item did not really change #26103")
 def test_faux_range_key_in_keyconditionexpression(test_table_gsi_2):
     p = random_string()
     x = random_string()
@@ -2318,7 +2318,7 @@ def test_gsi_query_exclusivestartkey_missing_column(test_table_gsi_5):
 # When Query'ing on a certain GSI partition key and/or sort key,
 # ExclusiveStartKey must have the same partition/sort key value.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_gsi_query_exclusivestartkey_wrong_partition(test_table_gsi_5):
     # The error that DynamoDB reports if the wrong partition is mentioned
     # in ExclusiveStartKey is "The provided starting key is outside query
@@ -2369,7 +2369,7 @@ def test_gsi_query_exclusivestartkey_wrong_partition(test_table_gsi_5):
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key columns of the base and the GSI.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_gsi_query_exclusivestartkey_spurious_column(test_table_gsi_5):
     query_args = {
         'ConsistentRead': False,

--- a/test/alternator/test_gsi_updatetable.py
+++ b/test/alternator/test_gsi_updatetable.py
@@ -381,7 +381,7 @@ def test_gsi_creates_and_deletes(dynamodb):
 # skipped while filling the GSI - even if Scylla actually capable of
 # representing such empty view keys (see issue #9375).
 # Reproduces issue #9424.
-@pytest.mark.xfail(reason="issue #9424")
+@pytest.mark.xfail(reason="Alternator GSIs should exclude items with empty-string key components #9424")
 def test_gsi_backfill_empty_string(dynamodb):
     # First create, and fill, a table without GSI:
     with new_test_table(dynamodb,
@@ -677,7 +677,7 @@ def test_gsi_backfill_oversized_key(dynamodb):
 # item that has an attribute longer than that should simply be skipped
 # during view building.
 # Reproduces issue #10347.
-@pytest.mark.xfail(reason="issue #10347: key length limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_gsi_backfill_key_limits(dynamodb):
     # First create, and fill, a table without GSI:
     with new_test_table(dynamodb,

--- a/test/alternator/test_limits.py
+++ b/test/alternator/test_limits.py
@@ -334,7 +334,7 @@ def test_limit_attribute_length_gsi_lsi_bad_incoherent_names(dynamodb):
 # attributes projected as part as ALL can be bigger (up to the usual 64KB
 # limit).
 # Reproduces issue #9169.
-@pytest.mark.xfail(reason="issue #5036: projection in GSI and LSI not supported")
+@pytest.mark.xfail(reason="Alternator: support Projection in GSI and LSI #5036")
 def test_limit_attribute_length_gsi_lsi_projection_bad(dynamodb):
     too_long_name = random_string(256)
     with pytest.raises(ClientError, match='ValidationException.*25[56]'):
@@ -751,7 +751,7 @@ def test_deeply_nested_expression_5(test_table_s):
 # decision. In any case, Alternator must have some key-length limits (the
 # internal implementation limits key length to 64 KB), so the test after this
 # one should pass.
-@pytest.mark.xfail(reason="issue #10347: sort key limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_limit_sort_key_len_1024(test_table_ss, test_table_sb):
     p = random_string()
     # String sort key with length 1024 is fine:
@@ -789,7 +789,7 @@ def test_limit_sort_key_len_1024(test_table_ss, test_table_sb):
 # Alternator decides to adopt a different sort-key-length limit from
 # DynamoDB. We do have to adopt *some* limit because the internal Scylla
 # implementation has a 64 KB limit on key lengths.
-@pytest.mark.xfail(reason="issue #10347: sort key limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_limit_sort_key_len(test_table_ss, test_table_sb):
     p = random_string()
     # String sort key with length 1024 is fine:
@@ -859,7 +859,7 @@ def test_limit_sort_key_len_lsi(dynamodb):
 # decision. In any case, Alternator must have some key-length limits (the
 # internal implementation limits key length to 64 KB), so even if this test
 # won't pass, the one after it should pass.
-@pytest.mark.xfail(reason="issue #10347: sort key limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_limit_partition_key_len_2048(test_table_s, test_table_b):
     # String partition key with length 2048 is fine:
     item = {'p': 'x'*2048, 'z': 'hello'}
@@ -892,7 +892,7 @@ def test_limit_partition_key_len_2048(test_table_s, test_table_b):
 # Alternator decides to adopt a different sort-key-length limit from
 # DynamoDB. We do have to adopt *some* limit because the internal Scylla
 # implementation has a 64 KB limit on key lengths.
-@pytest.mark.xfail(reason="issue #10347: sort key limits not enforced")
+@pytest.mark.xfail(reason="Alternator doesn't limit partition and sort key lengths #10347")
 def test_limit_partition_key_len(test_table_s, test_table_b):
     # String partition key with length 2048 is fine:
     item = {'p': 'x'*2048, 'z': 'hello'}

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -318,7 +318,7 @@ def test_lsi_describe_indexstatus(test_table_lsi_1):
 # In addition to the basic listing of an LSI in DescribeTable tested above,
 # in this test we check additional fields that should appear in each LSI's
 # description.
-@pytest.mark.xfail(reason="issues #7550, #11466")
+@pytest.mark.xfail(reason="Alternator: missing ItemCount field in return of DescribeTable #7550, Alternator: missing IndexSizeBytes field in return of DescribeTable #11466")
 def test_lsi_describe_fields(test_table_lsi_1):
     desc = test_table_lsi_1.meta.client.describe_table(TableName=test_table_lsi_1.name)
     assert 'Table' in desc

--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -147,7 +147,7 @@ def test_too_large_request_content_length(dynamodb, test_table, mb):
 # we can use the same limit too. In all useful cases, headers will be
 # much shorter.
 # Reproduces #23438.
-@pytest.mark.xfail(reason="issue #23438")
+@pytest.mark.xfail(reason="Alternator should reject requests with very large headers #23438")
 def test_too_large_request_headers(dynamodb, test_table):
     # First prepare a valid signed request, which works:
     req = get_signed_request(dynamodb, 'PutItem',
@@ -177,7 +177,7 @@ def test_too_large_request_headers(dynamodb, test_table):
 # can use the same limit too. In all useful cases, the request line will
 # be much shorter (for ordinary API requests, it is even empty).
 # Reproduces #23438.
-@pytest.mark.xfail(reason="issue #23438")
+@pytest.mark.xfail(reason="Alternator should reject requests with very large headers #23438")
 def test_too_large_request_line(dynamodb, test_table):
     # First prepare a valid signed request, which works:
     req = get_signed_request(dynamodb, 'PutItem',
@@ -594,7 +594,7 @@ def test_keep_alive(dynamodb, test_table, use_keep_alive):
 # We don't want to store the malformed value on disk and only discover the
 # problem when reading the value back. We want the write to fail immediately,
 # and this is what this test checks. Reproduces issue #8070.
-@pytest.mark.xfail(reason="issue #8070")
+@pytest.mark.xfail(reason="Alternator: validate user-provided nested document structure during first write #8070")
 @pytest.mark.parametrize("op", ['PutItem', 'UpdateItem', 'BatchWriteItem'])
 def test_write_malformed_value(dynamodb, test_table_s, op):
     p = random_string()

--- a/test/alternator/test_query.py
+++ b/test/alternator/test_query.py
@@ -395,7 +395,7 @@ def test_query_exclusivestartkey_missing_sortkey(test_table_sn):
 # When Query'ing on the partition key 'right', ExclusiveStartKey must be in
 # the same partition 'right' being queried - it must not be some other
 # partition. Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_exclusivestartkey_wrong_partition(test_table_sn):
     # The error that DynamoDB reports if the wrong partition is mentioned
     # in ExclusiveStartKey is "The provided starting key is outside query
@@ -410,7 +410,7 @@ def test_query_exclusivestartkey_wrong_partition(test_table_sn):
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key (here a partition key and sort key)
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_exclusivestartkey_spurious_column(test_table_sn):
     p = random_string()
     # The error that DynamoDB reports if ExclusiveStartKey has spurious
@@ -440,7 +440,7 @@ def test_query_no_sort_key(test_table_s):
 # response shouldn't include the given key, the response would be completely
 # empty...  So DynamoDB doesn't allow this case at all.
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_query_no_sort_key_exclusive_start_key(test_table_s):
     p = random_string()
     # DynamoDB gives the error message "The provided exclusive start key

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -462,7 +462,7 @@ def test_scan_long_partition_tombstone_string(dynamodb, query_tombstone_page_lim
 #
 @pytest.mark.parametrize("KB", [
     pytest.param(1500, marks=pytest.mark.xfail(
-        reason="Issue #10327: small tables don't respect paging limits")),
+        reason="Page size in whole-table scan of a small table is larger than 1 MB #10327")),
     8000
 ])
 def test_scan_paging_missing_limit(dynamodb, KB):
@@ -501,7 +501,7 @@ def test_scan_exclusivestartkey_missing_sortkey(filled_test_table):
 # Check that ExclusiveStartKey cannot contain any spurious column names
 # beyond the actual primary key (here a partition key and sort key)
 # Reproduces issue #26988.
-@pytest.mark.xfail(reason="issue #26988")
+@pytest.mark.xfail(reason="Alternator 'Query' is missing some checks on ExclusiveStartKey #26988")
 def test_scan_exclusivestartkey_spurious_column(filled_test_table):
     test_table, items = filled_test_table
     p = random_string()

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -1050,7 +1050,7 @@ def test_streams_updateitem_identical(test_table_ss_keys_only, test_table_ss_new
 # different serialization (the map's elements are ordered differently).
 # Since the value is nevertheless the same, here too we expect not to see
 # a change event in the stream. Reproduces issue #27375.
-@pytest.mark.xfail(reason="issue #27375")
+@pytest.mark.xfail(reason="Alternator streams may generate event even if item did not really change #27375")
 def test_streams_updateitem_equal_but_not_identical(test_table_ss_keys_only, test_table_ss_new_image, test_table_ss_old_image, test_table_ss_new_and_old_images, dynamodb, dynamodbstreams):
     def do_updates(table, p, c):
         events = []
@@ -2027,7 +2027,7 @@ def test_stream_table_name_length_192_update(dynamodb, dynamodbstreams):
 # modes, and reproduces #28439 when it failed only in always_use_lwt mode.
 # This is a Scylla-only test because it checks write isolation modes, which
 # don't exist in DynamoDB.
-@pytest.mark.parametrize('mode', ['only_rmw_uses_lwt', pytest.param('always_use_lwt', marks=pytest.mark.xfail(reason='#28439')), 'unsafe_rmw', 'forbid_rmw'])
+@pytest.mark.parametrize('mode', ['only_rmw_uses_lwt', pytest.param('always_use_lwt', marks=pytest.mark.xfail(reason="Streams will output wrong log, when BatchWriteItem is used to update multiple items from the same partition #28439")), 'unsafe_rmw', 'forbid_rmw'])
 def test_streams_multiple_items_one_partition(dynamodb, dynamodbstreams, scylla_only, mode):
     with create_table_ss(dynamodb, dynamodbstreams, 'NEW_AND_OLD_IMAGES') as stream:
         table, stream_arn = stream

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -314,7 +314,7 @@ def test_table_streams_off(dynamodb):
 # the result was no longer a disaster, but is still an error from CreateTable
 # saying that the column name ':attrs' is reserved.
 # Reproduces #5009
-@pytest.mark.xfail(reason="#5009: name ':attrs' not allowed for key column")
+@pytest.mark.xfail(reason="Alternator: don't forbid attribute name \":attrs\" as a key #5009")
 def test_create_table_special_column_name(dynamodb):
     for c in ['attrs', ':attrs']:
         # Try the suspicious attribute name as a partition key:
@@ -621,7 +621,7 @@ def test_delete_table_description(dynamodb):
 
 # Test that DeleteTable returns correct TableDescription (issue #11472) and has no not implemented fields (see #5026 issue)
 # after any field implementation move its testing code to the 'test_delete_table_description' test
-@pytest.mark.xfail(reason="#5026: TableDescription still doesn't implement these fields")
+@pytest.mark.xfail(reason="Alternator: missing fields in return of DescribeTable #5026")
 def test_delete_table_description_missing_fields(dynamodb):
     table_name = unique_table_name()
 

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -449,7 +449,7 @@ def test_missing_tag_value(dynamodb, test_table):
 # Reproduces #16908
 @pytest.mark.parametrize("is_ascii", [
         True,
-        pytest.param(False, marks=pytest.mark.xfail(reason="#16908"))])
+        pytest.param(False, marks=pytest.mark.xfail(reason="Alternator TagResource should allow (and count) unicode characters #16908"))])
 def test_tag_key_length_128_allowed(dynamodb, test_table, is_ascii):
     client = dynamodb.meta.client
     arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']
@@ -472,7 +472,7 @@ def test_tag_key_length_129_forbidden(dynamodb, test_table):
 # Reproduces #16908
 @pytest.mark.parametrize("is_ascii", [
         True,
-        pytest.param(False, marks=pytest.mark.xfail(reason="#16908"))])
+        pytest.param(False, marks=pytest.mark.xfail(reason="Alternator TagResource should allow (and count) unicode characters #16908"))])
 def test_tag_value_length_256_allowed(dynamodb, test_table, is_ascii):
     client = dynamodb.meta.client
     arn = client.describe_table(TableName=test_table.name)['Table']['TableArn']

--- a/test/alternator/test_transact.py
+++ b/test/alternator/test_transact.py
@@ -25,7 +25,7 @@ from .util import random_string
 ##########################################################################
 
 # Single Put action without a condition
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_put_unconditional(test_table_s):
     p = random_string()
     x = random_string()
@@ -38,7 +38,7 @@ def test_transact_write_items_single_put_unconditional(test_table_s):
     assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
 
 # Single Put action with a true condition - succeeds
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_put_true(test_table_s):
     p = random_string()
     x = random_string()
@@ -55,7 +55,7 @@ def test_transact_write_items_single_put_true(test_table_s):
 
 # Single Put action with a false condition fails with a
 # TransactionCanceledException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_put_false(test_table_s):
     p = random_string()
     x = random_string()
@@ -75,7 +75,7 @@ def test_transact_write_items_single_put_false(test_table_s):
 # Verify that a transaction's Put action, behaves like a PutItem request,
 # and not like a CQL Insert, in that it completely replaces an existing item -
 # it doesn't merge the new data into the existing item.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_put_replaces(test_table_s):
     p = random_string()
     x = random_string()
@@ -90,7 +90,7 @@ def test_transact_write_items_single_put_replaces(test_table_s):
     assert {'p': p, 'y': y} == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
 
 # Single Delete action without a condition
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_delete_unconditional(test_table_s):
     p = random_string()
     x = random_string()
@@ -106,7 +106,7 @@ def test_transact_write_items_single_delete_unconditional(test_table_s):
     assert 'Item' not in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
 
 # Single Delete action with a true condition succeeds
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_delete_true(test_table_s):
     p = random_string()
     x = random_string()
@@ -126,7 +126,7 @@ def test_transact_write_items_single_delete_true(test_table_s):
 
 # Single Delete action with a false condition fails with a
 # TransactionCanceledException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_delete_false(test_table_s):
     p = random_string()
     x = random_string()
@@ -146,7 +146,7 @@ def test_transact_write_items_single_delete_false(test_table_s):
 
 # Single ConditionCheck action without a condition is, unsurprisingly,
 # not allowed - resulting in ValidationException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_conditioncheck_unconditional(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*[cC]onditionExpression'):
@@ -158,7 +158,7 @@ def test_transact_write_items_single_conditioncheck_unconditional(test_table_s):
 
 # Single ConditionCheck action with a true condition succeeds, but
 # doesn't do anything (since it's just a condition check, not a write)
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_conditioncheck_true(test_table_s):
     p = random_string()
     test_table_s.meta.client.transact_write_items(TransactItems=[{
@@ -172,7 +172,7 @@ def test_transact_write_items_single_conditioncheck_true(test_table_s):
 
 # Single ConditionCheck action with a false condition fails with a
 # TransactionCanceledException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_conditioncheck_false(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='TransactionCanceledException'):
@@ -191,7 +191,7 @@ def test_transact_write_items_single_conditioncheck_false(test_table_s):
 # those in UpdateExpression and/or ConditionExpression.
 
 # Single Update action without a condition
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_update_unconditional(test_table_s):
     p = random_string()
     item = {'p': p, 'x': 42}
@@ -208,7 +208,7 @@ def test_transact_write_items_single_update_unconditional(test_table_s):
     assert item == test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item']
 
 # Single Update action with a true condition succeeds
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_update_true(test_table_s):
     p = random_string()
     item = {'p': p, 'x': 42}
@@ -228,7 +228,7 @@ def test_transact_write_items_single_update_true(test_table_s):
 
 # Single Update action with a false condition fails with a
 # TransactionCanceledException
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_single_update_false(test_table_s):
     p = random_string()
     item = {'p': p, 'x': 42}
@@ -255,7 +255,7 @@ def test_transact_write_items_single_update_false(test_table_s):
 # if we increment the same counter twice it happens twice. But if we do
 # use ClientRequestToken and pass the same one twice, only the first increment
 # happens.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_clientrequesttoken(test_table_s):
     p = random_string()
     item = {'p': p, 'x': 42}
@@ -295,7 +295,7 @@ def test_transact_write_items_clientrequesttoken(test_table_s):
 # table name, we can't reuse the same ClientRequestToken or we'll get a
 # IdempotentParameterMismatch error. We must use a random token - and
 # a random one-character string is not enough to avoid test flakiness.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_clientrequesttoken_length(test_table_s):
     p = random_string()
     item = {'p': p}
@@ -313,7 +313,7 @@ def test_transact_write_items_clientrequesttoken_length(test_table_s):
 
 # Check that if the same ClientRequestToken is used for two transactions,
 # but they are different, an IdempotentParameterMismatch error is thrown.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_clientrequesttoken_mismatch(test_table_s):
     transaction1 = [{'Put': {'TableName': test_table_s.name, 'Item': {'p': random_string()}}}]
     transaction2 = [{'Put': {'TableName': test_table_s.name, 'Item': {'p': random_string()}}}]
@@ -329,7 +329,7 @@ def test_transact_write_items_clientrequesttoken_mismatch(test_table_s):
 # begin with a successful TransactWriteItems transaction, where some of
 # the actions have successful conditions, and some don't have conditions
 # at all, and all the actions are performed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_multi_action_true(test_table_s):
     p1 = random_string()
     p2 = random_string()
@@ -366,7 +366,7 @@ def test_transact_write_items_multi_action_true(test_table_s):
 # Test a transaction with several actions, one of which has a false
 # condition. The entire transaction should fail, and none of its actions
 # (not even those with true conditions or no conditions) should be performed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_multi_action_false(test_table_s):
     p1 = random_string()
     p2 = random_string()
@@ -404,7 +404,7 @@ def test_transact_write_items_multi_action_false(test_table_s):
 # Test that it's not allowed for two actions in the same transaction to
 # target the same item (this limitation also includes ConditionCheck
 # actions).
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_multi_action_conflict(test_table_s):
     p1 = random_string()
     p2 = random_string()
@@ -448,7 +448,7 @@ def test_transact_write_items_multi_action_conflict(test_table_s):
 
 # Test that a transaction may involve more than one table, not just more than
 # one item.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_multi_table_true(test_table_s, test_table_ss):
     p1 = random_string()
     p2 = random_string()
@@ -474,7 +474,7 @@ def test_transact_write_items_multi_table_true(test_table_s, test_table_ss):
     assert item2 == test_table_ss.get_item(Key={'p': p2, 'c': c2}, ConsistentRead=True)['Item']
 
 # Check that a TransactWriteItems with zero items is not allowed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_empty(test_table_s):
     with pytest.raises(ClientError, match='ValidationException.*[tT]ransactItems'):
         test_table_s.meta.client.transact_write_items(TransactItems=[])
@@ -482,7 +482,7 @@ def test_transact_write_items_empty(test_table_s):
 # Check that a TransactWriteItems with 100 items is allowed. The limit
 # used to be just 25 items, but it was increased to 100 in September 2022.
 # The next test will check that *more* than 100 items is not allowed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_100(test_table_s):
     p = random_string()
     items = [{'p': p + str(i), 'x': i} for i in range(100)]
@@ -496,7 +496,7 @@ def test_transact_write_items_100(test_table_s):
         assert item == test_table_s.get_item(Key={'p': item['p']}, ConsistentRead=True)['Item']
 
 # Check that a transaction with 101 (>100) items is rejected.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_101(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*[tT]ransactItems.*100'):
@@ -515,7 +515,7 @@ def test_transact_write_items_101(test_table_s):
 # new item in the transaction - so the transaction itself reaches 5MB in
 # size. In the next test we will check what happens for Update or Delete
 # actions which may themselves have small size but refer to large items.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_put_5MB(test_table_s):
     p = random_string()
     # We will write 50 items of roughly 100KB each, reaching around 5MB
@@ -541,7 +541,7 @@ def test_transact_write_items_put_5MB(test_table_s):
 # (DynamoDB refers to it as "transaction payload" in the error messages) is
 # what matters, not the size of the items. A delete transaction that deletes
 # 5 MB of items but the transaction itself is small - is allowed.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_delete_5MB(test_table_s):
     p = random_string()
     # Write (not in a transaction) 50 items of roughly 100 KB each, so their
@@ -579,7 +579,7 @@ def test_transact_write_items_delete_5MB(test_table_s):
 # But verify that aggregate transaction size of 3MB is fine. Note that
 # individual items are limited to 400KB, so we must a transaction with
 # several smaller items.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_put_3MB(test_table_s):
     p = random_string()
     # We will write 30 items of roughly 100KB each, reaching around 3MB
@@ -611,7 +611,7 @@ def test_transact_write_items_put_3MB(test_table_s):
 #    tests.
 # 4. ThrottlingError - similar, for on-demand tables that haven't scaled
 #    enough yet.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_cancellation_reasons_conditionalcheckfailed(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='TransactionCanceledException') as e:
@@ -710,7 +710,7 @@ def test_transact_write_cancellation_reasons_conditionalcheckfailed(test_table_s
 # It's not clear how DynamoDB decided which case will return a
 # ValidationException and which a ValidationError, but let's be compatible
 # with what DynamoDB does.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_cancellation_reasons_validationerror(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='TransactionCanceledException') as e:
@@ -758,7 +758,7 @@ def test_transact_write_cancellation_reasons_validationerror(test_table_s):
 # ValidationException. Below we'll see in other tests that this is not
 # always true - in some other types of errors, we actually do get a
 # ValidationException.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_cancellation_reasons_validationerror_one(test_table_s):
     with pytest.raises(ClientError, match='TransactionCanceledException') as e:
         test_table_s.meta.client.transact_write_items(TransactItems=[
@@ -777,7 +777,7 @@ def test_transact_write_cancellation_reasons_validationerror_one(test_table_s):
 # condition to fail.
 # Note that ReturnValuesOnConditionCheckFailure is specified for a
 # specific action, not for the entire transaction.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_returnvaluesonconditioncheckfailure(test_table_s):
     p = random_string()
     item = {'p': p, 'x': 42, 'y': 'dog'}
@@ -854,7 +854,7 @@ def test_transact_write_items_returnvaluesonconditioncheckfailure(test_table_s):
 # the latter.
 
 # Check ConditionExpression reference to missing ExpressionAttributeNames
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_missing_name(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*#xyz'):
@@ -867,7 +867,7 @@ def test_transact_write_items_missing_name(test_table_s):
             }}])
 
 # Check ConditionExpression value missing in ExpressionAttributeValues
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_missing_value(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*:xyz'):
@@ -880,7 +880,7 @@ def test_transact_write_items_missing_value(test_table_s):
             }}])
 
 # Check unused name in ExpressionAttributeName
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_unused_name(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*unused.*#xyz'):
@@ -894,7 +894,7 @@ def test_transact_write_items_unused_name(test_table_s):
             }}])
 
 # Check unused value in ExpressionAttributeValues
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_unused_value(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*unused.*:xyz'):
@@ -909,7 +909,7 @@ def test_transact_write_items_unused_value(test_table_s):
 
 # Syntax error in a ConditionExpression in one action also returns a
 # ValidationException for the entire transaction, not per item:
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_syntax_error(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*Syntax error'):
@@ -928,7 +928,7 @@ def test_transact_write_items_syntax_error(test_table_s):
 # return a ValidationException here and we change the test to accept both.
 # But the important point is that the single exception is returned for the
 # entire transaction - not per item.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_write_items_serialization_exception(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='SerializationException'):
@@ -947,7 +947,7 @@ def test_transact_write_items_serialization_exception(test_table_s):
 ##########################################################################
 
 # Test basic transaction with one "Get" action
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_one(test_table_s):
     p = random_string()
     x = random_string()
@@ -965,7 +965,7 @@ def test_transact_get_items_one(test_table_s):
 
 # If a Get transaction can't find an item with the given key, it's not
 # an error - one of the Responses entries will just not have an "Item":
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_missing(test_table_s):
     p = random_string()
     ret = test_table_s.meta.client.transact_get_items(TransactItems=[
@@ -980,7 +980,7 @@ def test_transact_get_items_missing(test_table_s):
 # Test the ProjectionExpression parameter for a Get action, asking not to
 # get the entire item and rather just get specific attributes. See more
 # extensive tests for ProjectionExpression in test_projection_expression.py.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_projection_expression(test_table_s):
     p = random_string()
     item = {'p': p, 'x': 1, 'y': 2, 'z': 3}
@@ -997,7 +997,7 @@ def test_transact_get_items_projection_expression(test_table_s):
     assert {'x': item['x'], 'z': item['z']} == ret['Responses'][0]['Item']
 
 # ProjectionExpression also supports ExpressionAttributeNames.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_projection_expression_attribute_names(test_table_s):
     p = random_string()
     item = {'p': p, 'x': 1, 'y': 2, 'z': 3}
@@ -1017,7 +1017,7 @@ def test_transact_get_items_projection_expression_attribute_names(test_table_s):
 # If ExpressionAttributeNames is missing a name, or has an unused name,
 # it's an error. As we saw above in other cases, it's a ValidationException
 # for the entire transaction - not a TransactionCanceledException.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_unused_expressionattributenames(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*unused.*#qq'):
@@ -1030,7 +1030,7 @@ def test_transact_get_items_unused_expressionattributenames(test_table_s):
                 'ExpressionAttributeNames': {'#xx': 'x', '#zz': 'z', '#qq': 'q'}
             }}])
 
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_missing_expressionattributenames(test_table_s):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*#zz'):
@@ -1047,7 +1047,7 @@ def test_transact_get_items_missing_expressionattributenames(test_table_s):
 # read 100 small items in one transaction - the limit used to be just 25
 # items, but it was increased to 100 in September 2022 so let's verify that
 # it works.
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_100(test_table_s):
     p = random_string()
     items = [{'p': p + str(i), 'x': i} for i in range(100)]
@@ -1069,7 +1069,7 @@ def test_transact_get_items_100(test_table_s):
         assert response['Item'] == items[i]
 
 # A transaction with 100 read actions is the limit, and 101 are not allowed:
-@pytest.mark.xfail(reason="#5064 - transactions not yet supported")
+@pytest.mark.xfail(reason='Alternator: support "transactions" feature #5064')
 def test_transact_get_items_101(test_table_s):
     with pytest.raises(ClientError, match='ValidationException.*[tT]ransactItems.*100'):
         test_table_s.meta.client.transact_get_items(TransactItems=[

--- a/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
+++ b/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
@@ -52,7 +52,7 @@ def testSelectDistinctWithDeletions(cql, test_keyspace):
         assert len(rows) == 9
 
 # Reproduces issue #10354
-@pytest.mark.xfail(reason="#10354 - we forgot to allow SELECT DISTINCT filtering on static column")
+@pytest.mark.xfail(reason="SELECT DISTINCT should allow filter on static columns, not just partition keys #10354")
 def testSelectDistinctWithWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, a int, b int, PRIMARY KEY (k, a))") as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
@@ -94,7 +94,7 @@ def testSelectDistinctWithWhereClause(cql, test_keyspace):
                    row(70))
 
 # Reproduces issue #10354
-@pytest.mark.xfail(reason="#10354 - we forgot to allow SELECT DISTINCT filtering on static column")
+@pytest.mark.xfail(reason="SELECT DISTINCT should allow filter on static columns, not just partition keys #10354")
 def testSelectDistinctWithWhereClauseOnStaticColumn(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, a int, s int static, s1 int static, b int, PRIMARY KEY (k, a))") as table:
         for i in range(10):
@@ -155,7 +155,7 @@ def _testSelectDistinctWithPaging(cql, table):
                           row(4, 4))
 
 # Reproduces issue #10354
-@pytest.mark.xfail(reason="#10354 - we forgot to allow SELECT DISTINCT filtering on static column")
+@pytest.mark.xfail(reason="SELECT DISTINCT should allow filter on static columns, not just partition keys #10354")
 def testSelectDistinctWithStaticColumnsAndPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))") as table:
         # Test with only static data

--- a/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
@@ -261,7 +261,7 @@ def testCounterCastsInSelectionClause(cql, test_keyspace):
                    row(2, 2, 2, 2, 2.0, 2.0, Decimal("2"), "2", "2"))
 
 # Verifies that the {@code CAST} function can be used in the values of {@code INSERT INTO} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInInsertIntoValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         # Simple cast
@@ -296,7 +296,7 @@ def testCastsInInsertIntoValues(cql, test_keyspace):
         #assertRows(execute(cql, table, "SELECT v FROM %s"), row(6))
 
 # Verifies that the {@code CAST} function can be used in the values of {@code UPDATE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInUpdateValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         # Simple cast
@@ -331,7 +331,7 @@ def testCastsInUpdateValues(cql, test_keyspace):
         #assertRows(execute(cql, table, "SELECT v FROM %s"), row(6))
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code UPDATE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInUpdateWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         for i in range(1,7):
@@ -369,7 +369,7 @@ def testCastsInUpdateWhereClause(cql, test_keyspace):
         #assertRows(execute(cql, table, "SELECT v FROM %s WHERE k = ?", 6), row(6))
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code SELECT} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInSelectWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key)") as table:
         for i in range(1,7):
@@ -401,7 +401,7 @@ def testCastsInSelectWhereClause(cql, test_keyspace):
         #assertRows(execute(cql, table, String.format("SELECT k FROM %%s WHERE k = CAST(%s(6) AS int)", intToFloat())), row(6))
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code DELETE} statements.
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInDeleteWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key)") as table:
         for i in range(1, 7):
@@ -473,7 +473,7 @@ def testCastsInDeleteWhereClause(cql, test_keyspace):
 #    }
 
 # Verifies that the {@code CAST} function can be used in the {@code WHERE} clause of {@code CREATE MATERIALIZED
-@pytest.mark.xfail(reason="issue #14522")
+@pytest.mark.xfail(reason="Support CAST function not only in SELECT #14522")
 def testCastsInCreateViewWhereClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         viewName = test_keyspace + ".mv_with_cast"

--- a/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
@@ -16,7 +16,7 @@ from cassandra.protocol import FunctionFailure
 from cassandra.util import Date
 from datetime import datetime
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testStringConcatenation(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b ascii, c text, PRIMARY KEY(a, b, c))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES ('जॉन', 'Doe', 'जॉन Doe')")
@@ -28,7 +28,7 @@ def testStringConcatenation(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT a + ' ' + a, a + ' ' + b, b + ' ' + a, b + ' ' + b FROM %s WHERE a = 'जॉन' AND b = 'Doe' AND c = 'जॉन Doe'"),
             row("जॉन जॉन", "जॉन Doe", "Doe जॉन", "Doe Doe"))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testSingleOperations(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY(a, b, c))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (1, 2, 3, 4, 5.5, 6.5, 7, 8.5)")
@@ -235,7 +235,7 @@ def testSingleOperations(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT a + d, b + d, c + d, d + d, e + d, f + d, g + d, h + d FROM %s WHERE a = 1 AND b = 2"),
                    row(None, None, None, None, None, None, None, None))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testModuloWithDecimals(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(numerator decimal, dec_mod decimal, int_mod int, bigint_mod bigint, PRIMARY KEY(numerator, dec_mod))") as table:
         execute(cql, table, "INSERT INTO %s (numerator, dec_mod, int_mod, bigint_mod) VALUES (123456789112345678921234567893123456, 2, 2, 2)")
@@ -243,7 +243,7 @@ def testModuloWithDecimals(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT numerator % dec_mod, numerator % int_mod, numerator % bigint_mod from %s"),
                    row(Decimal("0"), Decimal("0.0"), Decimal("0.0")))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testSingleOperationsWithLiterals(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, c1 tinyint, c2 smallint, v text, PRIMARY KEY(pk, c1, c2))") as table:
         execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (2, 2, 2, 'test')")
@@ -483,7 +483,7 @@ def testSingleOperationsWithLiterals(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT a, b, 1 + 1, 2 - 1, 2 * 2, 2 / 1 , 2 % 1, (int) -1 FROM %s WHERE a = 1 AND b = 2"),
                    row(1, 2, 2, 1, 4, 2, 0, -1))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testDivisionWithDecimals(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(numerator decimal, denominator decimal, PRIMARY KEY ((numerator, denominator)))") as table:
         execute(cql, table, "INSERT INTO %s (numerator, denominator) VALUES (8.5, 200000000000000000000000000000000000)")
@@ -493,7 +493,7 @@ def testDivisionWithDecimals(cql, test_keyspace):
                    row(Decimal("0.0000000000000000000000000000000000425")),
                    row(Decimal("3333.33333333333333333333333333333333")))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testWithCounters(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b counter)") as table:
         execute(cql, table, "UPDATE %s SET b = b + 1 WHERE a = 1")
@@ -557,7 +557,7 @@ def testWithCounters(cql, test_keyspace):
 
         assertRows(execute(cql, table, "SELECT -b FROM %s WHERE a = 1"), row(-2))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testPrecedenceAndParentheses(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (2, 5, 25, 4)")
@@ -618,7 +618,7 @@ def testPrecedenceAndParentheses(cql, test_keyspace):
             assertRows(execute(cql, table, "SELECT * FROM %s WHERE a = ? AND b = (int) ? / (2 + 2)", 2, 20),
                    row(2, 5, 25, 4))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testWithDivisionByZero(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a tinyint, b smallint, c int, d bigint, e float, f double, g varint, h decimal, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e, f, g, h) VALUES (0, 2, 3, 4, 5.5, 6.5, 7, 8.5)")
@@ -655,7 +655,7 @@ def testWithDivisionByZero(cql, test_keyspace):
                                   OperationExecutionException,
                                   "SELECT h / a FROM %s WHERE a = 0 AND b = 2")
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testWithNanAndInfinity(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b double, c decimal)") as table:
         assertInvalidMessage(cql, table, "Ambiguous '+' operation with args ? and 1: use type hint to disambiguate, example '(int) ?'",
@@ -702,7 +702,7 @@ def testWithNanAndInfinity(cql, test_keyspace):
                                   OperationExecutionException,
                                   "SELECT c + (float) -INFINITY FROM %s")
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testInvalidTypes(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b boolean, c text)") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, True, "test")
@@ -718,7 +718,7 @@ def testInvalidTypes(cql, test_keyspace):
         assertInvalidMessage(cql, table, "the '/' operation is not supported between NaN and b", "SELECT NaN / b FROM %s")
         assertInvalidMessage(cql, table, "the '/' operation is not supported between -Infinity and b", "SELECT -Infinity / b FROM %s")
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testOverflow(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b tinyint, c smallint)") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 1, 1, 1)
@@ -727,7 +727,7 @@ def testOverflow(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT a + (int) ?, b + (tinyint) ?, c + (smallint) ? FROM %s", 2147483647, 127, 32767),
                    row(-2147483648, -128, -32768))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testOperationsWithDuration(cql, test_keyspace):
     # Test with timestamp type.
     with create_table(cql, test_keyspace, "(pk int, time timestamp, v int, primary key (pk, time))") as table:
@@ -811,7 +811,7 @@ def testOperationsWithDuration(cql, test_keyspace):
                              FunctionFailure,
                              "SELECT * FROM %s WHERE pk = 1 AND time > ? - 10m", Date("2016-10-04"))
 
-@pytest.mark.xfail(reason="#2693")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def testFunctionException(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, c1 int, c2 int, v text, primary key (pk, c1, c2))") as table:
         execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (1, 0, 2, 'test')")

--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -137,7 +137,7 @@ def testSelectJsonWithPagingWithFrozenUDT(cql, test_keyspace):
                           ["{\"a\": 1, \"b\": 2, \"c\": [\"1\", \"2\"]}", "[\"" + str(uuid) + "\", 4]", "4"])
 
 # Reproduces issue #7911, #7912, #7914, #7915, #7944, #7954
-@pytest.mark.xfail(reason="issues #7914, #7915, #7944, #7954")
+@pytest.mark.xfail(reason='fromJson() integer overflow should cause an error, not silent wrap-around #7914, fromJson() should accept "true" and "false" also as strings #7915, fromJson() should not accept the empty string "" as a number #7944, fromJson() fails to set null tuple elements #7954')
 def testFromJsonFct(cql, test_keyspace):
     abc_tuple = collections.namedtuple('abc_tuple', ['a', 'b', 'c'])
     with create_type(cql, test_keyspace, "(a int, b uuid, c set<text>)") as type_name:
@@ -683,7 +683,7 @@ class EquivalentIp:
         return f'EquivalentIp("{self.obj}")'
 
 # Reproduces issue #7972, #7988, #7997, #8001
-@pytest.mark.xfail(reason="issues #7997, #8001")
+@pytest.mark.xfail(reason='toJson() is missing a timezone on timestamp #7997, Documented unit "µs" not supported for assigning a "duration" type #8001')
 def testToJsonFct(cql, test_keyspace):
     abc_tuple = collections.namedtuple('abc_tuple', ['a', 'b', 'c'])
     with create_type(cql, test_keyspace, "(a int, b uuid, c set<text>)") as type_name:
@@ -996,7 +996,7 @@ def testSelectJsonSyntax(cql, test_keyspace):
                 ["{\"system.tojson(system.blobasint(system.intasblob(v)))\": \"1\"}"])
 
 # Reproduces issues #8085
-@pytest.mark.xfail(reason="issues #8085")
+@pytest.mark.xfail(reason="INSERT JSON with bad arguments should yield InvalidRequest error, not internal error #8085")
 def testInsertJsonSyntax(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, v int)") as table:
         execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"v\": 0}")
@@ -1062,7 +1062,7 @@ def testInsertJsonSyntaxDefaultUnset(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k=2"), [2, None, None])
 
 # Reproduces issues #8078, #8086
-@pytest.mark.xfail(reason="issues #8086")
+@pytest.mark.xfail(reason="INSERT JSON cannot handle user-defined types with case-sensitive component names #8086")
 def testCaseSensitivity(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int primary key, \"Foo\" int)") as table:
         execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"\\\"Foo\\\"\": 0}")
@@ -1120,7 +1120,7 @@ def testInsertJsonSyntaxWithCollections(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT k, lf FROM %s"), [0, [1, 2, 3]])
 
 # Reproduces issue #8087
-@pytest.mark.xfail(reason="issue #8087")
+@pytest.mark.xfail(reason="SELECT JSON incorrectly quotes strings inside map keys #8087")
 def testInsertJsonSyntaxWithNonNativeMapKeys(cql, test_keyspace):
     # JSON doesn't allow non-string keys, so we accept string representations of any type as map keys and
     # return maps with string keys when necessary.
@@ -1229,7 +1229,7 @@ def testInsertJsonSyntaxWithTuplesAndUDTs(cql, test_keyspace):
             execute(cql, table, "INSERT INTO %s JSON ?", "{\"k\": 0, \"a\": {\"a\": 0, \"b\": [1, 2, 3], \"c\": null}, \"b\": null}")
 
 # done for CASSANDRA-11146
-@pytest.mark.xfail(reason="issue #8092")
+@pytest.mark.xfail(reason="SELECT JSON missing null component after adding field to UDT definition #8092")
 def testAlterUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as type_name:
         with create_table(cql, test_keyspace, "(" +
@@ -1264,7 +1264,7 @@ def testEmptyStringJsonSerialization(cql, test_keyspace):
 
 # CASSANDRA-14286
 # Reproduces #8100
-@pytest.mark.xfail(reason="issue #28467")
+@pytest.mark.xfail(reason="SELECT JSON with IN and ORDER BY does not obey the ORDER BY #8100")
 def testJsonOrdering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a INT, b INT, PRIMARY KEY(a, b))") as table:
         execute(cql, table, "INSERT INTO %s(a, b) VALUES (20, 30);")

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
@@ -451,7 +451,7 @@ TOO_BIG = 1024 * 65
 # make sure we check conditional and unconditional statements,
 # both singly and in batches (CASSANDRA-10536)
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 @pytest.mark.parametrize("test_keyspace",
                          ["tablets", "vnodes"],
                          indirect=True)
@@ -510,7 +510,7 @@ def testIndexOnPartitionKeyInsertValueOver64k(cql, test_keyspace):
         #}
 
 # Reproduces issue #8708:
-@pytest.mark.xfail(reason="issue #8708")
+@pytest.mark.xfail(reason="Secondary index is missing partitions with only a static row #8708")
 def testIndexOnPartitionKeyWithStaticColumnAndNoRows(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk1 int, pk2 int, c int, s int static, v int, PRIMARY KEY((pk1, pk2), c))") as table:
         execute(cql, table, "CREATE INDEX ON %s (pk2)")
@@ -565,7 +565,7 @@ def testIndexOnClusteringColumnInsertValueOver64k(cql, test_keyspace):
         #}
 
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 @pytest.mark.parametrize("test_keyspace",
                          ["tablets", "vnodes"],
                          indirect=True)
@@ -587,7 +587,7 @@ def testIndexOnFullCollectionEntryInsertCollectionValueOver64k(cql, test_keyspac
                    "INSERT INTO %s (a, b) VALUES (0, ?) IF NOT EXISTS;\n" +
                    "APPLY BATCH", map)
 
-@pytest.mark.xfail(reason="issue #2203")
+@pytest.mark.xfail(reason='Secondary index CREATE INDEX syntax is missing the "values" option #2203')
 def testPrepareStatementsWithLIKEClauses(cql, test_keyspace):
     SASI = 'org.apache.cassandra.index.sasi.SASIIndex'
     with create_table(cql, test_keyspace, "(a int, c1 text, c2 text, v1 text, v2 text, v3 int, PRIMARY KEY (a, c1, c2))") as table:
@@ -696,7 +696,7 @@ def testIndexesOnNonStaticColumnsWhereSchemaIncludesStaticColumns(cql, test_keys
 # Reproduces Scylla issues #4244 (mixing single-column and multi-columns
 # restriction) and #8711 (Finding or filtering with an empty string with
 # a secondary index seems to be broken).
-@pytest.mark.xfail(reason="issues #4244, #8711")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244, Finding or filtering with an empty string with a secondary index seems to be broken #8711")
 def testWithEmptyRestrictionValueAndSecondaryIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))") as table:
         execute(cql, table, "CREATE INDEX ON %s(c)")
@@ -1026,7 +1026,7 @@ def testIndexOnNonFrozenCollectionOfFrozenUDT(cql, test_keyspace):
             assert_invalid_message(cql, table, "ALLOW FILTERING",
                              "SELECT * FROM %s WHERE v CONTAINS ?", udt1)
 
-@pytest.mark.xfail(reason="#8745")
+@pytest.mark.xfail(reason='Secondary index CREATE INDEX syntax is missing the "values" option #8745')
 def testIndexOnNonFrozenUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int)") as t:
         with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, v {t})") as table:

--- a/test/cqlpy/cassandra_tests/validation/entities/type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/type_test.py
@@ -20,7 +20,7 @@ def testNonExistingOnes(cql, test_keyspace):
     # reported instead of just doing nothing:
     execute(cql, test_keyspace, "DROP TYPE IF EXISTS keyspace_does_not_exist.type_does_not_exist")
 
-@pytest.mark.skip(reason="Issue #9300")
+@pytest.mark.skip(reason="testNowToUUIDCompatibility is flaky #9300")
 def testNowToUUIDCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b uuid, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")
@@ -33,7 +33,7 @@ def testDateCompatibility(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, unixTimestampOf(now()), dateOf(now()), dateOf(now()))")
         assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b <= toUnixTimestamp(now())"))) == 1
 
-@pytest.mark.skip(reason="Issue #9300")
+@pytest.mark.skip(reason="testNowToUUIDCompatibility is flaky #9300")
 def testReversedTypeCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b timeuuid, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -35,7 +35,7 @@ def read_function_from_file(file_name, wasm_name=None, udf_name=None):
         print(f"Can't open {wat_path}.\nPlease build Wasm examples.")
         exit(1)
 
-@pytest.mark.skip(reason="Issue #22799")
+@pytest.mark.skip(reason="CI regression in test - uf_types_test test_complex_null_values #22799")
 def test_complex_null_values(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(txt text, i int)") as type:
         schema = f"(key int primary key, lst list<double>, st set<text>, mp map<int, boolean>, tup frozen<tuple<double, text, int, boolean>>, udt frozen<{type}>)"
@@ -163,10 +163,10 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
                     assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1"), row("called"))
                     assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 2"), row(None))
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
+@pytest.mark.xfail(reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855")
+@pytest.mark.xfail(reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860")
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_set_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<set<int>>)") as table:
         with new_secondary_index(cql, table, "FULL(b)"):
@@ -200,10 +200,10 @@ def test_function_with_frozen_set_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<set<int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
+@pytest.mark.xfail(reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855")
+@pytest.mark.xfail(reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860")
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_list_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<list<int>>)") as table:
         with new_secondary_index(cql, table, "FULL(b)"):
@@ -237,10 +237,10 @@ def test_function_with_frozen_list_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<list<int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
-@pytest.mark.xfail(reason="Issue #13855")
-@pytest.mark.xfail(reason="Issue #13860")
-@pytest.mark.xfail(reason="Issue #13866")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
+@pytest.mark.xfail(reason="UDF with a non-frozen collection parameter cannot be called on a frozen value #13855")
+@pytest.mark.xfail(reason="A non-frozen collection returned by a UDF cannot be used as a frozen one #13860")
+@pytest.mark.xfail(reason="Argument and return types in UDFs can be frozen #13866")
 def test_function_with_frozen_map_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<map<int, int>>)") as table:
         with new_secondary_index(cql, table, "FULL(b)"):
@@ -274,7 +274,7 @@ def test_function_with_frozen_map_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<map<int, int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
 def test_function_with_frozen_tuple_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<tuple<int, int>>)") as table:
         with new_secondary_index(cql, table, "b"):
@@ -311,7 +311,7 @@ def test_function_with_frozen_tuple_type(cql, test_keyspace):
             cql.execute(f"DROP FUNCTION {test_keyspace}.{fun_name} (frozen<tuple<int, int>>)")
             assertRowCount(cql.execute(f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{fun_name}'"), 0)
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip(reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands #13746")
 def test_function_with_frozen_udt_type(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(f int)") as type:
         with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b frozen<{type}>)") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -93,7 +93,7 @@ def testDropWithTimestamp(cql, test_keyspace):
                [1, 4, 4, 4],
                [1, 100, 100, 100])
 
-@pytest.mark.xfail(reason="Issue #9930")
+@pytest.mark.xfail(reason="Forbid re-adding static columns as regular and vice versa #9930")
 def testDropAddWithDifferentKind(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int static,  PRIMARY KEY (a, b))") as table:
         execute(cql, table, "ALTER TABLE %s DROP c")
@@ -168,7 +168,7 @@ def testAlterIndexInterval(cql, test_keyspace):
 
 # Migrated from cql_tests.py:TestCQL.create_alter_options_test()
 # Reproduces #9935
-@pytest.mark.xfail(reason="Issue #9935")
+@pytest.mark.xfail(reason="Scylla stores un-expanded compaction class name in system tables #9935")
 def testCreateAlterKeyspaces(cql, test_keyspace, this_dc):
     # ScyllaDB allows default parameters on CREATE KEYSPACE, so these checks
     # are no longer valid:
@@ -272,7 +272,7 @@ def testDoubleWith(cql, test_keyspace):
     for stmt in stmts:
         assert_invalid_throw(cql, test_keyspace, SyntaxException, stmt)
 
-@pytest.mark.xfail(reason="Issue #8948")
+@pytest.mark.xfail(reason='Cassandra 3.11.10 uses "class" instead of "sstable_compression" for compression settings by default #8948')
 def testAlterTableWithCompression(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b int, c int, primary key (a, b))") as table:
         [ks, cf] = table.split('.')

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -623,7 +623,7 @@ TOO_BIG = 1024 * 65
 
 # from SecondaryIndexTest
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 def testCompactTableWithValueOver64k(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int,  b blob, PRIMARY KEY (a)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "CREATE INDEX ON %s(b)")
@@ -760,7 +760,7 @@ def testFunctionsWithCompactStorage(cql, test_keyspace):
                    row(3, 2, 5, 2, 9.5, 18.5, 9.25))
 
 # BatchTest
-@pytest.mark.xfail(reason="issue #12471")
+@pytest.mark.xfail(reason="Range deletions on COMPACT STORAGE is not supported #12471")
 def testBatchRangeDelete(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(partitionKey int, clustering int, value int, primary key (partitionKey, clustering)) WITH COMPACT STORAGE") as table:
         value = 0
@@ -1058,7 +1058,7 @@ def testDeleteWithOneClusteringColumns(cql, test_keyspace, forceFlush):
         assertInvalidMessage(cql, table, "value",
                              "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND value = ?", 0, 1, 3)
 
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244")
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
     with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2)) WITH COMPACT STORAGE") as table:
@@ -1255,7 +1255,7 @@ def testCompactStorage(cql, test_keyspace):
         assert_rows2(execute(cql, table, "INSERT INTO %s (partition, key, owner) VALUES ('a', 'c', 'x') IF NOT EXISTS"), [row(True)], [row(True,None,None,None)])
 
 # SelectGroupByTest
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 3, 6)")
@@ -2140,7 +2140,7 @@ def testSelectDistinct(cql, test_keyspace):
 
 REQUIRES_ALLOW_FILTERING_MESSAGE = "Cannot execute this query as it might involve data filtering and thus may have unpredictable performance. If you want to execute this query despite the performance unpredictability, use ALLOW FILTERING"
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringOnCompactTablesWithoutIndices(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2278,7 +2278,7 @@ def testFilteringOnCompactTablesWithoutIndices(cql, test_keyspace):
                              "SELECT * FROM %s WHERE c > ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2426,7 +2426,7 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
                              "SELECT * FROM %s WHERE c CONTAINS ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringOnCompactTablesWithoutIndicesAndWithSets(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<set<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2609,7 +2609,7 @@ def executeFilteringOnly(cql, table, statement):
     assert_invalid(cql, table, statement)
     return execute_without_paging(cql, table, statement + " ALLOW FILTERING")
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testAllowFilteringOnPartitionKeyWithCounters(cql, test_keyspace):
     for compactStorageClause in ["", " WITH COMPACT STORAGE"]:
         with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY ((a, b), c)) " + compactStorageClause) as table:
@@ -2643,7 +2643,7 @@ def testAllowFilteringOnPartitionKeyWithCounters(cql, test_keyspace):
                            row(21, 22, 23, 24),
                            row(21, 22, 26, 27))
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithLists(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<list<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2791,7 +2791,7 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithLists(cq
                              unset())
 
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithMaps(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<map<int, int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -2953,7 +2953,7 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithMaps(cql
                              "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS KEY ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithSets(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c frozen<set<int>>, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
@@ -3103,7 +3103,7 @@ def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndicesAndWithSets(cql
                              "SELECT * FROM %s WHERE a >= 1 AND c CONTAINS ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testAllowFilteringOnPartitionKeyOnCompactTablesWithoutIndices(cql, test_keyspace):
     # Test COMPACT table with clustering columns
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY ((a, b), c)) WITH COMPACT STORAGE") as table:
@@ -3422,7 +3422,7 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithMaps(cql, test_keyspace):
                              "SELECT * FROM %s WHERE c CONTAINS KEY ? ALLOW FILTERING",
                              unset())
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringOnCompactTable(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, 13, 14)
@@ -3510,7 +3510,7 @@ def testFilteringOnCompactTable(cql, test_keyspace):
             assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE b > 12 AND c < 25 AND d CONTAINS 2"),
                        row(21, 22, 23, [2, 4]))
 
-@pytest.mark.xfail(reason="issue #12526")
+@pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526")
 def testFilteringWithCounters(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 14, 11, 12, 13)
@@ -3591,7 +3591,7 @@ def testClusteringOrderWithSlice(cql, test_keyspace):
 
 EMPTY_BYTE_BUFFER = b""
 
-@pytest.mark.parametrize("options", ["", pytest.param(" WITH COMPACT STORAGE", marks=pytest.mark.xfail(reason="issue #12526, #12749"))])
+@pytest.mark.parametrize("options", ["", pytest.param(" WITH COMPACT STORAGE", marks=pytest.mark.xfail(reason="Support filtering on COMPACT tables #12526, Unsupported empty clustering key in COMPACT table #12749"))])
 def testEmptyRestrictionValue(cql, test_keyspace, options):
     with create_table(cql, test_keyspace, "(pk blob, c blob, v blob, PRIMARY KEY ((pk), c))" + options) as table:
         execute(cql, table, "INSERT INTO %s (pk, c, v) VALUES (?, ?, ?)",
@@ -3712,7 +3712,7 @@ def testEmptyRestrictionValue(cql, test_keyspace, options):
             assert_rows(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND v = textAsBlob('') ALLOW FILTERING;"),
                        row(b"foo123", b"3", EMPTY_BYTE_BUFFER))
 
-@pytest.mark.xfail(reason="issue #12749")
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749")
 def testEmptyRestrictionValueWithMultipleClusteringColumns(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk blob, c1 blob, c2 blob, v blob, PRIMARY KEY (pk, c1, c2)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (pk, c1, c2, v) VALUES (?, ?, ?, ?)", b"foo123", b"1", b"1", b"1")
@@ -3790,7 +3790,7 @@ def testEmptyRestrictionValueWithMultipleClusteringColumns(cql, test_keyspace):
 
             assertEmpty(execute(cql, table, "SELECT * FROM %s WHERE pk = textAsBlob('foo123') AND (c1, c2) < (textAsBlob(''), textAsBlob('1'));"))
 
-@pytest.mark.xfail(reason="issue #12749")
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749")
 @pytest.mark.parametrize("options", [" WITH COMPACT STORAGE", " WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c DESC)"])
 def testEmptyRestrictionValueWithOrderBy(cql, test_keyspace, options):
     orderingClause = "" if "ORDER" in options else "ORDER BY c DESC"
@@ -3824,7 +3824,7 @@ def testEmptyRestrictionValueWithOrderBy(cql, test_keyspace, options):
                              EMPTY_BYTE_BUFFER,
                              b"4")
 
-@pytest.mark.xfail(reason="issue #12749")
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749")
 @pytest.mark.parametrize("options", [" WITH COMPACT STORAGE", " WITH COMPACT STORAGE AND CLUSTERING ORDER BY (c1 DESC, c2 DESC)"])
 def testEmptyRestrictionValueWithMultipleClusteringColumnsAndOrderBy(cql, test_keyspace, options):
     orderingClause = "" if "ORDER" in options else "ORDER BY c1 DESC, c2 DESC"
@@ -4215,7 +4215,7 @@ def testDeleteWithCompactStaticFormat(cql, test_keyspace):
 
 # Test for CASSANDRA-13917
 # Reproduces #12815
-@pytest.mark.xfail(reason="issue #12815")
+@pytest.mark.xfail(reason="Hidden column \"value\" in compact table isn't completely hidden #12815")
 def testDeleteWithCompactNonStaticFormat(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
@@ -4265,7 +4265,7 @@ def testInsertWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(reason="Hidden column \"value\" in compact table isn't completely hidden #12815")
 def testInsertWithCompactNonStaticFormat(cql, test_keyspace):
     do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
     do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
@@ -4339,7 +4339,7 @@ def testSelectWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(reason="Hidden column \"value\" in compact table isn't completely hidden #12815")
 def testSelectWithCompactNonStaticFormat(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
@@ -4403,7 +4403,7 @@ def testUpdateWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip(reason="Hidden column \"value\" in compact table isn't completely hidden #12815")
 def testUpdateWithCompactNonStaticFormat(cql, test_keyspace):
     do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
     do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")

--- a/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
@@ -338,7 +338,7 @@ def test_emptyValues(cql, test_keyspace):
 #         assertRows(execute("SELECT f([1.0, 2.0], value) FROM %s"), expected);
 #     }
 
-@pytest.mark.xfail(reason="Issue #5411")
+@pytest.mark.xfail(reason="Allow using terms in selection clause within SELECT statement #5411")
 def test_token(cql , test_keyspace):
     with create_table(cql, test_keyspace, "(pk vector<int, 2> primary key)") as table:
 

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -61,7 +61,7 @@ def testCreateTinyintColumns(cql, test_keyspace):
         #assertInvalidMessage(cql, table, "Expected 1 byte for a tinyint (0)",
         #                     "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", "3", (byte) 1, ByteBufferUtil.EMPTY_BYTE_BUFFER)
 
-@pytest.mark.xfail(reason="Issue #8001")
+@pytest.mark.xfail(reason='Documented unit "µs" not supported for assigning a "duration" type #8001')
 def testCreateTableWithDurationColumns(cql, test_keyspace):
     t = unique_name()
     # Messages in Scylla and Cassandra are slightly different - Cassandra
@@ -336,7 +336,7 @@ def testCreateKeyspaceWithNetworkTopologyStrategyNoOptions(cql):
 # Test {@link ConfigurationException} is not thrown on create SimpleStrategy keyspace without any options.
 # Reproduces one aspect of #8892 (a default_keyspace_rf allows creating
 # a keyspace without specifying a replication factor).
-@pytest.mark.xfail(reason="Issue #8892")
+@pytest.mark.xfail(reason="Forbid re-adding static columns as regular and vice versa #8892")
 def testCreateKeyspaceWithSimpleStrategyNoOptions(cql):
     n = unique_name()
     execute(cql, n, "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy' }")
@@ -587,7 +587,7 @@ def assertSchemaOption(cql, table, option, expected):
     [ks, cf] = table.split('.')
     assertRows(execute(cql, table, "SELECT " + option + " FROM system_schema.tables WHERE keyspace_name = '" + ks + "' and table_name = '" + cf + "';"), row(expected))
 
-@pytest.mark.xfail(reason="Issue #8948, #6442")
+@pytest.mark.xfail(reason='Cassandra 3.11.10 uses "class" instead of "sstable_compression" for compression settings by default #8948, Always print all schema parameters (including default values) #6442')
 def testCreateTableWithCompression(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b int, c int, primary key (a, b))") as table:
         assertSchemaOption(cql, table, "compression", {"chunk_length_in_kb": "16", "class": "org.apache.cassandra.io.compress.LZ4Compressor"})

--- a/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
@@ -438,7 +438,7 @@ def testDeleteWithOneClusteringColumns(cql, test_keyspace, forceFlush):
         assertInvalidMessage(cql, table, "where clause",
                              "DELETE FROM %s WHERE partitionKey = ? AND clustering = ? AND value = ?", 0, 1, 3)
 
-@pytest.mark.xfail(reason="#4244")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244")
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithTwoClusteringColumns(cql, test_keyspace, forceFlush):
     with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, PRIMARY KEY (partitionKey, clustering_1, clustering_2))") as table:
@@ -666,7 +666,7 @@ def testDeleteWithRangeAndOneClusteringColumn(cql, test_keyspace, forceFlush):
         assertInvalid(cql, table,
                              "DELETE value FROM %s WHERE partitionKey = ?", 2)
 
-@pytest.mark.xfail(reason="#13250")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #13250")
 @pytest.mark.parametrize("forceFlush", [False, True])
 def testDeleteWithRangeAndTwoClusteringColumns(cql, test_keyspace, forceFlush):
     with create_table(cql, test_keyspace, "(partitionKey int, clustering_1 int, clustering_2 int, value int, primary key (partitionKey, clustering_1, clustering_2))") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_invalidate_sized_records_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_invalidate_sized_records_test.py
@@ -27,7 +27,7 @@ from ...porting import *
 LARGE_BLOB = b'x' * (2**16)
 MEDIUM_BLOB = b'x' * (2**15 + 9)
 
-@pytest.mark.xfail(reason="issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def testsingleValuePk(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob PRIMARY KEY)") as table:
         # reproduces #12247:
@@ -40,7 +40,7 @@ def testsingleValuePk(cql, test_keyspace):
         with pytest.raises(InvalidRequest, match='Key may not be empty'):
             execute(cql, table, "INSERT INTO %s (a) VALUES (?)", b'')
 
-@pytest.mark.xfail(reason="issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 # Currently fails on Cassandra due to CASSANDRA-19270
 def testcompositeValuePk(cql, test_keyspace, cassandra_bug):
     with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY ((a, b)))") as table:
@@ -76,7 +76,7 @@ def testcompositeValuePk(cql, test_keyspace, cassandra_bug):
 
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", b'', MEDIUM_BLOB)
 
-@pytest.mark.xfail(reason="issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def testsingleValueClustering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY (a, b))") as table:
         # reproduces #12247:
@@ -96,7 +96,7 @@ def testsingleValueClustering(cql, test_keyspace):
         # For backwards compatability reasons, need to keep empty support
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (?, ?)", MEDIUM_BLOB, b'')
 
-@pytest.mark.xfail(reason="issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def testcompositeValueClustering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob, b blob, c blob, PRIMARY KEY (a, b, c))") as table:
         # sum of columns is too large
@@ -110,7 +110,7 @@ def testcompositeValueClustering(cql, test_keyspace):
         with pytest.raises(InvalidRequest, match=f'Key length of {len(MEDIUM_BLOB)+len(LARGE_BLOB)} is longer than maximum of 65535'):
             execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", MEDIUM_BLOB, MEDIUM_BLOB, LARGE_BLOB)
 
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 def testsingleValueIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a blob, b blob, PRIMARY KEY (a))") as table:
         execute(cql, table, "CREATE INDEX single_value_index ON %s (b)")

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
@@ -54,7 +54,7 @@ def testInsertWithUnset(cql, test_keyspace):
 MAX_TTL = 20 * 365 * 24 * 60 * 60
 
 # Reproduces #12243:
-@pytest.mark.xfail(reason="Issue #12243")
+@pytest.mark.xfail(reason='Setting USING TTL of "null" should be allowed #12243')
 def testInsertWithTtl(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v int)") as table:
         # test with unset
@@ -164,7 +164,7 @@ def testInsertWithAStaticColumn(cql, test_keyspace, forceFlush):
                              "INSERT INTO %s (partitionKey, clustering_2, staticValue) VALUES (0, 0, 'A')")
 
 # Reproduces #6447 and #12243:
-@pytest.mark.xfail(reason="Issue #12243")
+@pytest.mark.xfail(reason='Setting USING TTL of "null" should be allowed #12243')
 def testInsertWithDefaultTtl(cql, test_keyspace):
     secondsPerMinute = 60
     with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10*secondsPerMinute}") as table:
@@ -195,14 +195,14 @@ def testInsertWithDefaultTtl(cql, test_keyspace):
 TOO_BIG = 1024 * 65
 
 # Reproduces #12247:
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def testPKInsertWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
         assertInvalidThrow(cql, table, InvalidRequest,
                            "INSERT INTO %s (a, b) VALUES (?, 'foo')", 'x'*TOO_BIG)
 
 # Reproduces #12247:
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def testCKInsertWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
         assertInvalidThrow(cql, table, InvalidRequest,

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
@@ -36,7 +36,7 @@ def testInsertSetIfNotExists(cql, test_keyspace, is_scylla):
                    row(True,None,None) if is_scylla else row(True))
         assertRows(execute(cql, table, "SELECT * FROM %s "), row(0, {1, 2, 3}))
 
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeUDT(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:   
@@ -266,7 +266,7 @@ def checkInvalidUDT(cql, table, condition, value, expected):
     assertInvalidThrow(cql, table, expected, "DELETE FROM %s WHERE k = 0 IF " + condition)
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, value))
 
-@pytest.mark.xfail(reason="Issue #13624")
+@pytest.mark.xfail(reason="Add support for UDT subfields in LWT expression #13624")
 def testUDTField(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:   
@@ -395,7 +395,7 @@ def testUDTField(cql, test_keyspace):
                 checkDoesNotApplyUDT(cql, table, "v.b != null AND v.b IN ()", v)
 
 # Migrated from cql_tests.py:TestCQL.whole_list_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeList(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "list<text>"
@@ -553,7 +553,7 @@ def testExpandedListItem(cql, test_keyspace):
             #check_invalid_list(cql, table, "l[null] = null", InvalidRequest)
 
 # Migrated from cql_tests.py:TestCQL.whole_set_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeSet(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "set<text>"
@@ -632,7 +632,7 @@ def check_invalid_set(cql, table, condition, expected):
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, {"bar", "foo"}))
 
 # Migrated from cql_tests.py:TestCQL.whole_map_conditional_test()
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testWholeMap(cql, test_keyspace):
     for frozen in [False, True]:   
         typename = "map<text,text>"
@@ -800,7 +800,7 @@ def check_invalid_map(cql, table, condition, expected):
     assertInvalidThrow(cql, table, expected, "DELETE FROM %s WHERE k=0 IF " + condition)
     assertRows(execute(cql, table, "SELECT * FROM %s"), row(0, {"foo": "bar"}))
 
-@pytest.mark.xfail(reason="Issue #13586")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586")
 def testInMarkerWithUDTs(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(a int, b text)") as typename:
         for frozen in [False, True]:
@@ -856,7 +856,7 @@ def testInMarkerWithUDTs(cql, test_keyspace):
                 assertInvalidMessage(cql, table, "unset",
                                  "UPDATE %s SET v = {a: 0, b: 'bc'} WHERE k = 0 IF v.a IN ?", unset())
 
-@pytest.mark.xfail(reason="Issues #13586, #5855")
+@pytest.mark.xfail(reason="Add support for CONTAINS and CONTAINS KEY in LWT expressions #13586, lwt: comparing NULL collection with empty value in IF condition yields incorrect results #5855")
 def testNonFrozenEmptyCollection(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k int PRIMARY KEY, l list<text>)") as table:
         execute(cql, table, "INSERT INTO %s (k, l) VALUES (0, null)")

--- a/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
@@ -10,7 +10,7 @@
 
 from ...porting import *
 
-@pytest.mark.xfail(reason="Issue #2060, #13109")
+@pytest.mark.xfail(reason="Allow mixing token and partition key restrictions #2060, Incorrect sort order when combining IN, GROUP BY and ORDER BY #13109")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, primary key (a, b, c, d))") as table:
 
@@ -605,7 +605,7 @@ def testGroupByWithRangeNamesQueryWithoutPaging(cql, test_keyspace):
                    row(1, 1, 2, 2, 2),
                    row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #13109")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, GROUP BY and ORDER BY #13109")
 def testGroupByWithStaticColumnsWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------
@@ -1570,7 +1570,7 @@ def testGroupByWithRangeNamesQueryWithPaging(cql, test_keyspace):
                           row(1, 1, 2, 2, 2),
                           row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #21267")
+@pytest.mark.xfail(reason="Group By + Order By + Limit produces incorrect results #21267")
 def testGroupByWithStaticColumnsWithPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------

--- a/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
@@ -19,7 +19,7 @@ def testSparseTable(cql, test_keyspace):
                 execute(cql, table, "INSERT INTO %s (userid, url, day, month, year) VALUES (?, ?, 1, 'jan', 2012)", i, f"http://foo.{tld}")
         assertRowCount(execute(cql, table, "SELECT * FROM %s LIMIT 4"), 4)
 
-@pytest.mark.xfail(reason="issues #15099")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, and ORDER BY #15099")
 def testPerPartitionLimit(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b))") as table:
         for i in range(5):
@@ -284,7 +284,7 @@ def testLimitWithDeletedRowsAndStaticColumns(cql, test_keyspace):
                    row(1, -1, 1, 1),
                    row(5, -1, 1, 1))
 
-@pytest.mark.xfail(reason="issue #15099")
+@pytest.mark.xfail(reason="Incorrect sort order when combining IN, and ORDER BY #15099")
 def testFilteringOnClusteringColumnsWithLimitAndStaticColumns(cql, test_keyspace):
     # With only one clustering column
     with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, PRIMARY KEY (a, b))") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
@@ -30,8 +30,8 @@ def testSingleClusteringInvalidQueries(cql, test_keyspace):
 
 # We need to skip this test because issue #13241 causes it to frequently
 # crash Scylla, and not just fail cleanly.
-@pytest.mark.skip(reason="Issue #13241")
-@pytest.mark.xfail(reason="Issue #4244")
+@pytest.mark.skip(reason="Multi-column IN restriction with tuples of different lengths crashes Scylla #13241")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def testMultiClusteringInvalidQueries(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))") as table:
         assertInvalidSyntax(cql, table, "SELECT * FROM %s WHERE a = 0 AND (b, c) > ()")
@@ -115,7 +115,7 @@ def testMultiClusteringInvalidQueries(cql, test_keyspace):
         assertInvalidMessage(cql, table, "Column \"c\" cannot be restricted by two inequalities not starting with the same column",
                              "SELECT * FROM %s WHERE a = ? AND (b, c) > (?, ?) AND (c) < (?)", 0, 0, 0, 0)
 
-@pytest.mark.xfail(reason="Issue #64, #4244")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix #64, Add support for mixing token, multi- and single-column restrictions #4244")
 def testMultiAndSingleColumnRelationMix(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0)
@@ -191,7 +191,7 @@ def testMultiAndSingleColumnRelationMix(cql, test_keyspace):
                    row(0, 0, 0, 0),
                    row(0, 0, 1, 0))
 
-@pytest.mark.xfail(reason="Issue #64, #4244")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix #64, Add support for mixing token, multi- and single-column restrictions #4244")
 def testSeveralMultiColumnRelation(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0)
@@ -268,7 +268,7 @@ def testSinglePartitionInvalidQueries(cql, test_keyspace):
         assertInvalidMessage(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: b",
                              "SELECT * FROM %s WHERE (b) = (?)", 0)
 
-@pytest.mark.xfail(reason="Issue #4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def testSingleClustering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, primary key (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c) VALUES (?, ?, ?)", 0, 0, 0)
@@ -327,7 +327,7 @@ def testNonEqualsRelation(cql, test_keyspace):
         assertInvalidMessage(cql, table, "Unsupported \"!=\" relation: (b) != (0)",
                              "SELECT * FROM %s WHERE a = 0 AND (b) != (0)")
 
-@pytest.mark.xfail(reason="Issue #4244")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4244")
 def testMultipleClustering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c, d))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 0, 0, 0, 0)
@@ -732,7 +732,7 @@ def testMultipleClusteringReversedComponents(cql, test_keyspace):
                    row(0, 1, 1, 0)
         )
 
-@pytest.mark.xfail(reason="Issue #4178, #13250")
+@pytest.mark.xfail(reason="Not covered corner case for key prefix optimization in filtering #4178, one-element multi-column restriction should be handled like a single-column restriction #13250")
 def testMultipleClusteringWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d))") as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
@@ -812,7 +812,7 @@ def testMultipleClusteringWithIndex(cql, test_keyspace):
         assertInvalidMessage(cql, table, "unset value",
                              "SELECT * FROM %s WHERE (b, c) >= (?, ?) AND e = ?  ALLOW FILTERING", 1, 1, UNSET_VALUE)
 
-@pytest.mark.xfail(reason="Issue #8627")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #8627")
 def testMultipleClusteringWithIndexAndValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b blob, c int, d int, PRIMARY KEY (a, b, c))") as table:
         execute(cql, table, "CREATE INDEX ON %s (b)")
@@ -850,7 +850,7 @@ def testMultiColumnRestrictionsWithIndex(cql, test_keyspace):
         assertInvalidMessage(cql, table, errorMsg,
                              "SELECT * FROM %s WHERE a = 0 AND (b,c) > (1,0) AND (d,e) < (2,2) AND v = 0 ALLOW FILTERING")
 
-@pytest.mark.xfail(reason="Issue #4178")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #4178")
 def testMultiplePartitionKeyAndMultiClusteringWithIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, f int, PRIMARY KEY ((a, b), c, d, e))") as table:
         execute(cql, table, "CREATE INDEX ON %s (c)")
@@ -950,7 +950,7 @@ def testINWithDuplicateValue(cql, test_keyspace):
         assertRows(execute(cql, table, "SELECT * FROM %s WHERE k1 = ? AND (k2) IN ((?), (?))", 1, 1, 1),
                    row(1, 1, 1))
 
-@pytest.mark.xfail(reason="Issue #13250")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #13250")
 def testWithUnsetValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, i int, j int, s text, PRIMARY KEY (k,i,j))") as table:
         execute(cql, table, "CREATE INDEX s_index ON %s (s)")
@@ -1825,7 +1825,7 @@ def testMixedOrderColumnsInReverse(cql, test_keyspace):
 
 # Check select on tuple relations, see CASSANDRA-8613
 # migrated from cql_tests.py:TestCQL.simple_tuple_query_test()
-@pytest.mark.xfail(reason="Issue #64")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix. #64")
 def testSimpleTupleQuery(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d, e))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (0, 2, 0, 0, 0)")

--- a/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -390,7 +390,7 @@ def testINWithDuplicateValue(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT * FROM %s WHERE k1 = ? AND k2 IN (?, ?)", 1, 1, 1),
                    [1, 1, 1])
 
-@pytest.mark.xfail(reason="#10577 - max-clustering-key-restrictions-per-query is too low for this test")
+@pytest.mark.xfail(reason="Is max-clustering-key-restrictions-per-query too low? #10577")
 def testLargeClusteringINValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))") as table:
         execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (0, 0, 0)")

--- a/test/cqlpy/cassandra_tests/validation/operations/select_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_test.py
@@ -793,7 +793,7 @@ def testSelectDistinctWithWhereClause(cql, test_keyspace):
                    [70])
 
 # Reproduces issue #10354
-@pytest.mark.xfail(reason="#10354 - we forgot to allow SELECT DISTINCT filtering on static column")
+@pytest.mark.xfail(reason="SELECT DISTINCT should allow filter on static columns, not just partition keys #10354")
 def testSelectDistinctWithWhereClauseOnStaticColumn(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, a int, s int static, s1 int static, b int, PRIMARY KEY (k, a))") as table:
         for i in range(10):
@@ -1279,7 +1279,7 @@ def testFilteringWithoutIndicesWithFrozenCollections(cql, test_keyspace):
                              "SELECT * FROM %s WHERE e[1] = ? ALLOW FILTERING",
                              UNSET_VALUE)
 # Reproduces #8627
-@pytest.mark.xfail(reason="#8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 def testIndexQueryWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c blob, PRIMARY KEY (a, b))") as table:
         TOO_BIG = 1024 * 65
@@ -1298,7 +1298,7 @@ def testIndexQueryWithValueOver64K(cql, test_keyspace):
         assert_empty(execute(cql, table, "SELECT * FROM %s WHERE c = ?  ALLOW FILTERING", too_big))
 
 # Reproduces #10366
-@pytest.mark.xfail(reason="#10366 - server error instead of InvalidRequest")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #10366 - server error instead of InvalidRequest")
 def testPKQueryWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b text, PRIMARY KEY (a, b))") as table:
         TOO_BIG = 1024 * 65
@@ -1307,7 +1307,7 @@ def testPKQueryWithValueOver64K(cql, test_keyspace):
                            "SELECT * FROM %s WHERE a = ?", too_big)
 
 # Reproduces #10366
-@pytest.mark.xfail(reason="#10366 - server error instead of silent return")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #10366 - server error instead of silent return")
 def testCKQueryWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b text, PRIMARY KEY (a, b))") as table:
         TOO_BIG = 1024 * 65
@@ -1549,7 +1549,7 @@ def testAllowFilteringOnPartitionAndClusteringKey(cql, test_keyspace):
                                     [21, 12, 25, 24, 25],
                                     [21, 12, 26, 34, 35])
 
-@pytest.mark.xfail(reason="#10358")
+@pytest.mark.xfail(reason="Comparison with UNSET_VALUE should produce an error #10358")
 def testAllowFilteringOnPartitionKeyWithoutIndicesWithCollections(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c list<int>, d set<int>, e map<int, int>, PRIMARY KEY ((a, b)))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, [1, 6], {2, 12}, {1: 6})")
@@ -1758,7 +1758,7 @@ def testFilteringOnClusteringColumns(cql, test_keyspace):
                        [21, 28, 29, 30],
                        [31, 32, 33, 34])
 
-@pytest.mark.xfail(reason="#4244")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244")
 def testFilteringWithMultiColumnSlices(cql, test_keyspace):
     #/----------------------------------------
     #/ Multi-column slices for clustering keys
@@ -1888,7 +1888,7 @@ def testContainsOnPartitionKey(cql, test_keyspace):
 def testContainsOnPartitionKeyPart(cql, test_keyspace):
     dotestContainsOnPartitionKey(cql, test_keyspace, "(pk frozen<map<int, int>>, ck int, v int, PRIMARY KEY ((pk, ck)))")
 
-@pytest.mark.xfail(reason="#10443")
+@pytest.mark.xfail(reason="SELECT with IN and ORDER BY orders rows per partition instead of for the entire response #10443")
 def testFilteringWithOrderClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d list<int>, PRIMARY KEY (a, b, c))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (?, ?, ?, ?)", 11, 12, 13, [1,4])

--- a/test/cqlpy/cassandra_tests/validation/operations/update_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/update_test.py
@@ -427,7 +427,7 @@ def testUpdateWithStaticList(cql, test_keyspace):
 
         assertRows(execute(cql, table, "SELECT l FROM %s WHERE k = 0"), row(["v1", "v4", "v3"]))
 
-@pytest.mark.xfail(reason="#12243")
+@pytest.mark.xfail(reason='Setting USING TTL of "null" should be allowed #12243')
 def testUpdateWithDefaultTtl(cql, test_keyspace):
     secondsPerMinute = 60
     with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b int) WITH default_time_to_live = {10 * secondsPerMinute}") as table:

--- a/test/cqlpy/test_aggregate.py
+++ b/test/cqlpy/test_aggregate.py
@@ -179,7 +179,7 @@ def test_aggregation_inf_nan(cql, table1):
 # scenarios tested in this test - averaging 1 and 2 or 1.1 and 1.2 -
 # don't do something that any reasonable user might expect, and will need
 # to be fixed.
-@pytest.mark.xfail(reason="issue #13601")
+@pytest.mark.xfail(reason='Average of "decimal" values rounds the average if all inputs are integers #13601')
 def test_avg_decimal(cql, table1, cassandra_bug):
     p = unique_key_int()
     cql.execute(f"insert into {table1} (p, c, dc) values ({p}, 1, 1.0)")

--- a/test/cqlpy/test_allow_filtering.py
+++ b/test/cqlpy/test_allow_filtering.py
@@ -114,7 +114,7 @@ def test_allow_filtering_partition_slice_and_restriction(cql, table1):
 # like 'v=2' doesn't change any of the above, so doesn't require filtering.
 # Reproduces #7964 on Scylla, and also wrong on Cassandra so marked
 # cassandra_bug.
-@pytest.mark.xfail(reason="#7964")
+@pytest.mark.xfail(reason="Further restricting a query already limited to a single row should not require ALLOW FILTERING #7964")
 def test_allow_filtering_single_row(cql, table1, cassandra_bug):
     check_af_optional(cql, table1, 'k=1 AND c=2', lambda row: row.k==1 and row.c==2)
     # Reproduces #7964, as ALLOW FILTERING is considered mandatory, not optional
@@ -310,7 +310,7 @@ def test_allow_filtering_prefix(cql, table3):
 # reproduces issue #5545 / #13533
 def test_allow_filtering_pk_in(cql, table1):
     check_af_optional(cql, table1, 'k IN (1,2)', lambda row: row.k in {1,2})
-@pytest.mark.xfail(reason="issue #5545, #13533: Scylla supports IN on indexed column, but only with ALLOW FILTERING")
+@pytest.mark.xfail(reason="WHERE IN secondary_index requires ALLOW FILTERING unlike in Cassandra #5545, WHERE IN is much slower than individual selects #13533")
 def test_allow_filtering_index_in(cql, table2):
     check_af_optional(cql, table2, 'a IN (1,2)', lambda row: row.a in {1,2})
 
@@ -331,7 +331,7 @@ def table2local(cql, test_keyspace):
     wait_for_local_index(cql, table, 'k', 'a', everything)
     yield (table, everything)
     cql.execute("DROP TABLE " + table)
-@pytest.mark.xfail(reason="issue #13533: Scylla supports IN on indexed column, but only with ALLOW FILTERING")
+@pytest.mark.xfail(reason="WHERE IN is much slower than individual selects #13533")
 def test_allow_filtering_local_index_in(cql, table2local, scylla_only):
     check_af_optional(cql, table2local, 'k = 0 AND a IN (1,2)', lambda row: row.a in {1,2})
 
@@ -465,7 +465,7 @@ def test_allow_filtering_clustering_key_multicolumn_syntax(cql, table1):
 # Moreover, if we have multiple clustering key columns, c1 and c2,
 # (c2)=(10) should be allowed just like c2=10 (and require filtering
 # just like it) - we shouldn't complain that c1 is missing. Reproduces #13250.
-@pytest.mark.xfail(reason="issue #13250")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #13250")
 def test_allow_filtering_compound_clustering_key_multicolumn_syntax(cql, table3):
     check_af_mandatory(cql, table3, 'c1=10', lambda row: row.c1==10)
     check_af_mandatory(cql, table3, '(c1)=(10)', lambda row: row.c1==10)

--- a/test/cqlpy/test_counter.py
+++ b/test/cqlpy/test_counter.py
@@ -38,7 +38,7 @@ def test_counter_to_blob(cql, table1, table2):
         cql.execute(f"SELECT counterasblob(i) FROM {table1} WHERE p={p}")
     # The opposite order is allowed in Scylla because of #14319, so let's
     # split it into a second test test_counter_to_blob2:
-@pytest.mark.xfail(reason="issue #14319")
+@pytest.mark.xfail(reason="Maybe inconsistent handling of implicit timestamp<->bigint conversion #14319")
 def test_counter_to_blob2(cql, table1, table2):
     p = unique_key_int()
     cql.execute(f'UPDATE {table2} SET c = c + 1000 WHERE p = {p}')

--- a/test/cqlpy/test_empty.py
+++ b/test/cqlpy/test_empty.py
@@ -51,7 +51,7 @@ def test_insert_empty_string_key_with_flush(cql, table1, scylla_only):
 # In contrast with normal tables where an empty clustering key is allowed,
 # in a WITH COMPACT STORAGE table, an empty clustering key is not allowed.
 # As usual, an empty partition key is not allowed either.
-@pytest.mark.xfail(reason="issue #12749, misleading error message")
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749, misleading error message")
 def test_insert_empty_string_key_compact(compact_storage, cql, test_keyspace):
     schema = 'p text, c text, v text, primary key (p, c)'
     with new_test_table(cql, test_keyspace, schema, 'WITH COMPACT STORAGE') as table:
@@ -63,7 +63,7 @@ def test_insert_empty_string_key_compact(compact_storage, cql, test_keyspace):
 
 # However, in a COMPACT STORAGE table with a *compound* clustering key (more
 # than one clustering key column), setting one of them to empty *is* allowed.
-@pytest.mark.xfail(reason="issue #12749")
+@pytest.mark.xfail(reason="Unsupported empty clustering key in COMPACT table #12749")
 def test_insert_empty_string_compound_clustering_key_compact(compact_storage, cql, test_keyspace):
     schema = 'p text, c1 text, c2 text, v text, primary key (p, c1, c2)'
     with new_test_table(cql, test_keyspace, schema, 'WITH COMPACT STORAGE') as table:
@@ -181,14 +181,14 @@ def test_empty_string_for_string_types_json(cql, table_all_scalar, t):
 # constant, but the string needs to follow a particular format and in
 # particular the empty string should not be allowed.
 # Reproduces #10625.
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Empty composite partition keys are allowed in Scylla #10625")
 @pytest.mark.parametrize("t", ["date", "time"])
 def test_empty_string_for_fussy_string_types(cql, table_all_scalar, t):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
         cql.execute(f"INSERT INTO {table_all_scalar} (p,v{t}) VALUES ({p}, '')")
 
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Empty composite partition keys are allowed in Scylla #10625")
 @pytest.mark.parametrize("t", ["date", "time"])
 def test_empty_string_for_fussy_string_types_json(cql, table_all_scalar, t):
     p = unique_key_int()
@@ -200,14 +200,14 @@ def test_empty_string_for_fussy_string_types_json(cql, table_all_scalar, t):
 # empty string doesn't make sense as an IP address or a timestamp.
 # We consider this a Cassandra bug, hence the tag "cassandra_bug" below.
 # Reproduces #10625.
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Empty composite partition keys are allowed in Scylla #10625")
 @pytest.mark.parametrize("t", ["inet", "timestamp"])
 def test_empty_string_for_fussy_string_types2(cql, table_all_scalar, t, cassandra_bug):
     p = unique_key_int()
     with pytest.raises(InvalidRequest):
         cql.execute(f"INSERT INTO {table_all_scalar} (p,v{t}) VALUES ({p}, '')")
 
-@pytest.mark.xfail(reason="issue #10625")
+@pytest.mark.xfail(reason="Empty composite partition keys are allowed in Scylla #10625")
 @pytest.mark.parametrize("t", ["inet", "timestamp"])
 def test_empty_string_for_fussy_string_types2_json(cql, table_all_scalar, t, cassandra_bug):
     p = unique_key_int()
@@ -227,7 +227,7 @@ def test_empty_string_for_other_types(cql, table_all_scalar, t):
 # Reproduces #7944 and #10625.
 # See also test_json.py::test_fromjson_{varint,int}_empty_string*
 # which reproduces the same bug but just for two specific types.
-@pytest.mark.xfail(reason="issue #7944")
+@pytest.mark.xfail(reason="fromJson() should not accept the empty string as a number #7944")
 @pytest.mark.parametrize("t", ["bigint", "blob", "boolean", "decimal", "double", "duration", "float", "int", "smallint", "timeuuid", "tinyint", "uuid", "varint"])
 def test_empty_string_for_other_types_json(cql, table_all_scalar, t, cassandra_bug):
     p = unique_key_int()
@@ -240,7 +240,7 @@ def test_empty_string_for_other_types_json(cql, table_all_scalar, t, cassandra_b
 # a big problem for regular columns, but for key columns it is bad -
 # namely, because the partition key cannot be empty.
 # See #10625, #7944
-@pytest.mark.xfail(reason="issue #7944, Scylla returns internal server error")
+@pytest.mark.xfail(reason="fromJson() should not accept the empty string as a number #7944, Scylla returns internal server error")
 def test_empty_string_for_nonstring_partition_key1(cql, test_keyspace):
     schema = 'p int primary key, v int'
     with new_test_table(cql, test_keyspace, schema) as table:

--- a/test/cqlpy/test_filtering.py
+++ b/test/cqlpy/test_filtering.py
@@ -397,8 +397,8 @@ def do_test_filter_UDT_restriction(cql, test_keyspace, frozen):
 # in Cassandra the behavior is the former - and this is what this test
 # expects. In Scylla it's currently the latter, causing this test to fail.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12102")),
-        pytest.param(False, marks=pytest.mark.xfail(reason="#12102"))])
+        pytest.param(True, marks=pytest.mark.xfail(reason="With filtering, page size counts unfiltered rows. Should be filtered rows? #12102")),
+        pytest.param(False, marks=pytest.mark.xfail(reason="With filtering, page size counts unfiltered rows. Should be filtered rows? #12102"))])
 def test_filter_and_fetch_size(cql, test_keyspace, use_index, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int primary key, x int, y int') as table:
         if use_index:

--- a/test/cqlpy/test_group_by.py
+++ b/test/cqlpy/test_group_by.py
@@ -115,7 +115,7 @@ def test_group_by_clustering_prefix_with_limit(cql, table1):
 
 # Same as the above test, but also add paging, and check that the LIMIT
 # is handled correctly (limits the total number of returned results)
-@pytest.mark.xfail(reason="issue #5362")
+@pytest.mark.xfail(reason="LIMIT is not doing it right when using GROUP BY #5362")
 def test_group_by_clustering_prefix_with_limit_and_paging(cql, table1):
     results = list(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1'))
     assert len(results) == 4
@@ -232,7 +232,7 @@ def test_group_by_non_aggregated_mutation_attribute_of_column(cql, table1):
 
 # This test is from cassandra_tests/validation/operations/select_group_by_test.py::testGroupByWithPaging()
 # Reproduces #21267
-@pytest.mark.xfail(reason="issue #21267")
+@pytest.mark.xfail(reason="GROUP BY returns incorrect values for rows with only static column set #21267")
 def test_group_by_static_column(cql, test_keyspace):
 
     with new_test_table(cql, test_keyspace, "a int, b int, c int, s int static, d int, primary key (a, b, c)") as table:

--- a/test/cqlpy/test_json.py
+++ b/test/cqlpy/test_json.py
@@ -215,7 +215,7 @@ def test_fromjson_bigint_nonoverflow(cql, table1):
 # standard suggests it may be fine to botch it up, so it might be acceptable
 # to fail this test.
 # Reproduces #10100 and #10137.
-@pytest.mark.xfail(reason="issue #10137")
+@pytest.mark.xfail(reason="INSERT JSON of bigint (64-bit) in scientific notation is not accurate above 2^53 #10137")
 def test_fromjson_bigint_nonoverflow_scientific(cql, table1, cassandra_bug):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, bigv) VALUES (?, fromJson(?))")
@@ -244,12 +244,12 @@ def test_fromjson_int_empty_string_prepared(cql, table1, cassandra_bug):
     stmt = cql.prepare(f"INSERT INTO {table1} (p, v) VALUES (?, fromJson(?))")
     with pytest.raises(FunctionFailure):
         cql.execute(stmt, [p, '""'])
-@pytest.mark.xfail(reason="issue #7944")
+@pytest.mark.xfail(reason="fromJson() should not accept the empty string as a number #7944")
 def test_fromjson_varint_empty_string_unprepared(cql, table1):
     p = unique_key_int()
     with pytest.raises(FunctionFailure):
         cql.execute(f"INSERT INTO {table1} (p, vi) VALUES ({p}, fromJson('\"\"'))")
-@pytest.mark.xfail(reason="issue #7944")
+@pytest.mark.xfail(reason="fromJson() should not accept the empty string as a number #7944")
 def test_fromjson_varint_empty_string_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, vi) VALUES (?, fromJson(?))")
@@ -386,7 +386,7 @@ def test_fromjson_map_key_timestamp(cql, table1):
 # that a normal value is allowed. For example, it cannot be given as an
 # element of a list.
 # Reproduces #7954.
-@pytest.mark.xfail(reason="issue #7954")
+@pytest.mark.xfail(reason="fromJson() fails to set null tuple elements #7954")
 def test_fromjson_null_constant(cql, table1):
     p = unique_key_int()
     # Check that a "null" JSON constant can be used to unset a column
@@ -493,7 +493,7 @@ def test_fromjson_timestamp_submilli(cql, table1, cassandra_bug):
 # We need to skip this test because in debug mode memory allocation is not
 # bounded, and this test can hang or crash instead of failing immediately.
 # We also have a smaller xfailing test below, test_tojson_decimal_high_mantissa2.
-@pytest.mark.skip(reason="issue #8002")
+@pytest.mark.skip(reason="toJson() of decimal type doesn't use exponents so can produce huge output #8002")
 def test_tojson_decimal_high_mantissa(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, dec) VALUES ({p}, ?)")
@@ -505,7 +505,7 @@ def test_tojson_decimal_high_mantissa(cql, table1):
 # that a much smaller exponent, 1e1000 works (this is not surprising) but
 # results in 1000 digits of output. This hints that 1e1000000000 will not
 # work at all, without testing it directly as above.
-@pytest.mark.xfail(reason="issue #8002")
+@pytest.mark.xfail(reason="toJson() of decimal type doesn't use exponents so can produce huge output #8002")
 def test_tojson_decimal_high_mantissa2(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, dec) VALUES ({p}, ?)")
@@ -543,7 +543,7 @@ def test_select_json_function_call(cql, table1):
 # This is issue #8087.
 # This issue is also reproduced by the much more comprehensive test
 # cassandra_tests/validation/entities/json_test.py::testInsertJsonSyntaxWithNonNativeMapKeys
-@pytest.mark.xfail(reason="issue #8087")
+@pytest.mark.xfail(reason="SELECT JSON incorrectly quotes strings inside map keys #8087")
 def test_select_json_string_in_nonstring_map_key(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, tupmap) VALUES ({p}, ?)")

--- a/test/cqlpy/test_key_length.py
+++ b/test/cqlpy/test_key_length.py
@@ -34,7 +34,7 @@ def table1(cql, test_keyspace):
 # partition key should fail, with a clean InvalidRequest - not some internal
 # server error or worse.
 # Reproduces #12247
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def test_insert_65k_pk(cql, table1):
     stmt = cql.prepare(f'INSERT INTO {table1} (p, c) VALUES (?,?)')
     # Cassandra writes: "Key length of 66560 is longer than maximum of 65535"
@@ -42,7 +42,7 @@ def test_insert_65k_pk(cql, table1):
         cql.execute(stmt, ['x'*(65*1024), 'hello'])
 
 # Reproduces #12247
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def test_insert_65k_ck(cql, table1):
     stmt = cql.prepare(f'INSERT INTO {table1} (p, c) VALUES (?,?)')
     # Cassandra writes: "Key length of 66560 is longer than maximum of 65535"
@@ -53,7 +53,7 @@ def test_insert_65k_ck(cql, table1):
 # key should fail, with a clean InvalidRequest - not some internal server
 # error or worse.
 # Reproduces #10366.
-@pytest.mark.xfail(reason="Issue #10366")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #10366")
 def test_where_65k_pk(cql, table1):
     stmt = cql.prepare(f'SELECT * FROM {table1} WHERE p = ?')
     # Cassandra writes: "Key length of 66560 is longer than maximum of 65535"
@@ -68,7 +68,7 @@ def test_where_65k_pk(cql, table1):
 # return no match as Cassandra does. In any case, returning some ugly internal
 # error (as happened in Scylla) is a bug.
 # Reproduces #10366.
-@pytest.mark.xfail(reason="Issue #10366")
+@pytest.mark.xfail(reason="Enforce Key-length limits during SELECT #10366")
 def test_where_65k_ck(cql, table1):
     stmt = cql.prepare(f'SELECT * FROM {table1} WHERE p = ? AND c = ?')
     try:
@@ -87,7 +87,7 @@ def test_where_65k_ck(cql, table1):
 # Scylla shouldn't impose its own smaller size limit - but in issue #16772,
 # it did (the limit was 65533).
 
-@pytest.mark.xfail(reason="Issue #16772")
+@pytest.mark.xfail(reason="Key length should be limited to exactly 65535, not less #16772")
 def test_insert_65535_pk(cql, table1):
     stmt = cql.prepare(f'INSERT INTO {table1} (p, c) VALUES (?,?)')
     p = random_string(length=65535)
@@ -96,7 +96,7 @@ def test_insert_65535_pk(cql, table1):
     stmt = cql.prepare(f'SELECT p,c FROM {table1} WHERE p=?')
     assert list(cql.execute(stmt, [p])) == [(p, c)]
 
-@pytest.mark.xfail(reason="Issue #16772")
+@pytest.mark.xfail(reason="Key length should be limited to exactly 65535, not less #16772")
 def test_insert_65535_ck(cql, table1):
     stmt = cql.prepare(f'INSERT INTO {table1} (p, c) VALUES (?,?)')
     p = unique_key_string()  # not particularly long
@@ -111,7 +111,7 @@ def test_insert_65535_ck(cql, table1):
 # first component, and the regular column *name* as the second component.
 # This should work - Scylla shouldn't try to limit the sum of these lengths
 # or something.
-@pytest.mark.xfail(reason="Issue #16772")
+@pytest.mark.xfail(reason="Key length should be limited to exactly 65535, not less #16772")
 def test_insert_65535_ck_with_regular_column(cql, table1):
     stmt = cql.prepare(f'INSERT INTO {table1} (p, c, v) VALUES (?,?,?)')
     p = unique_key_string()  # not particularly long
@@ -138,7 +138,7 @@ def table2(cql, test_keyspace):
 # instead of the expected InvalidRequest error, it generates an internal
 # server error (i.e., NoHostAvailable) with the message "'H' format requires
 # 0 <= number <= 65535".
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def test_insert_65k_pk_compound(cql, table2, cassandra_bug):
     stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
     big = 'x'*(65*1024)
@@ -147,7 +147,7 @@ def test_insert_65k_pk_compound(cql, table2, cassandra_bug):
     with pytest.raises(InvalidRequest, match='Key length'):
         cql.execute(stmt, ['dog', big, 'cat', 'mouse'])
 
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def test_insert_65k_ck_composite(cql, table2):
     stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
     big = 'x'*(65*1024)
@@ -182,7 +182,7 @@ def test_insert_total_compound_pk_ok(cql, table2):
     stmt = cql.prepare(f'SELECT * FROM {table2} WHERE p1=? AND p2=?')
     assert list(cql.execute(stmt, [p1, p2])) == [(p1, p2, c1, c2)]
 
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def test_insert_total_compound_pk_err(cql, table2):
     stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
     # A total compound pk of size 65536 is definitely too long
@@ -225,7 +225,7 @@ def test_insert_total_composite_ck_ok(cql, table2):
     stmt = cql.prepare(f'SELECT * FROM {table2} WHERE p1=? AND p2=?')
     assert list(cql.execute(stmt, [p1, p2])) == [(p1, p2, c1, c2)]
 
-@pytest.mark.xfail(reason="Issue #12247")
+@pytest.mark.xfail(reason="Better error reporting for oversized keys during INSERT #12247")
 def test_insert_total_composite_ck_err(cql, table2):
     stmt = cql.prepare(f'INSERT INTO {table2} (p1, p2, c1, c2) VALUES (?,?,?,?)')
     # A total composite ck of size 65536 is definitely too long

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -190,7 +190,7 @@ def test_lwt_insert_if_not_exists(cql, table1):
 
 # Similarly to the above test, INSERT JSON should also accept IF NOT EXISTS
 # and work as expected with it. Reproduces issue #8682.
-@pytest.mark.xfail(reason="issue #8682")
+@pytest.mark.xfail(reason="INSERT JSON ... IF NOT EXISTS ignores IF_NOT_EXISTS #8682")
 def test_lwt_insert_json_if_not_exists(cql, table1):
     p = unique_key_int()
     # The row doesn't yet exist, IF NOT EXISTS will insert it.

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -391,7 +391,7 @@ def test_mv_synchronous_updates(cql, test_keyspace, scylla_only):
 # message about a key being too long appears in the log.
 # Note that the same issue also applies to secondary indexes, and this is
 # tested in test_secondary_index.py.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
         with new_materialized_view(cql, table, select='*', pk='v,p', where='v is not null and p is not null') as mv:
@@ -409,11 +409,11 @@ def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
 # copied to the view. The view building cannot return an error to the user,
 # but we do expect it to skip the problematic row and continue to complete
 # the rest of the view build.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 # This test currently breaks the build (it repeats a failing build step,
 # and never complete) and we cannot quickly recognize this failure, so
 # to avoid a very slow failure, we currently "skip" this test.
-@pytest.mark.skip(reason="issue #8627, fails very slow")
+@pytest.mark.skip(reason="Cleanly reject updates with indexed values where value > 64k #8627, fails very slow")
 def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
         # No materialized view yet - a "big" value in v is perfectly fine:
@@ -532,7 +532,7 @@ def test_view_builder_suspend_with_partition_tombstone(cql, test_keyspace, scyll
 # columns.
 # This test reproduces issue issue #11979, that Scylla used to require
 # IS NOT NULL inconsistently.
-@pytest.mark.xfail(reason="issue #11979")
+@pytest.mark.xfail(reason='Make requirement of "IS NOT NULL" in materialized view more consistent #11979')
 def test_is_not_null_requirement(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int, c int, v int, primary key (p, c)') as table:
         # missing "v is not null":
@@ -706,7 +706,7 @@ def test_mv_long_delete(cql, test_keyspace):
 # this column is used in a materialized view, its order in the view inherits
 # the same reversed sort order it had in the base table.
 # Reproduces #12308
-@pytest.mark.xfail(reason="issue #12308")
+@pytest.mark.xfail(reason="In Scylla, MV CLUSTERING ORDER BY defaults to natural order. In Cassandra the base's order is inherited #12308")
 def test_mv_inherit_clustering_order(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)', 'with clustering order by (c DESC)') as table:
         # note no explicit clustering order on c in the materialized view:
@@ -777,7 +777,7 @@ def test_mv_override_clustering_order_quoted(cql, test_keyspace):
 # The following test verifies that these bad WITH CLUSTERING ORDER BY
 # clauses are indeed rejected.
 # Reproduces #12936.
-@pytest.mark.xfail(reason="issue #12936")
+@pytest.mark.xfail(reason="In MV definition, CLUSTERING ORDER BY should require strict clustering-column order #12936")
 def test_mv_override_clustering_order_bad1(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p,c)') as table:
         # Mis-ordered clustering columns: c,x on PRIMARY KEY, but

--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -61,7 +61,7 @@ def test_selector_mintimeuuid(cql, table1):
 # doesn't. I'm not sure which behavior we should consider correct, but it's
 # useful to have a test that demonstrates this incompatibility.
 # Reproduces #14319.
-@pytest.mark.xfail(reason="issue #14319")
+@pytest.mark.xfail(reason="Maybe inconsistent handling of implicit timestamp<->bigint conversion #14319")
 def test_selector_mintimeuuid_64bit(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, g) VALUES ({p}, 123)")

--- a/test/cqlpy/test_scan.py
+++ b/test/cqlpy/test_scan.py
@@ -23,7 +23,7 @@ from cassandra.query import SimpleStatement
 # This test focuses on cases which do not need ALLOW FILTERING. The next
 # test will focus on those that do.
 # Reproduces issue #64 and #4244
-@pytest.mark.xfail(reason="issues #64 and #4244")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix #64, Add support for mixing token, multi- and single-column restrictions #4244")
 def test_multi_column_restrictions_ck(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, c3 int, PRIMARY KEY (p, c1, c2, c3)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c1, c2, c3) VALUES (1, ?, ?, ?)")
@@ -99,7 +99,7 @@ def test_multi_column_range_restrictions_and_filtering(cql, test_keyspace):
 # We add another clustering key column to ensure that filtering *in*
 # a long partition is really needed - not just filtering on the partitions
 # (these are two different code paths).
-@pytest.mark.xfail(reason="issue #64")
+@pytest.mark.xfail(reason="CQL Multi column restrictions are allowed only on a clustering key prefix. #64")
 def test_multi_column_restrictions_ck_filtering(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c0 int, c1 int, c2 int, c3 int, PRIMARY KEY (p, c0, c1, c2, c3)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c0, c1, c2, c3) VALUES (1, 1, ?, ?, ?)")
@@ -128,7 +128,7 @@ def test_multi_column_restrictions_ck_filtering(cql, test_keyspace):
 # Reproduces #4244. Contrasting with the other reproducers for #4244 above,
 # in this test the single-column restriction is on the same column as the
 # multi-column restriction, not a different column.
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244")
 def test_multi_column_and_single_column_restriction_same_ck(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, PRIMARY KEY (p, c1, c2)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c1, c2) VALUES (1, ?, ?)")
@@ -149,7 +149,7 @@ def test_multi_column_and_single_column_restriction_same_ck(cql, test_keyspace):
 # on the same column and on a different column..
 # Reproduces issue #4244 (note that this is a different aspect of #4244 than
 # the multi-column restriction problems reproduced by other tests above).
-@pytest.mark.xfail(reason="issue #4244")
+@pytest.mark.xfail(reason="Add support for mixing token, multi- and single-column restrictions #4244")
 def test_restriction_token_and_nontoken(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c) VALUES (?, ?)")

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -271,7 +271,7 @@ def test_range_deletion(cql, test_keyspace, scylla_only):
 # Reproduces #8627:
 # Test that trying to insert a value for an indexed column that exceeds 64KiB fails,
 # because this value is too large to be written as a key in the underlying index
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 def test_too_large_indexed_value(cql, test_keyspace):
     schema = 'p int, c int, v text, primary key (p,c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -286,7 +286,7 @@ def test_too_large_indexed_value(cql, test_keyspace):
 # to 64 KB. When a collection is indexed, the insertion of oversized elements
 # should fail cleanly at the time of write.
 # Reproduces #8627
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 def test_too_large_indexed_collection_value(cql, test_keyspace):
     schema = 'p int, c int, m map<text,text>, primary key (p,c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -303,7 +303,7 @@ def test_too_large_indexed_collection_value(cql, test_keyspace):
 # to a table with pre-existing data. The background index-building process
 # cannot return an error to the user, but we do expect it to skip the
 # problematic row and continue to complete the rest of the index build.
-@pytest.mark.xfail(reason="issue #8627")
+@pytest.mark.xfail(reason="Cleanly reject updates with indexed values where value > 64k #8627")
 def test_too_large_indexed_value_build(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
         # No index yet - a "big" value in v is perfectly fine:
@@ -378,7 +378,7 @@ def test_instant_table_recreation(cql, test_keyspace):
 # a full-index scan (the amount of output is proportional to the read).
 # Additionally, with unnecessary parentheses the query also works, and isn't
 # handled like a multi-column restriction (reproduces #13250).
-@pytest.mark.xfail(reason="issue #13250")
+@pytest.mark.xfail(reason="one-element multi-column restriction should be handled like a single-column restriction #13250")
 def test_index_scan_multicolumn_syntax(cql, test_keyspace):
     schema = 'p int, c1 int, c2 int, primary key (p, c1, c2)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -507,7 +507,7 @@ def test_index_in_restriction(cql, test_keyspace, cassandra_bug):
 # Reproduces #10649 - when use_index=True the test failed because LIMIT
 # returned fewer than the requested number of rows.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Combination of secondary index and LIMIT can produce too few results #10649")), False])
 def test_filter_and_limit(cql, test_keyspace, use_index, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int primary key, x int, y int') as table:
         if use_index:
@@ -543,7 +543,7 @@ def test_filter_and_limit(cql, test_keyspace, use_index, driver_bug_1):
 # Reproduces #10649 - when use_index=True the test failed because LIMIT
 # returned fewer than the requested number of rows.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Combination of secondary index and LIMIT can produce too few results #10649")), False])
 def test_filter_and_limit_clustering(cql, test_keyspace, use_index):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, x int, PRIMARY KEY(pk, ck)') as table:
         if use_index:
@@ -575,7 +575,7 @@ def test_filter_and_limit_clustering(cql, test_keyspace, use_index):
 # who discovered #10649, and involves slightly different code paths in
 # Scylla (the index-driver query needs to read individual rows, not
 # entire partitions, from the base table).
-@pytest.mark.xfail(reason="#10649")
+@pytest.mark.xfail(reason="Combination of secondary index and LIMIT can produce too few results #10649")
 def test_filter_and_limit_2(cql, test_keyspace):
     schema = 'pk int, ck1 int, ck2 int, x int, PRIMARY KEY (pk, ck1, ck2)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -603,7 +603,7 @@ def test_filter_and_limit_2(cql, test_keyspace):
 # conjunction filtering. A user tried this variant in issue #12766.
 # This is a scylla_only test because local index is a Scylla-only feature.
 @pytest.mark.parametrize("use_local_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#10649")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Combination of secondary index and LIMIT can produce too few results #10649")), False])
 def test_filter_and_limit_local_index(cql, test_keyspace, use_local_index, driver_bug_1, scylla_only):
     with new_test_table(cql, test_keyspace, 'p int, c int, x int, y int, primary key (p, c)') as table:
         if use_local_index:
@@ -1118,7 +1118,7 @@ def test_index_quoted_names(cql, test_keyspace):
         for name in quoted_names:
             assert [(1,2)] == list(cql.execute(f'SELECT pk,ck FROM {table} WHERE {name} CONTAINS KEY 3'))
 
-@pytest.mark.xfail(reason="#10713 - local collection indexing is not implemented yet")
+@pytest.mark.xfail(reason="Local secondary indexing for collections #10713")
 def test_local_secondary_index_on_collection(cql, test_keyspace):
     schema = 'pk int, ck int, l list<int>, PRIMARY KEY (pk, ck)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -1287,7 +1287,7 @@ def test_index_paging_pk_only(cql, test_keyspace):
 # one component), the restriction can match the entire partition, but paging
 # still needs to page through it - and not return the entire partition as one
 # page! Reproduces #7432.
-@pytest.mark.xfail(reason="issue #7432")
+@pytest.mark.xfail(reason="Some queries with secondary indexes return too large pages #7432")
 def test_index_paging_match_partition(cql, test_keyspace):
     schema = 'p1 int, p2 int, c int, primary key (p1,p2,c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -1320,7 +1320,7 @@ def test_index_paging_match_partition(cql, test_keyspace):
 # Currently, paging of queries that uses secondary indexes on static columns
 # is unable to page through partitions of the base table and must return them
 # in whole. Related to #7432.
-@pytest.mark.xfail(reason="issue #7432")
+@pytest.mark.xfail(reason="Some queries with secondary indexes return too large pages #7432")
 def test_index_paging_static_column(cql, test_keyspace):
     schema = 'p int, c int, s int static, PRIMARY KEY(p, c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -1350,7 +1350,7 @@ def test_index_paging_static_column(cql, test_keyspace):
 # returns all the results in one page instead of stopping. So the following
 # test passes with use_group_by = False but failed with use_group_by = True.
 @pytest.mark.parametrize("use_group_by", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#7432")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Some queries with secondary indexes return too large pages #7432")), False])
 def test_index_paging_group_by(cql, test_keyspace, use_group_by):
     schema = 'p int, c1 int, c2 int, primary key (p,c1,c2)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -1441,7 +1441,7 @@ def test_static_column_index_build(cql, test_keyspace):
 # restrictions. Reproduces #12829.
 # NOTE: currently marked with skip instead of xfail because
 # on_internal_error() crashes Scylla.
-@pytest.mark.skip(reason="issue #12829")
+@pytest.mark.skip(reason="DB error when querying by primary key, clustering key and index on static column #12829")
 def test_static_column_index_restrictions(cql, test_keyspace):
     schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -1722,7 +1722,7 @@ def test_index_non_eq_relation(cql, test_keyspace):
 # but failed with an index (use_index=True) - it seems the PER PARTITION LIMIT
 # request was just ignored.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12762")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Strange result on select query with partition limit and index #12762")), False])
 def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_index):
     with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
         if use_index:
@@ -1746,7 +1746,7 @@ def test_index_filtering_scan_and_per_partition_limit(cql, test_keyspace, use_in
 # the second result, and so on, and not skip to the next partition until
 # we have one post-filtered result.
 @pytest.mark.parametrize("use_index", [
-        pytest.param(True, marks=pytest.mark.xfail(reason="#12762")), False])
+        pytest.param(True, marks=pytest.mark.xfail(reason="Strange result on select query with partition limit and index #12762")), False])
 def test_index_filtering2_scan_and_per_partition_limit(cql, test_keyspace, use_index):
     with new_test_table(cql, test_keyspace, "p int, c int, v int, z int, PRIMARY KEY (p, c)") as table:
         if use_index:
@@ -1767,7 +1767,7 @@ def test_index_filtering2_scan_and_per_partition_limit(cql, test_keyspace, use_i
 # the ALLOW FILTERING request right after the CREATE INDEX causes an
 # exception in SecondaryIndexManagement and a failed read. This is despite
 # CASSANDRA-8505 claiming that this issue was already fixed in 2015.
-@pytest.mark.xfail(reason="issue #7963")
+@pytest.mark.xfail(reason="Secondary index shouldn't be used before fully built #7963")
 def test_unbuilt_index_not_used(cql, test_keyspace, cassandra_bug):
     # The bigger "count" is the slower the test and the higher the chance
     # of reproducing the bug #7963. With dev build on my laptop, count=100
@@ -1817,7 +1817,7 @@ def wait_for_index(cql, keyspace, index_name, timeout_sec=60):
 # pages through the results, and between two pages adds a secondary-index
 # that could be used - or not - for continuing the request, but certainly
 # shouldn't break the request. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(reason="Adding a secondary index can break an ongoing paged read using another index #18992")
 def test_paging_and_create_index(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1853,7 +1853,7 @@ def test_paging_and_create_index(cql, test_keyspace):
 # This test is the same as the previous one, but in this test the request
 # filters on both v1 and v2 is already using an index for column v2, and
 # now between the pages we add an index for v1. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(reason="Adding a secondary index can break an ongoing paged read using another index #18992")
 def test_paging_and_create_index2(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1897,7 +1897,7 @@ def test_paging_and_create_index2(cql, test_keyspace):
 # will do the same without ALLOW FILTERING in the query - and we'll see the
 # query can't be resumed after the index is dropped.
 # Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+@pytest.mark.xfail(reason="Adding a secondary index can break an ongoing paged read using another index #18992")
 def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -2062,7 +2062,7 @@ def test_index_in_API(cql, test_keyspace):
 # from the index view (where the LIMIT is correctly applied). A mismatch is
 # always interpreted as more pages being available, which in this case is incorrect.
 # See `generate_view_paging_state_from_base_query_results()` for more details.
-@pytest.mark.xfail(reason="issue #22158")
+@pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #22158")
 def test_limit_partition(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'pk1 int, pk2 int, ck int, primary key ((pk1, pk2), ck)') as table:
         cql.execute(f'CREATE INDEX ON {table}(pk2)')
@@ -2084,7 +2084,7 @@ def test_limit_partition(cql, test_keyspace):
 # Same as test_limit_partition above, except that it uses partition slices
 # instead of whole partitions. This is achieved by indexing the first clustering
 # key column.
-@pytest.mark.xfail(reason="issue #22158")
+@pytest.mark.xfail(reason="Secondary index query may exceed the LIMIT #22158")
 def test_limit_partition_slice(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'pk int, ck1 int, ck2 int, primary key (pk, ck1, ck2)') as table:
         cql.execute(f'CREATE INDEX ON {table}(ck1)')
@@ -2116,7 +2116,7 @@ def test_limit_partition_slice(cql, test_keyspace):
 # assumes that the last partition of the previous page was fully read, so it
 # completely ignores it when preparing the second page. This logic is
 # implemented in `find_index_partition_ranges()`.
-@pytest.mark.xfail(reason="issue #25839")
+@pytest.mark.xfail(reason="Secondary index: large rows + paging cause incomplete results #25839")
 def test_short_read(cql, test_keyspace):
     page_memory_limit = 1024 if is_scylla(cql) else 1024 * 1024  # 1MiB in Cassandra, 1KiB in Scylla (for faster execution)
     row_size = page_memory_limit // 2  # will cause short read after 2 rows
@@ -2137,7 +2137,7 @@ def test_short_read(cql, test_keyspace):
 # Another reproducer for issue #25839, this time asking for a count() as
 # a user tried in #28026 and noticing that adding an additional column
 # to the selection causes the count to become smaller.
-@pytest.mark.xfail(reason="issue #25839")
+@pytest.mark.xfail(reason="Secondary index: large rows + paging cause incomplete results #25839")
 def test_short_count(cql, test_keyspace):
     # Newer Scylla have configurable query_page_size_in_bytes so we can set
     # it low to have a faster test. Older Scylla and Cassandra have hard-coded

--- a/test/cqlpy/test_select_collection_element.py
+++ b/test/cqlpy/test_select_collection_element.py
@@ -147,7 +147,7 @@ def test_set_subscript(cql, test_keyspace):
         assert list(cql.execute(f"SELECT s[20] FROM {table} WHERE p={p}")) == [(20,)]
 
 # scylla only because cassandra doesn't support lua language
-@pytest.mark.xfail(reason="#22075")
+@pytest.mark.xfail(reason="Selecting collection elements with slice syntax and remaining Cassandra compatibility #22075")
 def test_subscript_function_arg(scylla_only, cql, test_keyspace, table1):
     fn = "(k int) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return k+1'"
     with new_function(cql, test_keyspace, fn, 'add_one'):

--- a/test/cqlpy/test_select_from_mutation_fragments.py
+++ b/test/cqlpy/test_select_from_mutation_fragments.py
@@ -504,7 +504,7 @@ def test_many_partitions(cql, test_keyspace, scylla_only):
         assert len(pks) == num_partitions
 
 
-@pytest.mark.xfail(reason="issue #18768; token() filtering doesn't work with MUTATION_FRAGMENTS")
+@pytest.mark.xfail(reason="token() filtering doesn't work with mutation_fragments #18768")
 def test_mutation_fragments_vs_token(cql, test_keyspace, scylla_only):
     with util.new_test_table(cql, test_keyspace, 'pk int PRIMARY KEY, c int') as table:
         print(f'INSERT INFO {table} (pk, c) VALUES (0, 0)')

--- a/test/cqlpy/test_sstable_compression.py
+++ b/test/cqlpy/test_sstable_compression.py
@@ -16,7 +16,7 @@ from cassandra.protocol import ConfigurationException, SyntaxException
 # given as a "sstable_compression" attribute, but newer Cassandra switched
 # to "class". Check that we support this new name class.
 # Reproduces #8948.
-@pytest.mark.xfail(reason="#8948")
+@pytest.mark.xfail(reason='Cassandra 3.11.10 uses "class" instead of "sstable_compression" for compression settings by default #8948')
 def test_compression_class(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int primary key, v int", "with compression = { 'class': 'LZ4Compressor' }") as table:
         pass
@@ -37,7 +37,7 @@ def table_lz4(cql, test_keyspace):
 # "sstable_compression" attribute was used to set the compression class,
 # when reading the schema we should see "class".
 # Reproduces #8948.
-@pytest.mark.xfail(reason="#8948")
+@pytest.mark.xfail(reason='Cassandra 3.11.10 uses "class" instead of "sstable_compression" for compression settings by default #8948')
 def test_read_compression_class(cql, table_lz4):
     [ks, cf] = table_lz4.split('.')
     opts = cql.execute(f"SELECT compression FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='{cf}'").one().compression
@@ -48,7 +48,7 @@ def test_read_compression_class(cql, table_lz4):
 # explicitly, some default value is nevertheless used, and its value should
 # be readable from the schema.
 # Reproduces #6442.
-@pytest.mark.xfail(reason="#6442")
+@pytest.mark.xfail(reason="Always print all schema parameters (including default values) #6442")
 def test_read_chunk_length(cql, table_lz4):
     [ks, cf] = table_lz4.split('.')
     opts = cql.execute(f"SELECT compression FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='{cf}'").one().compression

--- a/test/cqlpy/test_static.py
+++ b/test/cqlpy/test_static.py
@@ -27,7 +27,7 @@ def table1(cql, test_keyspace):
 # and we have no good explanation why Scylla's behavior is more correct than
 # Cassandra. If we later decide that we consider *both* behaviors equally
 # correct, we can change the test to accept both and make it pass.
-@pytest.mark.xfail(reason="issue #10091")
+@pytest.mark.xfail(reason="because of static column, a of SELECT of partition no clustering rows can return a row anyway #10091")
 def test_static_not_selected(cql, table1):
     p = unique_key_int()
     # The partition p doesn't exist, so the following select yields nothing:

--- a/test/cqlpy/test_system_tables.py
+++ b/test/cqlpy/test_system_tables.py
@@ -64,7 +64,7 @@ def write_table_and_estimate_partitions(cql, test_keyspace, N):
 # up to 14%. So just to be generous let's allow a 25% inaccuracy for this
 # small test. In issue #9083 we noted that Scylla had much larger errors -
 # reporting as much as 10880 (!) partitions when we have just 1000.
-@pytest.mark.xfail(reason="issue #9083")
+@pytest.mark.xfail(reason="system.size_estimates.partitions_count cannot reflect the number of partitions in the table #9083")
 def test_partitions_estimate_simple_small(cql, test_keyspace):
     N = 1000
     count = write_table_and_estimate_partitions(cql, test_keyspace, N)
@@ -76,7 +76,7 @@ def test_partitions_estimate_simple_small(cql, test_keyspace):
 # This is a relatively long test (takes around 2 seconds), and isn't
 # needed to reproduce #9083 (the previous shorter test does it too),
 # so we skip this test.
-@pytest.mark.xfail(reason="issue #9083")
+@pytest.mark.xfail(reason="system.size_estimates.partitions_count cannot reflect the number of partitions in the table #9083")
 @pytest.mark.skip(reason="slow test, remove skip to try it anyway")
 def test_partitions_estimate_simple_large(cql, test_keyspace):
     N = 10000

--- a/test/cqlpy/test_type_duration.py
+++ b/test/cqlpy/test_type_duration.py
@@ -41,7 +41,7 @@ def table1(cql, test_keyspace):
 # Test each of the units which are supposed to be allowed, separately -
 # y, mo, w, d, h, m, s, ms, us *or* µs, ns:
 # Reproduces issue #8001
-@pytest.mark.xfail(reason="issue #8001")
+@pytest.mark.xfail(reason='Documented unit "µs" not supported for assigning a "duration" type #8001')
 def test_type_duration_human_readable_input_units(cql, table1):
     # Map of allowed units and their expected meaning.
     units = {

--- a/test/cqlpy/test_type_time.py
+++ b/test/cqlpy/test_type_time.py
@@ -25,7 +25,7 @@ def table1(cql, test_keyspace):
 # optional and if provided, can be less than the nanosecond). The following
 # tests verify that these different initialization options actually work.
 # Reproduces issue #7987
-@pytest.mark.xfail(reason="issue #7987")
+@pytest.mark.xfail(reason="Unprepared statement fails to set time column from an integer #7987")
 def test_type_time_from_int_unprepared(cql, table1):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, 123)")

--- a/test/cqlpy/test_type_timestamp.py
+++ b/test/cqlpy/test_type_timestamp.py
@@ -39,7 +39,7 @@ def table2(cql, test_keyspace):
 # and then read - so that is the Cassandra-compatible approach - but
 # arguably a more correct and useful behavior would be to fail the write
 # up-front, even before reaching the read.
-@pytest.mark.xfail(reason="issue #11588")
+@pytest.mark.xfail(reason="Timestamp validation happens during read, instead of during write #11588")
 def test_type_timestamp_overflow(cql, table1):
     p = unique_key_int()
     t = 1667215862 * 1000000
@@ -135,7 +135,7 @@ def test_type_timestamp_comparison(cql, table2):
 # Cassandra 4 added the feature of arithmetic between values in general, and
 # timestamps in particular (to which durations can be added). Scylla used to
 # be missing this feature - see #2693, #2694 and their many duplicates.
-@pytest.mark.xfail(reason="issue #2693, #2694")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693, Support operators on date-times #2694")
 def test_type_timestamp_arithmetic(cql, table2):
     p = unique_key_int()
     cql.execute(f"INSERT INTO {table2} (p, c, t) VALUES ({p}, 1, '2011-02-03 04:05:12.345+0000')")

--- a/test/cqlpy/test_unset.py
+++ b/test/cqlpy/test_unset.py
@@ -74,7 +74,7 @@ def test_update_unset_value_basic(cql, table1):
 # such case the whole write request will fail instead of parts of it being
 # skipped. See discussion in pull request #12517.
 
-@pytest.mark.xfail(reason="issue #2693 - Scylla doesn't yet support arithmetic expressions")
+@pytest.mark.xfail(reason="Support arithmetic operators #2693")
 def test_update_unset_value_expr_arithmetic(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f'UPDATE {table1} SET a=(int)?+1 WHERE p={p}')


### PR DESCRIPTION
…ue titles

Replace short, uninformative reason= strings in pytest.mark.xfail and pytest.mark.skip decorators with descriptive strings that include the actual GitHub issue title, making it immediately clear why a test is expected to fail or skipped without requiring a GitHub lookup.

Examples:
  Before: reason="issue #10347: key length limits not enforced"
  After:  reason="Alternator doesn't limit partition and sort key lengths #10347"

  Before: reason="#5064 - transactions not yet supported"
  After:  reason='Alternator: support "transactions" feature #5064'

  Before: reason="issues #7550, #11466"
  After:  reason="Alternator: missing ItemCount field in return of DescribeTable #7550, Alternator: missing IndexSizeBytes field in return of DescribeTable #11466"

Format: "<GitHub issue title> #<number>", or when multiple issues
are referenced: "<Title one> #1234, <Title two> #5678".

Reason strings that already contained meaningful descriptions were left unchanged.

No xfail/skip marker types were changed - this is purely a reason string clarification patch.

Scope: 284 reason string replacements across 55 test files in test/alternator/ (12 files) and test/cqlpy/ (43 files), covering ~75 distinct GitHub issues.

No need to backport - improvement in life quality only.