### PR TITLE
reader_concurrency_semaphore: skip preemptive abort for permits waiting for memory

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -371,7 +371,7 @@ public:
     }
 
     void on_preemptive_aborted() {
-        if (_state != reader_permit::state::waiting_for_admission && _state != reader_permit::state::waiting_for_memory) {
+        if (_state != reader_permit::state::waiting_for_admission) {
             on_internal_error(rcslog, format("on_preemptive_aborted(): permit in invalid state {}", _state));
         }
 
@@ -1533,19 +1533,24 @@ void reader_concurrency_semaphore::maybe_admit_waiters() noexcept {
             // + permit.timeout() < db::no_timeout -- to avoid preemptively aborting reads without timeout.
             //                                        Useful is tests when _preemptive_abort_factor is set to 1.0
             //                                        to avoid additional sleeps to wait for the read to be shed.
-            const auto time_budget = permit.timeout() - permit.created();
-            const auto remaining_time = permit.timeout() - db::timeout_clock::now();
-            if (remaining_time > db::timeout_clock::duration::zero() &&
-                    permit.timeout() < db::no_timeout &&
-                    remaining_time <= _preemptive_abort_factor() * time_budget) {
-                permit.on_preemptive_aborted();
-                using ms = std::chrono::milliseconds;
-                tracing::trace(permit.trace_state(), "[reader concurrency semaphore {}] read shed as unlikely to finish (elapsed: {}, timeout: {}, preemptive_factor: {})",
-                               _name,
-                               std::chrono::duration_cast<ms>(time_budget - remaining_time),
-                               std::chrono::duration_cast<ms>(time_budget),
-                               _preemptive_abort_factor());
-                continue;
+            //
+            // Only apply to permits waiting for admission -- permits waiting for memory are already
+            // executing reads and should not be preemptively aborted.
+            if (permit.get_state() == reader_permit::state::waiting_for_admission) {
+                const auto time_budget = permit.timeout() - permit.created();
+                const auto remaining_time = permit.timeout() - db::timeout_clock::now();
+                if (remaining_time > db::timeout_clock::duration::zero() &&
+                        permit.timeout() < db::no_timeout &&
+                        remaining_time <= _preemptive_abort_factor() * time_budget) {
+                    permit.on_preemptive_aborted();
+                    using ms = std::chrono::milliseconds;
+                    tracing::trace(permit.trace_state(), "[reader concurrency semaphore {}] read shed as unlikely to finish (elapsed: {}, timeout: {}, preemptive_factor: {})",
+                                   _name,
+                                   std::chrono::duration_cast<ms>(time_budget - remaining_time),
+                                   std::chrono::duration_cast<ms>(time_budget),
+                                   _preemptive_abort_factor());
+                    continue;
+                }
             }
 
             if (permit.get_state() == reader_permit::state::waiting_for_memory) {

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -2409,6 +2409,10 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_double_permit_abort) 
 }
 
 SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_abort_preemptively_aborted_permit) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
     const auto initial_resources = reader_concurrency_semaphore::resources{2, 2 * 1024};
     const auto serialize_multiplier = 2;
     // Ensure permits are shed immediately during admission.
@@ -2421,27 +2425,24 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_abort_preemptively_ab
 
     // Set a ridiculously long timeout to ensure permit will not be rejected due to timeout
     auto timeout = db::timeout_clock::now() + 60min;
-    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
-    auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}).get();
+    auto units1 = permit1.request_memory(2024).get();
 
-    auto permit2_units1 = permit2.request_memory(1024).get();
-    auto permit1_units = permit1.request_memory(8 * 1024).get();
+    reader_permit_opt permit2_holder;
+    auto permit2_fut = semaphore.with_permit(schema, test_name.c_str(), 1024, timeout, {}, permit2_holder, [] (reader_permit) {
+        BOOST_FAIL("unexpected call to with permit lambda");
+        return make_ready_future<>();
+    });
 
-    // permit1 is now the blessed one
+    // Triggers maybe_admit_waiters()
+    units1.reset_to_zero();
 
-    auto permit2_units2_fut = permit2.request_memory(1024);
-    BOOST_REQUIRE(!permit2_units2_fut.available());
-    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_memory, 1);
+    BOOST_REQUIRE(eventually_true([&] { return permit2_fut.failed(); }));
+    BOOST_REQUIRE_THROW(permit2_fut.get(), named_semaphore_aborted);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().total_reads_shed_due_to_overload, 1);
 
-    permit1_units.reset_to_zero();
-
-    const auto futures_failed = eventually_true([&] { return permit2_units2_fut.failed(); });
-    BOOST_CHECK(futures_failed);
-    BOOST_CHECK_EQUAL(semaphore.get_stats().total_reads_shed_due_to_overload, 1);
-
-    simple_schema ss;
-    auto irh = semaphore.register_inactive_read(make_empty_mutation_reader(ss.schema(), permit2));
-    BOOST_REQUIRE_THROW(permit2_units2_fut.get(), named_semaphore_aborted);
+    auto irh = semaphore.register_inactive_read(make_empty_mutation_reader(schema, *permit2_holder));
+    BOOST_CHECK(!irh);
 }
 
 /// Test that if no count resources are currently used, a single permit is always admitted regardless of available memory.
@@ -2579,20 +2580,19 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_preemptive_abort_requ
 
     // Triggers maybe_admit_waiters()
     units1.reset_to_zero();
-    BOOST_REQUIRE(eventually_true([&] { return mem_fut.failed(); }));
-    BOOST_REQUIRE_THROW(std::rethrow_exception(mem_fut.get_exception()), semaphore_aborted);
+
+    // Consume mem_fut to properly account for the 1024 bytes consumed by
+    // on_granted_memory(). In debug mode, the .then() continuation that creates
+    // the resource_units may be deferred due to yielding, so we must .get() it
+    // to ensure the resource_units is created and can be properly destroyed.
+    { auto u = mem_fut.get(); }
 
     // on_granted_memory() consumes stale _requested_memory (1024) + 512,
     // but resource_units only tracks 512 — the difference leaks.
     { auto u = permit2->request_memory(512).get(); }
 
-    // Destroy permit2 and verify ~impl() detects the leak.
-    auto prev_internal_errors = seastar::internal::internal_errors;
-    auto reset_abort = defer([prev = set_abort_on_internal_error(false)] {
-        set_abort_on_internal_error(prev);
-    });
+    // Shouldn't fail if SCYLLADB-1016 is fixed.
     permit2 = {};
-    BOOST_REQUIRE_GT(seastar::internal::internal_errors, prev_internal_errors);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Permits in the `waiting_for_memory` state represent already-executing reads that are blocked on memory allocation. Preemptively aborting them is wasteful -- these reads have already consumed resources and made progress, so they should be allowed to complete.

Restrict the preemptive abort check in maybe_admit_waiters() to only apply to permits in the `waiting_for_admission` state, and tighten the state validation in `on_preemptive_aborted()` accordingly.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1016

Backport not needed. The commit introducing replica load shedding is not part of 2026.1