### PR TITLE
s3/client: Don't reconstruct regex on every parse_content_range call

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1214,7 +1214,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
     future<> _filling_fiber = make_ready_future<>();
 
     static content_range parse_content_range(const std::string& header) {
-        std::regex pattern(R"(bytes (\d+)-(\d+)/(\d+))");
+        static const std::regex pattern(R"(bytes (\d+)-(\d+)/(\d+))");
         std::smatch match;
 
         if (std::regex_match(header, match, pattern)) {


### PR DESCRIPTION
Make the pattern static const so it is compiled once at first call rather than on every Content-Range header parse.

Minor optimization, not worth backporting