### PR TITLE
sstables_loader: use new sstable add path

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -221,10 +221,16 @@ private:
         sst->set_sstable_level(0);
         auto units = co_await sst_manager.dir_semaphore().get_units(1);
         sstables::sstable_open_config cfg {
+            .unsealed_sstable = true,
             .ignore_component_digest_mismatch = db.get_config().ignore_component_digest_mismatch(),
         };
         co_await sst->load(table.get_effective_replication_map()->get_sharder(*table.schema()), cfg);
-        co_await table.add_sstable_and_update_cache(sst);
+        co_await table.add_new_sstable_and_update_cache(sst, [&sst_manager, sst] (sstables::shared_sstable loading_sst) -> future<> {
+            if (loading_sst == sst) {
+                auto writer_cfg = sst_manager.configure_writer(loading_sst->get_origin());
+                co_await loading_sst->seal_sstable(writer_cfg.backup);
+            }
+        });
     }
 
     future<>
@@ -295,7 +301,8 @@ private:
                         sstables::sstable_state::normal,
                         sstables::sstable::component_basename(
                             _table.schema()->ks_name(), _table.schema()->cf_name(), descriptor.version, gen, descriptor.format, it->first),
-                        sstables::sstable_stream_sink_cfg{.last_component = std::next(it) == components.cend()});
+                        sstables::sstable_stream_sink_cfg{.last_component = std::next(it) == components.cend(),
+                                                           .leave_unsealed = true});
                     auto out = co_await sstable_sink->output(foptions, stream_options);
 
                     input_stream src(co_await [this, &it, sstable, f = files.at(it->first)]() -> future<input_stream<char>> {


### PR DESCRIPTION
Use add_new_sstable_and_update_cache() when attaching SSTables
downloaded by the node-scoped local loader.

This is the correct variant for new SSTables: it can unlink the
SSTable on failure to add it, and it can split the SSTable if a
tablet split is in progress. The older
add_sstable_and_update_cache() helper is intended for preexisting
SSTables that are already stable on disk.

Additionally, downloaded SSTables are now left unsealed (TemporaryTOC)
until they are successfully added to the table's SSTable set. The
download path (download_fully_contained_sstables) passes
leave_unsealed=true to create_stream_sink, and attach_sstable opens
the SSTable with unsealed_sstable=true and seals it only inside the
on_add callback — matching the pattern used by stream_blob.cc and
storage_service.cc for tablet streaming.

This prevents a data-resurrection hazard: previously, if the process
crashed between download and attach_sstable, or if attach_sstable
failed mid-loop, sealed (TOC) SSTables would remain in the table
directory and be reloaded by distributed_loader on restart. With
TemporaryTOC, sstable_directory automatically cleans them up on
restart instead.

Fixes  https://scylladb.atlassian.net/browse/SCYLLADB-1085.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>