### PR TITLE
test/nodetool: rest_api_mock_server: add retry for status code 404

### DIFF
--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -84,6 +84,12 @@ def rest_api_mock_server(request, server_address):
             break
         except requests.exceptions.ConnectionError:
             time.sleep(interval)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                # The server is up but the endpoint is not ready yet, keep waiting
+                time.sleep(interval)
+            else:
+                raise
     else:
         server_process.terminate()
         server_process.wait()


### PR DESCRIPTION
This fixtures starts the mock server and immediately connects to it to setup the expected requests. The connection attempt might be too early, so there is a retry loop with a timeout. The loop currently checks for requests.exception.ConnectionError. We've seen a case where the connection is successful but the request fails with 404. The mock started the server but didn't setup the routes yet. Add a retry for http 404 to handle this.

Fixes: SCYLLADB-966

Backport: this problem was seen once in 2 years, so no need to backport unless it starts to pop up on release branches