### PR TITLE
test/cluster: fix flaky test_cleanup_stop by using asyncio.sleep

### DIFF
--- a/test/cluster/test_sstable_cleanup_stop.py
+++ b/test/cluster/test_sstable_cleanup_stop.py
@@ -11,7 +11,6 @@ from test.cluster.util import check_token_ring_and_group0_consistency, new_test_
 import pytest
 import asyncio
 import logging
-import time
 
 logger = logging.getLogger(__name__)
 @pytest.mark.asyncio
@@ -53,7 +52,7 @@ async def test_cleanup_stop(manager: ManagerClient):
         await s0_log.wait_for('sstable_cleanup_wait: waiting', from_mark=s0_mark)
 
         stop_cleanup = asyncio.create_task(manager.api.stop_compaction(servers[0].ip_addr, "CLEANUP"))
-        time.sleep(1)
+        await asyncio.sleep(1)
 
         await manager.api.message_injection(servers[0].ip_addr, "sstable_cleanup_wait")
         await stop_cleanup


### PR DESCRIPTION
The test was using `time.sleep(1)` (a blocking call) to wait after scheduling the `stop_compaction` task, intending to let it register on the server before releasing the `sstable_cleanup_wait` injection point.

However, `time.sleep()` blocks the asyncio event loop entirely, so the `asyncio.create_task(stop_compaction)` task never gets to run during the sleep. After the sleep, the directly-awaited `message_injection()` runs first, releasing the injection point before `stop_compaction` is even sent. By the time `stop_compaction` reaches Scylla, the cleanup has already completed successfully -- no exception is raised and the test fails.

Fix by replacing `time.sleep(1)` with `await asyncio.sleep(1)`, which yields control to the event loop and allows the `stop_compaction` task to actually send its HTTP request before `message_injection` is called.

Fixes: SCYLLADB-834

Backport: test was introduced by b607b1c284, need backport to 2025.4