### PR TITLE
test_mutation_schema_change: use tablets

### DIFF
--- a/test/cluster/test_mutation_schema_change.py
+++ b/test/cluster/test_mutation_schema_change.py
@@ -21,7 +21,6 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
-@pytest.mark.enable_tablets(False)                       # uses lightweight transactions
 async def test_mutation_schema_change(manager, random_tables):
     """
         Cluster A, B, C
@@ -83,7 +82,6 @@ async def test_mutation_schema_change(manager, random_tables):
 
 
 @pytest.mark.asyncio
-@pytest.mark.enable_tablets(False)                       # uses lightweight transactions
 async def test_mutation_schema_change_restart(manager, random_tables):
     """
         Cluster A, B, C


### PR DESCRIPTION
The `enable_tablets(false)` was added when LWT wasn't supported for tablets, now it's, so no need in this attribute are more.

The test covers behavior which should work in similar way for both vnodes and tablets -> it doesn't seem it would benefit much from running it in both `enable_tablets(true)` and `enable_tablets(false)` modes.

backport: no need (minor improvement in test coverage)