### PR TITLE
cmake: fix precompiled header (PCH) creation

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -87,6 +87,11 @@ target_include_directories(wasmtime_bindings
 target_link_libraries(wasmtime_bindings
   INTERFACE Rust::rust_combined)
 if (Scylla_USE_PRECOMPILED_HEADER_USE)
+  # The PCH from scylla-precompiled-header is compiled with Seastar's compile
+  # flags, including sanitizer flags in Debug/Sanitize modes. Any target reusing
+  # this PCH must have matching compile options, otherwise the compiler rejects
+  # the PCH due to flag mismatch (e.g., -fsanitize=address).
+  target_link_libraries(wasmtime_bindings PRIVATE Seastar::seastar)
   target_precompile_headers(wasmtime_bindings REUSE_FROM scylla-precompiled-header)
 endif()
 
@@ -108,5 +113,6 @@ target_include_directories(inc
 target_link_libraries(inc
   INTERFACE Rust::rust_combined)
 if (Scylla_USE_PRECOMPILED_HEADER_USE)
+  target_link_libraries(inc PRIVATE Seastar::seastar)
   target_precompile_headers(inc REUSE_FROM scylla-precompiled-header)
 endif()


### PR DESCRIPTION
Two issues prevented the precompiled header from compiling successfully when using CMake directly (rather than the configure.py + ninja build system):

- Propagate build flags to Rust binding targets reusing the
   PCH. The wasmtime_bindings and inc targets reuse the PCH
   from scylla-precompiled-header, which is compiled with
   Seastar's flags (including sanitizer flags in
   Debug/Sanitize modes). Without matching compile options,
   the compiler rejects the PCH due to flag mismatch (e.g.,
   -fsanitize=address). Link these targets against
   Seastar::seastar to inherit the required compile options.

Symptoms:

- If trying to build this configuration the build fails with
```
FAILED: rust/CMakeFiles/wasmtime_bindings.dir/__/gen/rust/wasmtime_bindings.cc.o
    /usr/lib64/ccache/clang++ -DDEBUG -DDEBUG_LSA_SANITIZER -DSANITIZE -DSCYLLA_BUILD_MODE=debug -DSCYLLA_ENABLE_ERROR_INJECTION -I/home/user/Development/scylladb_1/build/debug/gen -g -Og -g -gz -std=gnu++23 -fvisibility-inlines-hidden -fcolor-diagnostics -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -ffile-prefix-map=/home/user/Development/scylladb_1/= -ffile-prefix-map=/home/user/Development/scylladb_1/build/debug=. -ffile-prefix-map=/home/user/Development/scylladb_1/build/debug/=debug -fextend-variable-liveness=none -march=westmere -Winvalid-pch -Xclang -include-pch -Xclang /home/user/Development/scylladb_1/build/debug/CMakeFiles/scylla-precompiled-header.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /home/user/Development/scylladb_1/build/debug/CMakeFiles/scylla-precompiled-header.dir/cmake_pch.hxx -MD -MT rust/CMakeFiles/wasmtime_bindings.dir/__/gen/rust/wasmtime_bindings.cc.o -MF rust/CMakeFiles/wasmtime_bindings.dir/__/gen/rust/wasmtime_bindings.cc.o.d -o rust/CMakeFiles/wasmtime_bindings.dir/__/gen/rust/wasmtime_bindings.cc.o -c /home/user/Development/scylladb_1/build/debug/gen/rust/wasmtime_bindings.cc
    error: AST file '/home/user/Development/scylladb_1/build/debug/CMakeFiles/scylla-precompiled-header.dir/cmake_pch.hxx.pch' was compiled with the target feature '-fsanitize=address' but the current translation unit is not
    1 error generated.
```

No need to backport it since we are not actively using cmake in our CI
