### PR TITLE
test/alternator,cqlpy: avoid xfail_strict against DynamoDB/Cassandra

### DIFF
--- a/test/alternator/run
+++ b/test/alternator/run
@@ -10,7 +10,7 @@ import requests
 # When tests are to be run against AWS (the "--aws" option), it is not
 # necessary to start Scylla at all. All we need to do is to run pytest.
 if '--aws' in sys.argv:
-    success = run.run_pytest(sys.path[0], sys.argv[1:])
+    success = run.run_pytest(sys.path[0], ['-o', 'xfail_strict=false'] + sys.argv[1:])
     exit(0 if success else 1)
 
 # check_alternator() below uses verify=False to accept self-signed SSL

--- a/test/cqlpy/run-cassandra
+++ b/test/cqlpy/run-cassandra
@@ -209,7 +209,7 @@ pid = run.run_with_temporary_dir(cmd)
 ip = run.pid_to_ip(pid)
 
 run.wait_for_services(pid, [lambda: check_cql(ip)])
-success = run.run_pytest(sys.path[0], ['--host', ip] + sys.argv[1:])
+success = run.run_pytest(sys.path[0], ['-o', 'xfail_strict=false', '--host', ip] + sys.argv[1:])
 
 run.summary = 'Cassandra tests pass' if success else 'Cassandra tests failure'
 


### PR DESCRIPTION
Recently, in commit 7b30a3981ba52ea6de9b7ce3f2c15c43c459e019, we added to pytest.ini the option xfail_strict. This option causes every time a test XPASSes, i.e., an XFAIL test actually passes, to be considered an error and fail the test.

While this has some benefits, it's a big problem when running tests against a reference implementation like DynamoDB or Cassandra: We typically mark a test "xfail" if the test shows a known bug - i.e., if the test fails on Scylla but passes on the reference system (DynamoDB or Cassandra). This means that when running "test/cqlpy/run-cassandra" or "test/alternator/run --aws", we expect to see many tests XPASS, and now this will cause these runs to "fail".

So in this patch we add the xfail_strict=false to cqlpy/run-cassandra and alternator/run --aws. This option is not added to cqlpy/run or to alternator/run without --aws, and also doesn't affect test.py or Jenkins.

P.S. This is another nail in the coffin of doing "cd test/alternator; pytest --aws". You should get used to running Alternator tests through test/alternator/run, even if you don't need to run Scylla (the "--aws" option doesn't run Scylla).