### PR TITLE
test.py: use safe_drive_shutdown in the tests

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -16,6 +16,7 @@ import re
 
 from test.alternator.util import create_test_table, is_aws, scylla_log
 from test.cqlpy.conftest import host  # add required fixtures
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.runner import testpy_test_fixture_scope
 from test.pylib.suite.python import add_host_option
 from urllib.parse import urlparse
@@ -455,4 +456,4 @@ def cql(dynamodb):
     except NoHostAvailable:
         pytest.skip('Could not connect to Scylla-only CQL API')
     yield ret
-    cluster.shutdown()
+    safe_driver_shutdown(cluster)

--- a/test/cluster/auth_cluster/test_maintenance_socket.py
+++ b/test/cluster/auth_cluster/test_maintenance_socket.py
@@ -10,6 +10,7 @@ from cassandra import Unauthorized, InvalidRequest
 from cassandra.connection import UnixSocketEndPoint
 from cassandra.policies import WhiteListRoundRobinPolicy
 from test.cluster.conftest import cluster_con
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
 
@@ -29,7 +30,7 @@ def cql_clusters() -> Generator[CqlClusters, None, None]:
     clusters: CqlClusters = []
     yield clusters
     for c in reversed(clusters):
-        c.shutdown()
+        safe_driver_shutdown(c)
 
 
 async def get_ready_maintenance_session(socket_path: str, timeout: int = 60):

--- a/test/cluster/dtest/conftest.py
+++ b/test/cluster/dtest/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from test.cluster.dtest.dtest_config import DTestConfig
 from test.cluster.dtest.dtest_setup import DTestSetup
 from test.cluster.dtest.dtest_setup_overrides import DTestSetupOverrides
+from test.pylib.driver_utils import safe_driver_shutdown
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -97,7 +98,7 @@ def fixture_dtest_setup(request: FixtureRequest,
     dtest_setup.jvm_args = []
 
     for con in dtest_setup.connections:
-        con.cluster.shutdown()
+        safe_driver_shutdown(con.cluster)
     dtest_setup.connections = []
 
     try:


### PR DESCRIPTION
These methods for closing driver was missed during original fix done in https://github.com/scylladb/scylladb/pull/28957

Fixes: SCYLLADB-900

No backport, framework enhancement only.