### PR TITLE
test: Lower default log level from DEBUG to INFO

### DIFF
--- a/test.py
+++ b/test.py
@@ -355,7 +355,6 @@ def run_pytest(options: argparse.Namespace) -> tuple[int, list[SimpleNamespace]]
         if 'debug' in options.modes:
             threads = int(threads * 0.5)
         args.extend([
-            "--log-level=DEBUG",  # Capture logs
             f'--junit-xml={junit_output_file}',
             "-rf",
             '--test-py-init',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,6 @@
 #
 
 import pytest
-
 from test import TEST_RUNNER
 from test.pylib.report_plugin import ReportPlugin
 

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -383,7 +383,7 @@ def pytest_runtest_makereport(item, call):
         rep = outcome.get_result()
         # we only look at actual failing test calls, not setup/teardown
         pytest_tests_logs = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
-        if rep.failed or _pytest_config.getoption("--save-log-on-success"):
+        if rep.failed or (_pytest_config.getoption("--save-log-on-success") and rep.when == "teardown"):
             mode = "a" if os.path.exists(pytest_tests_logs) else "w"
             with open(pytest_tests_logs/ f"{item._nodeid.replace("::", "-").replace("/", "-")}-{rep.when}-{HOST_ID}.log",mode) as f:
                 f.write(rep.longreprtext + "\n")

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -11,9 +11,13 @@ junit_log_passing_tests = False
 
 log_format = %(asctime)s.%(msecs)03d %(levelname)s>  %(message)s
 log_date_format = %H:%M:%S
-
 log_file_format = %(asctime)s.%(msecs)03d %(processName)s %(threadName)s %(taskName)s %(levelname)s %(name)s>  %(message)s
-log_file_level = DEBUG
+
+#Capture logs, folder pytest_tests_logs
+log_level=INFO
+
+#File logs, folder pytest_logs
+log_file_level = INFO
 
 markers =
     slow: tests that take more than 30 seconds to run


### PR DESCRIPTION
1. test.py — Removed --log-level=DEBUG flag from pytest args
2. test/pytest.ini — Changed log_level to INFO (that was set DEBUG in test.py), changed log_file_level from DEBUG to INFO, added clarifying comments

+minor fix 

[test/pylib: save logs on success only during teardown phase](https://github.com/scylladb/scylladb/pull/29086/changes/0ede308a041d7699257e272711a027ff4710e28f)
Previously, when --save-log-on-success was enabled, logs were saved
for every test phase (setup, call, teardown)in 3 files. Restrict it to only
the teardown phase, that contains all 3 in case of test success,
to avoid redundant log entries.

