### PR TITLE
test.py: fix RuntimeException during driver shutdown

### DIFF
--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -10,6 +10,7 @@ import logging
 from test.pylib.rest_client import get_host_api_address, read_barrier
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, wait_for
 from test.pylib.manager_client import ManagerClient
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.cluster.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
         delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, \
         wait_for_token_ring_and_group0_consistency, wait_until_driver_service_level_created, get_topology_coordinator, \
@@ -198,7 +199,7 @@ async def test_connections_parameters_auto_update(manager: ManagerClient, build_
     })
 
     for cluster_conn in cluster_connections:
-        cluster_conn.shutdown()
+        safe_driver_shutdown(cluster_conn)
 
 @pytest.mark.asyncio
 async def test_service_level_cache_after_restart(manager: ManagerClient):

--- a/test/cluster/dtest/dtest_setup.py
+++ b/test/cluster/dtest/dtest_setup.py
@@ -18,6 +18,8 @@ from cassandra.cluster import EXEC_PROFILE_DEFAULT, NoHostAvailable, default_lbp
 from cassandra.cluster import Cluster as PyCluster
 from cassandra.policies import ExponentialReconnectionPolicy, WhiteListRoundRobinPolicy
 
+from test.pylib.driver_utils import safe_driver_shutdown
+
 from test.cluster.dtest.dtest_class import (
     get_auth_provider,
     get_ip_from_node,
@@ -167,7 +169,7 @@ class DTestSetup:
 
             def __cleanup(self):
                 if self.session:
-                    self.session.cluster.shutdown()
+                    safe_driver_shutdown(self.session.cluster)
                     self.session = None
 
         return ClusterSession(session)

--- a/test/cluster/test_maintenance_mode.py
+++ b/test/cluster/test_maintenance_mode.py
@@ -10,6 +10,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
 from test.pylib.manager_client import ManagerClient
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.conftest import cluster_con
 from test.pylib.util import gather_safely, wait_for_cql_and_get_hosts
@@ -189,5 +190,5 @@ async def test_maintenance_mode(manager: ManagerClient):
     logger.info("Checking tables in normal mode")
     await gather_safely(*(check_table_in_normal_mode(table, key) for table, key in key_on_server_a_per_table.items()))
 
-    cluster.shutdown()
-    maintenance_cluster.shutdown()
+    safe_driver_shutdown(cluster)
+    safe_driver_shutdown(maintenance_cluster)

--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -13,6 +13,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.rest_client import read_barrier
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
@@ -138,7 +139,7 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
     # replica, 1 pending replica, CL=LOCAL_QUORUM requires 2 normal replicas). So, we can start sending writes to dc2
     # only after increasing RF to 3, which we do - see finish_writes_dc2.
     await finish_writes()
-    ccluster_all_nodes.shutdown()
+    safe_driver_shutdown(ccluster_all_nodes)
     ccluster_dc1 = cluster_con(
             [srv.ip_addr for srv in live_servers],
             load_balancing_policy=WhiteListRoundRobinPolicy([srv.ip_addr for srv in live_servers]))
@@ -226,5 +227,5 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
 
     await finish_writes_dc1()
     await finish_writes_dc2()
-    ccluster_dc1.shutdown()
-    ccluster_dc2.shutdown()
+    safe_driver_shutdown(ccluster_dc1)
+    safe_driver_shutdown(ccluster_dc2)

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -224,6 +224,10 @@ import ssl
 # only one that matches this wildcard, but this can be overridden
 # by setting a SCYLLA environment variable:
 source_path = os.path.realpath(os.path.join(__file__, '../../..'))
+if source_path not in sys.path:
+    sys.path.append(source_path)
+from test.pylib.driver_utils import safe_driver_shutdown
+
 scylla = None
 def find_scylla():
     global scylla
@@ -430,7 +434,7 @@ def check_cql(ip, ssl_context=None):
     try:
         cluster = get_cql_cluster(ip, ssl_context)
         cluster.connect()
-        cluster.shutdown()
+        safe_driver_shutdown(cluster)
     except cassandra.cluster.NoHostAvailable:
         raise NotYetUp
     # Any other exception may indicate a problem, and is passed to the caller.

--- a/test/cqlpy/test_ssl.py
+++ b/test/cqlpy/test_ssl.py
@@ -16,6 +16,8 @@ import re
 import ssl
 import time
 
+from test.pylib.driver_utils import safe_driver_shutdown
+
 
 # This function normalizes the SSL cipher suite name (a string),
 # which we need to do because tests use python library and scylla server uses C library,
@@ -118,7 +120,7 @@ def try_connect(orig_cluster, ssl_version):
         session = cluster.connect()
         yield session
     finally:
-        cluster.shutdown()
+        safe_driver_shutdown(cluster)
 
 # Test that if we try to connect to an SSL port with *unencrypted* CQL,
 # it doesn't work.
@@ -135,6 +137,8 @@ def test_non_tls_on_tls(cql):
         port=cql.cluster.port,
         protocol_version=cql.cluster.protocol_version,
         auth_provider=cql.cluster.auth_provider)
-    with pytest.raises(cassandra.cluster.NoHostAvailable, match="ProtocolError"):
-        cluster.connect()
-    cluster.shutdown() # can't be reached
+    try:
+        with pytest.raises(cassandra.cluster.NoHostAvailable, match="ProtocolError"):
+            cluster.connect()
+    finally:
+        safe_driver_shutdown(cluster)

--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -20,6 +20,8 @@ from cassandra.auth import PlainTextAuthProvider
 from cassandra.cluster import Cluster, ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.policies import RoundRobinPolicy
 
+from test.pylib.driver_utils import safe_driver_shutdown
+
 def random_string(length=10, chars=string.ascii_uppercase + string.digits):
     return ''.join(random.choice(chars) for x in range(length))
 
@@ -232,8 +234,10 @@ def cql_session(host, port, is_ssl, username, password, request_timeout=120, pro
         connect_timeout = 60,
         control_connection_timeout = 60,
     )
-    yield cluster.connect()
-    cluster.shutdown()
+    try:
+        yield cluster.connect()
+    finally:
+        safe_driver_shutdown(cluster)
 
 @contextmanager
 def new_user(cql, username='', with_superuser_privileges=False):

--- a/test/pylib/driver_utils.py
+++ b/test/pylib/driver_utils.py
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+"""Utilities for working with the scylla-driver (cassandra-driver)."""
+
+import logging
+
+from cassandra.cluster import Cluster  # type: ignore # pylint: disable=no-name-in-module
+
+logger = logging.getLogger(__name__)
+
+# How long to wait for the driver's Task Scheduler thread to finish
+_SCHEDULER_JOIN_TIMEOUT = 2.0
+
+
+def safe_driver_shutdown(cluster: Cluster) -> None:
+    """Shut down a cassandra-driver Cluster, working around the Task Scheduler race.
+
+    Works around a race where the "Task Scheduler" thread raises RuntimeError
+    after Cluster.shutdown() returns, or during the call itself.
+    """
+    # Capture scheduler thread before shutdown to join it later
+    scheduler = getattr(cluster, 'scheduler', None)
+
+    try:
+        cluster.shutdown()
+    except RuntimeError as exc:
+        if 'cannot schedule new futures after shutdown' not in str(exc):
+            raise
+        logger.debug("Suppressed expected RuntimeError during driver shutdown: %s", exc)
+
+    if scheduler:
+        scheduler.join(timeout=_SCHEDULER_JOIN_TIMEOUT)
+        if scheduler.is_alive():
+            logger.warning("Driver Task Scheduler thread did not terminate within %.1fs", _SCHEDULER_JOIN_TIMEOUT)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -22,6 +22,7 @@ from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient, ScyllaMe
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, universalasync_typed_wrap, Host
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer, ScyllaVersionDescription
+from test.pylib.driver_utils import safe_driver_shutdown
 from cassandra.cluster import Session as CassandraSession, \
     ExecutionProfile, EXEC_PROFILE_DEFAULT  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.policies import LoadBalancingPolicy, RoundRobinPolicy, WhiteListRoundRobinPolicy
@@ -114,7 +115,7 @@ class ManagerClient:
         """Disconnect from cluster"""
         if self.ccluster is not None:
             logger.debug("shutting down driver")
-            self.ccluster.shutdown()
+            safe_driver_shutdown(self.ccluster)
             self.ccluster = None
         self.cql = None
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -31,6 +31,7 @@ from test.pylib.host_registry import Host, HostRegistry
 from test.pylib.pool import Pool
 from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
 from test.pylib.util import LogPrefixAdapter, read_last_line, gather_safely, get_xdist_worker_id, scale_timeout_by_mode
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from functools import partial
 import aiohttp
@@ -924,7 +925,7 @@ class ScyllaServer:
             self.control_connection.shutdown()
             self.control_connection = None
         if self.control_cluster is not None:
-            self.control_cluster.shutdown()
+            safe_driver_shutdown(self.control_cluster)
             self.control_cluster = None
         self._cleanup_notify_socket()
 


### PR DESCRIPTION
There is a race condition in driver that raises the RuntimeException. This pollutes the output, so this PR is just silencing this exception.

Fixes: SCYLLADB-900

No backport, framework enhancement only.