### PR TITLE
cql3: fix DESCRIBE INDEX WITH INTERNALS name

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -743,7 +743,7 @@
                "parameters":[
                   {
                      "name":"tag",
-                     "description":"the tag given to the snapshot",
+                     "description":"The snapshot tag to delete. If omitted, all snapshots are removed.",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",
@@ -751,7 +751,7 @@
                   },
                   {
                      "name":"kn",
-                     "description":"Comma-separated keyspaces name that their snapshot will be deleted",
+                     "description":"Comma-separated list of keyspace names to delete snapshots from. If omitted, snapshots are deleted from all keyspaces.",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",
@@ -759,7 +759,7 @@
                   },
                   {
                      "name":"cf",
-                     "description":"an optional table name that its snapshot will be deleted",
+                     "description":"A table name used to filter which table's snapshots are deleted. If omitted or empty, snapshots for all tables are eligible. When provided together with 'kn', the table is looked up in each listed keyspace independently. For secondary indexes, the logical index name (e.g. 'myindex') can be used and is resolved automatically.",
                      "required":false,
                      "allowMultiple":false,
                      "type":"string",

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -2046,6 +2046,8 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
                 co_await snap_ctl.local().take_column_family_snapshot(keynames[0], column_families, tag, opts);
             }
             co_return json_void();
+        } catch (const data_dictionary::no_such_column_family& e) {
+            throw httpd::bad_param_exception(e.what());
         } catch (...) {
             apilog.error("take_snapshot failed: {}", std::current_exception());
             throw;
@@ -2082,6 +2084,8 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         try {
             co_await snap_ctl.local().clear_snapshot(tag, keynames, column_family);
             co_return json_void();
+        } catch (const data_dictionary::no_such_column_family& e) {
+            throw httpd::bad_param_exception(e.what());
         } catch (...) {
             apilog.error("del_snapshot failed: {}", std::current_exception());
             throw;

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -187,8 +187,26 @@ future<> snapshot_ctl::do_take_column_family_snapshot(sstring ks_name, std::vect
 }
 
 future<> snapshot_ctl::clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, sstring cf_name) {
-    return run_snapshot_modify_operation([this, tag = std::move(tag), keyspace_names = std::move(keyspace_names), cf_name = std::move(cf_name)] {
-        return _db.local().clear_snapshot(tag, keyspace_names, cf_name);
+    co_return co_await run_snapshot_modify_operation([this, tag = std::move(tag), keyspace_names = std::move(keyspace_names), cf_name = std::move(cf_name)] (this auto) -> future<> {
+        // clear_snapshot enumerates keyspace_names and uses cf_name as a
+        // filter in each. When cf_name needs resolution (e.g. logical index
+        // name -> backing table name), the result may differ per keyspace,
+        // so resolve and clear individually.
+        if (!cf_name.empty() && !keyspace_names.empty()) {
+            std::vector<std::pair<sstring, sstring>> resolved_targets;
+            resolved_targets.reserve(keyspace_names.size());
+
+            // Resolve every keyspace first so a later failure doesn't delete
+            // snapshots that were already matched in earlier keyspaces.
+            for (const auto& ks_name : keyspace_names) {
+                resolved_targets.emplace_back(ks_name, resolve_table_name(ks_name, cf_name));
+            }
+            for (auto& [ks_name, resolved_cf_name] : resolved_targets) {
+                co_await _db.local().clear_snapshot(tag, {ks_name}, std::move(resolved_cf_name));
+            }
+            co_return;
+        }
+        co_await _db.local().clear_snapshot(std::move(tag), std::move(keyspace_names), cf_name);
     });
 }
 

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -22,6 +22,7 @@
 #include "index/secondary_index_manager.hh"
 #include "replica/database.hh"
 #include "replica/global_table_ptr.hh"
+#include "replica/schema_describe_helper.hh"
 #include "sstables/sstables_manager.hh"
 #include "service/storage_proxy.hh"
 
@@ -196,7 +197,26 @@ snapshot_ctl::get_snapshot_details() {
     using snapshot_map = std::unordered_map<sstring, db_snapshot_details>;
 
     co_return co_await run_snapshot_list_operation(coroutine::lambda([this] () -> future<snapshot_map> {
-        return _db.local().get_snapshot_details();
+        auto details = co_await _db.local().get_snapshot_details();
+
+        for (auto& [snapshot_name, snapshot_details] : details) {
+            for (auto& table : snapshot_details) {
+                auto schema = _db.local().as_data_dictionary().try_find_table(
+                        table.ks, table.cf);
+                if (!schema || !schema->schema()->is_view()) {
+                    continue;
+                }
+
+                auto helper = replica::make_schema_describe_helper(
+                        schema->schema(), _db.local().as_data_dictionary());
+                if (helper.type == schema_describe_helper::type::index) {
+                    table.cf = secondary_index::index_name_from_table_name(
+                            table.cf);
+                }
+            }
+        }
+
+        co_return details;
     }));
 }
 

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -18,6 +18,8 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "db/snapshot-ctl.hh"
 #include "db/snapshot/backup_task.hh"
+#include "db/schema_tables.hh"
+#include "index/secondary_index_manager.hh"
 #include "replica/database.hh"
 #include "replica/global_table_ptr.hh"
 #include "sstables/sstables_manager.hh"
@@ -154,7 +156,31 @@ future<> snapshot_ctl::do_take_cluster_column_family_snapshot(std::vector<sstrin
     );
 }
 
+sstring snapshot_ctl::resolve_table_name(const sstring& ks_name, const sstring& name) const {
+    try {
+        _db.local().find_uuid(ks_name, name);
+        return name;
+    } catch (const data_dictionary::no_such_column_family&) {
+        // The name may be a logical index name (e.g. "myindex").
+        // Only indexes with a backing view have a separate backing table
+        // that can be snapshotted. Custom indexes such as vector indexes
+        // do not, so keep rejecting them here rather than mapping them to
+        // a synthetic name.
+        auto schema = _db.local().find_indexed_table(ks_name, name);
+        if (schema) {
+            const auto& im = schema->all_indices().at(name);
+            if (db::schema_tables::view_should_exist(im)) {
+                return secondary_index::index_table_name(name);
+            }
+        }
+        throw;
+    }
+}
+
 future<> snapshot_ctl::do_take_column_family_snapshot(sstring ks_name, std::vector<sstring> tables, sstring tag, snapshot_options opts) {
+    for (auto& t : tables) {
+        t = resolve_table_name(ks_name, t);
+    }
     co_await check_snapshot_not_exist(ks_name, tag, tables);
     co_await replica::database::snapshot_tables_on_all_shards(_db, ks_name, std::move(tables), std::move(tag), opts);
 }

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -133,6 +133,12 @@ private:
 
     future<> check_snapshot_not_exist(sstring ks_name, sstring name, std::optional<std::vector<sstring>> filter = {});
 
+    // Resolve a user-provided table name that may be a logical index name
+    // (e.g. "myindex") to its backing column family name (e.g.
+    // "myindex_index"). Returns the name unchanged if it already
+    // matches a column family.
+    sstring resolve_table_name(const sstring& ks_name, const sstring& name) const;
+
     future<> run_snapshot_modify_operation(noncopyable_function<future<>()> &&);
 
     template <typename Func>

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1186,10 +1186,18 @@ cql3::description schema::describe(const schema_describe_helper& helper, cql3::d
         }
     });
 
+    // For indexes, cf_name() returns the backing materialized view's
+    // table name (e.g. "myindex_index"), not the logical index name
+    // (e.g. "myindex"). Derive the correct name so all callers get
+    // the user-facing index name.
+    sstring name = helper.type == schema_describe_helper::type::index
+            ? secondary_index::index_name_from_table_name(cf_name())
+            : cf_name();
+
     return cql3::description {
         .keyspace = ks_name(),
         .type = std::move(type),
-        .name = cf_name(),
+        .name = std::move(name),
         .create_statement = desc_opt == cql3::describe_option::NO_STMTS
                 ? std::nullopt
                 : std::make_optional(get_create_statement(helper, desc_opt == cql3::describe_option::STMTS_AND_INTERNALS))

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -1459,9 +1459,7 @@ def test_describe_secondary_index(cql, test_keyspace, scylla_only):
         assert result.type == "index"
 
         assert hasattr(result, "name")
-        # FIXME: This should be equal to `index_name` instead of the name of the underlying materialized view.
-        underlying_mv_name = f"{index_name}_index"
-        assert result.name == underlying_mv_name
+        assert result.name == index_name
 
         assert hasattr(result, "create_statement")
         assert result.create_statement == stmt

--- a/test/rest_api/rest_util.py
+++ b/test/rest_api/rest_util.py
@@ -16,6 +16,7 @@ def new_test_snapshot(rest_api, keyspaces=[], tables=[], tag=""):
     if not tag:
         tag = f"test_snapshot_{int(time.time() * 1000)}"
     params = { "tag": tag }
+    delete_params = []
     if type(keyspaces) is str:
         params["kn"] = keyspaces
     else:
@@ -23,15 +24,22 @@ def new_test_snapshot(rest_api, keyspaces=[], tables=[], tag=""):
     if tables:
         if type(tables) is str:
             params["cf"] = tables
+            delete_params.append(dict(params))
         else:
             params["cf"] = ",".join(tables)
+            # DELETE /storage_service/snapshots accepts a single table name.
+            # When the snapshot spans multiple tables, clean it up per table.
+            delete_params.extend([{**params, "cf": table} for table in tables])
+    else:
+        delete_params.append(dict(params))
     resp = rest_api.send("POST", "storage_service/snapshots", params)
     resp.raise_for_status()
     try:
         yield tag
     finally:
-        resp = rest_api.send("DELETE", "storage_service/snapshots", params)
-        resp.raise_for_status()
+        for delete_param in delete_params:
+            resp = rest_api.send("DELETE", "storage_service/snapshots", delete_param)
+            resp.raise_for_status()
 
 # Tries to inject an error via Scylla REST API. It only works in specific
 # build modes (dev, debug, sanitize), so this function will trigger a test

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -420,11 +420,11 @@ def test_storage_service_snapshot_mv_si(cql, this_dc, rest_api):
                     })
 
                 with new_secondary_index(cql, table, 'v', 'si') as si:
-                    named_index_desc = cql.execute(f"DESC INDEX {si}").one()
-                    with new_test_snapshot(rest_api, keyspace, named_index_desc.name) as snap:
+                    index_name = si.split('.')[1]
+                    with new_test_snapshot(rest_api, keyspace, index_name) as snap:
                         verify_snapshot_details(rest_api, {
                             'key': snap,
-                            'value': [{'ks': keyspace, 'cf': named_index_desc.name, 'total': 0, 'live': 0}]
+                            'value': [{'ks': keyspace, 'cf': index_name, 'total': 0, 'live': 0}]
                         })
 
                 ks, cf = table.split('.')

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -437,7 +437,140 @@ def test_storage_service_snapshot_mv_si(cql, this_dc, rest_api):
                         if data['key'] == snapshot:
                             assert len([v for v in data['value'] if not v['ks'].startswith('system')]) == 1
 
-# ...but not when the snapshot is automatic (pre-scrub).
+# Verify that deleting a snapshot works correctly when multiple keyspaces are
+# specified in a single DELETE request together with a table name filter.
+# The filter should keep its plain table-name meaning in each keyspace.
+def test_snapshot_delete_cf_multi_keyspace(cql, this_dc, rest_api):
+    ks_opts = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}"
+    with new_test_keyspace(cql, ks_opts) as ks1:
+        with new_test_keyspace(cql, ks_opts) as ks2:
+            # Use the same table name in both keyspaces so the cf filter
+            # matches in both when deleting.
+            cf = unique_name()
+            other_cf = unique_name()
+            cql.execute(f"CREATE TABLE {ks1}.{cf} (p int PRIMARY KEY, v text)")
+            cql.execute(f"CREATE TABLE {ks2}.{cf} (p int PRIMARY KEY, v text)")
+            cql.execute(f"CREATE TABLE {ks1}.{other_cf} (p int PRIMARY KEY, v text)")
+            tag = f"test_snapshot_{int(time.time() * 1000)}"
+
+            for ks in [ks1, ks2]:
+                resp = rest_api.send("POST", "storage_service/snapshots",
+                                     {"tag": tag, "kn": ks, "cf": cf})
+                resp.raise_for_status()
+            resp = rest_api.send("POST", "storage_service/snapshots",
+                                 {"tag": tag, "kn": ks1, "cf": other_cf})
+            resp.raise_for_status()
+
+            verify_snapshot_details(rest_api, {
+                'key': tag,
+                'value': [
+                    {'ks': ks1, 'cf': cf, 'total': 0, 'live': 0},
+                    {'ks': ks2, 'cf': cf, 'total': 0, 'live': 0},
+                    {'ks': ks1, 'cf': other_cf, 'total': 0, 'live': 0},
+                ]
+            })
+
+            # Delete using multiple keyspaces + table name filter.
+            resp = rest_api.send("DELETE", "storage_service/snapshots",
+                                 {"tag": tag, "kn": f"{ks1},{ks2}", "cf": cf})
+            resp.raise_for_status()
+
+            # Verify that only snapshots matching the requested cf were deleted.
+            verify_snapshot_details(rest_api, {
+                'key': tag,
+                'value': [
+                    {'ks': ks1, 'cf': other_cf, 'total': 0, 'live': 0},
+                ]
+            })
+
+
+# Verify that the same logical secondary-index name is resolved independently
+# in each keyspace during multi-keyspace snapshot deletion.
+def test_snapshot_delete_cf_multi_keyspace_secondary_index(cql, this_dc, rest_api):
+    ks_opts = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}"
+    with new_test_keyspace(cql, ks_opts) as ks1:
+        with new_test_keyspace(cql, ks_opts) as ks2:
+            schema = 'p int PRIMARY KEY, v text'
+            with new_test_table(cql, ks1, schema) as table1:
+                with new_test_table(cql, ks2, schema) as table2:
+                    with new_secondary_index(cql, table1, 'v', 'si'):
+                        with new_secondary_index(cql, table2, 'v', 'si'):
+                            tag = f"test_snapshot_{int(time.time() * 1000)}"
+
+                            for ks in [ks1, ks2]:
+                                resp = rest_api.send("POST", "storage_service/snapshots",
+                                                     {"tag": tag, "kn": ks, "cf": "si"})
+                                resp.raise_for_status()
+
+                            verify_snapshot_details(rest_api, {
+                                'key': tag,
+                                'value': [
+                                    {'ks': ks1, 'cf': 'si', 'total': 0, 'live': 0},
+                                    {'ks': ks2, 'cf': 'si', 'total': 0, 'live': 0},
+                                ]
+                            })
+
+                            resp = rest_api.send("DELETE", "storage_service/snapshots",
+                                                 {"tag": tag, "kn": f"{ks1},{ks2}", "cf": "si"})
+                            resp.raise_for_status()
+
+                            resp = rest_api.send("GET", "storage_service/snapshots")
+                            for data in resp.json():
+                                if data['key'] == tag:
+                                    remaining = [v for v in data['value'] if v['ks'] in (ks1, ks2)]
+                                    assert remaining == [], f"Expected no snapshots, got {remaining}"
+
+
+# Vector indexes do not have backing view tables, so snapshot requests that use
+# their logical names must be rejected as bad requests.
+def test_storage_service_snapshot_vector_index_rejected(cql, this_dc, rest_api, scylla_only, skip_without_tablets):
+    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
+        schema = 'p int PRIMARY KEY, v vector<float, 3>'
+        with new_test_table(cql, keyspace, schema) as table:
+            cql.execute(f"CREATE CUSTOM INDEX ann_idx ON {table}(v) USING 'vector_index'")
+            resp = rest_api.send("POST", "storage_service/snapshots",
+                                 {"tag": f"test_snapshot_{int(time.time() * 1000)}", "kn": keyspace, "cf": "ann_idx"})
+            assert resp.status_code == requests.codes.bad_request
+
+
+# Same for DELETE: a vector index name is not a snapshotable table filter.
+def test_snapshot_delete_cf_vector_index_rejected(cql, this_dc, rest_api, scylla_only, skip_without_tablets):
+    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
+        schema = 'p int PRIMARY KEY, v vector<float, 3>'
+        with new_test_table(cql, keyspace, schema) as table:
+            cql.execute(f"CREATE CUSTOM INDEX ann_idx ON {table}(v) USING 'vector_index'")
+            with new_test_snapshot(rest_api, keyspaces=keyspace) as tag:
+                resp = rest_api.send("DELETE", "storage_service/snapshots",
+                                     {"tag": tag, "kn": keyspace, "cf": "ann_idx"})
+                assert resp.status_code == requests.codes.bad_request
+
+
+# Verify that multi-keyspace deletion resolves every keyspace before deleting
+# anything. If one keyspace has a secondary index and another has a vector
+# index with the same logical name, the request must fail without deleting the
+# secondary-index snapshot.
+def test_snapshot_delete_cf_multi_keyspace_mixed_index_kinds_is_atomic(cql, this_dc, rest_api, scylla_only, skip_without_tablets):
+    ks_opts = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}"
+    with new_test_keyspace(cql, ks_opts) as ks_si:
+        with new_test_keyspace(cql, ks_opts) as ks_vector:
+            with new_test_table(cql, ks_si, 'p int PRIMARY KEY, v text') as table_si:
+                with new_test_table(cql, ks_vector, 'p int PRIMARY KEY, v vector<float, 3>') as table_vector:
+                    with new_secondary_index(cql, table_si, 'v', 'shared_idx'):
+                        cql.execute(f"CREATE CUSTOM INDEX shared_idx ON {table_vector}(v) USING 'vector_index'")
+                        tag = f"test_snapshot_{int(time.time() * 1000)}"
+
+                        with new_test_snapshot(rest_api, keyspaces=ks_si, tables='shared_idx', tag=tag):
+                            resp = rest_api.send("DELETE", "storage_service/snapshots",
+                                                 {"tag": tag, "kn": f"{ks_si},{ks_vector}", "cf": "shared_idx"})
+                            assert resp.status_code == requests.codes.bad_request
+
+                            verify_snapshot_details(rest_api, {
+                                'key': tag,
+                                'value': [{'ks': ks_si, 'cf': 'shared_idx', 'total': 0, 'live': 0}]
+                            })
+
+# Keyspace scrub takes an automatic pre-scrub snapshot, so it must still work
+# when the keyspace contains materialized views or secondary indexes.
 def test_materialized_view_pre_scrub_snapshot(cql, this_dc, rest_api):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
         schema = 'p int, v text, primary key (p)'


### PR DESCRIPTION
This series fixes two related inconsistencies around secondary-index
names.
1. `DESCRIBE INDEX ... WITH INTERNALS` returned the backing
   materialized-view name in the `name` column instead of the logical
   index name.
2. The snapshot REST API accepted backing table names for MV-backed
   secondary indexes, but not the logical index names exposed to users.

The snapshot side now resolves logical secondary-index names to backing
table names where applicable, reports logical index names in snapshot
details, rejects vector index names with HTTP 400, and keeps multi-keyspace
DELETE atomic by resolving all keyspaces before deleting anything.
The tests were also extended accordingly, and the snapshot test helper
was fixed to clean up multi-table snapshots using one DELETE per table.

Fixes: SCYLLADB-1122

Minor bugfix, no need to backport.