### PR TITLE
perf-alternator: wait for alternator port before running workload

### DIFF
--- a/test/perf/perf_alternator.cc
+++ b/test/perf/perf_alternator.cc
@@ -77,8 +77,9 @@ static future<> make_request(http::experimental::client& cli, sstring operation,
     });
 }
 
-static void wait_for_alternator(const test_config& c) {
+static void wait_for_alternator(const test_config& c, abort_source& as) {
     for (int attempt = 0; attempt < 3000; ++attempt) {
+        as.check();
         try {
             auto cli = get_client(c);
             auto close = defer([&] { cli.close().get(); });
@@ -86,7 +87,7 @@ static void wait_for_alternator(const test_config& c) {
             return;
         } catch (...) {
         }
-        sleep(std::chrono::milliseconds(100)).get();
+        sleep_abortable(std::chrono::milliseconds(100), as).get();
         if (attempt >= 100 && attempt % 10 == 0) {
             std::cout << fmt::format("Retrying connect to alternator port (attempt {})", attempt + 1) << std::endl;
         }
@@ -389,7 +390,7 @@ auto make_client_pool(const test_config& c) {
 void workload_main(const test_config& c, sharded<abort_source>* as) {
     std::cout << "Running test with config: " << c << std::endl;
 
-    wait_for_alternator(c);
+    wait_for_alternator(c, as->local());
 
     auto cli = get_client(c);
     auto finally = defer([&] {

--- a/test/perf/perf_cql_raw.cc
+++ b/test/perf/perf_cql_raw.cc
@@ -17,6 +17,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/temporary_buffer.hh>
@@ -682,8 +683,9 @@ static void prepopulate(const raw_cql_test_config& cfg) {
     }
 }
 
-static void wait_for_cql(const raw_cql_test_config& cfg) {
+static void wait_for_cql(const raw_cql_test_config& cfg, abort_source& as) {
     for (int attempt = 0; attempt < 3000; ++attempt) {
+        as.check();
         try {
             auto cs = connect(socket_address{net::inet_address{cfg.remote_host}, cfg.port}).get();
             auto conn = make_connection(std::move(cs), cfg);
@@ -691,9 +693,8 @@ static void wait_for_cql(const raw_cql_test_config& cfg) {
             conn->stop().get();
             return;
         } catch (...) {
-            // not ready yet
         }
-        sleep(std::chrono::milliseconds(100)).get();
+        sleep_abortable(std::chrono::milliseconds(100), as).get();
         if (attempt >= 100 && attempt % 10 == 0) {
             std::cout << format("Retrying connect to cql port (attempt {})", attempt+1) << std::endl;
         }
@@ -713,7 +714,7 @@ static void workload_main(const raw_cql_test_config& cfg, sharded<abort_source>*
             });
         }).get();
     });
-    wait_for_cql(cfg);
+    wait_for_cql(cfg, as->local());
     if (cfg.workload != "connect") {
         prepopulate(cfg);
     }


### PR DESCRIPTION
This patch is mostly for the purpose of running pgo CI job.

We may receive connection error if asyncio.sleep(5) in
pgo.py is not sufficient waiting time.

In pgo.py we do wait for port but only for cql,
anyway it's better to have high level check than
trying to wait for alternator port there.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1071
Backport: 2026.1 - it failed on CI for that build