### PR TITLE
test/scylla_gdb: fix flakiness by preparing objects at test time

### DIFF
--- a/test/scylla_gdb/gdb_utils.py
+++ b/test/scylla_gdb/gdb_utils.py
@@ -4,7 +4,7 @@
 """
 GDB helper functions for `scylla_gdb` tests.
 They should be loaded to GDB by "-x {dir}/gdb_utils.py}",
-when loaded, they can be run in gdb e.g. `python get_sstables()`
+when loaded, they can be run in gdb e.g. `$get_sstables()`
 
 Depends on helper functions injected to GDB by `scylla-gdb.py` script.
 (sharded, for_each_table, seastar_lw_shared_ptr, find_sstables, find_vptrs, resolve,
@@ -15,39 +15,65 @@ import gdb
 import uuid
 
 
-def get_schema():
-    """Execute GDB commands to get schema information."""
-    db = sharded(gdb.parse_and_eval('::debug::the_database')).local()
-    table = next(for_each_table(db))
-    ptr = seastar_lw_shared_ptr(table['_schema']).get()
-    print('schema=', ptr)
+class get_schema(gdb.Function):
+    """Finds and returns a schema pointer."""
+
+    def __init__(self):
+        super(get_schema, self).__init__('get_schema')
+
+    def invoke(self):
+        db = sharded(gdb.parse_and_eval('::debug::the_database')).local()
+        table = next(for_each_table(db))
+        return seastar_lw_shared_ptr(table['_schema']).get()
 
 
-def get_sstables():
-    """Execute GDB commands to get sstables information."""
-    sst = next(find_sstables())
-    print(f"sst=(sstables::sstable *)", sst)
+class get_sstable(gdb.Function):
+    """Finds and returns an sstable pointer."""
+
+    def __init__(self):
+        super(get_sstable, self).__init__('get_sstable')
+
+    def invoke(self):
+        return next(find_sstables())
 
 
-def get_task():
+class get_task(gdb.Function):
     """
-    Some commands need a task to work on. The following fixture finds one.
+    Finds and returns a Scylla fiber task.
     Because we stopped Scylla while it was idle, we don't expect to find
     any ready task with get_local_tasks(), but we can find one with a
     find_vptrs() loop. I noticed that a nice one (with multiple tasks chained
     to it for "scylla fiber") is one from http_server::do_accept_one.
     """
-    for obj_addr, vtable_addr in find_vptrs():
-        name = resolve(vtable_addr, startswith='vtable for seastar::continuation')
-        if name and 'do_accept_one' in name:
-            print(f"task={obj_addr.cast(gdb.lookup_type('uintptr_t'))}")
-            break
+    def __init__(self):
+        super(get_task, self).__init__('get_task')
+
+    def invoke(self):
+        for obj_addr, vtable_addr in find_vptrs():
+            name = resolve(vtable_addr, startswith='vtable for seastar::continuation')
+            if name and 'do_accept_one' in name:
+                return obj_addr.cast(gdb.lookup_type('uintptr_t'))
 
 
-def get_coroutine():
-    """Similar to get_task(), but looks for a coroutine frame."""
-    target = 'service::topology_coordinator::run() [clone .resume]'
-    for obj_addr, vtable_addr in find_vptrs():
-        name = resolve(vtable_addr)
-        if name and name.strip() == target:
-            print(f"coroutine_config={obj_addr.cast(gdb.lookup_type('uintptr_t'))}")
+class get_coroutine(gdb.Function):
+    """
+    Finds and returns a coroutine frame.
+    Prints COROUTINE_NOT_FOUND if the coroutine is not present.
+    """
+    def __init__(self):
+        super(get_coroutine, self).__init__('get_coroutine')
+
+    def invoke(self):
+        target = 'service::topology_coordinator::run() [clone .resume]'
+        for obj_addr, vtable_addr in find_vptrs():
+            name = resolve(vtable_addr)
+            if name and name.strip() == target:
+                return obj_addr.cast(gdb.lookup_type('uintptr_t'))
+        print("COROUTINE_NOT_FOUND")
+
+
+# Register the functions in GDB
+get_schema()
+get_sstable()
+get_task()
+get_coroutine()

--- a/test/scylla_gdb/test_schema_commands.py
+++ b/test/scylla_gdb/test_schema_commands.py
@@ -7,7 +7,6 @@ Each only checks that the command does not fail - but not what it does or return
 """
 
 import pytest
-import re
 
 from test.scylla_gdb.conftest import execute_gdb_command
 
@@ -23,20 +22,6 @@ pytestmark = [
     ),
 ]
 
-
-@pytest.fixture(scope="module")
-def schema(gdb_cmd):
-    """
-    Returns pointer to schema of the first table it finds
-    Even without any user tables, we will always have system tables.
-    """
-    result = execute_gdb_command(gdb_cmd, full_command="python get_schema()").stdout
-    match = re.search(r"schema=\s*(0x[0-9a-fA-F]+)", result)
-    schema_pointer = match.group(1) if match else None
-
-    return schema_pointer
-
-
 @pytest.mark.parametrize(
     "command",
     [
@@ -45,21 +30,17 @@ def schema(gdb_cmd):
         "schema (const schema *)",  # `schema` requires type-casted pointer
     ],
 )
-def test_schema(gdb_cmd, command, schema):
-    assert schema, "Failed to find schema of any table"
-
-    result = execute_gdb_command(gdb_cmd, f"{command} {schema}")
+def test_schema(gdb_cmd, command):
+    result = execute_gdb_command(gdb_cmd, f"{command} $get_schema()")
     assert result.returncode == 0, (
         f"GDB command {command} failed. stdout: {result.stdout} stderr: {result.stderr}"
     )
 
 
-def test_generate_object_graph(gdb_cmd, schema, request):
-    assert schema, "Failed to find schema of any table"
-
+def test_generate_object_graph(gdb_cmd, request):
     tmpdir = request.config.getoption("--tmpdir")
     result = execute_gdb_command(
-        gdb_cmd, f"generate-object-graph -o {tmpdir}/og.dot -d 2 -t 10 {schema}"
+        gdb_cmd, f"generate-object-graph -o {tmpdir}/og.dot -d 2 -t 10 $get_schema()"
     )
     assert result.returncode == 0, (
         f"GDB command `generate-object-graph` failed. stdout: {result.stdout} stderr: {result.stderr}"

--- a/test/scylla_gdb/test_sstable_commands.py
+++ b/test/scylla_gdb/test_sstable_commands.py
@@ -7,7 +7,6 @@ Each only checks that the command does not fail - but not what it does or return
 """
 
 import pytest
-import re
 
 from test.scylla_gdb.conftest import execute_gdb_command
 
@@ -24,16 +23,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
-def sstable(gdb_cmd):
-    """Finds sstable"""
-    result = execute_gdb_command(gdb_cmd, full_command="python get_sstables()").stdout
-    match = re.search(r"(\(sstables::sstable \*\) 0x)([0-9a-f]+)", result)
-    sstable_pointer = match.group(0).strip() if match else None
-
-    return sstable_pointer
-
-
 @pytest.mark.parametrize(
     "command",
     [
@@ -41,10 +30,8 @@ def sstable(gdb_cmd):
         "sstable-index-cache",
     ],
 )
-def test_sstable(gdb_cmd, command, sstable):
-    assert sstable, "No sstable was found"
-
-    result = execute_gdb_command(gdb_cmd, f"{command} {sstable}")
+def test_sstable(gdb_cmd, command):
+    result = execute_gdb_command(gdb_cmd, f"{command} $get_sstable()")
     assert result.returncode == 0, (
         f"GDB command {command} failed. stdout: {result.stdout} stderr: {result.stderr}"
     )

--- a/test/scylla_gdb/test_task_commands.py
+++ b/test/scylla_gdb/test_task_commands.py
@@ -6,8 +6,6 @@ Tests for commands, that need a some task to work on.
 Each only checks that the command does not fail - but not what it does or returns.
 """
 
-import re
-
 import pytest
 
 from test.scylla_gdb.conftest import execute_gdb_command
@@ -25,59 +23,25 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
-def task(gdb_cmd):
-    """
-    Finds a Scylla fiber task using a `find_vptrs()` loop.
-
-    Since Scylla is fresh‑booted, `get_local_tasks()` returns nothing.
-    Nevertheless, a `find_vptrs()` scan can still discover the first task
-    skeleton created by `http_server::do_accept_one` (often the earliest
-    “Scylla fiber” to appear).
-    """
-    result = execute_gdb_command(gdb_cmd, full_command="python get_task()").stdout
-    match = re.search(r"task=(\d+)", result)
-    task = match.group(1) if match else None
-    return task
-
-
-@pytest.fixture(scope="module")
-def coroutine_task(gdb_cmd, scylla_server):
-    """
-    Finds a coroutine task, similar to the `task` fixture.
-
-    This fixture executes the `coroutine_config` script in GDB to locate a
-    specific coroutine task.
-    """
-    result = execute_gdb_command(gdb_cmd, full_command="python get_coroutine()").stdout
-    match = re.search(r"coroutine_config=\s*(.*)", result)
-    if not match:
-        # See https://github.com/scylladb/scylladb/issues/22501
-        pytest.skip("Failed to find coroutine task. Skipping test.")
-
-    return match.group(1).strip()
-
-
-def test_coroutine_frame(gdb_cmd, coroutine_task):
+def test_coroutine_frame(gdb_cmd):
     """
     Offsets the pointer by two words to shift from the outer coroutine frame
     to the inner `seastar::task`, as required by `$coro_frame`, which expects
     a `seastar::task*`.
     """
-    assert coroutine_task, "No coroutine task was found"
-
     result = execute_gdb_command(
-        gdb_cmd, full_command=f"p *$coro_frame({coroutine_task} + 16)"
+        gdb_cmd, full_command="p *$coro_frame($get_coroutine() + 16)"
     )
+    if "COROUTINE_NOT_FOUND" in result.stdout:
+        # See https://github.com/scylladb/scylladb/issues/22501
+        pytest.skip("Failed to find coroutine task. Skipping test.")
     assert result.returncode == 0, (
         f"GDB command `coro_frame` failed. stdout: {result.stdout} stderr: {result.stderr}"
     )
 
 
-def test_fiber(gdb_cmd, task):
-    assert task, f"No task was found using `find_vptrs()`"
-
-    result = execute_gdb_command(gdb_cmd, f"fiber {task}")
+def test_fiber(gdb_cmd):
+    result = execute_gdb_command(gdb_cmd, "fiber $get_task()")
     assert result.returncode == 0, (
         f"GDB command `fiber` failed. stdout: {result.stdout} stderr: {result.stderr}"
     )


### PR DESCRIPTION
Fixtures previously ran GDB once (module scope) to find live objects (sstables, tasks, schemas) and stored their addresses. Tests then reused those addresses in separate GDB invocations. Sometimes these addresses would become stale and the test would step on use-after-free (e.g. sstables compacted away between invocations).

Fix by dropping the fixtures. The helper functions used by the fixtures to obtain the required objects are converted to gdb convenience functions, which can be used in the same expression as the test command invocation. Thus, the object is aquired on-demand at the moment it is used, so it is guaranteed to be fresh and relevant.

Fixes: SCYLLADB-1020

Backport: problem was introduced in https://github.com/scylladb/scylladb/commit/e978cc2a800b4e2b4e39d90eb52d957798a1ff54, which is not in any release