### PR TITLE
test/cluster: mark test_alternator_concurrent_rmw_same_partition_different_server not strictly xfail

### DIFF
--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -1205,7 +1205,7 @@ async def test_zero_token_node_load_balancer(manager, tablets):
     assert got == expected
     table.delete()
 
-@pytest.mark.xfail(reason="#16261")
+@pytest.mark.xfail(reason="#16261", strict=False)
 async def test_alternator_concurrent_rmw_same_partition_different_server(manager: ManagerClient):
     """A reproducer for issue #16261: When sending RMW (read-modify-write)
        operations to the same partition (different item) on different server


### PR DESCRIPTION
A few days ago, in commit 7b30a39 we added to pytest.ini the option xfail_strict. This option causes every time a test XPASSes, i.e., an xfail test actually passes - to be considered an error and fail the test.

But some tests demonstrate a timing-related bug and do not reproduce the bug every single time. An example we noticed in one CI run is:

test/cluster/test_alternator.py::test_alternator_concurrent_rmw_same_partition_different_server

This test reproduces a timing-related bug (if you do an LWT write to one partition on to two different coordinators "at the same time", you can get a failure), but only most of the time, not 100% of the time.

The solution is to add "strict=False" for the xfail marker on this specific test. This undoes the xfail_strict for this specific test, accepting that this specific test can either pass or fail. Note that this does NOT make this test worthless - we still see this test failing most of the time, and when a developer finally fixes this issue, the test will begin to pass all the time.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-941