### PR TITLE
test_fencing: add missing await-s

### DIFF
--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -414,15 +414,15 @@ async def test_lwt_fencing_upgrade(manager: ManagerClient, scylla_2025_1: Scylla
 
         logger.info("LWT workoad started")
         lwt_workload_task = asyncio.create_task(lwt_workload())
-        wait_for_some_lwts()
+        await wait_for_some_lwts()
 
         logger.info(f"Upgrading {servers[0].server_id}")
         await manager.server_change_version(servers[0].server_id, scylla_binary)
-        wait_for_some_lwts()
+        await wait_for_some_lwts()
 
         logger.info(f"Downgrading {servers[0].server_id}")
         await manager.server_change_version(servers[0].server_id, scylla_2025_1.path)
-        wait_for_some_lwts()
+        await wait_for_some_lwts()
 
         for s in servers:
             # Ensure all hosts are alive before restarting the last server,
@@ -441,7 +441,7 @@ async def test_lwt_fencing_upgrade(manager: ManagerClient, scylla_2025_1: Scylla
 
         logger.info("Done upgrading servers")
 
-        wait_for_some_lwts()
+        await wait_for_some_lwts()
 
         stop = True
         await lwt_workload_task


### PR DESCRIPTION
Fixes [SCYLLADB-1099](https://scylladb.atlassian.net/browse/SCYLLADB-1099)

backport: doesn't seem worth the efforts (minor problem with pytest output)

[SCYLLADB-1099]: https://scylladb.atlassian.net/browse/SCYLLADB-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ