### PR TITLE
object_store: Don't leave dangling objects by iterating moved-from na…

### DIFF
--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -276,7 +276,7 @@ public:
             co_await f.close();
 
             auto names = ranges | std::views::transform([](auto& p) { return p.name; }) | std::ranges::to<std::vector<std::string>>();
-            co_await _client->merge_objects(bucket, object, std::move(names), {}, as);
+            co_await _client->merge_objects(bucket, object, names, {}, as);
 
             co_await parallel_for_each(names, [this, bucket](auto& name) -> future<> {
                 co_await _client->delete_object(bucket, name);

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -1104,7 +1104,7 @@ future<> utils::gcp::storage::client::copy_object(std::string_view bucket_in, st
     }
 }
 
-future<utils::gcp::storage::object_info> utils::gcp::storage::client::merge_objects(std::string_view bucket_in, std::string_view dest_object_name, std::vector<std::string> source_object_names, rjson::value metadata, seastar::abort_source* as) {
+future<utils::gcp::storage::object_info> utils::gcp::storage::client::merge_objects(std::string_view bucket_in, std::string_view dest_object_name, const std::vector<std::string>& source_object_names, rjson::value metadata, seastar::abort_source* as) {
     rjson::value compose = rjson::empty_object();
     rjson::value source_objects = rjson::empty_array();
 

--- a/utils/gcp/object_storage.hh
+++ b/utils/gcp/object_storage.hh
@@ -139,7 +139,7 @@ namespace utils::gcp::storage {
          * Merges sub-objects into a new destination. Actual file will be composed in order of subobject in `source_object`.
          * @return info of the created, merged object.
          */
-        future<object_info> merge_objects(std::string_view bucket, std::string_view dest_object_name, std::vector<std::string> source_objects, rjson::value metadata = {}, seastar::abort_source* = nullptr);
+        future<object_info> merge_objects(std::string_view bucket, std::string_view dest_object_name, const std::vector<std::string>& source_objects, rjson::value metadata = {}, seastar::abort_source* = nullptr);
 
         /**
          * Creates a data_sink for uploading data to a given name in bucket.


### PR DESCRIPTION
…mes vector

The code in upload_file std::move()-s vector of names into merge_objects() method, then iterates over this vector to delete objects. The iteration is apparently a no-op on moved-from vector.

The fix is to make merge_objects() helper get vector of names by const reference -- the method doesn't modify the names collection, the caller keeps one in stable storage.

Fixes #29060

The code appeared in 2026.1, worth fixing it there as well