### PR TITLE
scylla-gdb: fix sstable-summary crash on ms-format sstables

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -952,6 +952,8 @@ class sstring:
 
     @staticmethod
     def to_hex(data, size):
+        if size == 0:
+            return ''
         inf = gdb.selected_inferior()
         return bytes(inf.read_memory(data, size)).hex()
 
@@ -974,6 +976,8 @@ class sstring:
             return self.ref['u']['external']['str']
 
     def as_bytes(self):
+        if len(self) == 0:
+            return b''
         inf = gdb.selected_inferior()
         return bytes(inf.read_memory(self.data(), len(self)))
 
@@ -5636,6 +5640,8 @@ class scylla_sstable_summary(gdb.Command):
         self.inf = gdb.selected_inferior()
 
     def to_hex(self, data, size):
+        if size == 0:
+            return ''
         return bytes(self.inf.read_memory(data, size)).hex()
 
     def invoke(self, arg, for_tty):
@@ -5647,6 +5653,10 @@ class scylla_sstable_summary(gdb.Command):
             sst = seastar_lw_shared_ptr(arg).get().dereference()
         else:
             sst = arg
+        ms_version = int(gdb.parse_and_eval('sstables::sstable_version_types::ms'))
+        if int(sst['_version']) >= ms_version:
+            gdb.write("sstable uses ms format (trie-based index); summary is not populated.\n")
+            return
         summary = seastar_lw_shared_ptr(sst['_components']['_value']).get().dereference()['summary']
 
         gdb.write("header: {}\n".format(summary['header']))


### PR DESCRIPTION
## Summary

Fixes SCYLLADB-1180: The `scylla sstable-summary` GDB command crashes with `ValueError: Argument "count" should be greater than zero` when inspecting ms-format (trie-based) sstables.

### Root Cause

ms-format sstables (version 5) use trie-based indexes and don't populate the traditional `summary` structure — all summary fields are zeroed out. When `sstring.__str__()` → `as_hex()` → `to_hex()` calls `gdb.read_memory(data, 0)`, it raises `ValueError` because the count must be > 0.

### Changes

- Add zero-length guards to `sstring.to_hex()` and `sstring.as_bytes()` to return early when data length is zero — consistent with the existing guard in `managed_bytes.get()`
- Add the same guard to `scylla_sstable_summary.to_hex()`
- Detect ms-format sstables (version == 5) early in `scylla_sstable_summary.invoke()` and print an informative message instead of attempting to read the unpopulated summary

### Testing

These are defensive guards in GDB helper code. The crash is only reproducible when debugging a ScyllaDB process with ms-format sstables loaded.

A follow-up PR will add proper ms-format support by reading from `_partitions_db_footer` to display first/last keys and partition count for ms-format sstables.