### PR TITLE
cql3: remove RF-rack-valid warning in create mv/index

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -334,15 +334,6 @@ create_index_statement::validate_while_executing(data_dictionary::database db, l
             // The type of the thrown exception is not specified, so we need to wrap it here.
             throw exceptions::invalid_request_exception(e.what());
         }
-
-        if (db.find_keyspace(keyspace()).uses_tablets()) {
-            warnings.emplace_back(
-                "Creating an index in a keyspace that uses tablets requires "
-                "the keyspace to remain RF-rack-valid while the index exists. "
-                "Some operations will be restricted to enforce this: altering the keyspace's replication "
-                "factor, adding a node in a new rack, and removing or decommissioning a node that would "
-                "eliminate a rack.");
-        }
     }
 
     validate_for_local_index(*schema);

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -152,15 +152,6 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
         throw exceptions::invalid_request_exception(e.what());
     }
 
-    if (db.find_keyspace(keyspace()).uses_tablets()) {
-        warnings.emplace_back(
-            "Creating a materialized view in a keyspaces that uses tablets requires "
-            "the keyspace to remain RF-rack-valid while the materialized view exists. "
-            "Some operations will be restricted to enforce this: altering the keyspace's replication "
-            "factor, adding a node in a new rack, and removing or decommissioning a node that would "
-            "eliminate a rack.");
-    }
-
     if (schema->is_counter()) {
         throw exceptions::invalid_request_exception(format("Materialized views are not supported on counter tables"));
     }

--- a/test/cluster/mv/test_mv_with_tablets_restrictions.py
+++ b/test/cluster/mv/test_mv_with_tablets_restrictions.py
@@ -81,11 +81,7 @@ async def test_create_mv_and_index_restrictions_in_tablet_keyspaces(manager: Man
 
     for schema_kind in ["view", "index", "vector"]:
         # Create MV/index with RF=Racks - should always succeed
-        if rf_kind == "numeric" and schema_kind != "vector":
-            expected_warning = "requires the keyspace to remain RF-rack-valid"
-        else:
-            expected_warning = None
-        await test_create_mv_or_index_with_rf(cql, schema_kind, 3, expected_warning=expected_warning)
+        await test_create_mv_or_index_with_rf(cql, schema_kind, 3)
 
         # Create MV/index with RF!=Racks - should fail for numeric RF.
         # vector indexes are exempted from this restriction.


### PR DESCRIPTION
In CREATE MV/INDEX in a tablets keyspace we add a warning that the keyspace must remain RF-rack-valid. The warning is not relevant anymore because now all keyspaces are rack-list-based and therefore are always RF-rack-valid.

backport not needed - just a small cleanup and improvement to user experience