### PR TITLE
hints: Use shorter fault-injection overload

### DIFF
--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -50,9 +50,7 @@ future<> hint_endpoint_manager::do_store_hint(schema_ptr s, lw_shared_ptr<const 
     size_t mut_size = fm->representation().size();
     shard_stats().size_of_hints_in_progress += mut_size;
 
-    if (utils::get_local_injector().enter("slow_down_writing_hints")) {
-        co_await seastar::sleep(std::chrono::seconds(10));
-    }
+    co_await utils::get_local_injector().inject("slow_down_writing_hints", std::chrono::seconds(10));
 
     try {
         const auto shared_lock = co_await get_shared_lock(file_update_mutex());


### PR DESCRIPTION
In order to apply fsult-injected delay, there's the inject(duration) overload. Results in shorter code

Code refactoring, not backporting