### PR TITLE
reader_concurrency_semaphore: fix leak in on_preemptive_aborted()

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -204,12 +204,19 @@ private:
         }
     }
 
-    void on_permit_inactive(reader_permit::state st) {
-        // If the permit is registered as inactive, while waiting for memory,
-        // clear the memory amount, the requests are failed anyway.
+    // Clear _requested_memory if the permit is leaving the waiting_for_memory
+    // state. The pending memory request is being failed, so _requested_memory
+    // must be reset to prevent a subsequent request_memory() from accumulating
+    // on top of the stale value, which would cause on_granted_memory() to
+    // consume more than the returned resource_units tracks.
+    void maybe_clear_requested_memory() noexcept {
         if (_state == reader_permit::state::waiting_for_memory) {
             _requested_memory = {};
         }
+    }
+
+    void on_permit_inactive(reader_permit::state st) {
+        maybe_clear_requested_memory();
         _state = st;
         if (_marked_as_awaits) {
             on_permit_not_awaits();
@@ -374,6 +381,8 @@ public:
         if (_state != reader_permit::state::waiting_for_admission && _state != reader_permit::state::waiting_for_memory) {
             on_internal_error(rcslog, format("on_preemptive_aborted(): permit in invalid state {}", _state));
         }
+
+        maybe_clear_requested_memory();
 
         auto ex = named_semaphore_aborted(_semaphore._name);
         _ex = std::make_exception_ptr(ex);

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -2592,13 +2592,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_preemptive_abort_requ
     // but resource_units only tracks 512 — the difference leaks.
     { auto u = permit2->request_memory(512).get(); }
 
-    // Destroy permit2 and verify ~impl() detects the leak.
-    auto prev_internal_errors = seastar::internal::internal_errors;
-    auto reset_abort = defer([prev = set_abort_on_internal_error(false)] {
-        set_abort_on_internal_error(prev);
-    });
+    // Shouldn't fail if SCYLLADB-1016 is fixed.
     permit2 = {};
-    BOOST_REQUIRE_GT(seastar::internal::internal_errors, prev_internal_errors);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
on_preemptive_aborted() does not clear _requested_memory when the permit
is in the waiting_for_memory state. A subsequent request_memory() call
accumulates on top of the stale value, causing on_granted_memory() to
consume more than resource_units tracks.

This commit fixes the above by resetting `_requested_memory`
in `on_preemptive_aborted`, just as `on_permit_inactive` already does.

Moreover, this PR includes a reliable reproducer of the issue. 

Fixes: SCYLLADB-1016

Backport: not needed, `on_preemptive_aborted` is only on master.