### PR TITLE
test: add a missing reconnect_driver in test_sstable_compression_dictionaries_upgrade.py

### DIFF
--- a/test/cluster/test_sstable_compression_dictionaries_upgrade.py
+++ b/test/cluster/test_sstable_compression_dictionaries_upgrade.py
@@ -16,6 +16,7 @@ from test.pylib.manager_client import ManagerClient, ServerInfo
 from test.pylib.rest_client import read_barrier, HTTPError
 from test.pylib.scylla_cluster import ScyllaVersionDescription
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
+from test.cluster.util import reconnect_driver
 from cassandra.cluster import ConsistencyLevel
 from cassandra.policies import FallthroughRetryPolicy
 from cassandra.protocol import ServerError
@@ -161,6 +162,7 @@ async def test_upgrade_and_rollback(manager: ManagerClient, scylla_2025_1: Scyll
     )
 
     logger.info("Waiting for SSTABLE_COMPRESSION_DICTS cluster feature")
+    cql = await reconnect_driver(manager)
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     await asyncio.gather(*(wait_for_feature("SSTABLE_COMPRESSION_DICTS", cql, h, time.time() + 60) for h in hosts))
 


### PR DESCRIPTION
Need to work around https://github.com/scylladb/python-driver/issues/295, lest a CQL query fail spuriously after the cluster restart.

Fixes: SCYLLADB-1114

Can be backported to prevent spurious test failures in stable branches.