### PR TITLE
ldap: fix use-after-move crash in ldap_reuser::reap()

### DIFF
--- a/ent/ldap/ldap_connection.cc
+++ b/ent/ldap/ldap_connection.cc
@@ -482,6 +482,8 @@ void ldap_reuser::reap(conn_ptr& conn) {
 }
 
 future<> ldap_reuser::stop() {
-    reap(_conn);
-    return std::move(_reaper);
+    return _gate.close().then([this] {
+        reap(_conn);
+        return std::move(_reaper);
+    });
 }

--- a/ent/ldap/ldap_connection.hh
+++ b/ent/ldap/ldap_connection.hh
@@ -13,6 +13,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/semaphore.hh>
@@ -167,6 +168,7 @@ class ldap_reuser {
     sequential_producer<conn_ptr> _make_conn; // TODO: This type can be a parameter.
     conn_ptr _conn;
     seastar::future<> _reaper; ///< Closes and deletes all connections produced.
+    seastar::gate _gate;
 
   public:
     ldap_reuser(sequential_producer<conn_ptr>::factory_t&& f);
@@ -179,10 +181,11 @@ class ldap_reuser {
     /// Invokes fn on a valid ldap_connection, managing its lifetime and validity.
     template<std::invocable<ldap_connection&> Func>
     std::invoke_result_t<Func, ldap_connection&> with_connection(Func fn) {
+        auto holder = _gate.hold();
         if (_conn && _conn->is_live()) {
-            return invoke(std::move(fn));
+            return invoke(std::move(fn), std::move(holder));
         } else {
-            return _make_conn().then([this, fn = std::move(fn)] (conn_ptr&& conn) mutable {
+            return _make_conn().then([this, fn = std::move(fn), holder = std::move(holder)] (conn_ptr&& conn) mutable {
                 if (_conn) {
                     if (!_conn->is_live()) {
                         reap(_conn);
@@ -194,7 +197,7 @@ class ldap_reuser {
                     _conn = std::move(conn);
                 }
                 _make_conn.clear(); // So _make_conn doesn't keep a shared-pointer copy that escapes reaping.
-                return invoke(std::move(fn));
+                return invoke(std::move(fn), std::move(holder));
             });
         }
     }
@@ -202,9 +205,9 @@ class ldap_reuser {
   private:
     /// Invokes fn on a copy of _conn and schedules its reaping.
     template<std::invocable<ldap_connection&> Func>
-    std::invoke_result_t<Func, ldap_connection&> invoke(Func fn) {
+    std::invoke_result_t<Func, ldap_connection&> invoke(Func fn, seastar::gate::holder holder) {
         conn_ptr conn(_conn);
-        return fn(*conn).finally([this, conn = std::move(conn)] () mutable { reap(conn); });
+        return fn(*conn).finally([this, conn = std::move(conn), holder = std::move(holder)] () mutable { reap(conn); });
     }
 
     /// Decreases conn reference count.  If this is the last fiber using conn, closes and disposes of it.


### PR DESCRIPTION
After stop() moved _reaper, in-flight with_connection() callbacks could still call reap(), which accessed the moved-from future causing a SIGSEGV in future_base::detach_promise(). Add a seastar::gate so stop() waits for all in-flight operations before moving _reaper.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1043

Backport: no, minor issue visible just in test, existing since long time.