### PR TITLE
docs: update vector search filtering to reflect primary key support only

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -292,18 +292,14 @@ For example::
       ORDER BY embedding ANN OF [0.1, 0.2, 0.3, 0.4] LIMIT 5;
 
 
-Vector queries also support filtering with ``WHERE`` clauses on columns that are part of the primary key
-or columns provided in a definition of the index.
+Vector queries also support filtering with ``WHERE`` clauses on columns that are part of the primary key.
+See :ref:`WHERE <where-clause>`.
 
 For example::
 
     SELECT image_id FROM ImageEmbeddings
       WHERE user_id = 'user123'
       ORDER BY embedding ANN OF [0.1, 0.2, 0.3, 0.4] LIMIT 5;
-
-The supported operations are equal relations (``=`` and ``IN``) with restrictions as in regular ``WHERE`` clauses. See :ref:`WHERE <where-clause>`.
-
-Other filtering scenarios are currently not supported.
 
 .. note::
 


### PR DESCRIPTION
Remove outdated references to filtering on columns provided in the index definition, and remove the note about equal relations (= and IN) being the only supported operations. Vector search filtering currently supports WHERE clauses on primary key columns only.

Fixes: SCYLLADB-881