### PR TITLE
Strong consistency: allow taking snapshots (but not transfer) and make them less likely

### DIFF
--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -137,6 +137,12 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
 
     auto& persistence_ref = *storage;
     auto config = raft::server::configuration {
+        // Snapshotting is not implemented yet for strong consistency,
+        // so effectively disable periodic snapshotting.
+        // TODO: Revert after snapshots are implemented
+        .snapshot_threshold = std::numeric_limits<size_t>::max(),
+        .snapshot_threshold_log_size = 10 * 1024 * 1024, // 10MB
+        .max_log_size = 20 * 1024 * 1024, // 20MB
         .enable_forwarding = false,
         .on_background_error = [tablet, group_id](std::exception_ptr e) {
             on_internal_error(logger, 

--- a/service/strong_consistency/state_machine.cc
+++ b/service/strong_consistency/state_machine.cc
@@ -79,11 +79,16 @@ public:
     }
 
     future<raft::snapshot_id> take_snapshot() override {
-        throw std::runtime_error("take_snapshot() not implemented");
+        // Until snapshot transfer is fully implemented, return a fake ID
+        // and don't actually do anything. As long as we don't do snapshot
+        // transfers (attempting to do that throws an exception), we should
+        // be safe.
+        return make_ready_future<raft::snapshot_id>(raft::snapshot_id(utils::make_random_uuid()));
     }
 
     void drop_snapshot(raft::snapshot_id id) override {
-        throw std::runtime_error("drop_snapshot() not implemented");
+        // Taking a snapshot is a no-op, so dropping a snapshot is also a no-op.
+        (void) id;
     }
 
     future<> load_snapshot(raft::snapshot_id id) override {


### PR DESCRIPTION
While working on benchmarks for strong consistency we noticed that the raft logic attempted to take snapshots during the benchmark. Snapshot transfer is not implemented for strong consistency yet and the methods that take or transfer snapshots throw exceptions. This causes the raft groups to stop working completely.

While implementing snapshot transfers is out of scope, we can implement some mitigations now to stop the tests from breaking:

- The first commit adjusts the configuration options. First, it disables periodic snapshotting (i.e. creating a snapshot every X log entries). Second, it increases the memory threshold for the raft log before which a snapshot is created from 2MB to 10MB.
- The second commit relaxes the take snapshot / drop snapshot methods and makes it possible to actually use them - they are no-ops. It is still forbidden to transfer snapshots.

I am including both commits because applying only the first one didn't completely prevent the issue from occurring when testing locally.

Refs: SCYLLADB-1115

Strong consistency is experimental, no need for backport.