### PR TITLE
test/cluster: retry create_table on transient schema agreement timeout

### DIFF
--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -808,7 +808,16 @@ async def test_index_requires_rf_rack_valid_keyspace(manager: ManagerClient):
 
     # Create a table with tablets and no indexes, then add a GSI - the update should fail
     table_name = unique_table_name()
-    create_table_with_index(alternator, table_name, index_type=None, initial_tablets='1')
+    # The server waits 10s for schema agreement after creating a table,
+    # which may not be enough after a sequence of rapid schema changes
+    # on a multi-node cluster (see SCYLLADB-1135). Retry if needed.
+    for attempt in range(2):
+        try:
+            create_table_with_index(alternator, table_name, index_type=None, initial_tablets='1')
+            break
+        except ClientError as e:
+            if 'schema agreement' not in str(e) or attempt == 1:
+                raise
     with pytest.raises(ClientError, match=expected_err_update_add_gsi):
         alternator.meta.client.update_table(
             TableName=table_name,


### PR DESCRIPTION
## Summary

- Fixes intermittent failure in `test_index_requires_rf_rack_valid_keyspace` where `create_table` fails with "Unable to reach schema agreement" after the server's hardcoded 10s timeout is exceeded.
- Adds a retry (up to 2 attempts) on schema agreement errors for the specific `create_table` call, rather than increasing the server-side timeout.

The failure occurs because the 4-node cluster with 4 racks can take longer than 10s for gossip-based schema version propagation after a sequence of rapid schema changes earlier in the test.

Fixes: SCYLLADB-1135