### PR TITLE
mutation/collection_mutation: don't copy the serialized collection

### DIFF
--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -261,7 +261,7 @@ static collection_mutation serialize_collection_mutation(
 
         writev(v.serialize());
     }
-    return collection_mutation(type, ret);
+    return collection_mutation(type, std::move(ret));
 }
 
 collection_mutation collection_mutation_description::serialize(const abstract_type& type) const {


### PR DESCRIPTION
serialize_collection_mutation() copies the serialized collection into the returned collection_mutation object. Change to move to avoid the copy.

Fixes: SCYLLADB-1041

Backport: trivial fix which helps large collection workloads, should be backported everywhere