### PR TITLE
test: mv: fix flaky wait for commitlog sync

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2647,7 +2647,7 @@ future<> view_builder::add_new_view(view_ptr view, build_step& step) {
     }
 
     if (this_shard_id() == smp::count - 1) {
-        co_await utils::get_local_injector().inject("add_new_view_pause_last_shard", utils::wait_for_message(5min));
+        inject_failure("add_new_view_fail_last_shard");
     }
 
     co_await _sys_ks.register_view_for_building(view->ks_name(), view->cf_name(), step.current_token());

--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -119,8 +119,7 @@ async def test_view_building_during_drop_index(manager: ManagerClient):
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_interrupt_view_build_shard_registration(manager: ManagerClient):
     cmdline = ['--smp=4']
-    cfg = {"commitlog_sync_period_in_ms": 1000}
-    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    servers = await manager.servers_add(1, cmdline=cmdline)
     server = servers[0]
 
     logger.info("Populate table")
@@ -132,7 +131,7 @@ async def test_interrupt_view_build_shard_registration(manager: ManagerClient):
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (p, c) VALUES ({k}, {k+1});") for k in range(n_partitions)])
 
     # pause the last shard so it won't be registered
-    await manager.api.enable_injection(server.ip_addr, "add_new_view_pause_last_shard", one_shot=True)
+    await manager.api.enable_injection(server.ip_addr, "add_new_view_fail_last_shard", one_shot=False)
 
     await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv AS SELECT p, c FROM {ks}.test WHERE p IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c, p)")
 
@@ -142,10 +141,9 @@ async def test_interrupt_view_build_shard_registration(manager: ManagerClient):
         if len(rows) > 0:
             return True
     await wait_for(some_registered, time.time() + 60)
-    await asyncio.sleep(2) # ensure commitlog sync
 
     # restart while some shards registered but the last shard didn't
-    await manager.server_stop(server.server_id)
+    await manager.server_stop_gracefully(server.server_id)
 
     await manager.server_start(server.server_id)
     cql = await reconnect_driver(manager)


### PR DESCRIPTION
Previously the test test_interrupt_view_build_shard_registration stopped the node ungracefully and used commitlog periodic mode to persist the view build progress in a not very reliable way.

It can happen that due to timing issues, the view build progress is not persisted, or some of it is persisted in a different ordering than expected.

To make the test more reliable we change it to stop the node gracefully, so the commitlog is persisted in a graceful and consistent way, without using the periodic mode delay. We need to also change the injection for the shutdown to not get stuck.

Fixes SCYLLADB-1005

no backport - minor CI stability