### PR TITLE
test/cluster/test_repair.py: use tablets in test_repair_timestamp_difference

### DIFF
--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -293,7 +293,7 @@ async def test_repair_timtestamp_difference(manager):
 
     cql = manager.get_cql()
 
-    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'enabled': false}")
+    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
     cql.execute("CREATE TABLE ks.tbl (pk int, ck UUID, v text, PRIMARY KEY (pk, ck))")
 
     nodes = [node1, node2]


### PR DESCRIPTION
After repair, the test does a major to compact all sstables into a single one, so the results can be simply checked by a select from mutation_fragments() query. Sometimes off-strategy happens parallel to this major, so after the major there are still 2 sstables, resulting in the test failing when checking that the query returns just a single row. To fix, just use tablets for the test table, tablets don't use off-strategy anymore.

Fixes: SCYLLADB-940

Backport: test flakyness only seen on master, no backport just yet.