### PR TITLE
Squash two primary-replica restoration tests together

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -894,10 +894,12 @@ async def test_restore_primary_replica(manager: ManagerClient, object_storage, d
         scope = domain
         expected_replicas = 2
     else:
-        racks = 2 if domain == 'rack' else 1
-        rf = 2 if domain == 'rack' else 1
-        topology = topo(rf = rf, nodes = 2, racks = racks, dcs = dcs)
-        scope = "dc" if domain == 'rack' else "all"
+        if domain == 'rack':
+            topology = topo(rf = 2, nodes = 2, racks = 2, dcs = dcs)
+            scope = "dc"
+        else:
+            topology = topo(rf = 1, nodes = 2, racks = 1, dcs = dcs)
+            scope = "all"
         expected_replicas = 1
 
     ks = 'ks'


### PR DESCRIPTION
The test_restore_primary_replica_same_domain and test_restore_primary_replica_different_domain tests have very much in common. Previously both tests were also split each into two, so we have four tests, and now we have two that can also be squashed, the lines-of-code savings still worth it.

This is the continuation of #28569 

Tests improvement, not backporting