### PR TITLE
test: avoid split/major compaction deadlock in tablet split test

### DIFF
--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -1297,11 +1297,11 @@ async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClie
 
         logger.info("Force compaction of split sstable containing expired tombstone")
         await manager.api.stop_compaction(servers[0].ip_addr, "SPLIT")
-        await manager.api.keyspace_compaction(servers[0].ip_addr, ks)
-
-        await s1_log.wait_for(f"split_sstable_rewrite: released", from_mark=s1_mark)
+        compaction_task = asyncio.create_task(manager.api.keyspace_compaction(servers[0].ip_addr, ks))
 
         await manager.api.disable_injection(servers[0].ip_addr, "split_sstable_rewrite")
+        await s1_log.wait_for(f"split_sstable_rewrite: released", from_mark=s1_mark)
+        await compaction_task
 
         await manager.api.disable_injection(servers[0].ip_addr, "tablet_split_finalization_postpone")
         await s1_log.wait_for('Detected tablet split for table', from_mark=s1_mark)


### PR DESCRIPTION
Run keyspace compaction asynchronously in
`test_tombstone_gc_correctness_during_tablet_split` and only await it after `split_sstable_rewrite` is disabled.

The problem is that `keyspace_compaction()` starts with a flush, and that flush can take around five seconds. During that window the split compaction is stopped before major compaction is retried. The stop aborts the in-flight major compaction attempt, then the split proceeds far enough to enter the `split_sstable_rewrite` injection point.

At that point the test used to wait synchronously for major compaction to finish, but major compaction cannot finish yet: when it retries, it needs the same semaphore that is still effectively tied up behind the blocked split rewrite. So the test waits for major compaction, while the split waits for the injection to be released, and the code that would release that injection never runs.

Starting major compaction as a task breaks that cycle. The test can first disable `split_sstable_rewrite`, let the split get out of the way, and only then wait for major compaction to complete.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-827.
