### PR TITLE
db: use prefix tombstones in DROP TABLE schema mutations

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2023,25 +2023,26 @@ static void make_drop_table_or_view_mutations(schema_ptr schema_table,
             api::timestamp_type timestamp,
             utils::chunked_vector<mutation>& mutations) {
     auto pkey = partition_key::from_singular(*schema_table, table_or_view->ks_name());
+    auto tomb = tombstone(timestamp, gc_clock::now());
+
     mutation m{schema_table, pkey};
     auto ckey = clustering_key::from_singular(*schema_table, table_or_view->cf_name());
-    m.partition().apply_delete(*schema_table, ckey, tombstone(timestamp, gc_clock::now()));
+    m.partition().apply_delete(*schema_table, ckey, tomb);
     mutations.emplace_back(m);
-    for (auto& column : table_or_view->v3().all_columns()) {
-        if (column.is_view_virtual()) {
-            drop_column_from_schema_mutation(view_virtual_columns(), table_or_view, column.name_as_text(), timestamp, mutations);
-        } else {
-            drop_column_from_schema_mutation(columns(), table_or_view, column.name_as_text(), timestamp, mutations);
-        }
-        if (column.is_computed()) {
-            drop_column_from_schema_mutation(computed_columns(), table_or_view, column.name_as_text(), timestamp, mutations);
-        }
-    }
-    for (auto& column : table_or_view->dropped_columns() | std::views::keys) {
-        drop_column_from_schema_mutation(dropped_columns(), table_or_view, column, timestamp, mutations);
-    }
+
+    auto drop_all_columns = [&] (schema_ptr s) {
+        mutation col_m{s, partition_key::from_singular(*s, table_or_view->ks_name())};
+        auto prefix_ckey = clustering_key::from_exploded(*s, {utf8_type->decompose(table_or_view->cf_name())});
+        col_m.partition().apply_delete(*s, prefix_ckey, tomb);
+        mutations.emplace_back(std::move(col_m));
+    };
+    drop_all_columns(columns());
+    drop_all_columns(view_virtual_columns());
+    drop_all_columns(computed_columns());
+    drop_all_columns(dropped_columns());
+
     mutation m1{scylla_tables(), pkey};
-    m1.partition().apply_delete(*scylla_tables(), ckey, tombstone(timestamp, gc_clock::now()));
+    m1.partition().apply_delete(*scylla_tables(), ckey, tomb);
     mutations.emplace_back(m1);
 }
 


### PR DESCRIPTION
When dropping a table, make_drop_table_or_view_mutations() creates a point tombstone in system_schema.columns for every column in the table.

The clustering key of system_schema.columns is (table_name, column_name). A clustering key with only the table_name component acts as a prefix tombstone. That tombstone covers all columns belonging to that table. This approach is already used by make_table_deleting_mutations() during CREATE TABLE.

Apply the same prefix tombstone approach to DROP TABLE for the columns, view_virtual_columns, computed_columns, and dropped_columns schema tables. This reduces tombstone accumulation in schema table sstables.

In test_max_cells test case, which repeatedly creates and drops a table with 32768 columns, overall test time improved from ~180s to ~157s on dev machine, which is ~12.7% improvement.

Refs SCYLLADB-815

Referenced issue occured on latest code. No backport needed.