### PR TITLE
Replace CAS estimated histogram with estimated_histogram_with_max

### DIFF
--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -123,12 +123,13 @@ static future<json::json_return_type>  sum_estimated_histogram(sharded<service::
     });
 }
 
-static future<json::json_return_type>  sum_estimated_histogram(sharded<service::storage_proxy>& proxy, utils::estimated_histogram service::storage_proxy_stats::stats::*f) {
+static future<json::json_return_type>  sum_estimated_histogram(sharded<service::storage_proxy>& proxy, service::storage_proxy_stats::cas_contention_histogram service::storage_proxy_stats::stats::*f) {
 
-    return two_dimensional_map_reduce(proxy, f, utils::estimated_histogram_merge,
-            utils::estimated_histogram()).then([](const utils::estimated_histogram& val) {
+    return two_dimensional_map_reduce(proxy, f, utils::estimated_histogram_with_max_merge<service::storage_proxy_stats::cas_contention_histogram::MAX>,
+            service::storage_proxy_stats::cas_contention_histogram()).then([](const service::storage_proxy_stats::cas_contention_histogram& val) {
         utils_json::estimated_histogram res;
-        res = val;
+        res.bucket_offsets = val.get_buckets_offsets();
+        res.buckets = val.get_buckets_counts();
         return make_ready_future<json::json_return_type>(res);
     });
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3137,11 +3137,11 @@ void storage_proxy_stats::stats::register_stats() {
 
         sm::make_histogram("cas_read_contention", sm::description("how many contended reads were encountered"),
                        {storage_proxy_stats::current_scheduling_group_label(), basic_level, cas_label},
-                       [this]{ return cas_read_contention.get_histogram(1, 8);}).set_skip_when_empty(),
+                       [this]{ return to_metrics_histogram(cas_read_contention);}).set_skip_when_empty(),
 
         sm::make_histogram("cas_write_contention", sm::description("how many contended writes were encountered"),
                        {storage_proxy_stats::current_scheduling_group_label(), basic_level, cas_label},
-                       [this]{ return cas_write_contention.get_histogram(1, 8);}).set_skip_when_empty(),
+                       [this]{ return to_metrics_histogram(cas_write_contention);}).set_skip_when_empty(),
 
         sm::make_total_operations("cas_prune", cas_prune,
                        sm::description("how many times paxos prune was done after successful cas operation"),

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -18,7 +18,7 @@ namespace locator { class topology; }
 namespace service {
 
 namespace storage_proxy_stats {
-
+using cas_contention_histogram = utils::estimated_histogram_with_max<128>;
 // split statistics counters
 struct split_stats {
     static seastar::metrics::label datacenter_label;
@@ -88,7 +88,7 @@ struct write_stats {
 
     utils::timed_rate_moving_average_summary_and_histogram cas_write;
 
-    utils::estimated_histogram cas_write_contention;
+    cas_contention_histogram cas_write_contention;
 
     uint64_t writes = 0;
     // A CQL write query arrived to a non-replica node and was
@@ -137,7 +137,7 @@ struct stats : public write_stats {
     utils::timed_rate_moving_average cas_read_timeouts;
     utils::timed_rate_moving_average cas_read_unavailables;
 
-    utils::estimated_histogram cas_read_contention;
+    cas_contention_histogram cas_read_contention;
 
     uint64_t read_repair_attempts = 0;
     uint64_t read_repair_repaired_blocking = 0;

--- a/utils/estimated_histogram.hh
+++ b/utils/estimated_histogram.hh
@@ -129,6 +129,7 @@ public:
     static constexpr size_t NUM_BUCKETS = NUM_EXP_RANGES * Precision + 1;
     static constexpr unsigned BASESHIFT = log2floor(SCALED_MIN);
     static constexpr uint64_t LOWER_BITS_MASK = Precision - 1;
+    static constexpr uint64_t MAX = Max;
 private:
     std::array<uint64_t, NUM_BUCKETS> _buckets;
     uint64_t _total_sum = 0;
@@ -338,6 +339,41 @@ public:
 
     uint64_t& operator[](size_t b) noexcept {
         return _buckets[b];
+    }
+
+    /**
+     * @brief returns the offsets of all the buckets in the histogram, excluding duplicate limits for integer values when Min < Precision
+     * This method is useful for getting the bucket offsets for display or testing purposes.
+     * but should be avoided in performance sensitive code since it iterates over all the buckets and calculates the offsets.
+     * @return  a vector of bucket offsets, in the same order as the buckets, excluding duplicate offsets for integer values when Min < Precision
+     */
+    std::vector<uint64_t> get_buckets_offsets() const {
+        std::vector<uint64_t> limits;
+        limits.reserve(NUM_BUCKETS);
+        for (size_t i = 0; i < NUM_BUCKETS; i++) {
+            if (i  > 0 && get_bucket_lower_limit(i) == get_bucket_lower_limit(i - 1)) {
+                continue;
+            }
+            limits.push_back(get_bucket_lower_limit(i));
+        }
+        return limits;
+    }
+    /**
+     * @brief returns the count of all the buckets in the histogram, with counts of buckets with duplicate limits for integer values when Min < Precision merged together
+     * This method is useful for getting the bucket counts for display or testing purposes, but should be avoided in performance sensitive code since it iterates over all the buckets and calculates the limits.
+     * @return a vector of bucket counts, in the same order as the limits returned by get_buckets_limits()
+     */
+    std::vector<uint64_t> get_buckets_counts() const {
+        std::vector<uint64_t> counts;
+        counts.reserve(NUM_BUCKETS);
+        for (size_t i = 0; i < NUM_BUCKETS; i++) {
+            if (i  > 0 && get_bucket_lower_limit(i) == get_bucket_lower_limit(i - 1)) {
+                counts.back() += get(i);
+            } else {
+                counts.push_back(get(i));
+            }
+        }
+        return counts;
     }
 };
 


### PR DESCRIPTION
ScyllaDB uses estimated_histogram in many places.
We already have a more efficient alternative: estimated_histogram_with_max. It is both CPU- and
memory-efficient, and it can be exported as Prometheus native histograms.

Its main limitation (which also has benefits) is that the bucket layout is fixed at compile time, so
histograms with different configurations cannot be mixed.

The end goal is to replace all uses of estimated_histogram in the codebase.
That migration requires a few small API adjustments, so it is done in steps.

This PR replaces estimated_histogram for CAS contention.
The PR includes a patch that adds functionality to the base approx_exponential_histogram, which will be used by the API.

The specific histograms are defined in a single place and cover the range 1-100; this makes future changes easy.

**New feature, no need to backport**