### PR TITLE
Update call_sync_milestone_to_jira.yml in scylladb.git - add close trigger and VECTOR project sync

### DIFF
--- a/.github/workflows/call_sync_milestone_to_jira.yml
+++ b/.github/workflows/call_sync_milestone_to_jira.yml
@@ -1,8 +1,8 @@
-﻿name: Call Jira release creation for new milestone
+name: Call Jira release creation for new milestone
 
 on:
   milestone:
-    types: [created]
+    types: [created, closed]
 
 jobs:
   sync-milestone-to-jira:


### PR DESCRIPTION
## What changed
- Added `closed` to milestone event types in `call_sync_milestone_to_jira.yml` (`types: [created]` -> `types: [created, closed]`)
- Added `VECTOR` to the list of Jira project keys being synced (`jira_project_keys: SCYLLADB,CUSTOMER,SMI,RELENG` -> `jira_project_keys: SCYLLADB,CUSTOMER,SMI,RELENG,VECTOR`)

## Why (Requirements Summary)
- The `call_sync_milestone_to_jira.yml` workflow only triggered on milestone creation. When a GitHub milestone is closed, the corresponding Jira versions (in SCYLLADB, CUSTOMER, SMI, RELENG projects) should be marked as released. Adding the `closed` trigger enables the called workflow (`main_sync_milestone_to_jira_release.yml` in github-automation) to handle both creating and releasing Jira versions from GitHub milestone events.
- Added the VECTOR project so its Jira versions are also created/released when milestones are created or closed in scylladb.git.
- This is consistent with the same change already applied to the staging and scylla-machine-image repos.

Fixes:PM-216