### PR TITLE
test/cqlpy: mark test_unbuilt_index_not_used not strictly xfail

### DIFF
--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1767,7 +1767,7 @@ def test_index_filtering2_scan_and_per_partition_limit(cql, test_keyspace, use_i
 # the ALLOW FILTERING request right after the CREATE INDEX causes an
 # exception in SecondaryIndexManagement and a failed read. This is despite
 # CASSANDRA-8505 claiming that this issue was already fixed in 2015.
-@pytest.mark.xfail(reason="issue #7963")
+@pytest.mark.xfail(reason="issue #7963", strict=False)
 def test_unbuilt_index_not_used(cql, test_keyspace, cassandra_bug):
     # The bigger "count" is the slower the test and the higher the chance
     # of reproducing the bug #7963. With dev build on my laptop, count=100


### PR DESCRIPTION
A few days ago, in commit 7b30a3981ba52ea6de9b7ce3f2c15c43c459e019 we added to pytest.ini the option xfail_strict. This option causes every time a test XPASSes, i.e., an xfail test actually passes - to be considered an error and fail the test.

But some tests demonstrate a timing-related bug and do not reproduce the bug every single time. An example we noticed in one CI run is:

    test/cqlpy/test_secondary_index.py::test_unbuilt_index_not_used

This test reproduces a timing-related bug (if you read from a secondary index "too quickly" you can get wrong results), but only about 90% of the time, not 100% of the time.

The solution is to add "strict=False" for the xfail marker on this specific test. This undoes the xfail_strict for this specific test, accepting that this specific test can either pass or fail. Note that this does NOT make this test worthless - we still see this test failing most of the time, and when a developer finally fixes this issue, the test will begin to pass all the time.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-956 
(we'll probably need to follow up this fix with the same fix for other xfail tests that can sometime pass).
