### PR TITLE
directories: add missing seastar/util/closeable.hh include

### DIFF
--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -10,6 +10,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/util/closeable.hh>
 #include "init.hh"
 #include "supervisor.hh"
 #include "directories.hh"


### PR DESCRIPTION
Without this include the file would not compile on its own. The issue was most likely masked by the use of precompiled headers in our CI.

This broke very recently (I suspect 712ba5a31f6a7feb028921c985f667127571c871) so there is no need to backport.