### PR TITLE
cmake: fix broken build

### DIFF
--- a/idl/CMakeLists.txt
+++ b/idl/CMakeLists.txt
@@ -48,6 +48,7 @@ set(idl_headers
   messaging_service.idl.hh
   paxos.idl.hh
   raft.idl.hh
+  raft_util.idl.hh
   raft_storage.idl.hh
   group0.idl.hh
   hinted_handoff.idl.hh


### PR DESCRIPTION
Add raft_util.idl.hh to cmake to generate the code properly

No backport is needed since we dont use cmake in our CI