### PR TITLE
test/backup: Use unique_name() for backup prefix instead of cf_dir

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -189,18 +189,16 @@ async def do_test_backup_helper(manager: ManagerClient, object_storage,
     server = (await manager.servers_add(num_servers, config=cfg, cmdline=cmd))[0]
     ks, cf = create_ks_and_cf(manager.get_cql())
     snap_name, files = await take_snapshot_on_one_server(ks, server, manager, logger)
-    workdir = await manager.server_get_workdir(server.server_id)
-    cf_dir = os.listdir(f'{workdir}/data/{ks}')[0]
 
     await manager.api.enable_injection(server.ip_addr, breakpoint_name, one_shot=True)
     log = await manager.server_open_log(server.server_id)
     mark = await log.mark()
 
     print('Backup snapshot')
-    # use a unique(ish) path, because we're running more than one test using the same minio and ks/cf name.
+    # use a unique path, because we're running more than one test using the same minio and ks/cf name.
     # If we just use {cf}/backup, files like "schema.cql" and "manifest.json" will remain after previous test
     # case, and we will count these erroneously.
-    prefix = f'{cf_dir}/backup'
+    prefix = unique_name('backup_')
     tid = await manager.api.backup(server.ip_addr, ks, cf, snap_name, object_storage.address, object_storage.bucket_name, prefix)
 
     print(f'Started task {tid}, aborting it early')


### PR DESCRIPTION
The do_test_backup_abort() fetched the node's workdir and resolved cf_dir solely to construct a unique-ish backup prefix:

    prefix = f'{cf_dir}/backup'

The comment already acknowledged this was only "unique(ish)" — relying on the UUID-derived cf_dir name as a uniqueness source is roundabout. unique_name() is already imported and used for exactly this purpose elsewhere in the file.

Enhancing tests, not backporting