### PR TITLE
encryption: fix deadlock in encrypted_data_source::get()

### DIFF
--- a/ent/encryption/encrypted_file_impl.cc
+++ b/ent/encryption/encrypted_file_impl.cc
@@ -727,7 +727,12 @@ public:
 
         // now we need one page more to be able to save one for next lap
         auto fill_size = align_up(buf1.size(), block_size) + block_size - buf1.size();
-        auto buf2 = co_await _input.read_exactly(fill_size);
+        // If the underlying stream is already at EOF (e.g. buf1 came from
+        // cached _next while the previous read_exactly drained the source),
+        // skip the read_exactly call — it would return empty anyway.
+        auto buf2 = _input.eof()
+            ? temporary_buffer<char>()
+            : co_await _input.read_exactly(fill_size);
 
         temporary_buffer<char> output(buf1.size() + buf2.size());
 

--- a/test/boost/encrypted_file_test.cc
+++ b/test/boost/encrypted_file_test.cc
@@ -23,7 +23,10 @@
 #include "test/lib/tmpdir.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/exception_utils.hh"
+#include "test/lib/limiting_data_source.hh"
 #include "utils/io-wrappers.hh"
+
+#include <seastar/util/memory-data-source.hh>
 
 using namespace encryption;
 
@@ -593,6 +596,113 @@ static future<> test_random_data_source(std::vector<size_t> sizes) {
 SEASTAR_TEST_CASE(test_encrypted_data_source_simple) {
     std::vector<size_t> sizes({3200, 13086, 12065, 200, 11959, 12159, 12852});
     co_await test_random_data_source(sizes);
+}
+
+// Reproduces the production deadlock where encrypted SSTable component downloads
+// got stuck during restore. The encrypted_data_source::get() caches a block in
+// _next, then on the next call bypasses input_stream::read()'s _eof check and
+// calls input_stream::read_exactly() — which does NOT check _eof when _buf is
+// empty. This causes a second get() on the underlying source after EOS.
+//
+// In production the underlying source was chunked_download_source whose get()
+// hung forever. Here we simulate it with a strict source that fails the test.
+//
+// The fix belongs in seastar's input_stream::read_exactly(): check _eof before
+// calling _fd.get(), consistent with read(), read_up_to(), and consume().
+static future<> test_encrypted_source_copy(size_t plaintext_size) {
+    testlog.info("test_encrypted_source_copy: plaintext_size={}", plaintext_size);
+
+    key_info info{"AES/CBC", 256};
+    auto k = ::make_shared<symmetric_key>(info);
+
+    // Step 1: Encrypt the plaintext into memory buffers
+    auto plaintext = generate_random<char>(plaintext_size);
+    std::vector<temporary_buffer<char>> encrypted_bufs;
+    {
+        data_sink sink(make_encrypted_sink(create_memory_sink(encrypted_bufs), k));
+        co_await sink.put(plaintext.clone());
+        co_await sink.close();
+    }
+
+    // Flatten encrypted buffers into a single contiguous buffer
+    size_t encrypted_total = 0;
+    for (const auto& b : encrypted_bufs) {
+        encrypted_total += b.size();
+    }
+    temporary_buffer<char> encrypted(encrypted_total);
+    size_t pos = 0;
+    for (const auto& b : encrypted_bufs) {
+        std::copy(b.begin(), b.end(), encrypted.get_write() + pos);
+        pos += b.size();
+    }
+
+    // Step 2: Create a data source from the encrypted data that fails on
+    // post-EOS get() — simulating a source like chunked_download_source
+    // that would hang forever in this situation.
+    class strict_memory_source final : public limiting_data_source_impl {
+        bool _eof = false;
+    public:
+        strict_memory_source(temporary_buffer<char> data, size_t chunk_size)
+            : limiting_data_source_impl(
+                data_source(std::make_unique<util::temporary_buffer_data_source>(std::move(data))),
+                chunk_size) {}
+
+        future<temporary_buffer<char>> get() override {
+            BOOST_REQUIRE_MESSAGE(!_eof,
+                "get() called on source after it already returned EOS — "
+                "this is the production deadlock: read_exactly() does not "
+                "check _eof before calling _fd.get()");
+            auto buf = co_await limiting_data_source_impl::get();
+            _eof = buf.empty();
+            co_return buf;
+        }
+    };
+
+    // Step 3: Wrap in encrypted_data_source and drain via consume() —
+    // the exact code path used by seastar::copy() which is what
+    // sstables_loader_helpers::download_sstable() calls.
+    // Try multiple chunk sizes to hit different alignment scenarios.
+    for (size_t chunk_size : {1ul, 7ul, 4096ul, 8192ul, encrypted_total, encrypted_total + 1}) {
+        if (chunk_size == 0) continue;
+        auto src = data_source(make_encrypted_source(
+            data_source(std::make_unique<strict_memory_source>(encrypted.clone(), chunk_size)), k));
+        auto in = input_stream<char>(std::move(src));
+
+        // consume() is what seastar::copy() uses internally. It calls
+        // encrypted_data_source::get() via _fd.get() until EOF.
+        size_t total_decrypted = 0;
+        co_await in.consume([&total_decrypted](temporary_buffer<char> buf) {
+            total_decrypted += buf.size();
+            return make_ready_future<consumption_result<char>>(continue_consuming{});
+        });
+        co_await in.close();
+
+        BOOST_REQUIRE_EQUAL(total_decrypted, plaintext_size);
+    }
+}
+
+SEASTAR_TEST_CASE(test_encrypted_source_copy_8k) {
+    co_await test_encrypted_source_copy(8192);
+}
+
+SEASTAR_TEST_CASE(test_encrypted_source_copy_4k) {
+    co_await test_encrypted_source_copy(4096);
+}
+
+SEASTAR_TEST_CASE(test_encrypted_source_copy_small) {
+    co_await test_encrypted_source_copy(100);
+}
+
+SEASTAR_TEST_CASE(test_encrypted_source_copy_12k) {
+    co_await test_encrypted_source_copy(12288);
+}
+
+SEASTAR_TEST_CASE(test_encrypted_source_copy_unaligned) {
+    co_await test_encrypted_source_copy(8193);
+}
+
+SEASTAR_TEST_CASE(test_encrypted_source_copy_1byte) {
+    co_await test_encrypted_source_copy(1);
 }
 
 

--- a/test/lib/limiting_data_source.cc
+++ b/test/lib/limiting_data_source.cc
@@ -7,32 +7,22 @@
  */
 
 #include "limiting_data_source.hh"
-#include <seastar/core/iostream.hh>
-#include <seastar/core/temporary_buffer.hh>
-#include <cstdint>
 
 using namespace seastar;
 
-class limiting_data_source_impl final : public data_source_impl {
-    data_source _src;
-    size_t _limit;
-    temporary_buffer<char> _buf;
-    future<temporary_buffer<char>> do_get() {
+    future<temporary_buffer<char>> limiting_data_source_impl::do_get() {
         uint64_t size = std::min(_limit, _buf.size());
         auto res = _buf.share(0, size);
         _buf.trim_front(size);
         return make_ready_future<temporary_buffer<char>>(std::move(res));
     }
-public:
-    limiting_data_source_impl(data_source&& src, size_t limit)
+
+    limiting_data_source_impl::limiting_data_source_impl(data_source&& src, size_t limit)
         : _src(std::move(src))
         , _limit(limit)
     {}
 
-    limiting_data_source_impl(limiting_data_source_impl&&) noexcept = default;
-    limiting_data_source_impl& operator=(limiting_data_source_impl&&) noexcept = default;
-
-    virtual future<temporary_buffer<char>> get() override {
+    future<temporary_buffer<char>> limiting_data_source_impl::get() {
         if (_buf.empty()) {
             _buf.release();
             return _src.get().then([this] (auto&& buf) {
@@ -42,7 +32,7 @@ public:
         }
         return do_get();
     }
-    virtual future<temporary_buffer<char>> skip(uint64_t n) override {
+    future<temporary_buffer<char>> limiting_data_source_impl::skip(uint64_t n) {
         if (n < _buf.size()) {
             _buf.trim_front(n);
             return do_get();
@@ -54,7 +44,6 @@ public:
             return do_get();
         });
     }
-};
 
 data_source make_limiting_data_source(data_source&& src, size_t limit) {
     return data_source{std::make_unique<limiting_data_source_impl>(std::move(src), limit)};

--- a/test/lib/limiting_data_source.cc
+++ b/test/lib/limiting_data_source.cc
@@ -10,40 +10,40 @@
 
 using namespace seastar;
 
-    future<temporary_buffer<char>> limiting_data_source_impl::do_get() {
-        uint64_t size = std::min(_limit, _buf.size());
-        auto res = _buf.share(0, size);
-        _buf.trim_front(size);
-        return make_ready_future<temporary_buffer<char>>(std::move(res));
-    }
+future<temporary_buffer<char>> limiting_data_source_impl::do_get() {
+    uint64_t size = std::min(_limit, _buf.size());
+    auto res = _buf.share(0, size);
+    _buf.trim_front(size);
+    return make_ready_future<temporary_buffer<char>>(std::move(res));
+}
 
-    limiting_data_source_impl::limiting_data_source_impl(data_source&& src, size_t limit)
-        : _src(std::move(src))
-        , _limit(limit)
-    {}
+limiting_data_source_impl::limiting_data_source_impl(data_source&& src, size_t limit)
+    : _src(std::move(src))
+    , _limit(limit)
+{}
 
-    future<temporary_buffer<char>> limiting_data_source_impl::get() {
-        if (_buf.empty()) {
-            _buf.release();
-            return _src.get().then([this] (auto&& buf) {
-                _buf = std::move(buf);
-                return do_get();
-            });
-        }
-        return do_get();
-    }
-    future<temporary_buffer<char>> limiting_data_source_impl::skip(uint64_t n) {
-        if (n < _buf.size()) {
-            _buf.trim_front(n);
-            return do_get();
-        }
-        n -= _buf.size();
+future<temporary_buffer<char>> limiting_data_source_impl::get() {
+    if (_buf.empty()) {
         _buf.release();
-        return _src.skip(n).then([this] (auto&& buf) {
+        return _src.get().then([this] (auto&& buf) {
             _buf = std::move(buf);
             return do_get();
         });
     }
+    return do_get();
+}
+future<temporary_buffer<char>> limiting_data_source_impl::skip(uint64_t n) {
+    if (n < _buf.size()) {
+        _buf.trim_front(n);
+        return do_get();
+    }
+    n -= _buf.size();
+    _buf.release();
+    return _src.skip(n).then([this] (auto&& buf) {
+        _buf = std::move(buf);
+        return do_get();
+    });
+}
 
 data_source make_limiting_data_source(data_source&& src, size_t limit) {
     return data_source{std::make_unique<limiting_data_source_impl>(std::move(src), limit)};

--- a/test/lib/limiting_data_source.cc
+++ b/test/lib/limiting_data_source.cc
@@ -17,21 +17,20 @@ future<temporary_buffer<char>> limiting_data_source_impl::do_get() {
     return make_ready_future<temporary_buffer<char>>(std::move(res));
 }
 
-limiting_data_source_impl::limiting_data_source_impl(data_source&& src, size_t limit)
-    : _src(std::move(src))
-    , _limit(limit)
-{}
+limiting_data_source_impl::limiting_data_source_impl(data_source&& src, size_t limit) : _src(std::move(src)), _limit(limit) {
+}
 
 future<temporary_buffer<char>> limiting_data_source_impl::get() {
     if (_buf.empty()) {
         _buf.release();
-        return _src.get().then([this] (auto&& buf) {
+        return _src.get().then([this](auto&& buf) {
             _buf = std::move(buf);
             return do_get();
         });
     }
     return do_get();
 }
+
 future<temporary_buffer<char>> limiting_data_source_impl::skip(uint64_t n) {
     if (n < _buf.size()) {
         _buf.trim_front(n);
@@ -39,7 +38,7 @@ future<temporary_buffer<char>> limiting_data_source_impl::skip(uint64_t n) {
     }
     n -= _buf.size();
     _buf.release();
-    return _src.skip(n).then([this] (auto&& buf) {
+    return _src.skip(n).then([this](auto&& buf) {
         _buf = std::move(buf);
         return do_get();
     });

--- a/test/lib/limiting_data_source.hh
+++ b/test/lib/limiting_data_source.hh
@@ -12,7 +12,7 @@
 #include <seastar/core/temporary_buffer.hh>
 
 
-class limiting_data_source_impl final : public seastar::data_source_impl {
+class limiting_data_source_impl : public seastar::data_source_impl {
     seastar::data_source _src;
     size_t _limit;
     seastar::temporary_buffer<char> _buf;

--- a/test/lib/limiting_data_source.hh
+++ b/test/lib/limiting_data_source.hh
@@ -8,13 +8,25 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/temporary_buffer.hh>
 
-namespace seastar {
 
-class data_source;
+class limiting_data_source_impl final : public seastar::data_source_impl {
+    seastar::data_source _src;
+    size_t _limit;
+    seastar::temporary_buffer<char> _buf;
+    seastar::future<seastar::temporary_buffer<char>> do_get();
 
-}
+public:
+    limiting_data_source_impl(seastar::data_source&& src, size_t limit);
+
+    limiting_data_source_impl(limiting_data_source_impl&&) noexcept = default;
+    limiting_data_source_impl& operator=(limiting_data_source_impl&&) noexcept = default;
+
+    seastar::future<seastar::temporary_buffer<char>> get() override;
+    seastar::future<seastar::temporary_buffer<char>> skip(uint64_t n) override;
+};
 
 /// \brief Creates an data_source from another data_source but returns its data in chunks not bigger than a given limit
 ///


### PR DESCRIPTION
When encrypted_data_source::get() caches a trailing block in _next, the next call takes it directly — bypassing input_stream::read(), which checks _eof. It then calls input_stream::read_exactly() on the already-drained stream. Unlike read(), read_up_to(), and consume(), read_exactly() does not check _eof when the buffer is empty, so it calls _fd.get() on a source that already returned EOS.

In production this manifested as stuck encrypted SSTable component downloads during tablet restore: the underlying chunked_download_source hung forever on the post-EOS get(), causing 4 tablets to never complete. The stuck files were always block-aligned sizes (8k, 12k) where _next gets populated and the source is fully consumed in the same call.

Fix by checking _input.eof() before calling read_exactly(). When the stream already reached EOF, buf2 is known to be empty, so the call is skipped entirely.

A comprehensive test is added that uses a strict_memory_source which fails on post-EOS get(), reproducing the exact code path that caused the production deadlock.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1128

Backport to 2025.3/4 and 2026.1 is needed since it fixes a bug that may bite us in production, to be on the safe side