### PR TITLE
service level: fix crash during migration to driver server level

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -429,7 +429,7 @@ future<utils::chunked_vector<mutation>> service_level_controller::get_create_dri
 future<std::optional<service::group0_guard>> service_level_controller::migrate_to_driver_service_level(service::group0_guard guard, db::system_keyspace& sys_ks) {
     // Don't try creating driver service level too often if it already failed.
     // We don't want to block the topology coordinator.
-    if (_last_unsuccessful_driver_sl_creation_attemp + 5min < seastar::lowres_clock::now()) {
+    if (_sl_data_accessor && _last_unsuccessful_driver_sl_creation_attemp + 5min < seastar::lowres_clock::now()) {
         sl_logger.info("migrate_to_driver_service_level: starting sl:{} creation", service_level_controller::driver_service_level_name);
         try {
             service::group0_batch mc{std::move(guard)};


### PR DESCRIPTION
Before b59b3d4 the migration code checked that service level controller is on v2 version before migration and the check also implicitly checked that _sl_data_accessor field is already initialized, but now that the check is gone the migration can start before service level controller is fully initialized. Re add the check, but to a different place.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1049

No need to backport, new regression.