### PR TITLE
Remove upgrade view builder

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -355,35 +355,6 @@ static service::query_state& internal_distributed_query_state() {
     return qs;
 };
 
-future<> system_distributed_keyspace::start_view_build(sstring ks_name, sstring view_name) const {
-    auto host_id = _sp.local_db().get_token_metadata().get_my_id();
-    return _qp.execute_internal(
-            format("INSERT INTO {}.{} (keyspace_name, view_name, host_id, status) VALUES (?, ?, ?, ?)", NAME, VIEW_BUILD_STATUS),
-            db::consistency_level::ONE,
-            internal_distributed_query_state(),
-            { std::move(ks_name), std::move(view_name), host_id.uuid(), "STARTED" },
-            cql3::query_processor::cache_internal::no).discard_result();
-}
-
-future<> system_distributed_keyspace::finish_view_build(sstring ks_name, sstring view_name) const {
-    auto host_id = _sp.local_db().get_token_metadata().get_my_id();
-    return _qp.execute_internal(
-            format("UPDATE {}.{} SET status = ? WHERE keyspace_name = ? AND view_name = ? AND host_id = ?", NAME, VIEW_BUILD_STATUS),
-            db::consistency_level::ONE,
-            internal_distributed_query_state(),
-            { "SUCCESS", std::move(ks_name), std::move(view_name), host_id.uuid() },
-            cql3::query_processor::cache_internal::no).discard_result();
-}
-
-future<> system_distributed_keyspace::remove_view(sstring ks_name, sstring view_name) const {
-    return _qp.execute_internal(
-            format("DELETE FROM {}.{} WHERE keyspace_name = ? AND view_name = ?", NAME, VIEW_BUILD_STATUS),
-            db::consistency_level::ONE,
-            internal_distributed_query_state(),
-            { std::move(ks_name), std::move(view_name) },
-            cql3::query_processor::cache_internal::no).discard_result();
-}
-
 /* We want to make sure that writes/reads to/from CDC management-related distributed tables
  * are consistent: a read following an acknowledged write to the same partition should contact
  * at least one of the replicas that the write contacted.

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -87,11 +87,6 @@ public:
 
     bool started() const { return _started; }
 
-    future<std::unordered_map<locator::host_id, sstring>> view_status(sstring ks_name, sstring view_name) const;
-    future<> start_view_build(sstring ks_name, sstring view_name) const;
-    future<> finish_view_build(sstring ks_name, sstring view_name) const;
-    future<> remove_view(sstring ks_name, sstring view_name) const;
-
     future<> insert_cdc_generation(utils::UUID, const cdc::topology_description&, context);
     future<std::optional<cdc::topology_description>> read_cdc_generation(utils::UUID);
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2183,16 +2183,14 @@ future<> view_update_generator::mutate_MV(
     });
 }
 
-view_builder::view_builder(replica::database& db, db::system_keyspace& sys_ks, db::system_distributed_keyspace& sys_dist_ks, service::migration_notifier& mn, view_update_generator& vug, service::raft_group0_client& group0_client, cql3::query_processor& qp)
+view_builder::view_builder(replica::database& db, db::system_keyspace& sys_ks, service::migration_notifier& mn, view_update_generator& vug, service::raft_group0_client& group0_client, cql3::query_processor& qp)
         : _db(db)
         , _sys_ks(sys_ks)
-        , _sys_dist_ks(sys_dist_ks)
         , _group0_client(group0_client)
         , _qp(qp)
         , _mnotifier(mn)
         , _vug(vug)
         , _permit(_db.get_reader_concurrency_semaphore().make_tracking_only_permit(nullptr, "view_builder", db::no_timeout, {}))
-        , _upgrade_phaser("view_builder::upgrade_phaser")
 {
     setup_metrics();
 }
@@ -2559,44 +2557,23 @@ static future<> announce_with_raft(
 }
 
 future<> view_builder::mark_view_build_started(sstring ks_name, sstring view_name) {
-    co_await write_view_build_status(
-        [this, ks_name, view_name] () -> future<> {
-            auto host_id = _db.get_token_metadata().get_my_id();
-            co_await announce_with_raft(_qp, _group0_client, _as, [this, ks_name = std::move(ks_name), view_name = std::move(view_name), host_id] (auto ts) {
-                        return _sys_ks.make_view_build_status_mutation(ts, {ks_name, view_name}, host_id, build_status::STARTED);
-                    }, "view builder: mark view build STARTED");
-        },
-        [this, ks_name, view_name] () -> future<> {
-            co_await _sys_dist_ks.start_view_build(std::move(ks_name), std::move(view_name));
-        }
-    );
+    auto host_id = _db.get_token_metadata().get_my_id();
+    co_await announce_with_raft(_qp, _group0_client, _as, [this, ks_name = std::move(ks_name), view_name = std::move(view_name), host_id] (auto ts) {
+                return _sys_ks.make_view_build_status_mutation(ts, {ks_name, view_name}, host_id, build_status::STARTED);
+            }, "view builder: mark view build STARTED");
 }
 
 future<> view_builder::mark_view_build_success(sstring ks_name, sstring view_name) {
-    co_await write_view_build_status(
-        [this, ks_name, view_name] () -> future<> {
-            auto host_id = _db.get_token_metadata().get_my_id();
-            co_await announce_with_raft(_qp, _group0_client, _as, [this, ks_name = std::move(ks_name), view_name = std::move(view_name), host_id] (auto ts) {
-                        return _sys_ks.make_view_build_status_update_mutation(ts, {ks_name, view_name}, host_id, build_status::SUCCESS);
-                    }, "view builder: mark view build SUCCESS");
-        },
-        [this, ks_name, view_name] () -> future<> {
-            co_await _sys_dist_ks.finish_view_build(std::move(ks_name), std::move(view_name));
-        }
-    );
+    auto host_id = _db.get_token_metadata().get_my_id();
+    co_await announce_with_raft(_qp, _group0_client, _as, [this, ks_name = std::move(ks_name), view_name = std::move(view_name), host_id] (auto ts) {
+                return _sys_ks.make_view_build_status_update_mutation(ts, {ks_name, view_name}, host_id, build_status::SUCCESS);
+            }, "view builder: mark view build SUCCESS");
 }
 
 future<> view_builder::remove_view_build_status(sstring ks_name, sstring view_name) {
-    co_await write_view_build_status(
-        [this, ks_name, view_name] () -> future<> {
-            co_await announce_with_raft(_qp, _group0_client, _as, [this, ks_name = std::move(ks_name), view_name = std::move(view_name)] (auto ts) {
-                        return _sys_ks.make_remove_view_build_status_mutation(ts, {ks_name, view_name});
-                    }, "view builder: delete view build status");
-        },
-        [this, ks_name, view_name] () -> future<> {
-            co_await _sys_dist_ks.remove_view(std::move(ks_name), std::move(view_name));
-        }
-    );
+    co_await announce_with_raft(_qp, _group0_client, _as, [this, ks_name = std::move(ks_name), view_name = std::move(view_name)] (auto ts) {
+                return _sys_ks.make_remove_view_build_status_mutation(ts, {ks_name, view_name});
+            }, "view builder: delete view build status");
 }
 
 static future<std::unordered_map<locator::host_id, sstring>>
@@ -2618,13 +2595,8 @@ view_status_common(cql3::query_processor& qp, sstring ks_name, sstring cf_name, 
 }
 
 future<std::unordered_map<locator::host_id, sstring>> view_builder::view_status(sstring ks_name, sstring view_name) const {
-    if (_view_build_status_on == view_build_status_location::group0) {
-        co_return co_await view_status_common(_qp, db::system_keyspace::NAME, db::system_keyspace::VIEW_BUILD_STATUS_V2,
-                std::move(ks_name), std::move(view_name), db::consistency_level::LOCAL_ONE);
-    } else {
-        co_return co_await view_status_common(_qp, db::system_distributed_keyspace::NAME, db::system_distributed_keyspace::VIEW_BUILD_STATUS,
-                std::move(ks_name), std::move(view_name), db::consistency_level::ONE);
-    }
+    co_return co_await view_status_common(_qp, db::system_keyspace::NAME, db::system_keyspace::VIEW_BUILD_STATUS_V2,
+            std::move(ks_name), std::move(view_name), db::consistency_level::LOCAL_ONE);
 }
 
 future<std::unordered_map<sstring, sstring>>
@@ -2874,12 +2846,6 @@ future<> view_builder::generate_mutations_on_node_left(replica::database& db, db
     // When a node is removed, we delete all its rows from the view_build_status table together with
     // the topology update operation.
 
-    if (!db.features().view_build_status_on_group0) {
-        // We didn't upgrade to the v2 table yet. nothing to delete, and other nodes
-        // may not know about the v2 table.
-        co_return;
-    }
-
     auto& qp = sys_ks.query_processor();
     muts.reserve(muts.size() + db.get_views().size());
     // We expect the table to have a row for each existing view, so generate delete mutations for all views.
@@ -2892,142 +2858,7 @@ future<> view_builder::generate_mutations_on_node_left(replica::database& db, db
     }
 }
 
-future<> view_builder::migrate_to_v1_5(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard) {
-    // Update the view builder version to v1_5
-    auto version_mut = co_await sys_ks.make_view_builder_version_mutation(guard.write_timestamp(), db::system_keyspace::view_builder_version_t::v1_5);
-
-    // write the version as topology_change so that we can apply
-    // the change to the view_builder service in topology_state_load
-    service::topology_change change {
-        .mutations{canonical_mutation(std::move(version_mut))},
-    };
-
-    auto group0_cmd = group0_client.prepare_command(std::move(change), guard, "migrate view_build_status to v1_5");
-    co_await group0_client.add_entry(std::move(group0_cmd), std::move(guard), as);
-}
-
-future<> view_builder::migrate_to_v2(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard) {
-    inject_failure("view_builder_migrate_to_v2");
-
-    auto schema = qp.db().find_schema(db::system_distributed_keyspace::NAME, db::system_distributed_keyspace::VIEW_BUILD_STATUS);
-
-    // `system_distributed` keyspace has RF=3 and we need to scan it with CL=ALL
-    // To support migration on cluster with 1 or 2 nodes, set appropriate CL
-    auto nodes_count = tmptr->get_normal_token_owners().size();
-    auto cl = db::consistency_level::ALL;
-    if (nodes_count == 1) {
-        cl = db::consistency_level::ONE;
-    } else if (nodes_count == 2) {
-        cl = db::consistency_level::TWO;
-    }
-
-    auto rows = co_await qp.execute_internal(
-        format("SELECT keyspace_name, view_name, host_id, status, WRITETIME(status) AS ts FROM {}.{}", db::system_distributed_keyspace::NAME, db::system_distributed_keyspace::VIEW_BUILD_STATUS),
-        cl,
-        view_builder_query_state(),
-        {},
-        cql3::query_processor::cache_internal::no);
-
-    auto col_names = schema->all_columns() | std::views::transform([] (const auto& col) {return col.name_as_cql_string(); }) | std::ranges::to<std::vector<sstring>>();
-    auto col_names_str = fmt::to_string(fmt::join(col_names, ", "));
-    sstring val_binders_str = "?";
-    for (size_t i = 1; i < col_names.size(); ++i) {
-        val_binders_str += ", ?";
-    }
-
-    utils::chunked_vector<mutation> migration_muts;
-    migration_muts.reserve(rows->size() + 1);
-
-    // Insert all valid rows into the new table.
-    // Note the tables have the same schema.
-    for (const auto& row: *rows) {
-        // Skip adding the row if it doesn't belong to a known node.
-        // In the v1 table we may have left over rows that belong to nodes that were removed
-        // and we didn't clean them, so do that now.
-        auto host_id = row.get_as<utils::UUID>("host_id");
-        if (!tmptr->get_topology().find_node(locator::host_id(host_id))) {
-            vlogger.warn("Dropping a row from view_build_status: host {} does not exist", host_id);
-            continue;
-        }
-
-        // Skip adding left over rows that don't belong to known views.
-        auto ks_name = row.get_as<sstring>("keyspace_name");
-        auto view_name = row.get_as<sstring>("view_name");
-        if (!sys_ks.local_db().has_schema(ks_name, view_name)) {
-            vlogger.warn("Dropping a row from view_build_status: view {}.{} does not exist", ks_name, view_name);
-            continue;
-        }
-
-        std::vector<data_value_or_unset> values;
-        for (const auto& col: schema->all_columns()) {
-            if (row.has(col.name_as_text())) {
-                values.push_back(col.type->deserialize(row.get_blob_unfragmented(col.name_as_text())));
-            } else {
-                values.push_back(unset_value{});
-            }
-        }
-
-        // keep the row timestamp so it won't overwrite newer writes
-        auto row_ts = row.get_as<api::timestamp_type>("ts");
-
-        auto muts = co_await qp.get_mutations_internal(
-            seastar::format("INSERT INTO {}.{} ({}) VALUES ({})",
-                db::system_keyspace::NAME,
-                db::system_keyspace::VIEW_BUILD_STATUS_V2,
-                col_names_str,
-                val_binders_str),
-            view_builder_query_state(),
-            row_ts,
-            std::move(values));
-        if (muts.size() != 1) {
-            on_internal_error(vlogger, format("expecting single insert mutation, got {}", muts.size()));
-        }
-        migration_muts.push_back(std::move(muts[0]));
-    }
-
-    // Update the view builder version to v2
-    auto version_mut = co_await sys_ks.make_view_builder_version_mutation(guard.write_timestamp(), db::system_keyspace::view_builder_version_t::v2);
-    migration_muts.push_back(std::move(version_mut));
-
-    // write the version as topology_change so that we can apply
-    // the change to the view_builder service in topology_state_load
-    service::topology_change change {
-        .mutations{migration_muts.begin(), migration_muts.end()},
-    };
-
-    auto group0_cmd = group0_client.prepare_command(std::move(change), guard, "migrate view_build_status to v2");
-    co_await group0_client.add_entry(std::move(group0_cmd), std::move(guard), as);
-}
-
-future<> view_builder::upgrade_to_v1_5() {
-    if (_view_build_status_on == view_build_status_location::sys_dist_ks) {
-        // drain all write operations to the old table and start writing to both tables.
-        // note that we wait here only for operations that access the dist table and not group0, otherwise
-        // we get a deadlock.
-        _view_build_status_on = view_build_status_location::both;
-        co_await _upgrade_phaser.advance_and_await();
-    }
-}
-
-future<> view_builder::upgrade_to_v2() {
-    if (_view_build_status_on == view_build_status_location::group0) {
-        co_return;
-    }
-
-    _view_build_status_on = view_build_status_location::group0;
-
-    if (_init_virtual_table_on_upgrade) {
-        init_virtual_table();
-    }
-}
-
 void view_builder::init_virtual_table() {
-    if (_view_build_status_on != view_build_status_location::group0) {
-        // we didn't upgrade to v2 yet. defer the operation
-        _init_virtual_table_on_upgrade = true;
-        return;
-    }
-
     // We set the old system_distributed.view_build_status table to read virtually
     // from system.view_build_status_v2 in order to make the transition transparent for
     // readers of the table and maintain compatibility.

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -30,7 +30,6 @@
 namespace db {
 
 class system_keyspace;
-class system_distributed_keyspace;
 
 }
 
@@ -167,7 +166,6 @@ class view_builder final : public service::migration_listener::only_view_notific
 
     replica::database& _db;
     db::system_keyspace& _sys_ks;
-    db::system_distributed_keyspace& _sys_dist_ks;
     service::raft_group0_client& _group0_client;
     cql3::query_processor& _qp;
     service::migration_notifier& _mnotifier;
@@ -201,12 +199,6 @@ class view_builder final : public service::migration_listener::only_view_notific
     stats _stats;
     metrics::metric_groups _metrics;
 
-    enum class view_build_status_location { sys_dist_ks, group0, both };
-
-    view_build_status_location _view_build_status_on = view_build_status_location::sys_dist_ks;
-    bool _init_virtual_table_on_upgrade = false;
-    utils::phased_barrier _upgrade_phaser;
-
     struct view_builder_init_state {
         std::vector<future<>> bookkeeping_ops;
         std::vector<std::vector<view_build_init_status>> status_per_shard;
@@ -227,7 +219,7 @@ public:
     db::system_keyspace& get_sys_ks() noexcept { return _sys_ks; }
 
 public:
-    view_builder(replica::database&, db::system_keyspace&, db::system_distributed_keyspace&, service::migration_notifier&, view_update_generator& vug,
+    view_builder(replica::database&, db::system_keyspace&, service::migration_notifier&, view_update_generator& vug,
             service::raft_group0_client& group0_client, cql3::query_processor& qp);
     view_builder(view_builder&&) = delete;
 
@@ -250,14 +242,6 @@ public:
 
     static future<> generate_mutations_on_node_left(replica::database& db, db::system_keyspace& sys_ks, api::timestamp_type timestamp, locator::host_id host_id, utils::chunked_vector<canonical_mutation>& muts);
 
-    static future<> migrate_to_v1_5(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard);
-    static future<> migrate_to_v2(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard);
-
-    future<> upgrade_to_v1_5();
-    future<> upgrade_to_v2();
-
-    void init_virtual_table();
-
     virtual void on_create_view(const sstring& ks_name, const sstring& view_name) override;
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override;
     virtual void on_drop_view(const sstring& ks_name, const sstring& view_name) override;
@@ -271,6 +255,7 @@ public:
     future<> mark_existing_views_as_built();
     future<bool> check_view_build_ongoing(const locator::token_metadata& tm, const sstring& ks_name, const sstring& cf_name);
     future<> register_staging_sstable(sstables::shared_sstable sst, lw_shared_ptr<replica::table> table);
+    void init_virtual_table();
 
 private:
     build_step& get_or_create_build_step(table_id);
@@ -293,22 +278,6 @@ private:
     future<> handle_drop_view_local(const sstring& ks_name, const sstring& view_name, view_builder_units_opt units);
     future<> handle_drop_view_global_cleanup(const sstring& ks_name, const sstring& view_name);
     future<view_builder_units> get_or_adopt_view_builder_lock(view_builder_units_opt units);
-
-    template <typename Func1, typename Func2>
-    future<> write_view_build_status(Func1&& fn_group0, Func2&& fn_sys_dist) {
-        auto op = _upgrade_phaser.start();
-
-        // read locally so it doesn't change between async calls
-        const auto v = _view_build_status_on;
-
-        if (v == view_build_status_location::group0 || v == view_build_status_location::both) {
-            co_await fn_group0();
-        }
-
-        if (v == view_build_status_location::sys_dist_ks || v == view_build_status_location::both) {
-            co_await fn_sys_dist();
-        }
-    }
 
     future<> mark_view_build_started(sstring ks_name, sstring view_name);
     future<> mark_view_build_success(sstring ks_name, sstring view_name);

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -107,6 +107,7 @@ std::set<std::string_view> feature_service::supported_feature_set() const {
         "CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX"sv,
         "UUID_SSTABLE_IDENTIFIERS"sv,
         "GROUP0_SCHEMA_VERSIONING"sv,
+        "VIEW_BUILD_STATUS_ON_GROUP0"sv,
     };
 
     if (is_test_only_feature_deprecated()) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -121,7 +121,6 @@ public:
     gms::feature topology_requests_type_column { *this, "TOPOLOGY_REQUESTS_TYPE_COLUMN"sv };
     gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
     gms::feature zero_token_nodes { *this, "ZERO_TOKEN_NODES"sv };
-    gms::feature view_build_status_on_group0 { *this, "VIEW_BUILD_STATUS_ON_GROUP0"sv };
     gms::feature views_with_tablets { *this, "VIEWS_WITH_TABLETS"sv };
     gms::feature group0_limited_voters { *this, "GROUP0_LIMITED_VOTERS"sv };
     gms::feature compaction_history_upgrade { *this, "COMPACTION_HISTORY_UPGRADE"};

--- a/main.cc
+++ b/main.cc
@@ -1488,6 +1488,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                         "Cannot start - cluster is not yet upgraded to use service levels v2 and this version does not support legacy service levels. "
                         "If you are trying to upgrade the node then first upgrade the cluster to use service levels v2.");
                 }
+                if (sys_ks.local().get_view_builder_version().get() != db::system_keyspace::view_builder_version_t::v2) {
+                    throw std::runtime_error(
+                        "Cannot start - view builder has not been migrated to v2 and this version does not support legacy view builder. "
+                        "If you are trying to upgrade the node then first upgrade the cluster to use view builder v2.");
+                }
             }
 
             const auto listen_address = utils::resolve(cfg->listen_address, family).get();
@@ -1796,7 +1801,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             checkpoint(stop_signal, "starting the view builder");
-            view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notifier), std::ref(view_update_generator), std::ref(group0_client), std::ref(qp)).get();
+            view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(mm_notifier), std::ref(view_update_generator), std::ref(group0_client), std::ref(qp)).get();
             auto stop_view_builder = defer_verbose_shutdown("view builder", [cfg] {
                 view_builder.stop().get();
             });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -694,25 +694,6 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
     _topology_state_machine.reload_count++;
     auto& topology = _topology_state_machine._topology;
 
-    // the view_builder is migrated to v2 in view_builder::migrate_to_v2.
-    // it writes a v2 version mutation as topology_change, then we get here
-    // to update the service to start using the v2 table.
-    auto view_builder_version = co_await _sys_ks.local().get_view_builder_version();
-    switch (view_builder_version) {
-        case db::system_keyspace::view_builder_version_t::v1_5:
-            co_await _view_builder.invoke_on_all([] (db::view::view_builder& vb) -> future<> {
-                co_await vb.upgrade_to_v1_5();
-            });
-            break;
-        case db::system_keyspace::view_builder_version_t::v2:
-            co_await _view_builder.invoke_on_all([] (db::view::view_builder& vb) -> future<> {
-                co_await vb.upgrade_to_v2();
-            });
-            break;
-        default:
-            break;
-    }
-
     co_await _feature_service.container().invoke_on_all([&] (gms::feature_service& fs) {
         return fs.enable(topology.enabled_features | std::ranges::to<std::set<std::string_view>>());
     });
@@ -1416,14 +1397,11 @@ future<> storage_service::raft_initialize_discovery_leader(const join_node_reque
 
     insert_join_request_mutations.emplace_back(co_await _sys_ks.local().make_auth_version_mutation(write_timestamp, db::system_keyspace::auth_version_t::v2));
 
+    insert_join_request_mutations.emplace_back(co_await _sys_ks.local().make_view_builder_version_mutation(write_timestamp, db::system_keyspace::view_builder_version_t::v2));
+
     auto sl_driver_mutations = co_await qos::service_level_controller::get_create_driver_service_level_mutations(_sys_ks.local(), write_timestamp);
     for (auto& m : sl_driver_mutations) {
         insert_join_request_mutations.emplace_back(m);
-    }
-
-    if (!utils::get_local_injector().is_enabled("skip_vb_v2_version_mut")) {
-        insert_join_request_mutations.emplace_back(
-                co_await _sys_ks.local().make_view_builder_version_mutation(write_timestamp, db::system_keyspace::view_builder_version_t::v2));
     }
 
     topology_change change{std::move(insert_join_request_mutations)};
@@ -5836,9 +5814,7 @@ void storage_service::init_messaging_service() {
             // apply only for "legacy" snapshot pull RPCs.
             std::vector<table_id> additional_tables;
             if (params.tables.size() > 0 && params.tables[0] != db::system_keyspace::topology()->id()) {
-                if (ss._feature_service.view_build_status_on_group0) {
-                    additional_tables.push_back(db::system_keyspace::view_build_status_v2()->id());
-                }
+                additional_tables.push_back(db::system_keyspace::view_build_status_v2()->id());
                 if (ss._feature_service.compression_dicts) {
                     additional_tables.push_back(db::system_keyspace::dicts()->id());
                 }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -3851,32 +3851,6 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_migrate_system_t
     // it's in `topology_coordinator::enable_features` ,so  topology_coordinator will re-run its loop
     // and `maybe_migrate_system_tables` will be called.
 
-    // Check if we can upgrade the view_build_status table to v2, being managed by group0.
-    // First we upgrade to an intermediate version v1_5 where we write to both tables, then
-    // we upgrade to v2.
-    const auto view_builder_version = co_await _sys_ks.get_view_builder_version();
-    if (view_builder_version == db::system_keyspace::view_builder_version_t::v1 && _feature_service.view_build_status_on_group0) {
-        rtlogger.info("Migrating view_builder to v1_5");
-        auto tmptr = get_token_metadata_ptr();
-        co_await db::view::view_builder::migrate_to_v1_5(tmptr, _sys_ks, _sys_ks.query_processor(), _group0.client(), _as, std::move(guard));
-        co_return std::nullopt;
-    }
-
-    if (view_builder_version == db::system_keyspace::view_builder_version_t::v1_5) {
-        if (!get_dead_nodes().empty()) {
-            rtlogger.debug("Not all nodes are alive. Skipping system table migration until there are any dead nodes.");
-            co_return std::move(guard);
-        }
-
-        rtlogger.info("Migrating view_builder to v2");
-        // do a barrier to ensure all nodes applied the migration to v1_5 before we continue to v2
-        guard = co_await exec_global_command(std::move(guard), raft_topology_cmd::command::barrier, {_raft.id()});
-
-        auto tmptr = get_token_metadata_ptr();
-        co_await db::view::view_builder::migrate_to_v2(tmptr, _sys_ks, _sys_ks.query_processor(), _group0.client(), _as, std::move(guard));
-        co_return std::nullopt;
-    }
-
     if (_feature_service.driver_service_level) {
         const auto sl_driver_created = co_await _sys_ks.get_service_level_driver_created();
         if (!sl_driver_created.value_or(false)) {

--- a/test/cluster/test_view_build_status.py
+++ b/test/cluster/test_view_build_status.py
@@ -6,21 +6,14 @@
 import pytest
 import time
 import asyncio
-import logging
-from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_view, wait_for_view_v1
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_view
 from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.pylib.internal_types import ServerInfo
 from test.cluster.util import trigger_snapshot, wait_for, create_new_test_keyspace
-from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
-from cassandra.protocol import InvalidRequest
 from test.cluster.util import new_test_keyspace
 from test.cluster.test_view_building_coordinator import mark_all_servers, pause_view_building_tasks, \
         unpause_view_building_tasks, wait_for_some_view_build_tasks_to_get_stuck
-
-
-logger = logging.getLogger(__name__)
 
 async def create_keyspace(cql, disable_tablets=False):
     ks_options = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
@@ -40,10 +33,6 @@ async def get_view_builder_version(cql, **kwargs):
         return 1
     else:
         return int(result[0].value) // 10
-
-async def view_builder_is_v2(cql, **kwargs):
-    v = await get_view_builder_version(cql, **kwargs)
-    return v == 2 or None
 
 async def view_is_built_v2(cql, ks_name, view_name, node_count, **kwargs):
     done = await cql.run_async(f"SELECT COUNT(*) FROM system.view_build_status_v2 WHERE keyspace_name='{ks_name}' \
@@ -267,63 +256,6 @@ async def test_view_build_status_with_replace_node(manager: ManagerClient):
         return True
 
     await wait_for(node_rows_replaced, time.time() + 60)
-
-# Reproduces scylladb/scylladb#20754
-# View build status migration is doing read with CL=ALL, so it requires all nodes to be up.
-# Before the fix, the migration was triggered too early, causing unavailable exception in topology coordinator.
-# The error was triggered when the cluster started in raft topology without view build status v2.
-# It wasn't happening in gossip topology -> raft topology upgrade.
-@pytest.mark.asyncio
-@pytest.mark.skip_mode(mode='release', reason='error injection is not supported in release mode')
-async def test_migration_on_existing_raft_topology(request, manager: ManagerClient):
-    cfg = {
-        "error_injections_at_startup": [
-            {
-                "name": "suppress_features",
-                "value": "VIEW_BUILD_STATUS_ON_GROUP0"
-            },
-            "skip_vb_v2_version_mut"
-        ]
-    }
-    servers = await manager.servers_add(3, config=cfg)
-
-    logging.info("Waiting until driver connects to every server")
-    cql, hosts = await manager.get_ready_cql(servers)
-
-    ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}")
-    await create_table(cql, ks)
-    await create_mv(cql, ks, "vt1")
-
-    # Verify we're using v1 now
-    v = await get_view_builder_version(cql)
-    assert v == 1
-
-    await wait_for_row_count(cql, "system_distributed.view_build_status", 3, hosts[0])
-
-    result = await cql.run_async("SELECT * FROM system.view_build_status_v2")
-    assert len(result) == 0
-
-    # Enable suppressed `VIEW_BUILD_STATUS_ON_GROUP0` cluster feature
-    for srv in servers:
-        await manager.server_stop_gracefully(srv.server_id)
-        await manager.server_update_config(srv.server_id, "error_injections_at_startup", [])
-        await manager.server_start(srv.server_id)
-        await wait_for_cql_and_get_hosts(manager.get_cql(), servers, time.time() + 60)
-
-    logging.info("Waiting until view builder status is migrated")
-    await asyncio.gather(*(wait_for(lambda: view_builder_is_v2(cql, host=h), time.time() + 60) for h in hosts))
-
-    # Check that new writes are written to the v2 table
-    await create_mv(cql, ks, "vt2")
-    await asyncio.gather(*(wait_for_view_v2(cql, ks, "vt2", 3, host=h) for h in hosts))
-
-    await wait_for_row_count(cql, "system.view_build_status_v2", 6, hosts[0])
-
-    # Check if there is no error logs from raft topology
-    for srv in servers:
-        log = await manager.server_open_log(srv.server_id)
-        res = await log.grep(r'ERROR.*\[shard [0-9]: [a-z]+\] raft_topology - topology change coordinator fiber got error exceptions::unavailable_exception \(Cannot achieve consistency level for')
-        assert len(res) == 0
 
 # Test that when removing the view, its build status is cleaned from the status table
 @pytest.mark.asyncio

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -948,7 +948,7 @@ private:
                 _view_update_generator.stop().get();
             });
 
-            _view_builder.start(std::ref(_db), std::ref(_sys_ks), std::ref(_sys_dist_ks), std::ref(_mnotifier), std::ref(_view_update_generator), std::ref(group0_client), std::ref(_qp)).get();
+            _view_builder.start(std::ref(_db), std::ref(_sys_ks), std::ref(_mnotifier), std::ref(_view_update_generator), std::ref(group0_client), std::ref(_qp)).get();
             auto stop_view_builder = defer_verbose_shutdown("view builder", [this] {
                 _view_builder.stop().get();
             });


### PR DESCRIPTION
Since we do no longer support upgrade from versions that do not support
v2 of "view building status" code (building status is managed by raft) we can remove v1 code and upgrade code and make sure we do not boot with old "builder status" version.

v2 version was introduced by 8d25a4d67872d9324c1b238ef325ed53c34ea3c2 which is included in scylla-2025.1.0.


No backport needed since this is code removal.
