### PR TITLE
dtest: fix flaky test_writes_schema_recreated_while_node_down

### DIFF
--- a/test/cluster/dtest/schema_management_test.py
+++ b/test/cluster/dtest/schema_management_test.py
@@ -353,7 +353,7 @@ class TestSchemaManagement(Tester):
 
         logger.debug("Restarting node2")
         node2.start(wait_for_binary_proto=True)
-        session2 = self.patient_cql_connection(node2)
+        session2 = self.patient_exclusive_cql_connection(node2)
         read_barrier(session2)
 
         rows = session.execute(SimpleStatement("SELECT * FROM cf", consistency_level=ConsistencyLevel.ALL))
@@ -382,7 +382,7 @@ class TestSchemaManagement(Tester):
 
         logger.debug("Restarting node2")
         node2.start(wait_for_binary_proto=True)
-        session2 = self.patient_cql_connection(node2)
+        session2 = self.patient_exclusive_cql_connection(node2)
         read_barrier(session2)
 
         session.execute(SimpleStatement("INSERT INTO cf (p, v) VALUES (2, '2')", consistency_level=ConsistencyLevel.ALL))


### PR DESCRIPTION
`read_barrier(session2)` was supposed to ensure `node2` has caught up on schema
before a CL=ALL write. But `patient_cql_connection(node2)` creates a
cluster-aware driver session `(TokenAwarePolicy(DCAwareRoundRobinPolicy()))`
that can route the barrier CQL statement to any node — not necessarily `node2`.
If the barrier runs on `node1` or `node3` (which already have the new schema),
it's a no-op, and `node2` remains stale, thus the observed `WriteFailure`.
The fix is to switch to `patient_exclusive_cql_connection(node2)`,
which uses `WhiteListRoundRobinPolicy([node2_ip])` to pin all CQL to `node2`.
This is already the established pattern used by other tests in the same file.

Fixes: SCYLLADB-1139

No need to backport yet, appeared only on master.