### PR TITLE
Potential fix for code scanning alert no. 184: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trigger-scylla-ci.yaml
+++ b/.github/workflows/trigger-scylla-ci.yaml
@@ -1,5 +1,8 @@
 name: Trigger Scylla CI Route
 
+permissions:
+  contents: read
+
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylladb/security/code-scanning/184](https://github.com/scylladb/scylladb/security/code-scanning/184)

To fix the problem, explicitly restrict the GITHUB_TOKEN permissions for this workflow to the minimal required. The job only reads event context, uses environment variables, and calls an external Jenkins instance using `secrets`; it does not need write access to repository contents or other resources. In most cases, `contents: read` is sufficient (and is a good minimal baseline) unless the workflow actually needs to write anything via the GitHub API.

The best fix without changing existing functionality is to add a `permissions:` block at the root of the workflow (top level, alongside `name:` and `on:`). This will apply to all jobs that do not define their own `permissions:` block; here, there is only `trigger-jenkins`, so that is sufficient. We will set:

```yaml
permissions:
  contents: read
```

This documents the intent, constrains the token, and preserves all current behavior. No additional imports, actions, or methods are needed.

Concretely, in `.github/workflows/trigger-scylla-ci.yaml`, insert the `permissions:` block after the `name:` line and before `on:` (lines 1–3 region).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
