### PR TITLE
alternator/cluster-dtest: fix test_ttl_with_load_and_decommission flaky Connection refused error

### DIFF
--- a/test/cluster/dtest/alternator_tests.py
+++ b/test/cluster/dtest/alternator_tests.py
@@ -691,7 +691,7 @@ class TesterAlternator(BaseAlternator):
                 random.choice(nodes_for_maintenance).compact()
             except NodetoolError as exc:
                 error_message = str(exc)
-                valid_errors = ["ConnectException", "status code 404 Not Found"]
+                valid_errors = ["ConnectException", "Connection refused", "status code 404 Not Found"]
                 if not any(err in error_message for err in valid_errors):
                     raise
 


### PR DESCRIPTION
The native Scylla nodetool reports ECONNREFUSED as 'Connection refused',
not as 'ConnectException' (which is the Java nodetool format). Add
'Connection refused' to the valid_errors list so that transient
connection failures during concurrent decommission/bootstrap topology
changes are properly tolerated.

Fixes SCYLLADB-1167

~Problem was reported in 2026.1 and 2025.4, so let's backport there.~
Correction, the problem was reported by dtest 2026.1 with only the current Scylla, so no backport required after all.