### PR TITLE
s3: Don't rearm credential timers when credentials are not refreshed

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -161,8 +161,10 @@ shared_ptr<client> client::make(std::string ep, std::string region, std::string 
 
 future<> client::update_credentials_and_rearm() {
     _credentials = co_await _creds_provider_chain.get_aws_credentials();
-    _creds_invalidation_timer.rearm(_credentials.expires_at);
-    _creds_update_timer.rearm(_credentials.expires_at - 1h);
+    if (_credentials) {
+        _creds_invalidation_timer.rearm(_credentials.expires_at);
+        _creds_update_timer.rearm(_credentials.expires_at - 1h);
+    }
 }
 
 future<> client::authorize(http::request& req) {


### PR DESCRIPTION
The update_credentials_and_rearm() may get "empty" credentials from _creds_provider_chain.get_aws_credentials() -- it doesn't throw, but returns default-initialized value. In that case the expires_at will be set to time_point::min, and it's probably not a good idea to arm the refresh timer and, even worse idea, to subtract 1h from it.

Fixes #29056

S3 credential chains are there since 2025.3