### PR TITLE
call_validate_pr_author_email.yml: add missing workflow permissions

### DIFF
--- a/.github/workflows/call_validate_pr_author_email.yml
+++ b/.github/workflows/call_validate_pr_author_email.yml
@@ -7,6 +7,11 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   validate_pr_author_email:
     uses: scylladb/github-automation/.github/workflows/validate_pr_author_email.yml@main


### PR DESCRIPTION
## Summary

Fixes code scanning alert #172.

- Adds explicit `permissions` block (`contents: read`, `pull-requests: write`, `statuses: write`) matching the requirements of the called reusable workflow which checks out code, posts PR comments via `peter-evans/create-or-update-comment`, and sets commit statuses via `actions/github-script`.
- Follows the principle of least privilege consistent with other workflows in this repo.

Ref: https://github.com/scylladb/scylladb/security/code-scanning