### PR TITLE
Add process-exporter packaging and build integration

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -39,6 +39,11 @@ pip_dependencies = subprocess.run('./install-dependencies.sh --print-pip-runtime
 pip_symlinks = subprocess.run('./install-dependencies.sh --print-pip-symlinks', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
 node_exporter_filename = subprocess.run('./install-dependencies.sh --print-node-exporter-filename', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
 node_exporter_dirname = os.path.basename(node_exporter_filename).rstrip('.tar.gz')
+process_exporter_filename = subprocess.run('./install-dependencies.sh --print-process-exporter-filename', shell=True, capture_output=True, encoding='utf-8').stdout.strip()
+process_exporter_dirname = os.path.basename(process_exporter_filename).rstrip('.tar.gz')
+process_exporter_basename = os.path.basename(process_exporter_filename)
+process_exporter_version = process_exporter_basename.removeprefix('process-exporter-').split('.linux-', 1)[0]
+process_exporter_url = f'https://github.com/ncabatoff/process-exporter/releases/download/v{process_exporter_version}/{process_exporter_basename}'
 
 
 def get_os_ids():
@@ -2437,9 +2442,9 @@ def write_build_file(f,
         rule strip
             command = scripts/strip.sh $in
         rule package
-            command = scripts/create-relocatable-package.py --build-dir $builddir/$mode --node-exporter-dir $builddir/node_exporter --debian-dir $builddir/debian/debian $out
+            command = scripts/create-relocatable-package.py --build-dir $builddir/$mode --node-exporter-dir $builddir/node_exporter --process-exporter-dir $builddir/process_exporter --debian-dir $builddir/debian/debian $out
         rule stripped_package
-            command = scripts/create-relocatable-package.py --stripped --build-dir $builddir/$mode --node-exporter-dir $builddir/node_exporter --debian-dir $builddir/debian/debian $out
+            command = scripts/create-relocatable-package.py --stripped --build-dir $builddir/$mode --node-exporter-dir $builddir/node_exporter --process-exporter-dir $builddir/process_exporter --debian-dir $builddir/debian/debian $out
         rule debuginfo_package
             command = dist/debuginfo/scripts/create-relocatable-package.py --build-dir $builddir/$mode --node-exporter-dir $builddir/node_exporter $out
         rule rpmbuild
@@ -2845,9 +2850,9 @@ def write_build_file(f,
             include_scylla_and_iotune = f'$builddir/{mode}/scylla $builddir/{mode}/iotune $builddir/{mode}/patchelf'
             include_scylla_and_iotune_stripped = f'$builddir/{mode}/scylla.stripped $builddir/{mode}/iotune.stripped $builddir/{mode}/patchelf.stripped'
             include_scylla_and_iotune_debug = f'$builddir/{mode}/scylla.debug $builddir/{mode}/iotune.debug'
-        f.write(f'build $builddir/{mode}/dist/tar/{scylla_product}-unstripped-{scylla_version}-{scylla_release}.{arch}.tar.gz: package {include_scylla_and_iotune} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter/node_exporter | always\n')
+        f.write(f'build $builddir/{mode}/dist/tar/{scylla_product}-unstripped-{scylla_version}-{scylla_release}.{arch}.tar.gz: package {include_scylla_and_iotune} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter/node_exporter $builddir/process_exporter/process-exporter | always\n')
         f.write(f'  mode = {mode}\n')
-        f.write(f'build $builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz: stripped_package {include_scylla_and_iotune_stripped} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter/node_exporter.stripped | always\n')
+        f.write(f'build $builddir/{mode}/dist/tar/{scylla_product}-{scylla_version}-{scylla_release}.{arch}.tar.gz: stripped_package {include_scylla_and_iotune_stripped} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter/node_exporter.stripped $builddir/process_exporter/process-exporter.stripped | always\n')
         f.write(f'  mode = {mode}\n')
         f.write(f'build $builddir/{mode}/dist/tar/{scylla_product}-debuginfo-{scylla_version}-{scylla_release}.{arch}.tar.gz: debuginfo_package {include_scylla_and_iotune_debug} $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE $builddir/debian/debian $builddir/node_exporter/node_exporter.debug | always\n')
         f.write(f'  mode = {mode}\n')
@@ -3001,6 +3006,11 @@ def write_build_file(f,
         build $builddir/node_exporter/node_exporter: extract_node_exporter | always
         build $builddir/node_exporter/node_exporter.stripped: strip $builddir/node_exporter/node_exporter
         build $builddir/node_exporter/node_exporter.debug: phony $builddir/node_exporter/node_exporter.stripped
+        rule extract_process_exporter
+            command = [ -f {process_exporter_filename} ] || (mkdir -p $$(dirname {process_exporter_filename}) && curl -fSL -o {process_exporter_filename} {process_exporter_url}) && tar -C $builddir -xvpf {process_exporter_filename} --no-same-owner && rm -rfv $builddir/process_exporter && mv -v $builddir/{process_exporter_dirname} $builddir/process_exporter
+        build $builddir/process_exporter/process-exporter: extract_process_exporter | always
+        build $builddir/process_exporter/process-exporter.stripped: copy $builddir/process_exporter/process-exporter
+        build $builddir/process_exporter/process-exporter.debug: phony $builddir/process_exporter/process-exporter.stripped
         rule print_help
              command = ./scripts/build-help.sh
         build help: print_help | always

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -6,6 +6,7 @@ add_custom_command(
     scripts/create-relocatable-package.py
       --build-dir ${CMAKE_BINARY_DIR}/$<CONFIG>
       --node-exporter-dir ${CMAKE_BINARY_DIR}/node_exporter
+      --process-exporter-dir ${CMAKE_BINARY_DIR}/process_exporter
       --debian-dir ${CMAKE_BINARY_DIR}/debian
       ${unstripped_dist_pkg}
   DEPENDS
@@ -13,6 +14,7 @@ add_custom_command(
     ${CMAKE_BINARY_DIR}/$<CONFIG>/iotune
     ${CMAKE_BINARY_DIR}/$<CONFIG>/patchelf
     ${CMAKE_BINARY_DIR}/node_exporter/node_exporter
+    ${CMAKE_BINARY_DIR}/process_exporter/process-exporter
     ${CMAKE_BINARY_DIR}/debian
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
@@ -81,6 +83,25 @@ add_custom_command(
       --strip-components=1)
 add_stripped(${CMAKE_BINARY_DIR}/node_exporter/node_exporter)
 
+execute_process(
+  COMMAND
+    ${CMAKE_SOURCE_DIR}/install-dependencies.sh --print-process-exporter-filename
+  OUTPUT_VARIABLE
+    process_exporter_filename
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+add_custom_command(
+  OUTPUT
+    ${CMAKE_BINARY_DIR}/process_exporter/process-exporter
+  COMMAND
+    ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/process_exporter
+  COMMAND
+    ${TAR_COMMAND}
+      -C ${CMAKE_BINARY_DIR}/process_exporter
+      -xpf ${process_exporter_filename}
+      --no-same-owner
+      --strip-components=1)
+add_stripped(${CMAKE_BINARY_DIR}/process_exporter/process-exporter)
+
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/debian
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/debian/debian_files_gen.py
@@ -98,6 +119,7 @@ add_custom_command(
       --stripped
       --build-dir ${CMAKE_BINARY_DIR}/$<CONFIG>
       --node-exporter-dir ${CMAKE_BINARY_DIR}/node_exporter
+      --process-exporter-dir ${CMAKE_BINARY_DIR}/process_exporter
       --debian-dir ${CMAKE_BINARY_DIR}/debian
       ${stripped_dist_pkg}
   DEPENDS
@@ -105,6 +127,7 @@ add_custom_command(
     ${CMAKE_BINARY_DIR}/$<CONFIG>/patchelf.stripped
     ${CMAKE_BINARY_DIR}/$<CONFIG>/iotune.stripped
     ${CMAKE_BINARY_DIR}/node_exporter/node_exporter.stripped
+    ${CMAKE_BINARY_DIR}/process_exporter/process-exporter.stripped
     ${CMAKE_BINARY_DIR}/debian
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_custom_target(dist-server-tar

--- a/dist/common/process_exporter/process-exporter.yml
+++ b/dist/common/process_exporter/process-exporter.yml
@@ -1,0 +1,5 @@
+process_names:
+  - name: "scylla"
+    cmdline:
+      # Match the main Scylla binary in common installs (system packages or tarballs)
+      - '(?:^|/)(scylla|scylla\.bin)(?:\s|$)'

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -106,7 +106,8 @@ def interactive_choose_swap_size():
 
 pkg_files = {
         f'{PRODUCT}-tools': scylladir_p() / 'share/cassandra/bin/cqlsh',
-        f'{PRODUCT}-node-exporter': scylladir_p() / 'node_exporter/node_exporter'
+        f'{PRODUCT}-node-exporter': scylladir_p() / 'node_exporter/node_exporter',
+        f'{PRODUCT}-process-exporter': scylladir_p() / 'dependencies/process-exporter'
         }
 def do_verify_package(pkg):
     if is_offline():
@@ -178,6 +179,7 @@ if __name__ == '__main__':
 
     default_no_ntp_setup = False
     default_no_node_exporter = False
+    default_no_process_exporter = False
     default_no_kernel_check = False
     default_no_raid_setup = False
     default_no_coredump_setup = False
@@ -261,6 +263,9 @@ if __name__ == '__main__':
     parser.add_argument('--no-node-exporter', action='store_true',
                         default=default_no_node_exporter,
                         help='do not enable the node exporter')
+    parser.add_argument('--no-process-exporter', action='store_true',
+                        default=default_no_process_exporter,
+                        help='do not enable the process exporter')
     parser.add_argument('--no-cpuscaling-setup', action='store_true',
                         default=default_no_cpuscaling_setup,
                         help='skip cpu scaling setup')
@@ -313,6 +318,7 @@ if __name__ == '__main__':
     io_setup = args.io_setup
     version_check = not args.no_version_check
     node_exporter = not args.no_node_exporter
+    process_exporter = not args.no_process_exporter
     cpuscaling_setup = not args.no_cpuscaling_setup
     fstrim_setup = not args.no_fstrim_setup
     memory_setup = not args.no_memory_setup
@@ -500,6 +506,14 @@ if __name__ == '__main__':
         node_exporter_unit = systemd_unit('scylla-node-exporter')
         node_exporter_unit.enable()
         node_exporter_unit.start()
+
+    if do_verify_package(f'{PRODUCT}-process-exporter'):
+        process_exporter = interactive_ask_service('Do you want to enable process exporter to export Prometheus data about running processes?', 'Yes - enable process exporter. No - skip this step.', process_exporter)
+    args.no_process_exporter = not process_exporter
+    if process_exporter:
+        process_exporter_unit = systemd_unit('scylla-process-exporter')
+        process_exporter_unit.enable()
+        process_exporter_unit.start()
 
     if args.developer_mode:
         run_setup_script('developer mode', 'scylla_dev_mode_setup --developer-mode 1')

--- a/dist/common/supervisor/scylla-process-exporter.sh
+++ b/dist/common/supervisor/scylla-process-exporter.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. "$(dirname -- "$0")/scylla_util.sh"
+
+# scylladir is defined by scylla_util.sh
+# shellcheck disable=SC2154
+exec "$scylladir"/dependencies/process-exporter -config.path "$scylladir"/dependencies/process-exporter.yml

--- a/dist/common/systemd/scylla-process-exporter.service
+++ b/dist/common/systemd/scylla-process-exporter.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Prometheus exporter for process metrics
+
+[Service]
+Type=simple
+User=scylla
+Group=scylla
+ExecStart=/opt/scylladb/dependencies/process-exporter -config.path /opt/scylladb/dependencies/process-exporter.yml
+ExecReload=/bin/kill -HUP $MAINPID
+TimeoutStopSec=20
+SendSIGKILL=no
+Restart=always
+Slice=scylla-helper.slice
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -54,12 +54,18 @@ Breaks: scylla-enterprise-node-exporter (<< 2025.1.0~)
 Description: Prometheus exporter for machine metrics
  Prometheus exporter for machine metrics, written in Go with pluggable metric collectors.
 
+Package: %{product}-process-exporter
+Architecture: any
+Description: Prometheus exporter for process metrics
+ Prometheus exporter exposing process and thread metrics for processes matching a given name and/or regex.
+
 Package: %{product}
 Section: metapackages
 Architecture: any
 Depends: %{product}-server (= ${binary:Version})
  , %{product}-kernel-conf (= ${binary:Version})
  , %{product}-node-exporter (= ${binary:Version})
+ , %{product}-process-exporter (= ${binary:Version})
  , %{product}-cqlsh (= ${binary:Version})
 Replaces: scylla-enterprise (<< 2025.1.0~)
 Breaks: scylla-enterprise (<< 2025.1.0~)

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -31,6 +31,7 @@ ifeq ($(product),scylla)
 else
 	dh_installinit --no-start --name scylla-server
 	dh_installinit --no-start --name scylla-node-exporter
+	dh_installinit --no-start --name scylla-process-exporter
 endif
 	dh_installinit --no-start --name scylla-housekeeping-daily
 	dh_installinit --no-start --name scylla-housekeeping-restart

--- a/dist/debian/debian/scylla-process-exporter.install
+++ b/dist/debian/debian/scylla-process-exporter.install
@@ -1,0 +1,2 @@
+opt/scylladb/dependencies/process-exporter
+opt/scylladb/dependencies/process-exporter.yml

--- a/dist/debian/debian/scylla-process-exporter.postinst
+++ b/dist/debian/debian/scylla-process-exporter.postinst
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
+fi
+
+#DEBHELPER#

--- a/dist/debian/debian/scylla-process-exporter.postrm
+++ b/dist/debian/debian/scylla-process-exporter.postrm
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -d /run/systemd/system ]; then
+    systemctl --system daemon-reload >/dev/null || true
+fi
+
+ #DEBHELPER#

--- a/dist/debian/debian/scylla-process-exporter.service
+++ b/dist/debian/debian/scylla-process-exporter.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Prometheus exporter for process metrics
+
+[Service]
+Type=simple
+User=scylla
+Group=scylla
+ExecStart=/opt/scylladb/dependencies/process-exporter -config.path /opt/scylladb/dependencies/process-exporter.yml
+ExecReload=/bin/kill -HUP $MAINPID
+TimeoutStopSec=20
+SendSIGKILL=no
+Restart=always
+Slice=scylla-helper.slice
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/docker/etc/supervisord.conf.d/scylla-process-exporter.conf
+++ b/dist/docker/etc/supervisord.conf.d/scylla-process-exporter.conf
@@ -1,0 +1,6 @@
+[program:scylla-process-exporter]
+command=/opt/scylladb/supervisor/scylla-process-exporter.sh
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/dist/docker/redhat/build_docker.sh
+++ b/dist/docker/redhat/build_docker.sh
@@ -78,6 +78,7 @@ packages=(
     "build/dist/$config/redhat/RPMS/$arch/$product-conf-$version-$release.$arch.rpm"
     "build/dist/$config/redhat/RPMS/$arch/$product-kernel-conf-$version-$release.$arch.rpm"
     "build/dist/$config/redhat/RPMS/$arch/$product-node-exporter-$version-$release.$arch.rpm"
+    "build/dist/$config/redhat/RPMS/$arch/$product-process-exporter-$version-$release.$arch.rpm"
     "tools/cqlsh/build/redhat/RPMS/$arch/$product-cqlsh-$version-$release.$arch.rpm"
     "tools/python3/build/redhat/RPMS/$arch/$product-python3-$version-$release.$arch.rpm"
 )
@@ -115,6 +116,7 @@ run mkdir -p /opt/scylladb/supervisor
 run touch /opt/scylladb/SCYLLA-CONTAINER-FILE
 bcp dist/common/supervisor/scylla-server.sh /opt/scylladb/supervisor/scylla-server.sh
 bcp dist/common/supervisor/scylla-node-exporter.sh /opt/scylladb/supervisor/scylla-node-exporter.sh
+bcp dist/common/supervisor/scylla-process-exporter.sh /opt/scylladb/supervisor/scylla-process-exporter.sh
 bcp dist/common/supervisor/scylla_util.sh /opt/scylladb/supervisor/scylla_util.sh
 
 # XXX: This is required to run setup scripts in root-mode with non-root user

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -12,6 +12,7 @@ Requires:       %{product}-conf = %{version}-%{release}
 Requires:       %{product}-python3 = %{version}-%{release}
 Requires:       %{product}-kernel-conf = %{version}-%{release}
 Requires:       %{product}-node-exporter = %{version}-%{release}
+Requires:       %{product}-process-exporter = %{version}-%{release}
 Requires:       %{product}-cqlsh = %{version}-%{release}
 Provides:       scylla-enterprise = %{version}-%{release}
 Obsoletes:      scylla-enterprise < 2025.1.0
@@ -39,7 +40,7 @@ Obsoletes:      scylla-enterprise < 2025.1.0
 Scylla is a highly scalable, eventually consistent, distributed,
 partitioned row DB.
 This package installs all required packages for ScyllaDB,  including
-%{product}-server, %{product}-node-exporter.
+%{product}-server, %{product}-node-exporter, %{product}-process-exporter.
 
 # this is needed to prevent python compilation error on CentOS (#2235)
 %if 0%{?rhel}
@@ -256,6 +257,35 @@ fi
 /opt/scylladb/node_exporter/licenses/LICENSE
 /opt/scylladb/node_exporter/licenses/NOTICE
 /etc/systemd/system/scylla-node-exporter.service.d/dependencies.conf
+
+%package process-exporter
+Group:          Applications/Databases
+Summary:        Prometheus exporter for process metrics
+License:        MIT
+URL:            https://github.com/ncabatoff/process-exporter
+
+%description process-exporter
+Prometheus exporter exposing process and thread metrics for processes matching a given name and/or regex.
+
+%post process-exporter
+if [ $1 -eq 1 ] ; then
+    /usr/bin/systemctl preset scylla-process-exporter.service ||:
+fi
+
+%preun process-exporter
+if [ $1 -eq 0 ] ; then
+    /usr/bin/systemctl --no-reload disable scylla-process-exporter.service ||:
+    /usr/bin/systemctl stop scylla-process-exporter.service ||:
+fi
+
+%postun process-exporter
+/usr/bin/systemctl daemon-reload ||:
+
+%files process-exporter
+%defattr(-,root,root)
+%{_unitdir}/scylla-process-exporter.service
+/opt/scylladb/dependencies/process-exporter
+/opt/scylladb/dependencies/process-exporter.yml
 
 %changelog
 * Tue Jul 21 2015 Takuya ASADA <syuu@cloudius-systems.com>

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -331,6 +331,29 @@ node_exporter_url() {
     echo "https://github.com/prometheus/node_exporter/releases/download/v$NODE_EXPORTER_VERSION/$(node_exporter_filename)"
 }
 
+PROCESS_EXPORTER_VERSION=0.8.7
+declare -A PROCESS_EXPORTER_CHECKSUM=(
+    ["x86_64"]=6d274cca5e94c6a25e55ec05762a472561859ce0a05b984aaedb67dd857ceee2
+    ["aarch64"]=4a2502f290323e57eeeb070fc10e64047ad0cd838ae5a1b347868f75667b5ab0
+)
+PROCESS_EXPORTER_DIR=/opt/scylladb/dependencies
+
+process_exporter_filename() {
+    echo "process-exporter-$PROCESS_EXPORTER_VERSION.linux-$(go_arch).tar.gz"
+}
+
+process_exporter_fullpath() {
+    echo "$PROCESS_EXPORTER_DIR/$(process_exporter_filename)"
+}
+
+process_exporter_checksum() {
+    sha256sum "$(process_exporter_fullpath)" | while read -r sum _; do [[ "$sum" == "${PROCESS_EXPORTER_CHECKSUM["$(arch)"]}" ]]; done
+}
+
+process_exporter_url() {
+    echo "https://github.com/ncabatoff/process-exporter/releases/download/v$PROCESS_EXPORTER_VERSION/$(process_exporter_filename)"
+}
+
 MINIO_BINARIES_DIR=/usr/local/bin
 
 minio_server_url() {
@@ -359,6 +382,7 @@ print_usage() {
     echo "  --print-pip-runtime-packages Print required pip packages for Scylla"
     echo "  --print-pip-symlinks Print list of pip provided commands which need to install to /usr/bin"
     echo "  --print-node-exporter-filename Print node_exporter filename"
+    echo "  --print-process-exporter-filename Print process_exporter filename"
     echo "  --future Install dependencies for future toolchain (Fedora rawhide based)"
     exit 1
 }
@@ -367,6 +391,7 @@ PRINT_PYTHON3=false
 PRINT_PIP=false
 PRINT_PIP_SYMLINK=false
 PRINT_NODE_EXPORTER=false
+PRINT_PROCESS_EXPORTER=false
 FUTURE=false
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -384,6 +409,10 @@ while [ $# -gt 0 ]; do
             ;;
         "--print-node-exporter-filename")
             PRINT_NODE_EXPORTER=true
+            shift 1
+            ;;
+        "--print-process-exporter-filename")
+            PRINT_PROCESS_EXPORTER=true
             shift 1
             ;;
         "--future")
@@ -417,6 +446,11 @@ fi
 
 if $PRINT_NODE_EXPORTER; then
     node_exporter_fullpath
+    exit 0
+fi
+
+if $PRINT_PROCESS_EXPORTER; then
+    process_exporter_fullpath
     exit 0
 fi
 
@@ -472,6 +506,17 @@ elif [ "$ID" = "fedora" ]; then
         curl -fSL -o "$(node_exporter_fullpath)" "$(node_exporter_url)"
         if ! node_exporter_checksum; then
             echo "$(node_exporter_filename) download failed"
+            exit 1
+        fi
+    fi
+
+    if [ -f "$(process_exporter_fullpath)" ] && process_exporter_checksum; then
+        echo "$(process_exporter_filename) already exists, skipping download"
+    else
+        mkdir -p "$PROCESS_EXPORTER_DIR"
+        curl -fSL -o "$(process_exporter_fullpath)" "$(process_exporter_url)"
+        if ! process_exporter_checksum; then
+            echo "$(process_exporter_filename) download failed"
             exit 1
         fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -418,6 +418,25 @@ EOS
     chmod 644 "$rsystemd"/scylla-node-exporter.service.d/nonroot.conf
 fi
 
+# scylla-process-exporter
+install -d -m755 "$rprefix"/dependencies
+install -m755 dependencies/process-exporter "$rprefix"/dependencies
+install -m644 dependencies/process-exporter.yml "$rprefix"/dependencies
+if ! $without_systemd; then
+    install -m644 dist/common/systemd/scylla-process-exporter.service -Dt "$rsystemd"
+fi
+if ! $nonroot && ! $without_systemd; then
+    : # no override needed; ExecStart path in the service file is absolute
+elif ! $without_systemd; then
+    install -d -m755 "$rsystemd"/scylla-process-exporter.service.d
+    cat << EOS > "$rsystemd"/scylla-process-exporter.service.d/nonroot.conf
+[Service]
+ExecStart=
+ExecStart=$rprefix/dependencies/process-exporter -config.path $rprefix/dependencies/process-exporter.yml
+EOS
+    chmod 644 "$rsystemd"/scylla-process-exporter.service.d/nonroot.conf
+fi
+
 # scylla-server
 install -m755 -d "$rprefix"
 install -m755 -d "$retc/scylla.d"
@@ -632,7 +651,7 @@ relocate_python3 "$rprefix"/scripts fix_system_distributed_tables.py
 
 if $supervisor; then
     install -d -m755 `supervisor_dir $retc`
-    for service in scylla-server scylla-jmx scylla-node-exporter; do
+    for service in scylla-server scylla-jmx scylla-node-exporter scylla-process-exporter; do
         if [ "$service" = "scylla-server" ]; then
             program="scylla"
         else

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -49,7 +49,7 @@ fi
 RELOC_PKG=$(readlink -f $RELOC_PKG)
 mkdir -p $BUILDDIR/
 RPMBUILD=$(readlink -f $BUILDDIR)
-tar -C $BUILDDIR/ -xpf $RELOC_PKG scylla/SCYLLA-RELOCATABLE-FILE scylla/SCYLLA-RELEASE-FILE scylla/SCYLLA-VERSION-FILE scylla/SCYLLA-PRODUCT-FILE scylla/dist/redhat
+tar -C $BUILDDIR/ -xpf $RELOC_PKG scylla/SCYLLA-RELOCATABLE-FILE scylla/SCYLLA-RELEASE-FILE scylla/SCYLLA-VERSION-FILE scylla/SCYLLA-PRODUCT-FILE scylla/dist/redhat scylla/dist/common
 cd $BUILDDIR/scylla
 
 RELOC_PKG_BASENAME=$(basename $RELOC_PKG)

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -125,6 +125,8 @@ ap.add_argument('--build-dir', default='build/release',
                 help='Build dir ("build/debug" or "build/release") to use')
 ap.add_argument('--node-exporter-dir', default='build/node_exporter',
                 help='the directory where node_exporter is located')
+ap.add_argument('--process-exporter-dir', default='build/process_exporter',
+                help='the directory where process_exporter is located')
 ap.add_argument('--debian-dir', default='build/debian/debian',
                 help='the directory where debian packaging is located')
 ap.add_argument('--stripped', action='store_true',
@@ -246,6 +248,12 @@ else:
     ar.reloc_add(f'{node_exporter_dir}/node_exporter', arcname='node_exporter/node_exporter')
 ar.reloc_add(f'{node_exporter_dir}/LICENSE', arcname='node_exporter/LICENSE')
 ar.reloc_add(f'{node_exporter_dir}/NOTICE', arcname='node_exporter/NOTICE')
+process_exporter_dir = args.process_exporter_dir
+if args.stripped:
+    ar.reloc_add(f'{process_exporter_dir}/process-exporter.stripped', arcname='dependencies/process-exporter')
+else:
+    ar.reloc_add(f'{process_exporter_dir}/process-exporter', arcname='dependencies/process-exporter')
+ar.reloc_add('dist/common/process_exporter/process-exporter.yml', arcname='dependencies/process-exporter.yml')
 ar.reloc_add('ubsan-suppressions.supp')
 ar.reloc_add('fix_system_distributed_tables.py')
 


### PR DESCRIPTION
Node exporter exports data for the whole node, but we're in many cases interested in data about individual processes, namely, the ScyllaDB daemon. There's [process exporter](https://github.com/ncabatoff/process-exporter) project that should help us with it.

This PR introduces process-exporter as a packaged Scylla component and wire it through install, setup, distro packaging, and build pipelines (including configure.py-generated Ninja rules used by dbuild).

Summary
- Add process-exporter service/runtime assets.
- Add process-exporter package metadata for Debian and RPM.
- Include process-exporter in relocatable/dist packaging.
- Fix dbuild path by generating process-exporter extraction/dependency rules from configure.py.
- Handle dbuild environment where process-exporter tarball may be missing.
- Avoid strip failure for process-exporter Go binary in generated Ninja rules.

Details

1) New process-exporter assets
- Added scylla-process-exporter.service
- Added scylla-process-exporter.sh
- Added scylla-process-exporter.conf
- Added process-exporter.yml

2) install-dependencies integration
- Added PROCESS_EXPORTER_VERSION=0.8.7
- Added checksums:
  - x86_64: 6d274cca5e94c6a25e55ec05762a472561859ce0a05b984aaedb67dd857ceee2
  - aarch64: 4a2502f290323e57eeeb070fc10e64047ad0cd838ae5a1b347868f75667b5ab0
- Added process-exporter filename/fullpath/url/checksum helpers.
- Added --print-process-exporter-filename option.
- Added Fedora download flow for process-exporter tarball.

3) Relocatable package content
- Updated scripts/create-relocatable-package.py:
  - Added --process-exporter-dir argument.
  - Added process-exporter binary to dependencies/process-exporter.
  - Added config file to dependencies/process-exporter.yml.

4) Installer and setup flow
- Updated install.sh:
  - Install process-exporter binary and config under /opt/scylladb/dependencies.
  - Install scylla-process-exporter systemd unit.
  - Add nonroot systemd override handling.
  - Include scylla-process-exporter in supervisor setup loop.
- Updated dist/common/scripts/scylla_setup:
  - Add package verification entry for process-exporter.
  - Add --no-process-exporter flag.
  - Add interactive prompt to enable/start process-exporter service.

5) Debian packaging
- Added scylla-process-exporter.install
- Updated dist/debian/debian/rules (dh_installinit for scylla-process-exporter)
- Updated dist/debian/control.template:
  - New %{product}-process-exporter package stanza.
  - Added %{product}-process-exporter to main metapackage Depends.

6) RPM packaging
- Updated dist/redhat/scylla.spec:
  - Added %{product}-process-exporter as dependency in main package.
  - Added %package process-exporter, description, lifecycle scripts, and files list.

7) Docker packaging
- Updated dist/docker/redhat/build_docker.sh:
  - Include process-exporter RPM in package list.
  - Copy scylla-process-exporter supervisor script into image.

8) Build system integration
- Updated CMakeLists.txt to include process-exporter in dist packaging path.
- Updated configure.py (critical for dbuild/ninja path):
  - Pass --process-exporter-dir to package and stripped_package rules.
  - Add process-exporter artifacts as dependencies of dist tar targets.
  - Generate extract_process_exporter rule in build.ninja.
  - Add fallback download in extract rule when tarball is missing in dbuild environment.
  - Use copy rule for process-exporter.stripped to avoid strip.sh failure on this Go binary.

Fixes #20016

**New Functionality, no need to backport**