### PR TITLE
doc: remove the instructions to install old versions from Web Installer

### DIFF
--- a/docs/getting-started/installation-common/scylla-web-installer.rst
+++ b/docs/getting-started/installation-common/scylla-web-installer.rst
@@ -36,11 +36,8 @@ release versions, run:
   curl -sSf get.scylladb.com/server | sudo bash -s -- --list-active-releases
 
 
-Versions 2025.1 and Later
-==============================
-
-Run the command with the ``--scylla-version`` option to specify the version
-you want to install.
+To install a non-default version, run the command with the ``--scylla-version``
+option to specify the version you want to install.
 
 **Example**
 
@@ -48,22 +45,6 @@ you want to install.
   :substitutions:
   
   curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version |CURRENT_VERSION|
-
-
-Versions Earlier than 2025.1
-================================
-
-To install a supported version of *ScyllaDB Enterprise*, run the command with:
-
-* ``--scylla-product scylla-enterprise`` to specify that you want to install
-  ScyllaDB Entrprise.
-* ``--scylla-version`` to specify the version you want to install.
-
-For example:
-
-.. code:: console
-  
-  curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-product scylla-enterprise --scylla-version 2024.1
 
 
 .. include:: /getting-started/_common/setup-after-install.rst


### PR DESCRIPTION
The Web Installer page includes instructions to install the old pre-2025.1 Enterprise versions, which are no longer supported (since we released 2026.1).
This PR removes those redundant and misleading instructions.

Fixes https://github.com/scylladb/scylladb/issues/29099

This fix should be backported to branch-2026.1, as it's relevant in version 2026.1 and later.