### PR TITLE
test/cqlpy/test_tombstone_limit.py: disable tombstone-gc for test table

### DIFF
--- a/test/cqlpy/test_tombstone_limit.py
+++ b/test/cqlpy/test_tombstone_limit.py
@@ -26,7 +26,7 @@ def all_tests_are_scylla_only(scylla_only):
 # Tests that need a single partition can co-locate their data in a single table.
 @pytest.fixture(scope="module")
 def table(cql, test_keyspace):
-    with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, PRIMARY KEY (pk, ck)') as table:
+    with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, PRIMARY KEY (pk, ck)', extra=" WITH tombstone_gc = {'mode': 'disabled'}") as table:
         yield table
 
 


### PR DESCRIPTION
Since 7564a56dc834ade99e5ec12c8ba6a8305d228153, all tables default to repair mode tombstone-gc, which is identical to immediate-mode for RF=1 tables. Consequently the tombstones written by the tests in this test file are immediately collectible and with some unlucky timing, some of them can be collected before the the check for the empty pages they should trigger, failing the test.
Disable tombstone-gc to remove this source of flakyness.

Fixes: SCYLLADB-1062

Backport: no backport needed, the offending commit (7564a56dc834ade99e5ec12c8ba6a8305d228153) is not in any release yet.