### PR TITLE
database: Rate limit all tokens from a range

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1699,7 +1699,7 @@ static db::rate_limiter::can_proceed account_singular_ranges_to_rate_limit(
         if (!range.is_singular()) {
             continue;
         }
-        auto token = dht::token::to_int64(ranges.front().start()->value().token());
+        auto token = dht::token::to_int64(range.start()->value().token());
         if (limiter.account_operation(read_label, token, table_limit, rate_limit_info) == db::rate_limiter::can_proceed::no) {
             // Don't return immediately - account all ranges first
             ret = can_proceed::no;


### PR DESCRIPTION
The limiter scans ranges to decide whether or not to rate-limit the query. However, when considering each range only the front one's token is accounted. This looks like a misprint.

The limiter was introduced in cc9a2ad41f

Fixes #29049

The code is there since 2025.1, suggest to backport all the way back