### PR TITLE
raft: Fix split mutations freeze

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -910,7 +910,7 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
                     frozen_muts_to_apply.push_back(co_await freeze_gently(mut));
                 } else {
                     co_await for_each_split_mutation(std::move(mut), max_size, [&] (mutation m) -> future<> {
-                        frozen_muts_to_apply.push_back(co_await freeze_gently(mut));
+                        frozen_muts_to_apply.push_back(co_await freeze_gently(m));
                     });
                 }
             }


### PR DESCRIPTION
Commit faa0ee9844 accidentally broke the way split snapshot mutation was frozen -- instead of appending the sub-mutation `m` the commit kept the old variable name of `mut` which in the new code corresponds to "old" non-split mutation

Fixes #29051

Present in 2026.1, worth backporting