### PR TITLE
Fix object storage lister entries walking loop

### DIFF
--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -189,7 +189,7 @@ public:
             {}
             future<std::optional<directory_entry>> get() override {
                 std::filesystem::path dir(_prefix);
-                do {
+                while (true) {
                     if (_pos == _info.size()) {
                         _info.clear();
                         _info = co_await _client->list_objects(_bucket, _prefix, _paging);
@@ -203,7 +203,7 @@ public:
                         continue;
                     }
                     co_return ent;
-                } while (false);
+                }
 
                 co_return std::nullopt;
             }

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -193,6 +193,7 @@ public:
                     if (_pos == _info.size()) {
                         _info.clear();
                         _info = co_await _client->list_objects(_bucket, _prefix, _paging);
+                        _pos = 0;
                     }
                     if (_info.empty()) {
                         break;


### PR DESCRIPTION
Two issues found in the lister returned by gs_client_wrapper::make_object_lister()
Lister can report EOF too early in case filter is active, another one is potential vector out-of-bounds access

Fixes #29058

The code appeared in 2026.1, worth fixing it there as well