### PR TITLE
[2026.1] test: test_remove_garbage_group0_members: wait for token ring and group0 consistency before removenode

### DIFF
--- a/test/cluster/test_topology_remove_garbage_group0.py
+++ b/test/cluster/test_topology_remove_garbage_group0.py
@@ -94,6 +94,8 @@ async def test_remove_garbage_group0_members(manager: ManagerClient):
     logging.info(f'stop {servers[1]}')
     await manager.server_stop_gracefully(servers[1].server_id)
 
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 60)
+
     logging.info(f'removenode {servers[1]} using {servers[2]}')
     await manager.remove_node(servers[2].server_id, servers[1].server_id)
 


### PR DESCRIPTION
The removenove initiator could have an outdated token ring (still considering
the node removed by the previous removenode a token owner) and unexpectedly
reject the operation.

Fix that by waiting for token ring and group0 consistency before removenode.
Note that the test already checks that consistency, but only for one node,
which is different from the removenode initiator.

This test has been removed in master together with the code being tested
(the gossip-based topology). Hence, the fix is submitted directly to 2026.1.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1103

Backport to all supported branches (other than 2026.1), as the test can fail
there.