### PR TITLE
pgo: use maintenance socket for CQL setup in PGO training

### DIFF
--- a/pgo/exec_cql.py
+++ b/pgo/exec_cql.py
@@ -8,9 +8,10 @@
 
 """exec_cql.py
 Execute CQL statements from a file where each non-empty, non-comment line is exactly one CQL statement.
+Connects via a Unix domain socket (maintenance socket), bypassing authentication.
 Requires python cassandra-driver. Stops at first failure.
 Usage:
-  ./exec_cql.py --file ./conf/auth.cql [--host 127.0.0.1 --port 9042]
+  ./exec_cql.py --file ./conf/auth.cql --socket /path/to/cql.m
 """
 import argparse, os, sys
 from typing import Sequence
@@ -26,18 +27,27 @@ def read_statements(path: str) -> list[tuple[int, str]]:
                 stms.append((lineno, line))
     return stms
 
-def exec_driver(statements: list[tuple[int, str]], host: str, port: int, timeout: float, username: str, password: str) -> int:
+def exec_statements(statements: list[tuple[int, str]], socket_path: str, timeout: float) -> int:
+    """Execute CQL statements via a Unix domain socket (maintenance socket).
+
+    The maintenance socket only starts listening after the auth subsystem is
+    fully initialised, so a successful connect means the node is ready.
+    """
+    from cassandra.cluster import Cluster
+    from cassandra.connection import UnixSocketEndPoint  # type: ignore
+    from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
+
+    ep = UnixSocketEndPoint(socket_path)
     try:
-        from cassandra.cluster import Cluster
-        from cassandra.auth import PlainTextAuthProvider  # type: ignore
-    except Exception:
-        print('ERROR: cassandra-driver not installed. Install with: pip install cassandra-driver', file=sys.stderr)
+        cluster = Cluster(
+            contact_points=[ep],
+            load_balancing_policy=WhiteListRoundRobinPolicy([ep]),
+        )
+        session = cluster.connect()
+    except Exception as e:
+        print(f'ERROR: failed to connect to maintenance socket {socket_path}: {e}', file=sys.stderr)
         return 2
-    auth_provider = None
-    if username != "":
-        auth_provider = PlainTextAuthProvider(username=username, password=password)
-    cluster = Cluster([host], port=port, auth_provider=auth_provider)
-    session = cluster.connect()
+
     try:
         for _, (lineno, s) in enumerate(statements, 1):
             try:
@@ -50,13 +60,11 @@ def exec_driver(statements: list[tuple[int, str]], host: str, port: int, timeout
     return 0
 
 def main(argv: Sequence[str]) -> int:
-    ap = argparse.ArgumentParser(description='Execute one-line CQL statements from file (driver only)')
+    ap = argparse.ArgumentParser(description='Execute one-line CQL statements from file via maintenance socket')
     ap.add_argument('--file', required=True)
-    ap.add_argument('--host', default='127.0.0.1')
-    ap.add_argument('--port', type=int, default=9042)
+    ap.add_argument('--socket', required=True,
+                    help='Path to the Unix domain maintenance socket (<workdir>/cql.m)')
     ap.add_argument('--timeout', type=float, default=30.0)
-    ap.add_argument('--username', default='cassandra')
-    ap.add_argument('--password', default='cassandra')
     args = ap.parse_args(argv)
     if not os.path.isfile(args.file):
         print(f"File not found: {args.file}", file=sys.stderr)
@@ -65,7 +73,7 @@ def main(argv: Sequence[str]) -> int:
     if not stmts:
         print('No statements found', file=sys.stderr)
         return 1
-    rc = exec_driver(stmts, args.host, args.port, args.timeout, args.username, args.password)
+    rc = exec_statements(stmts, args.socket, args.timeout)
     if rc == 0:
         print('All statements executed successfully')
     return rc

--- a/pgo/pgo.py
+++ b/pgo/pgo.py
@@ -452,6 +452,28 @@ async def merge_profraw(directory: PathLike) -> None:
     if glob.glob(f"{directory}/*.profraw"):
         await bash(fr"llvm-profdata merge {q(directory)}/*.profraw -output {q(directory)}/prof.profdata")
 
+def maintenance_socket_path(cluster_workdir: PathLike, addr: str) -> str:
+    """Returns the absolute path of the maintenance socket for a given node.
+
+    With ``maintenance_socket: workdir`` in scylla.yaml the socket lives at
+    ``<node-workdir>/cql.m``, i.e. ``<cluster_workdir>/<addr>/cql.m``.
+    """
+    return os.path.realpath(f"{cluster_workdir}/{addr}/cql.m")
+
+async def setup_cassandra_user(workdir: PathLike, addr: str) -> None:
+    """Create the ``cassandra`` superuser via the maintenance socket.
+
+    The default cassandra superuser is no longer seeded automatically, but
+    ``cassandra-stress`` hardcodes ``user=cassandra password=cassandra``.
+    We create the role over the maintenance socket so that cassandra-stress
+    and other tools that rely on the default credentials keep working.
+    """
+    socket = maintenance_socket_path(workdir, addr)
+    stmt = "CREATE ROLE cassandra WITH PASSWORD = 'cassandra' AND SUPERUSER = true AND LOGIN = true;"
+    f = q(socket)
+    # Write the statement to a temp file and execute it via exec_cql.py.
+    await bash(fr"""tmpf=$(mktemp); echo {q(stmt)} > "$tmpf"; python3 ./exec_cql.py --file "$tmpf" --socket {f}; rc=$?; rm -f "$tmpf"; exit $rc""")
+
 async def get_bolt_opts(executable: PathLike) -> list[str]:
     """Returns the extra opts which have to be passed to a BOLT-instrumented Scylla
     to trigger a generation of a BOLT profile file.
@@ -557,8 +579,10 @@ def kw(**kwargs):
 
 @contextlib.asynccontextmanager
 async def with_cs_populate(executable: PathLike, workdir: PathLike) -> AsyncIterator[str]:
-    """Provides a Scylla cluster and waits for compactions to end before stopping it."""
+    """Provides a Scylla cluster, creates the cassandra superuser, and waits
+    for compactions to end before stopping it."""
     async with with_cluster(executable=executable, workdir=workdir) as (addrs, procs):
+        await setup_cassandra_user(workdir, addrs[0])
         yield addrs[0]
         async with asyncio.timeout(3600):
             # Should it also flush memtables?
@@ -667,9 +691,10 @@ populators["decommission_dataset"] = populate_decommission
 # AUTH CONNECTIONS STRESS ==================================================
 
 async def populate_auth_conns(executable: PathLike, workdir: PathLike) -> None:
-    # Create roles, table and permissions via CQL script.
+    # Create roles, table and permissions via CQL script over the maintenance socket.
     async with with_cs_populate(executable=executable, workdir=workdir) as server:
-        await bash(fr"python3 ./exec_cql.py --file conf/auth.cql --host {server}")
+        socket = maintenance_socket_path(workdir, server)
+        await bash(fr"python3 ./exec_cql.py --file conf/auth.cql --socket {q(socket)}")
 
 async def train_auth_conns(executable: PathLike, workdir: PathLike) -> None:
     # Repeatedly connect as the reader user and perform simple reads to stress
@@ -722,7 +747,8 @@ populators["si_dataset"] = populate_si
 
 async def populate_counters(executable: PathLike, workdir: PathLike) -> None:
     async with with_cs_populate(executable=executable, workdir=workdir) as server:
-        await bash(fr"python3 ./exec_cql.py --file conf/counters.cql --host {server}")
+        socket = maintenance_socket_path(workdir, server)
+        await bash(fr"python3 ./exec_cql.py --file conf/counters.cql --socket {q(socket)}")
         # Sleeps added in reaction to schema disagreement errors.
         # FIXME: get rid of this sleep and find a sane way to wait for schema
         # agreement.


### PR DESCRIPTION
The default 'cassandra' superuesr was removed from ScyllaDB, which
broke PGO training. exec_cql.py relied on username/password auth
('cassandra'/'cassandra') to execute setup CQL scripts like auth.cql
and counters.cql.

Switch exec_cql.py to connect via the Unix domain maintenance socket
instead. The maintenance socket bypasses authentication, no credentials
are needed.

Tested locally by running:
```bash
./configure.py --mode=release --pgo --use-profile=""
ninja
```

Changes:
- exec_cql.py: replace host/port/username/password arguments with a
  single --socket argument; add connect_maintenance_socket() with
  wait ready logic
- pgo.py: add maintenance_socket_path() helper; update
  populate_auth_conns() and populate_counters() to pass the socket
  path to exec_cql.py

Fixes [SCYLLADB-1070](https://scylladb.atlassian.net/browse/SCYLLADB-1070)

This is a bugfix for the latest code. No backport needed.

[SCYLLADB-1070]: https://scylladb.atlassian.net/browse/SCYLLADB-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ