### PR TITLE
logstor: implement tablet split/merge and migration

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3052,7 +3052,7 @@ future<service::topology> system_keyspace::load_topology_state(const std::unorde
         co_return ret;
     }
 
-    const bool tablet_balancing_not_supported = _db.features().strongly_consistent_tables || _db.features().logstor;
+    const bool tablet_balancing_not_supported = _db.features().strongly_consistent_tables;
 
     for (auto& row : *rs) {
         if (!row.has("host_id")) {

--- a/docs/dev/logstor.md
+++ b/docs/dev/logstor.md
@@ -122,3 +122,88 @@ SELECT * FROM keyspace.table_name;
 ```cql
 DELETE FROM keyspace.table_name WHERE pk = 1;
 ```
+
+## On-Disk Format
+
+### Files
+
+Segments are stored in large pre-allocated files on disk. Each file holds a fixed number of segments determined by the `file_size / segment_size` ratio. File names follow the pattern:
+
+```
+ls_{shard_id}-{file_id}-Data.db
+```
+
+Files are pre-formatted (zero-filled) before use.
+
+### Segments
+
+Each segment is a contiguous fixed-size region within a file (default 128KB). A segment is identified by a `log_segment_id` (a 32-bit integer index), which maps to a file and offset within that file.
+
+A segment contains one or more **buffers** written sequentially. Each buffer is 4KB-block-aligned. A segment has one of two kinds:
+
+- **mixed**: written by normal user writes; may contain records from multiple tables and compaction groups. Contains multiple buffers.
+- **full**: written by compaction or the separator; contains records from a single table and token range. Contains exactly one buffer.
+
+### Buffer Layout
+
+A buffer within a segment has the following layout:
+
+```
+buffer_header
+(segment_header)?       -- present only when kind == full
+record_1
+record_2
+...
+record_n
+zero_padding            -- to align the entire buffer to block_alignment (4096 bytes)
+```
+
+buffer_header, segment_header, and records are aligned by `record_alignment` (8 bytes).
+
+#### Buffer Header
+
+A serialized form of `write_buffer::buffer_header`.
+
+| Offset | Size | Field       | Description |
+|--------|------|-------------|-------------|
+| 0      | 4    | `magic`     | `0x4C475342` ("LGSB"). Used to detect valid buffers during recovery. |
+| 4      | 4    | `data_size` | Size in bytes of all record data following the header(s). |
+| 8      | 2    | `seg_gen`   | Segment generation number. Incremented each time the segment slot is reused. Used during recovery to discard stale data. |
+| 10     | 1    | `kind`      | Segment kind: `0` = mixed, `1` = full. |
+| 11     | 1    | `version`   | Version of the write buffer format. |
+| 12     | 4    | `crc`       | CRC32 of all other fields in the buffer header. Used for validating the header. |
+
+#### Segment Header (full segments only)
+
+Immediately follows the buffer header when `kind == full`.
+
+A serialized form of `write_buffer::segment_header`.
+
+| Offset | Size | Field         | Description |
+|--------|------|---------------|-------------|
+| 16     | 16   | `table`       | UUID of the table this segment belongs to. |
+| 32     | 8    | `first_token` | Minimum token of all records in the segment (raw token number). |
+| 40     | 8    | `last_token`  | Maximum token of all records in the segment (raw token number). |
+
+#### Records
+
+Each record within the buffer is structured as:
+
+```
+record_header (4 bytes)
+record_data   (variable)
+zero_padding  -- to align to record_alignment (8 bytes)
+```
+
+**Record Header:**
+
+| Offset | Size | Field       | Description |
+|--------|------|-------------|-------------|
+| 0      | 4    | `data_size` | Size in bytes of the serialized `log_record` that follows. |
+
+**Record Data:**
+
+The record data is the serialized form of a `log_record`, which contains:
+- `key`: the partition key (`primary_index_key`), including a `decorated_key` with a token and partition key bytes.
+- `generation`: a 16-bit write generation number, used during recovery to resolve conflicts when the same key appears in multiple segments.
+- `mut`: the full partition value as a `canonical_mutation`.

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -219,6 +219,9 @@ public:
     // Merges all sstables from another group into this one.
     future<> merge_sstables_from(compaction_group& group);
 
+    // Merges all logstor segments from another group into this one.
+    future<> merge_logstor_segments_from(compaction_group& group);
+
     const lw_shared_ptr<sstables::sstable_set>& main_sstables() const noexcept;
     sstables::sstable_set make_main_sstable_set() const;
     void set_main_sstables(lw_shared_ptr<sstables::sstable_set> new_main_sstables);

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -484,6 +484,7 @@ public:
     virtual compaction_group& compaction_group_for_token(dht::token token) const = 0;
     virtual compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const = 0;
     virtual compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const = 0;
+    virtual compaction_group& compaction_group_for_logstor_segment(logstor::log_segment_id seg_id, dht::token first_token, dht::token last_token) const = 0;
 
     virtual size_t log2_storage_groups() const = 0;
     virtual storage_group& storage_group_for_token(dht::token) const = 0;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -18,6 +18,7 @@
 #include "compaction/compaction_manager.hh"
 #include "locator/tablets.hh"
 #include "replica/logstor/compaction.hh"
+#include "replica/logstor/segment_manager.hh"
 #include "sstables/sstable_set.hh"
 #include "utils/chunked_vector.hh"
 #include <absl/container/flat_hash_map.h>
@@ -309,6 +310,8 @@ public:
         return *_logstor_segments;
     }
 
+    future<utils::chunked_vector<logstor::segment_snapshot>> take_logstor_snapshot();
+
     friend class storage_group;
 };
 
@@ -392,8 +395,11 @@ public:
     // Make an sstable set spanning all sstables in the storage_group
     lw_shared_ptr<const sstables::sstable_set> make_sstable_set() const;
 
+    future<utils::chunked_vector<logstor::segment_snapshot>> take_logstor_snapshot() const;
+
     // Flush all memtables.
     future<> flush() noexcept;
+    future<> flush_separator() noexcept;
     bool can_flush() const;
     bool needs_flush() const;
     api::timestamp_type min_memtable_timestamp() const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1397,6 +1397,9 @@ public:
     // Takes snapshot of current sstable set all compaction groups.
     future<utils::chunked_vector<sstables::shared_sstable>> take_sstable_set_snapshot();
 
+    future<utils::chunked_vector<logstor::segment_snapshot>> take_logstor_snapshot(dht::token_range tr);
+    future<std::unique_ptr<logstor::segment_stream_sink>> create_logstor_segment_sink(replica::database&);
+
     // Clones storage of a given tablet. Memtable is flushed first to guarantee that the
     // snapshot (list of sstables) will include all the data written up to the time it was taken.
     // If leave_unsealead is set, all the destination sstables will be left unsealed.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -882,14 +882,6 @@ public:
         return make_mutation_reader(std::move(schema), std::move(permit), range, full_slice);
     }
 
-    mutation_reader make_logstor_mutation_reader(schema_ptr s,
-            reader_permit permit,
-            const dht::partition_range& pr,
-            const query::partition_slice& slice,
-            tracing::trace_state_ptr trace_state,
-            streamed_mutation::forwarding fwd,
-            mutation_reader::forwarding fwd_mr) const;
-
     // The streaming mutation reader differs from the regular mutation reader in that:
     //  - Reflects all writes accepted by replica prior to creation of the
     //    reader and a _bounded_ amount of writes which arrive later.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -17,6 +17,7 @@
 #include <seastar/core/when_all.hh>
 #include "replica/global_table_ptr.hh"
 #include "replica/logstor/compaction.hh"
+#include "replica/logstor/types.hh"
 #include "types/user.hh"
 #include "utils/assert.hh"
 #include "utils/hash.hh"
@@ -616,7 +617,7 @@ public:
                                           sstables::offstrategy offstrategy = sstables::offstrategy::no);
     future<> add_sstables_and_update_cache(const std::vector<sstables::shared_sstable>& ssts);
 
-    bool add_logstor_segment(logstor::segment_descriptor&, dht::token first_token, dht::token last_token);
+    bool add_logstor_segment(logstor::log_segment_id, logstor::segment_descriptor&, dht::token first_token, dht::token last_token);
 
     logstor::separator_buffer& get_logstor_separator_buffer(dht::token token, size_t write_size);
 
@@ -734,6 +735,8 @@ private:
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const;
     // Select a compaction group from a given sstable based on its token range.
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const;
+    // Select a compaction group from a given logstor segment based on its token range.
+    compaction_group& compaction_group_for_logstor_segment(logstor::log_segment_id, dht::token first_token, dht::token last_token) const;
     // Safely iterate through compaction groups, while performing async operations on them.
     future<> parallel_foreach_compaction_group(std::function<future<>(compaction_group&)> action);
     void for_each_compaction_group(std::function<void(compaction_group&)> action);

--- a/replica/logstor/compaction.hh
+++ b/replica/logstor/compaction.hh
@@ -35,6 +35,7 @@ struct segment_descriptor : public log_heap_hook<segment_descriptor_hist_options
     size_t record_count{0};
     segment_generation seg_gen{1};
     segment_set* owner{nullptr}; // non-owning, set when added to a segment_set
+    int ref_count{0};
 
     void reset(size_t segment_size) noexcept {
         free_space = segment_size;
@@ -92,6 +93,7 @@ struct segment_set {
         }
         desc.owner = this;
         _segments.push(desc);
+        ++desc.ref_count;
         ++_segment_count;
     }
 
@@ -105,6 +107,7 @@ struct segment_set {
         }
         _segments.erase(desc);
         desc.owner = nullptr;
+        --desc.ref_count;
         --_segment_count;
     }
 

--- a/replica/logstor/compaction.hh
+++ b/replica/logstor/compaction.hh
@@ -11,6 +11,7 @@
 #include "utils/chunked_vector.hh"
 #include "write_buffer.hh"
 #include "utils/log_heap.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace replica::logstor {
 
@@ -67,6 +68,18 @@ using segment_descriptor_hist = log_heap<segment_descriptor, segment_descriptor_
 struct segment_set {
     segment_descriptor_hist _segments;
     size_t _segment_count{0};
+
+    future<> merge(segment_set& other) {
+        while (!other._segments.empty()) {
+            auto& desc = other._segments.one_of_largest();
+            other._segments.erase(desc);
+            --other._segment_count;
+            desc.owner = this;
+            _segments.push(desc);
+            ++_segment_count;
+            co_await coroutine::maybe_yield();
+        }
+    }
 
     void add_segment(segment_descriptor& desc) {
         if (desc.owner) {
@@ -204,6 +217,7 @@ public:
     virtual future<> stop_ongoing_compactions(replica::compaction_group&) = 0;
 
     virtual future<compaction_reenabler> disable_compaction(replica::compaction_group&) = 0;
+    virtual compaction_reenabler disable_compaction_no_wait(replica::compaction_group&) = 0;
 };
 
 }

--- a/replica/logstor/compaction.hh
+++ b/replica/logstor/compaction.hh
@@ -93,6 +93,10 @@ struct segment_set {
     size_t segment_count() const noexcept {
         return _segment_count;
     }
+
+    bool empty() const noexcept {
+        return _segment_count == 0;
+    }
 };
 
 class segment_ref {
@@ -166,6 +170,10 @@ struct separator_buffer {
 
     bool can_fit(size_t write_size) const noexcept {
         return buf->can_fit(write_size);
+    }
+
+    bool empty() const noexcept {
+        return !buf->has_data();
     }
 };
 

--- a/replica/logstor/compaction.hh
+++ b/replica/logstor/compaction.hh
@@ -177,6 +177,20 @@ struct separator_buffer {
     }
 };
 
+class compaction_reenabler {
+    std::function<void()> _release;
+public:
+    compaction_reenabler() = default;
+    explicit compaction_reenabler(std::function<void()> release)
+        : _release(std::move(release)) {}
+    ~compaction_reenabler() { if (_release) _release(); }
+
+    compaction_reenabler(compaction_reenabler&&) = default;
+    compaction_reenabler& operator=(compaction_reenabler&&) = default;
+    compaction_reenabler(const compaction_reenabler&) = delete;
+    compaction_reenabler& operator=(const compaction_reenabler&) = delete;
+};
+
 class compaction_manager {
 public:
     virtual ~compaction_manager() = default;
@@ -188,6 +202,8 @@ public:
     virtual void submit(replica::compaction_group&) = 0;
 
     virtual future<> stop_ongoing_compactions(replica::compaction_group&) = 0;
+
+    virtual future<compaction_reenabler> disable_compaction(replica::compaction_group&) = 0;
 };
 
 }

--- a/replica/logstor/compaction.hh
+++ b/replica/logstor/compaction.hh
@@ -14,6 +14,8 @@
 
 namespace replica::logstor {
 
+extern seastar::logger logstor_logger;
+
 constexpr log_heap_options segment_descriptor_hist_options(4 * 1024, 3, 128 * 1024);
 
 struct segment_set;
@@ -67,6 +69,9 @@ struct segment_set {
     size_t _segment_count{0};
 
     void add_segment(segment_descriptor& desc) {
+        if (desc.owner) {
+            on_internal_error(logstor_logger, "add_segment called for segment that has an owner");
+        }
         desc.owner = this;
         _segments.push(desc);
         ++_segment_count;
@@ -77,6 +82,9 @@ struct segment_set {
     }
 
     void remove_segment(segment_descriptor& desc) {
+        if (desc.owner != this) {
+            on_internal_error(logstor_logger, "remove_segment called not from the owner");
+        }
         _segments.erase(desc);
         desc.owner = nullptr;
         --_segment_count;

--- a/replica/logstor/compaction.hh
+++ b/replica/logstor/compaction.hh
@@ -12,6 +12,11 @@
 #include "write_buffer.hh"
 #include "utils/log_heap.hh"
 #include <seastar/coroutine/maybe_yield.hh>
+#include "mutation_writer/token_group_based_splitting_writer.hh"
+
+namespace replica {
+class table;
+} // namespace replica
 
 namespace replica::logstor {
 
@@ -218,6 +223,8 @@ public:
 
     virtual future<compaction_reenabler> disable_compaction(replica::compaction_group&) = 0;
     virtual compaction_reenabler disable_compaction_no_wait(replica::compaction_group&) = 0;
+
+    virtual future<> split_compaction(replica::table&, replica::compaction_group&, mutation_writer::classify_by_token_group) = 0;
 };
 
-}
+} // namespace replica::logstor

--- a/replica/logstor/index.hh
+++ b/replica/logstor/index.hh
@@ -90,6 +90,15 @@ public:
         return std::nullopt;
     }
 
+    bool is_record_alive(const primary_index_key& key, log_location location) {
+        auto it = _partitions.find(key.dk, dht::ring_position_comparator(*_schema));
+        if (it != _partitions.end()) {
+            return it->_e.location == location;
+        } else {
+            return false;
+        }
+    }
+
     std::optional<index_entry> exchange(const primary_index_key& key, index_entry new_entry) {
         partitions_type::bound_hint hint;
         auto i = _partitions.lower_bound(key.dk, dht::ring_position_comparator(*_schema), hint);

--- a/replica/logstor/index.hh
+++ b/replica/logstor/index.hh
@@ -9,6 +9,7 @@
 
 #include "dht/decorated_key.hh"
 #include "dht/ring_position.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 #include "types.hh"
 #include "utils/bptree.hh"
 #include "utils/double-decker.hh"
@@ -150,6 +151,19 @@ public:
             return true;
         }
         return false;
+    }
+
+    future<> erase(const dht::partition_range& pr) {
+        dht::ring_position_comparator cmp(*_schema);
+        auto it = _partitions.lower_bound(dht::ring_position_view::for_range_start(pr), cmp);
+        auto end_it = _partitions.lower_bound(dht::ring_position_view::for_range_end(pr), cmp);
+        while (it != end_it) {
+            auto prev = it;
+            ++it;
+            prev.erase(dht::raw_token_less_comparator{});
+            --_key_count;
+            co_await coroutine::maybe_yield();
+        }
     }
 
     auto begin() const noexcept { return _partitions.begin(); }

--- a/replica/logstor/index.hh
+++ b/replica/logstor/index.hh
@@ -124,11 +124,11 @@ public:
         return false;
     }
 
-    std::pair<bool, std::optional<index_entry>> insert_if_newer(const primary_index_key& key, index_entry new_entry) {
+    std::pair<bool, std::optional<index_entry>> insert_if_newer(const primary_index_key& key, index_entry new_entry, bool prefer_on_tie) {
         partitions_type::bound_hint hint;
         auto i = _partitions.lower_bound(key.dk, dht::ring_position_comparator(*_schema), hint);
         if (hint.match) {
-            if (i->_e.generation < new_entry.generation) {
+            if (i->_e.generation < new_entry.generation || (i->_e.generation == new_entry.generation && prefer_on_tie)) {
                 auto old_entry = i->_e;
                 i->_e = std::move(new_entry);
                 return {true, std::make_optional(old_entry)};

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -52,6 +52,22 @@ size_t logstor::get_memory_usage() const {
     return _segment_manager.get_memory_usage();
 }
 
+segment_manager& logstor::get_segment_manager() noexcept {
+    return _segment_manager;
+}
+
+const segment_manager& logstor::get_segment_manager() const noexcept {
+    return _segment_manager;
+}
+
+compaction_manager& logstor::get_compaction_manager() noexcept {
+    return _segment_manager.get_compaction_manager();
+}
+
+const compaction_manager& logstor::get_compaction_manager() const noexcept {
+    return _segment_manager.get_compaction_manager();
+}
+
 future<> logstor::write(const mutation& m, compaction_group& cg, seastar::gate::holder cg_holder) {
     primary_index_key key(m.decorated_key());
     table_id table = m.schema()->id();
@@ -125,22 +141,6 @@ future<std::optional<canonical_mutation>> logstor::read(const schema& s, const p
 
         return std::optional<canonical_mutation>(std::move(record.mut));
     });
-}
-
-segment_manager& logstor::get_segment_manager() noexcept {
-    return _segment_manager;
-}
-
-const segment_manager& logstor::get_segment_manager() const noexcept {
-    return _segment_manager;
-}
-
-compaction_manager& logstor::get_compaction_manager() noexcept {
-    return _segment_manager.get_compaction_manager();
-}
-
-const compaction_manager& logstor::get_compaction_manager() const noexcept {
-    return _segment_manager.get_compaction_manager();
 }
 
 mutation_reader logstor::make_reader(schema_ptr schema,

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -1766,6 +1766,10 @@ void segment_manager_impl::write_to_separator(table& t, log_location prev_loc, l
 future<> compaction_manager_impl::flush_separator_buffer(separator_buffer buf, compaction_group& cg) {
     logstor_logger.trace("Flushing separator buffer with {} bytes", buf.buf->offset_in_buffer());
 
+    utils::get_local_injector().inject("fail_flush_separator_buffer", []() {
+        throw std::runtime_error("flush_separator_buffer failed by injection");
+    });
+
     if (buf.buf->has_data()) {
         auto sem_units = co_await get_units(_separator_flush_sem, 1);
         co_await with_scheduling_group(_cfg.separator_sg, [&] {

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -115,8 +115,7 @@ future<log_record> segment::read(log_location loc) {
 
     // Read the serialized record
     return _file.dma_read_exactly<char>(absolute_offset(loc.offset), loc.size).then([] (seastar::temporary_buffer<char> buf) {
-        seastar::simple_input_stream in(buf.begin(), buf.size());
-        return ser::deserialize(in, std::type_identity<log_record>{});
+        return ser::deserialize_from_buffer(buf, std::type_identity<log_record>{});
     });
 }
 
@@ -129,7 +128,6 @@ future<> writeable_segment::stop() {
         co_return;
     }
     co_await _write_gate.close();
-    _seg_ref = {};
 }
 
 log_location writeable_segment::allocate(size_t data_size) {
@@ -408,15 +406,10 @@ public:
 
     const stats& get_stats() const noexcept { return _stats; }
 
-    future<> write_to_separator(write_buffer&, segment_ref, size_t segment_seq_num);
-
     separator_buffer allocate_separator_buffer() override;
     future<> flush_separator_buffer(separator_buffer buf, compaction_group&) override;
 
 private:
-
-    bool is_record_alive(primary_index&, const primary_index_key&, log_location);
-    bool update_record_location(primary_index&, const primary_index_key&, log_location old_loc, log_location new_loc);
 
     void submit(compaction_group&) override;
     future<> stop_ongoing_compactions(compaction_group&) override;
@@ -462,14 +455,13 @@ enum class write_source {
     separator,
 };
 
+static constexpr size_t write_source_count = 3;
+
 static sstring write_source_to_string(write_source src) {
     switch (src) {
-    case write_source::normal_write:
-        return "normal_write";
-    case write_source::compaction:
-        return "compaction";
-    case write_source::separator:
-        return "separator";
+        case write_source::normal_write: return "normal_write";
+        case write_source::compaction: return "compaction";
+        case write_source::separator: return "separator";
     }
     return "unknown";
 }
@@ -484,11 +476,8 @@ public:
 
     struct stats {
         uint64_t segments_put{0};
-        uint64_t segments_get{0};
-        uint64_t compaction_segments_get{0};
-        uint64_t normal_segments_get{0};
+        std::array<uint64_t, write_source_count> segments_get{0};
         uint64_t normal_segments_wait{0};
-        uint64_t separator_segments_get{0};
     } _stats;
 
     segment_pool(size_t pool_size, size_t reserved_for_compaction)
@@ -514,12 +503,12 @@ public:
 
     future<seg_ptr> get_segment(write_source src) {
         seg_ptr seg;
-        switch (src) {
-        case write_source::compaction:
-            _stats.compaction_segments_get++;
+        if (src == write_source::compaction) {
+            _stats.segments_get[static_cast<size_t>(src)]++;
             co_return co_await _segments.pop_eventually();
-        case write_source::normal_write:
-            if (_segments.size() <= _reserved_for_compaction) {
+        }
+        if (_segments.size() <= _reserved_for_compaction) {
+            if (src == write_source::normal_write) {
                 _stats.normal_segments_wait++;
             }
             while (_segments.size() <= _reserved_for_compaction) {
@@ -527,17 +516,9 @@ public:
                     return _segments.size() > _reserved_for_compaction;
                 });
             }
-            _stats.normal_segments_get++;
-            co_return _segments.pop();
-        case write_source::separator:
-            while (_segments.size() <= _reserved_for_compaction) {
-                co_await _segment_available.wait([this] {
-                    return _segments.size() > _reserved_for_compaction;
-                });
-            }
-            _stats.separator_segments_get++;
-            co_return _segments.pop();
         }
+        _stats.segments_get[static_cast<size_t>(src)]++;
+        co_return _segments.pop();
     }
 
     size_t size() const noexcept {
@@ -553,8 +534,8 @@ class segment_manager_impl {
 
     struct stats {
         uint64_t segments_in_use{0};
-        uint64_t bytes_written{0};
-        uint64_t data_bytes_written{0};
+        std::array<uint64_t, write_source_count> bytes_written{0};
+        std::array<uint64_t, write_source_count> data_bytes_written{0};
         uint64_t bytes_read{0};
         uint64_t bytes_freed{0};
         uint64_t segments_allocated{0};
@@ -617,8 +598,8 @@ public:
     future<> start();
     future<> stop();
 
-    future<log_location> write(write_buffer&);
-    future<log_location> write_full_segment(write_buffer&, compaction_group&, write_source);
+    future<> write(write_buffer&);
+    future<> write_full_segment(write_buffer&, compaction_group&, write_source);
 
     future<log_record> read(log_location);
 
@@ -669,7 +650,7 @@ public:
     future<> discard_segments(segment_set&);
 
     size_t get_memory_usage() const {
-        return _cfg.max_separator_memory;
+        return _cfg.max_separator_memory + sizeof(_segment_descs);
     }
 
     future<> await_pending_writes() {
@@ -678,44 +659,15 @@ public:
 
 private:
 
-    struct segment_allocation_guard {
-        segment_manager_impl& sm;
-        std::optional<log_segment_id> segment_id;
-
-        segment_allocation_guard(segment_manager_impl& sm, log_segment_id seg_id) noexcept
-            : sm(sm)
-            , segment_id(seg_id)
-        {}
-
-        segment_allocation_guard(segment_allocation_guard&& other) noexcept
-            : sm(other.sm)
-            , segment_id(std::exchange(other.segment_id, std::nullopt))
-        {}
-
-        segment_allocation_guard& operator=(segment_allocation_guard&& other) = delete;
-        segment_allocation_guard(const segment_allocation_guard&) = delete;
-        segment_allocation_guard& operator=(const segment_allocation_guard&) = delete;
-
-        ~segment_allocation_guard() {
-            if (segment_id) {
-                sm._free_segments.push_back(*segment_id);
-                sm._segment_freed_cv.signal();
-            }
-        }
-
-        void release() noexcept {
-            segment_id.reset();
-        }
-    };
-
     future<> replenish_reserve();
+    future<seg_ptr> allocate_segment();
 
     future<> request_segment_switch();
     future<> switch_active_segment();
     std::chrono::microseconds calculate_separator_delay() const;
 
-    future<std::pair<segment_allocation_guard, seg_ptr>> allocate_and_create_new_segment();
-    future<segment_allocation_guard> allocate_segment();
+    future<> write_to_separator(write_buffer&, segment_ref, size_t segment_seq_num);
+    void write_to_separator(table&, log_location prev_loc, log_record, segment_ref);
 
     segment_ref make_segment_ref(log_segment_id seg_id) {
         return segment_ref(seg_id,
@@ -820,17 +772,17 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
                        sm::description("Counts number of segments in the segment pool.")),
         sm::make_counter("segment_pool_segments_put", _segment_pool.get_stats().segments_put,
                        sm::description("Counts number of segments returned to the segment pool.")),
-        sm::make_counter("segment_pool_normal_segments_get", _segment_pool.get_stats().normal_segments_get,
+        sm::make_counter("segment_pool_normal_segments_get", _segment_pool.get_stats().segments_get[static_cast<size_t>(write_source::normal_write)],
                        sm::description("Counts number of segments taken from the segment pool for normal writes.")),
-        sm::make_counter("segment_pool_compaction_segments_get", _segment_pool.get_stats().compaction_segments_get,
+        sm::make_counter("segment_pool_compaction_segments_get", _segment_pool.get_stats().segments_get[static_cast<size_t>(write_source::compaction)],
                        sm::description("Counts number of segments taken from the segment pool for compaction.")),
-        sm::make_counter("segment_pool_separator_segments_get", _segment_pool.get_stats().separator_segments_get,
+        sm::make_counter("segment_pool_separator_segments_get", _segment_pool.get_stats().segments_get[static_cast<size_t>(write_source::separator)],
                        sm::description("Counts number of segments taken from the segment pool for separator writes.")),
         sm::make_counter("segment_pool_normal_segments_wait", _segment_pool.get_stats().normal_segments_wait,
                        sm::description("Counts number of times normal writes had to wait for a segment to become available in the segment pool.")),
-        sm::make_counter("bytes_written", _stats.bytes_written,
+        sm::make_counter("bytes_written", _stats.bytes_written[static_cast<size_t>(write_source::normal_write)],
                        sm::description("Counts number of bytes written to the disk.")),
-        sm::make_counter("data_bytes_written", _stats.data_bytes_written,
+        sm::make_counter("data_bytes_written", _stats.data_bytes_written[static_cast<size_t>(write_source::normal_write)],
                        sm::description("Counts number of data bytes written to the disk.")),
         sm::make_counter("bytes_read", _stats.bytes_read,
                        sm::description("Counts number of bytes read from the disk.")),
@@ -842,9 +794,9 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
                        sm::description("Counts number of segments freed.")),
         sm::make_gauge("disk_usage", [this] { return _file_mgr.allocated_file_count() * _cfg.file_size; },
                        sm::description("Total disk usage.")),
-        sm::make_counter("compaction_bytes_written", _stats.compaction_bytes_written,
+        sm::make_counter("compaction_bytes_written", _stats.bytes_written[static_cast<size_t>(write_source::compaction)],
                        sm::description("Counts number of bytes written to the disk by compaction.")),
-        sm::make_counter("compaction_data_bytes_written", _stats.compaction_data_bytes_written,
+        sm::make_counter("compaction_data_bytes_written", _stats.data_bytes_written[static_cast<size_t>(write_source::compaction)],
                        sm::description("Counts number of data bytes written to the disk by compaction.")),
         sm::make_counter("segments_compacted", _compaction_mgr.get_stats().segments_compacted,
                        sm::description("Counts number of segments compacted.")),
@@ -854,9 +806,9 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
                        sm::description("Counts number of records skipped during compaction.")),
         sm::make_counter("compaction_records_rewritten", _compaction_mgr.get_stats().compaction_records_rewritten,
                        sm::description("Counts number of records rewritten during compaction.")),
-        sm::make_counter("separator_bytes_written", _stats.separator_bytes_written,
+        sm::make_counter("separator_bytes_written", _stats.bytes_written[static_cast<size_t>(write_source::separator)],
                        sm::description("Counts number of bytes written to the separator.")),
-        sm::make_counter("separator_data_bytes_written", _stats.separator_data_bytes_written,
+        sm::make_counter("separator_data_bytes_written", _stats.data_bytes_written[static_cast<size_t>(write_source::separator)],
                        sm::description("Counts number of data bytes written to the separator.")),
         sm::make_counter("separator_buffer_flushed", _compaction_mgr.get_stats().separator_buffer_flushed,
                        sm::description("Counts number of times the separator buffer has been flushed.")),
@@ -912,9 +864,9 @@ future<> segment_manager_impl::stop() {
     logstor_logger.info("Segment manager stopped");
 }
 
-future<log_location> segment_manager_impl::write(write_buffer& wb) {
+future<> segment_manager_impl::write(write_buffer& wb) {
+    write_source source = write_source::normal_write;
     auto holder = _async_gate.hold();
-    auto write_op = _writes_phaser.start();
 
     wb.finalize(block_alignment);
 
@@ -928,13 +880,17 @@ future<log_location> segment_manager_impl::write(write_buffer& wb) {
         co_await request_segment_switch();
     }
 
-    log_location loc;
-
     {
         seg_ptr seg = _active_segment;
         auto seg_holder = seg->hold();
         auto seg_ref = seg->ref();
         auto segment_seq_num = _segment_seq_num;
+        auto write_op = _writes_phaser.start();
+
+        // if we wrote a record to the segment but failed to write it to the separator, the segment should not be freed.
+        auto write_to_separator_failed = defer([seg_ref] mutable {
+            seg_ref.set_flush_failure();
+        });
 
         auto loc = seg->allocate(data.size());
         auto& desc = get_segment_descriptor(loc);
@@ -945,27 +901,26 @@ future<log_location> segment_manager_impl::write(write_buffer& wb) {
 
         desc.on_write(wb.get_net_data_size(), wb.get_record_count());
 
-        _stats.bytes_written += data.size();
-        _stats.data_bytes_written += wb.get_net_data_size();
+        _stats.bytes_written[static_cast<size_t>(source)] += data.size();
+        _stats.data_bytes_written[static_cast<size_t>(source)] += wb.get_net_data_size();
 
         // complete all buffered writes with their individual locations and wait
         // for them to be updated in the index.
         co_await wb.complete_writes(loc);
 
         co_await with_scheduling_group(_cfg.separator_sg, [&] {
-            return _compaction_mgr.write_to_separator(wb, std::move(seg_ref), segment_seq_num);
+            return write_to_separator(wb, std::move(seg_ref), segment_seq_num);
         });
+        write_to_separator_failed.cancel();
     }
 
     // flow control for separator debt
     if (auto separator_delay = calculate_separator_delay(); separator_delay.count() > 0) {
         co_await seastar::sleep(separator_delay);
     }
-
-    co_return loc;
 }
 
-future<log_location> segment_manager_impl::write_full_segment(write_buffer& wb, compaction_group& cg, write_source source) {
+future<> segment_manager_impl::write_full_segment(write_buffer& wb, compaction_group& cg, write_source source) {
     auto holder = _async_gate.hold();
 
     wb.finalize(block_alignment);
@@ -973,7 +928,7 @@ future<log_location> segment_manager_impl::write_full_segment(write_buffer& wb, 
     bytes_view data(reinterpret_cast<const int8_t*>(wb.data()), wb.offset_in_buffer());
 
     if (data.size() > _cfg.segment_size) {
-        throw std::runtime_error(fmt::format( "Write size {} exceeds segment size {}", data.size(), _cfg.segment_size));
+        throw std::runtime_error(fmt::format("Write size {} exceeds segment size {}", data.size(), _cfg.segment_size));
     }
 
     seg_ptr seg = co_await _segment_pool.get_segment(source);
@@ -989,26 +944,13 @@ future<log_location> segment_manager_impl::write_full_segment(write_buffer& wb, 
 
     desc.on_write(wb.get_net_data_size(), wb.get_record_count());
 
-    switch (source) {
-        case write_source::separator:
-            _stats.separator_bytes_written += data.size();
-            _stats.separator_data_bytes_written += wb.get_net_data_size();
-            break;
-        case write_source::compaction:
-            _stats.compaction_bytes_written += data.size();
-            _stats.compaction_data_bytes_written += wb.get_net_data_size();
-            break;
-        default:
-            _stats.bytes_written += data.size();
-            _stats.data_bytes_written += wb.get_net_data_size();
-            break;
-    }
+    _stats.bytes_written[static_cast<size_t>(source)] += data.size();
+    _stats.data_bytes_written[static_cast<size_t>(source)] += wb.get_net_data_size();
 
     co_await wb.complete_writes(loc);
     co_await seg->stop();
-    cg.add_logstor_segment(desc);
 
-    co_return loc;
+    cg.add_logstor_segment(desc);
 }
 
 void segment_manager_impl::free_record(log_location location) {
@@ -1074,9 +1016,8 @@ future<> segment_manager_impl::replenish_reserve() {
     while (true) {
         bool retry = false;
         try {
-            auto [seg_guard, seg] = co_await allocate_and_create_new_segment();
+            auto seg = co_await allocate_segment();
             co_await _segment_pool.put(std::move(seg));
-            seg_guard.release();
         } catch (abort_requested_exception&) {
             logstor_logger.debug("Reserve replenisher stopping due to abort");
             break;
@@ -1097,27 +1038,27 @@ future<> segment_manager_impl::replenish_reserve() {
     logstor_logger.debug("Reserve replenisher stopped");
 }
 
-future<std::pair<segment_manager_impl::segment_allocation_guard, seg_ptr>>
-segment_manager_impl::allocate_and_create_new_segment() {
-    auto seg_guard = co_await allocate_segment();
+future<seg_ptr> segment_manager_impl::allocate_segment() {
+    auto make_segment = [this] (log_segment_id seg_id) -> future<seg_ptr> {
+        try {
+            auto seg_loc = segment_id_to_file_location(seg_id);
+            auto file = co_await _file_mgr.get_file_for_write(seg_loc.file_id);
+            auto seg = make_lw_shared<writeable_segment>(seg_id, std::move(file), seg_loc.file_offset, _cfg.segment_size);
+            get_segment_descriptor(seg_id).reset(_cfg.segment_size);
+            _stats.segments_allocated++;
+            co_return std::move(seg);
+        } catch (...) {
+            _free_segments.push_back(seg_id);
+            _segment_freed_cv.signal();
+            throw;
+        }
+    };
 
-    auto seg_id = *seg_guard.segment_id;
-    auto seg_loc = segment_id_to_file_location(seg_id);
-    auto file = co_await _file_mgr.get_file_for_write(seg_loc.file_id);
-    auto seg = make_lw_shared<writeable_segment>(seg_id, std::move(file), seg_loc.file_offset, _cfg.segment_size);
-    get_segment_descriptor(seg_id).reset(_cfg.segment_size);
-    _stats.segments_allocated++;
-
-    co_return std::make_pair(std::move(seg_guard), std::move(seg));
-}
-
-future<segment_manager_impl::segment_allocation_guard>
-segment_manager_impl::allocate_segment() {
     while (true) {
         // first, allocate all new segments sequentially
         if (_next_new_segment_id < _max_segments) {
             auto seg_id = log_segment_id(_next_new_segment_id++);
-            co_return segment_allocation_guard(*this, seg_id);
+            co_return co_await make_segment(seg_id);
         }
 
         if (_free_segments.size() < _max_segments * trigger_compaction_threshold / 100) {
@@ -1128,7 +1069,7 @@ segment_manager_impl::allocate_segment() {
         if (!_free_segments.empty()) {
             auto seg_id = _free_segments.front();
             _free_segments.pop_front();
-            co_return segment_allocation_guard(*this, seg_id);
+            co_return co_await make_segment(seg_id);
         }
 
         // no free segments - wait for a segment to be freed.
@@ -1145,7 +1086,7 @@ void segment_manager_impl::free_segment(log_segment_id segment_id) noexcept {
 
     auto& desc = get_segment_descriptor(segment_id);
     if (desc.net_data_size(_cfg.segment_size) != 0) {
-        logstor_logger.error("Freeing segment {} that has data", segment_id);
+        on_internal_error(logstor_logger, format("Freeing segment {} that has data", segment_id));
     }
     desc.on_free_segment();
 
@@ -1209,8 +1150,7 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
         if (buffer_header_buf.size() < write_buffer::buffer_header_size) {
             break;
         }
-        seastar::simple_memory_input_stream buffer_header_stream(buffer_header_buf.get(), buffer_header_buf.size());
-        auto bh = ser::deserialize(buffer_header_stream, std::type_identity<write_buffer::buffer_header>{});
+        auto bh = ser::deserialize_from_buffer(buffer_header_buf, std::type_identity<write_buffer::buffer_header>{});
 
         // if buffer header is not valid, skip to next block
         if (bh.magic != write_buffer::buffer_header_magic) {
@@ -1231,8 +1171,7 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
             if (size_buf.size() < write_buffer::record_header_size) {
                 break;
             }
-            seastar::simple_memory_input_stream size_stream(size_buf.get(), size_buf.size());
-            auto rh = ser::deserialize(size_stream, std::type_identity<write_buffer::record_header>{});
+            auto rh = ser::deserialize_from_buffer(size_buf, std::type_identity<write_buffer::record_header>{});
             if (rh.data_size == 0) {
                 // End of records in this block
                 break;
@@ -1248,8 +1187,7 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
                 break;
             }
 
-            seastar::simple_memory_input_stream record_stream(record_buf.get(), record_buf.size());
-            auto record = ser::deserialize(record_stream, std::type_identity<log_record>{});
+            auto record = ser::deserialize_from_buffer(record_buf, std::type_identity<log_record>{});
 
             log_location loc {
                 .segment = segment_id,
@@ -1283,16 +1221,6 @@ future<> segment_manager_impl::for_each_record(const std::vector<log_segment_id>
     for (auto segment_id : segments) {
         co_await for_each_record(segment_id, callback);
     }
-}
-
-bool compaction_manager_impl::is_record_alive(primary_index& index, const primary_index_key& key, log_location loc) {
-    return index.get(key)
-        .transform([loc] (const index_entry& e) { return e.location == loc; })
-        .value_or(false);
-}
-
-bool compaction_manager_impl::update_record_location(primary_index& index, const primary_index_key& key, log_location old_loc, log_location new_loc) {
-    return index.update_record_location(key, old_loc, new_loc);
 }
 
 void compaction_manager_impl::submit(compaction_group& cg) {
@@ -1419,10 +1347,10 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
         future<> flush() {
             if (buf->has_data()) {
                 flush_count++;
-                auto base_location = co_await sm.write_full_segment(*buf, cg, write_source::compaction);
-                co_await when_all_succeed(pending_updates.begin(), pending_updates.end());
-                logstor_logger.trace("Compaction buffer flushed to {} with {} bytes", base_location, buf->get_net_data_size());
+                co_await sm.write_full_segment(*buf, cg, write_source::compaction);
+                logstor_logger.trace("Compaction buffer flushed with {} bytes", buf->get_net_data_size());
             }
+            co_await when_all_succeed(pending_updates.begin(), pending_updates.end());
             co_await buf->close();
             buf->reset();
             pending_updates.clear();
@@ -1440,11 +1368,13 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
     size_t records_rewritten = 0;
     size_t records_skipped = 0;
 
+    auto& index = cg.get_logstor_index();
+
     co_await _sm.for_each_record(segments,
-            [this, &cg, &records_rewritten, &records_skipped, &cb]
+            [this, &index, &records_rewritten, &records_skipped, &cb]
             (log_location read_location, log_record record) -> future<> {
 
-        if (!is_record_alive(cg.get_logstor_index(), record.key, read_location)) {
+        if (!index.is_record_alive(record.key, read_location)) {
             records_skipped++;
             _stats.compaction_records_skipped++;
             co_return;
@@ -1459,10 +1389,10 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
 
         // write the record and then update the index with the new location
         auto write_and_update_index = cb.buf->write(std::move(writer)).then_unpack(
-                [this, &cg, key = std::move(key), read_location, &records_rewritten, &records_skipped]
+                [this, &index, key = std::move(key), read_location, &records_rewritten, &records_skipped]
                 (log_location new_location, seastar::gate::holder op) {
 
-            if (update_record_location(cg.get_logstor_index(), key, read_location, new_location)) {
+            if (index.update_record_location(key, read_location, new_location)) {
                 _sm.free_record(read_location);
                 records_rewritten++;
             } else {
@@ -1506,7 +1436,6 @@ void compaction_manager_impl::controller::update(size_t segment_write_count, siz
 }
 
 separator_buffer compaction_manager_impl::allocate_separator_buffer() {
-    // TODO really ensure we have enough buffers
     if (_sm._available_separator_buffers.empty()) {
         throw std::runtime_error("No available separator buffers");
     }
@@ -1516,7 +1445,7 @@ separator_buffer compaction_manager_impl::allocate_separator_buffer() {
     return separator_buffer(wb);
 }
 
-future<> compaction_manager_impl::write_to_separator(write_buffer& wb, segment_ref seg_ref, size_t segment_seq_num) {
+future<> segment_manager_impl::write_to_separator(write_buffer& wb, segment_ref seg_ref, size_t segment_seq_num) {
     for (auto&& w : wb.records()) {
         co_await coroutine::maybe_yield();
 
@@ -1538,15 +1467,36 @@ future<> compaction_manager_impl::write_to_separator(write_buffer& wb, segment_r
 
         buf.pending_updates.push_back(
             buf.write(std::move(w.writer)).then_unpack([this, &index, key = std::move(key), prev_loc] (log_location new_loc, seastar::gate::holder op) {
-                if (update_record_location(index, key, prev_loc, new_loc)) {
-                    _sm.free_record(prev_loc);
+                if (index.update_record_location(key, prev_loc, new_loc)) {
+                    free_record(prev_loc);
                 } else {
-                    _sm.free_record(new_loc);
+                    free_record(new_loc);
                 }
-                return make_ready_future<>();
             }
         ));
     }
+}
+
+void segment_manager_impl::write_to_separator(table& t, log_location prev_loc, log_record record, segment_ref seg_ref) {
+    auto key = record.key;
+    auto& index = t.logstor_index();
+    log_record_writer writer(std::move(record));
+
+    auto& buf = t.get_logstor_separator_buffer(key.dk.token(), writer.size());
+
+    if (buf.held_segments.empty() || buf.held_segments.back().id() != seg_ref.id()) {
+        buf.held_segments.push_back(seg_ref);
+    }
+
+    buf.pending_updates.push_back(
+        buf.write(std::move(writer)).then_unpack([this, &index, key = std::move(key), prev_loc] (log_location new_loc, seastar::gate::holder op) {
+            if (index.update_record_location(key, prev_loc, new_loc)) {
+                free_record(prev_loc);
+            } else {
+                free_record(new_loc);
+            }
+        })
+    );
 }
 
 future<> compaction_manager_impl::flush_separator_buffer(separator_buffer buf, compaction_group& cg) {
@@ -1645,6 +1595,7 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
         if (!tp->uses_logstor()) {
             co_return;
         }
+        logstor_logger.info("Table {}.{} has {} entries in logstor index", tp->schema()->ks_name(), tp->schema()->cf_name(), tp->logstor_index().get_key_count());
         for (const auto& entry : tp->logstor_index()) {
             used_segments.set(entry.entry().location.segment.value);
             co_await coroutine::maybe_yield();
@@ -1743,11 +1694,7 @@ future<std::optional<segment_generation>> segment_manager_impl::recover_segment_
             continue;
         }
 
-        seastar::simple_memory_input_stream buffer_header_stream(
-            buffer_header_buf.begin(), buffer_header_buf.size());
-
-        auto bh = ser::deserialize(buffer_header_stream,
-            std::type_identity<write_buffer::buffer_header>{});
+        auto bh = ser::deserialize_from_buffer(buffer_header_buf, std::type_identity<write_buffer::buffer_header>{});
 
         if (bh.magic != write_buffer::buffer_header_magic) {
             continue;
@@ -1771,7 +1718,7 @@ future<> segment_manager_impl::add_segment_to_compaction_group(replica::database
                 if (!t.uses_logstor()) {
                     co_return;
                 }
-                if (t.logstor_index().get(record.key).transform([](auto&& entry) { return entry.location; }) == loc) {
+                if (t.logstor_index().is_record_alive(record.key, loc)) {
                     co_await callback(loc, std::move(record), t);
                 }
             } catch(const replica::no_such_column_family&) {
@@ -1828,30 +1775,14 @@ future<> segment_manager_impl::add_segment_to_compaction_group(replica::database
 
     if (need_separator) {
         auto seg_ref = make_segment_ref(seg_id);
+        auto write_to_separator_failed = defer([seg_ref] mutable {
+            seg_ref.set_flush_failure();
+        });
         co_await for_each_live_record([this, seg_ref] (log_location prev_loc, log_record record, table& t) -> future<> {
-            auto key = record.key;
-
-            auto& index = t.logstor_index();
-
-            log_record_writer writer(std::move(record));
-            auto& buf = t.get_logstor_separator_buffer(key.dk.token(), writer.size());
-
-            if (buf.held_segments.empty() || buf.held_segments.back().id() != seg_ref.id()) {
-                buf.held_segments.push_back(seg_ref);
-            }
-
-            buf.pending_updates.push_back(
-                buf.write(std::move(writer)).then_unpack([this, &index, key = std::move(key), prev_loc] (log_location new_loc, seastar::gate::holder op) {
-                    if (index.update_record_location(key, prev_loc, new_loc)) {
-                        free_record(prev_loc);
-                    } else {
-                        free_record(new_loc);
-                    }
-                    return make_ready_future<>();
-                }
-            ));
+            write_to_separator(t, prev_loc, std::move(record), seg_ref);
             return make_ready_future<>();
         });
+        write_to_separator_failed.cancel();
     }
 }
 
@@ -1883,7 +1814,7 @@ future<> segment_manager::stop() {
     return _impl->stop();
 }
 
-future<log_location> segment_manager::write(write_buffer& wb) {
+future<> segment_manager::write(write_buffer& wb) {
     return _impl->write(wb);
 }
 
@@ -1893,11 +1824,6 @@ future<log_record> segment_manager::read(log_location location) {
 
 void segment_manager::free_record(log_location location) {
     _impl->free_record(location);
-}
-
-future<> segment_manager::for_each_record(const std::vector<log_segment_id>& segments,
-                                        std::function<future<>(log_location, log_record)> callback) {
-    return _impl->for_each_record(std::move(segments), std::move(callback));
 }
 
 void segment_manager::set_trigger_compaction_hook(std::function<void()> fn) {

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -1247,7 +1247,7 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
         auto bh = ser::deserialize_from_buffer(buffer_header_buf, std::type_identity<write_buffer::buffer_header>{});
 
         // if the buffer is invalid then skip the rest of the segment - buffer writes are sequential and serialized.
-        if (bh.magic != write_buffer::buffer_header_magic) {
+        if (!write_buffer::validate_header(bh)) {
             break;
         }
 
@@ -1280,8 +1280,8 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
                 break;
             }
             auto rh = ser::deserialize_from_buffer(size_buf, std::type_identity<write_buffer::record_header>{});
-            if (rh.data_size == 0) {
-                // End of records in this block
+            if (rh.data_size == 0 || rh.data_size > _cfg.segment_size) {
+                // invalid record size
                 break;
             }
 
@@ -1961,7 +1961,7 @@ future<std::optional<segment_header>> segment_manager_impl::read_segment_header(
     simple_memory_input_stream bh_stream(header_buf.begin(), write_buffer::buffer_header_size);
     auto bh = ser::deserialize(bh_stream, std::type_identity<write_buffer::buffer_header>{});
 
-    if (bh.magic != write_buffer::buffer_header_magic) {
+    if (!write_buffer::validate_header(bh)) {
         co_return std::nullopt;
     }
 

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -1153,17 +1153,38 @@ void segment_manager_impl::free_segment(log_segment_id segment_id) noexcept {
 future<> segment_manager_impl::discard_segments(segment_set& ss) {
     auto holder = _async_gate.hold();
 
+    std::vector<log_segment_id> segments;
+    segments.reserve(ss.segment_count());
     while (!ss._segments.empty()) {
         co_await coroutine::maybe_yield();
         auto& desc = ss._segments.one_of_largest();
         auto seg_id = desc_to_segment_id(desc);
+        ss.remove_segment(desc);
 
         // the index should be cleared before discarding segments, so no data should be reachable
         desc.reset(_cfg.segment_size);
 
-        ss.remove_segment(desc);
-        free_segment(seg_id);
+        segments.push_back(seg_id);
     }
+
+    co_await max_concurrent_for_each(segments, 32, [this] (log_segment_id seg_id) -> future<> {
+        // Write a valid empty segment header with the next generation.
+        // This marks the segment as discarded while preserving the generation counter.
+        auto next_gen = get_segment_descriptor(seg_id).seg_gen;
+        ++next_gen;
+        auto buf = allocate_aligned_buffer<char>(block_alignment, 4096);
+        std::memset(buf.get(), 0, block_alignment);
+        simple_memory_output_stream out(buf.get(), write_buffer::buffer_header_size);
+        write_buffer::write_empty_header(out, next_gen);
+
+        auto [file_id, file_offset] = segment_id_to_file_location(seg_id);
+        auto file = co_await _file_mgr.get_file_for_write(file_id);
+        co_await file.dma_write(file_offset, buf.get(), block_alignment);
+
+        logstor_logger.trace("Discard segment {} next gen {}", seg_id, next_gen);
+
+        free_segment(seg_id);
+    });
 }
 
 future<> segment_manager_impl::for_each_record(log_segment_id segment_id,

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -462,15 +462,17 @@ enum class write_source {
     normal_write,
     compaction,
     separator,
+    streaming,
 };
 
-static constexpr size_t write_source_count = 3;
+static constexpr size_t write_source_count = 4;
 
 static sstring write_source_to_string(write_source src) {
     switch (src) {
         case write_source::normal_write: return "normal_write";
         case write_source::compaction: return "compaction";
         case write_source::separator: return "separator";
+        case write_source::streaming: return "streaming";
     }
     return "unknown";
 }
@@ -660,6 +662,7 @@ public:
     future<> for_each_record(const std::vector<log_segment_id>&,
                             std::function<future<>(log_location, log_record)>);
 
+    future<> load_segment(replica::database&, log_segment_id);
     future<> recover_segment(replica::database&, log_segment_id);
     future<std::optional<segment_header>> read_segment_header(log_segment_id);
     future<> add_segment_to_compaction_group(replica::database&, segment_descriptor&);
@@ -705,6 +708,9 @@ public:
     future<> await_pending_writes() {
         return _writes_phaser.advance_and_await();
     }
+
+    future<seastar::input_stream<char>> create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts);
+    future<std::unique_ptr<segment_stream_sink>> create_segment_output_stream(replica::database&);
 
 private:
 
@@ -772,6 +778,7 @@ private:
 
     friend class compaction_manager_impl;
     friend struct compaction_buffer;
+    friend class segment_stream_sink_impl;
 };
 
 segment_manager_impl::segment_manager_impl(segment_manager_config config)
@@ -2069,6 +2076,84 @@ size_t segment_manager::get_memory_usage() const {
 
 future<> segment_manager::await_pending_writes() {
     return _impl->await_pending_writes();
+}
+
+class segment_data_sink_impl : public data_sink_impl {
+    seg_ptr _segment;
+public:
+    segment_data_sink_impl(seg_ptr segment)
+        : _segment(std::move(segment))
+    {}
+
+    virtual future<> put(std::span<temporary_buffer<char>> data) override {
+        for (auto& buf : data) {
+            co_await _segment->append(bytes_view((const int8_t*)buf.get(), buf.size()));
+        }
+    }
+
+    virtual future<> close() override {
+        co_return;
+    }
+
+    virtual size_t buffer_size() const noexcept override {
+        return 128 * 1024;
+    }
+};
+
+future<seastar::input_stream<char>> segment_manager_impl::create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts) {
+    auto [file_id, file_offset] = segment_id_to_file_location(segment_id);
+    auto file = co_await _file_mgr.get_file_for_read(file_id);
+    auto stream = make_file_input_stream(std::move(file), file_offset, _cfg.segment_size, opts);
+    co_return std::move(stream);
+}
+
+class segment_stream_sink_impl : public segment_stream_sink {
+    segment_manager_impl& _sm;
+    replica::database& _db;
+    seg_ptr _seg;
+public:
+    segment_stream_sink_impl(segment_manager_impl& sm, replica::database& db, seg_ptr seg)
+        : _sm(sm), _db(db), _seg(std::move(seg))
+    {}
+public:
+    log_segment_id segment_id() const noexcept override {
+        return _seg->id();
+    }
+    future<output_stream<char>> output() override {
+        auto sink = std::make_unique<segment_data_sink_impl>(_seg);
+        auto stream = output_stream<char>(data_sink(std::move(sink)));
+        co_return std::move(stream);
+    }
+    future<> close() override {
+        co_await _seg->stop();
+        co_await _sm.load_segment(_db, _seg->id());
+    }
+    future<> abort() override {
+        _sm.free_segment(_seg->id());
+        co_return;
+    }
+};
+
+future<> segment_manager_impl::load_segment(replica::database& db, log_segment_id seg_id) {
+    // read the segment and populate the index
+    co_await recover_segment(db, seg_id);
+
+    auto& desc = get_segment_descriptor(seg_id);
+    co_await add_segment_to_compaction_group(db, desc);
+}
+
+future<std::unique_ptr<segment_stream_sink>> segment_manager_impl::create_segment_output_stream(replica::database& db) {
+    auto seg = co_await _segment_pool.get_segment(write_source::streaming);
+    _stats.segments_in_use++;
+    co_return std::make_unique<segment_stream_sink_impl>(*this, db, std::move(seg));
+}
+
+future<seastar::input_stream<char>> segment_manager::create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts) {
+    return _impl->create_segment_input_stream(segment_id, opts);
+}
+
+future<std::unique_ptr<segment_stream_sink>> segment_manager::create_segment_output_stream(replica::database& db) {
+    return _impl->create_segment_output_stream(db);
 }
 
 }

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -420,6 +420,7 @@ private:
     void submit(compaction_group&) override;
     future<> stop_ongoing_compactions(compaction_group&) override;
     future<compaction_reenabler> disable_compaction(replica::compaction_group&) override;
+    compaction_reenabler disable_compaction_no_wait(replica::compaction_group&) override;
 
     std::vector<log_segment_id> select_segments_for_compaction(const segment_descriptor_hist&);
     future<> do_compact(compaction_group&, abort_source&);
@@ -1344,6 +1345,23 @@ future<compaction_reenabler> compaction_manager_impl::disable_compaction(compact
     co_await state.completion.get_future();
 
     co_return compaction_reenabler([this, &cg] {
+        auto it = _groups.find(&cg);
+        if (it != _groups.end()) {
+            --it->second->compaction_disabled_counter;
+        }
+    });
+}
+
+compaction_reenabler compaction_manager_impl::disable_compaction_no_wait(compaction_group& cg) {
+    auto& state_ptr = _groups[&cg];
+    if (!state_ptr) {
+        state_ptr = std::make_unique<group_compaction_state>();
+    }
+    auto& state = *state_ptr;
+
+    ++state.compaction_disabled_counter;
+
+    return compaction_reenabler([this, &cg] {
         auto it = _groups.find(&cg);
         if (it != _groups.end()) {
             --it->second->compaction_disabled_counter;

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -709,6 +709,8 @@ public:
         return _writes_phaser.advance_and_await();
     }
 
+    future<utils::chunked_vector<segment_snapshot>> make_snapshot(compaction_group&);
+
     future<seastar::input_stream<char>> create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts);
     future<std::unique_ptr<segment_stream_sink>> create_segment_output_stream(replica::database&);
 
@@ -725,12 +727,18 @@ private:
     void write_to_separator(table&, log_location prev_loc, log_record, segment_ref);
 
     segment_ref make_segment_ref(log_segment_id seg_id) {
+        auto& desc = get_segment_descriptor(seg_id);
+        ++desc.ref_count;
+
         return segment_ref(seg_id,
             [this, seg_id] {
-                return free_segment(seg_id);
+                auto& desc = get_segment_descriptor(seg_id);
+                if (--desc.ref_count == 0) {
+                    return free_segment(seg_id);
+                }
             },
             [seg_id] {
-                logstor_logger.warn("Segment {} has no more references but it can't be freed", seg_id);
+                logstor_logger.warn("Segment {} can't be freed", seg_id);
             }
         );
     }
@@ -1146,6 +1154,9 @@ void segment_manager_impl::free_segment(log_segment_id segment_id) noexcept {
     if (desc.net_data_size(_cfg.segment_size) != 0) {
         on_internal_error(logstor_logger, format("Freeing segment {} that has data", segment_id));
     }
+    if (desc.ref_count != 0) {
+        on_internal_error(logstor_logger, format("Freeing segment {} with non-zero reference count", segment_id));
+    }
     desc.on_free_segment();
 
     // TODO write new generation?
@@ -1167,6 +1178,9 @@ future<> segment_manager_impl::discard_segments(segment_set& ss) {
         auto& desc = ss._segments.one_of_largest();
         auto seg_id = desc_to_segment_id(desc);
         ss.remove_segment(desc);
+        if (desc.ref_count != 0) {
+            on_internal_error(logstor_logger, format("Discarding segment {} with non-zero reference count", seg_id));
+        }
 
         // the index should be cleared before discarding segments, so no data should be reachable
         desc.reset(_cfg.segment_size);
@@ -1574,7 +1588,9 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
         logstor_logger.trace("Free segment {} by compaction", seg_id);
         auto& desc = _sm.get_segment_descriptor(seg_id);
         ss.remove_segment(desc);
-        _sm.free_segment(seg_id);
+        if (desc.ref_count == 0) {
+            _sm.free_segment(seg_id);
+        }
     }
 
     size_t new_segments = segments.size() > cb.flush_count ? segments.size() - cb.flush_count : 0;
@@ -1676,7 +1692,9 @@ future<> compaction_manager_impl::split_compaction(replica::table& t, compaction
             logstor_logger.trace("Free segment {} by split", seg_id);
             auto& desc = _sm.get_segment_descriptor(seg_id);
             src_segments.remove_segment(desc);
-            _sm.free_segment(seg_id);
+            if (desc.ref_count == 0) {
+                _sm.free_segment(seg_id);
+            }
         }
     }
 }
@@ -2006,6 +2024,26 @@ future<> segment_manager_impl::add_segment_to_compaction_group(replica::database
     }
 }
 
+future<utils::chunked_vector<segment_snapshot>> segment_manager_impl::make_snapshot(compaction_group& cg) {
+    auto& segments = cg.logstor_segments();
+
+    utils::chunked_vector<segment_snapshot> snp;
+    snp.reserve(segments.segment_count());
+    for (auto& desc : segments._segments) {
+        auto seg_id = desc_to_segment_id(desc);
+        snp.push_back(segment_snapshot{
+            .segment_id = seg_id,
+            .seg_ref = make_segment_ref(seg_id),
+            .source = [this, seg_id] (const file_input_stream_options& opts) {
+                return create_segment_input_stream(seg_id, opts);
+            }
+        });
+        co_await coroutine::maybe_yield();
+    }
+
+    co_return std::move(snp);
+}
+
 // segment_manager wrapper
 
 segment_manager::segment_manager(segment_manager_config config)
@@ -2148,8 +2186,8 @@ future<std::unique_ptr<segment_stream_sink>> segment_manager_impl::create_segmen
     co_return std::make_unique<segment_stream_sink_impl>(*this, db, std::move(seg));
 }
 
-future<seastar::input_stream<char>> segment_manager::create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts) {
-    return _impl->create_segment_input_stream(segment_id, opts);
+future<utils::chunked_vector<segment_snapshot>> segment_manager::make_snapshot(compaction_group& cg) {
+    return _impl->make_snapshot(cg);
 }
 
 future<std::unique_ptr<segment_stream_sink>> segment_manager::create_segment_output_stream(replica::database& db) {

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -1763,7 +1763,7 @@ future<> segment_manager_impl::add_segment_to_compaction_group(replica::database
     } else {
         auto tid = std::get<table_id>(*segment_table);
         auto& t = db.find_column_family(tid);
-        if (t.add_logstor_segment(desc, *first_token, *last_token)) {
+        if (t.add_logstor_segment(seg_id, desc, *first_token, *last_token)) {
             // all record belong to a single compaction group and the segment was added to the compaction group
             logstor_logger.debug("Add segment {} with {} record with tokens [{},{}] to table", seg_id, live_record_count, *first_token, *last_token);
         } else {

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -535,6 +535,41 @@ public:
     }
 };
 
+struct segment_header {
+    segment_kind kind;
+    segment_generation seg_gen;
+
+    struct mixed {};
+    struct full {
+        table_id table;
+        dht::token first_token;
+        dht::token last_token;
+    };
+
+    std::variant<mixed, full> v;
+};
+
+static segment_header make_segment_header(const write_buffer::buffer_header& bh, std::optional<write_buffer::segment_header> sh) {
+    segment_header seg_hdr {
+        .kind = bh.kind,
+        .seg_gen = bh.seg_gen,
+    };
+
+    switch (bh.kind) {
+    case segment_kind::full:
+        seg_hdr.v = segment_header::full {
+            .table = sh->table,
+            .first_token = sh->first_token,
+            .last_token = sh->last_token,
+        };
+        break;
+    case segment_kind::mixed:
+        seg_hdr.v = segment_header::mixed{};
+        break;
+    }
+    return seg_hdr;
+}
+
 class segment_manager_impl {
 
     struct stats {
@@ -612,13 +647,17 @@ public:
     void free_record(log_location);
 
     future<> for_each_record(log_segment_id,
+                            std::function<future<>(const segment_header&)>,
+                            std::function<future<>(log_location, log_record)>);
+
+    future<> for_each_record(log_segment_id,
                             std::function<future<>(log_location, log_record)>);
 
     future<> for_each_record(const std::vector<log_segment_id>&,
                             std::function<future<>(log_location, log_record)>);
 
     future<> recover_segment(replica::database&, log_segment_id);
-    future<std::optional<segment_generation>> recover_segment_generation(log_segment_id);
+    future<std::optional<segment_header>> read_segment_header(log_segment_id);
     future<> add_segment_to_compaction_group(replica::database&, segment_descriptor&);
 
     void trigger_compaction() {
@@ -754,7 +793,7 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
     _available_compaction_buffers.reserve(compaction_buffer_count);
     _compaction_buffer_pool.reserve(compaction_buffer_count);
     for (size_t i = 0; i < compaction_buffer_count; ++i) {
-        _compaction_buffer_pool.emplace_back(config.segment_size, false);
+        _compaction_buffer_pool.emplace_back(config.segment_size, segment_kind::full);
         _available_compaction_buffers.push_back(&_compaction_buffer_pool.back());
     }
 
@@ -763,7 +802,7 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
     _available_separator_buffers.reserve(separator_buffer_count);
     _separator_buffer_pool.reserve(separator_buffer_count);
     for (size_t i = 0; i < separator_buffer_count; ++i) {
-        _separator_buffer_pool.emplace_back(config.segment_size, false);
+        _separator_buffer_pool.emplace_back(config.segment_size, segment_kind::full);
         _available_separator_buffers.push_back(&_separator_buffer_pool.back());
     }
 
@@ -901,7 +940,7 @@ future<> segment_manager_impl::write(write_buffer& wb) {
             seg_ref.set_flush_failure();
         });
 
-        wb.write_header(desc.seg_gen);
+        wb.write_header(desc.seg_gen, std::nullopt);
 
         auto loc = co_await seg->append(data);
         sem_units.return_all();
@@ -944,7 +983,7 @@ future<> segment_manager_impl::write_full_segment(write_buffer& wb, compaction_g
     _stats.segments_in_use++;
     logstor_logger.trace("Write full segment {} from {}", seg->id(), write_source_to_string(source));
 
-    wb.write_header(desc.seg_gen);
+    wb.write_header(desc.seg_gen, cg.schema()->id());
 
     auto loc = co_await seg->append(data);
 
@@ -1122,6 +1161,7 @@ future<> segment_manager_impl::discard_segments(segment_set& ss) {
 }
 
 future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
+                                std::function<future<>(const segment_header&)> header_callback,
                                 std::function<future<>(log_location, log_record)> callback) {
     auto holder = _async_gate.hold();
 
@@ -1167,6 +1207,20 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
             break;
         }
 
+        std::optional<write_buffer::segment_header> sh;
+        if (bh.kind == segment_kind::full) {
+            // read segment header
+            auto segment_header_buf = co_await fin.read_exactly(write_buffer::segment_header_size);
+            current_position += write_buffer::segment_header_size;
+            if (segment_header_buf.size() < write_buffer::segment_header_size) {
+                break;
+            }
+            sh = ser::deserialize_from_buffer(segment_header_buf, std::type_identity<write_buffer::segment_header>{});
+        }
+
+        auto seg_hdr = make_segment_header(bh, sh);
+        co_await header_callback(seg_hdr);
+
         // TODO crc, torn writes
 
         const auto buffer_data_end_position = current_position + bh.data_size;
@@ -1211,6 +1265,11 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
             }
         }
 
+        if (seg_hdr.kind == segment_kind::full) {
+            // A segment of this kind has only a single buffer
+            break;
+        }
+
         if (current_position < buffer_data_end_position) {
             // skip remaining buffer data
             auto bytes_to_skip = buffer_data_end_position - current_position;
@@ -1220,6 +1279,13 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
     }
 
     co_await fin.close();
+}
+
+future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
+                                std::function<future<>(log_location, log_record)> callback) {
+    return for_each_record(segment_id,
+        [] (const segment_header&) { return make_ready_future<>(); },
+        std::move(callback));
 }
 
 future<> segment_manager_impl::for_each_record(const std::vector<log_segment_id>& segments,
@@ -1652,13 +1718,16 @@ future<> segment_manager_impl::recover_segment(replica::database& db, log_segmen
     auto& desc = get_segment_descriptor(segment_id);
     desc.reset(_cfg.segment_size);
 
-    auto seg_gen_opt = co_await recover_segment_generation(segment_id);
-    if (!seg_gen_opt) {
+    auto seg_hdr = co_await read_segment_header(segment_id);
+    if (!seg_hdr) {
+        logstor_logger.trace("Segment {} has invalid header, skipping", segment_id);
         co_return;
     }
-    desc.seg_gen = *seg_gen_opt;
+    desc.seg_gen = seg_hdr->seg_gen;
+    bool is_full_segment = seg_hdr->kind == segment_kind::full;
+    logstor_logger.trace("Recovering segment {} with generation {}", segment_id, desc.seg_gen);
 
-    co_await for_each_record(segment_id, [this, &desc, &db] (log_location loc, log_record record) -> future<> {
+    co_await for_each_record(segment_id, [this, &desc, &db, is_full_segment] (log_location loc, log_record record) -> future<> {
         logstor_logger.trace("Recovery: read record at {} gen {}", loc, record.generation);
 
         index_entry new_entry {
@@ -1671,7 +1740,7 @@ future<> segment_manager_impl::recover_segment(replica::database& db, log_segmen
             if (!t.uses_logstor()) {
                 co_return;
             }
-            auto [inserted, prev_entry] = t.logstor_index().insert_if_newer(record.key, new_entry);
+            auto [inserted, prev_entry] = t.logstor_index().insert_if_newer(record.key, new_entry, is_full_segment);
             if (inserted) {
                 desc.on_write(loc);
                 if (prev_entry) {
@@ -1686,96 +1755,60 @@ future<> segment_manager_impl::recover_segment(replica::database& db, log_segmen
     });
 }
 
-future<std::optional<segment_generation>> segment_manager_impl::recover_segment_generation(log_segment_id segment_id) {
+future<std::optional<segment_header>> segment_manager_impl::read_segment_header(log_segment_id segment_id) {
     auto [file_id, file_offset] = segment_id_to_file_location(segment_id);
     auto file = co_await _file_mgr.get_file_for_read(file_id);
 
-    std::optional<segment_generation> max_gen;
+    auto max_header_size = write_buffer::buffer_header_size + write_buffer::segment_header_size;
+    auto header_buf = co_await file.dma_read_exactly<char>(file_offset, max_header_size);
 
-    for (size_t current_position = 0; current_position < _cfg.segment_size; current_position += block_alignment) {
-        auto buffer_header_buf = co_await file.dma_read_exactly<char>(
-            file_offset + current_position, write_buffer::buffer_header_size);
-
-        if (buffer_header_buf.size() < write_buffer::buffer_header_size) {
-            continue;
-        }
-
-        auto bh = ser::deserialize_from_buffer(buffer_header_buf, std::type_identity<write_buffer::buffer_header>{});
-
-        if (bh.magic != write_buffer::buffer_header_magic) {
-            continue;
-        }
-
-        if (!max_gen || bh.seg_gen > *max_gen) {
-            max_gen = bh.seg_gen;
-        }
+    if (header_buf.size() < max_header_size) {
+        co_return std::nullopt;
     }
 
-    co_return max_gen;
+    simple_memory_input_stream bh_stream(header_buf.begin(), write_buffer::buffer_header_size);
+    auto bh = ser::deserialize(bh_stream, std::type_identity<write_buffer::buffer_header>{});
+
+    if (bh.magic != write_buffer::buffer_header_magic) {
+        co_return std::nullopt;
+    }
+
+    std::optional<write_buffer::segment_header> sh;
+    if (bh.kind == segment_kind::full) {
+        simple_memory_input_stream sh_stream(header_buf.begin() + write_buffer::buffer_header_size, write_buffer::segment_header_size);
+        sh = ser::deserialize(sh_stream, std::type_identity<write_buffer::segment_header>{});
+    }
+
+    co_return make_segment_header(bh, sh);
 }
 
 future<> segment_manager_impl::add_segment_to_compaction_group(replica::database& db, segment_descriptor& desc) {
     auto seg_id = desc_to_segment_id(desc);
-
-    auto for_each_live_record = [this, &db, seg_id] (std::function<future<>(log_location, log_record, table&)> callback) {
-        return for_each_record(seg_id, [&db, callback = std::move(callback)] (log_location loc, log_record record) -> future<> {
-            try {
-                auto& t = db.find_column_family(record.table);
-                if (!t.uses_logstor()) {
-                    co_return;
-                }
-                if (t.logstor_index().is_record_alive(record.key, loc)) {
-                    co_await callback(loc, std::move(record), t);
-                }
-            } catch(const replica::no_such_column_family&) {
-                co_return;
-            }
-        });
-    };
-
-    // find the segment's table and token range
-    struct mixed_tables{};
-    std::optional<std::variant<table_id, mixed_tables>> segment_table;
-    std::optional<dht::token> first_token;
-    std::optional<dht::token> last_token;
-    size_t live_record_count = 0;
-    co_await for_each_live_record([&segment_table, &first_token, &last_token, &live_record_count] (log_location loc, log_record record, table&) -> future<> {
-        ++live_record_count;
-
-        if (!segment_table) {
-            segment_table = record.table;
-        } else if (std::holds_alternative<table_id>(*segment_table) && std::get<table_id>(*segment_table) != record.table) {
-            segment_table = mixed_tables{};
-        }
-
-        auto record_token = record.key.dk.token();
-        if (!first_token || record_token < *first_token) {
-            first_token = record_token;
-        }
-        if (!last_token || record_token > *last_token) {
-            last_token = record_token;
-        }
+    auto maybe_header = co_await read_segment_header(seg_id);
+    if (!maybe_header) {
         co_return;
-    });
+    }
+    auto& header = *maybe_header;
 
     bool need_separator = false;
-    if (!segment_table) {
-        logstor_logger.warn("Segment {} has no live records, but was not freed. Freeing now.", seg_id);
-        desc.on_free_segment();
-        _free_segments.push_back(seg_id);
-    } else if (std::holds_alternative<mixed_tables>(*segment_table)) {
-        logstor_logger.debug("Segment {} has {} live records from multiple tables", seg_id, live_record_count);
+
+    if (header.kind == segment_kind::mixed) {
+        logstor_logger.debug("Recovering mixed segment {} using separator", seg_id);
         need_separator = true;
     } else {
-        auto tid = std::get<table_id>(*segment_table);
-        auto& t = db.find_column_family(tid);
-        if (t.add_logstor_segment(seg_id, desc, *first_token, *last_token)) {
-            // all record belong to a single compaction group and the segment was added to the compaction group
-            logstor_logger.debug("Add segment {} with {} record with tokens [{},{}] to table", seg_id, live_record_count, *first_token, *last_token);
-        } else {
-            // the record belong to different compaction groups - write to separator
-            logstor_logger.debug("Add segment {} with {} record with tokens [{},{}] to separator", seg_id, live_record_count, *first_token, *last_token);
-            need_separator = true;
+        auto& seg_header = std::get<segment_header::full>(header.v);
+        try {
+            auto& t = db.find_column_family(seg_header.table);
+            if (t.add_logstor_segment(seg_id, desc, seg_header.first_token, seg_header.last_token)) {
+                // all record belong to a single compaction group and the segment was added to the compaction group
+                logstor_logger.debug("Add segment {} with tokens [{},{}] to table", seg_id, seg_header.first_token, seg_header.last_token);
+            } else {
+                // the record belong to different compaction groups - write to separator
+                logstor_logger.debug("Add segment {} with tokens [{},{}] to separator", seg_id, seg_header.first_token, seg_header.last_token);
+                need_separator = true;
+            }
+        } catch(const replica::no_such_column_family&) {
+            co_return;
         }
     }
 
@@ -1784,8 +1817,15 @@ future<> segment_manager_impl::add_segment_to_compaction_group(replica::database
         auto write_to_separator_failed = defer([seg_ref] mutable {
             seg_ref.set_flush_failure();
         });
-        co_await for_each_live_record([this, seg_ref] (log_location prev_loc, log_record record, table& t) -> future<> {
-            write_to_separator(t, prev_loc, std::move(record), seg_ref);
+        co_await for_each_record(seg_id, [this, seg_ref, &db] (log_location prev_loc, log_record record) -> future<> {
+            try {
+                auto& t = db.find_column_family(record.table);
+                if (t.uses_logstor() && t.logstor_index().is_record_alive(record.key, prev_loc)) {
+                    write_to_separator(t, prev_loc, std::move(record), seg_ref);
+                }
+            } catch(const replica::no_such_column_family&) {
+                // ignore record
+            }
             return make_ready_future<>();
         });
         write_to_separator_failed.cancel();

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -72,6 +72,8 @@ class writeable_segment : public segment {
 
     uint32_t _current_offset = 0; // next offset for write
 
+    future<> do_write(log_location , bytes_view data);
+
 public:
     using segment::segment;
 
@@ -79,9 +81,9 @@ public:
 
     future<> stop();
 
-    // allocate and write a serialized sequence of records
-    log_location allocate(size_t data_size);
-    future<> write(log_location , bytes_view data);
+    // write a serialized sequence of records.
+    // must not be called concurrently.
+    future<log_location> append(bytes_view data);
 
     bool can_fit(size_t data_size) const noexcept {
         return _current_offset + data_size <= _max_size;
@@ -130,22 +132,25 @@ future<> writeable_segment::stop() {
     co_await _write_gate.close();
 }
 
-log_location writeable_segment::allocate(size_t data_size) {
+future<log_location> writeable_segment::append(bytes_view data) {
+    auto data_size = data.size();
+
     if (!can_fit(data_size)) {
         throw std::runtime_error("Entry too large for remaining segment space");
     }
 
-    auto current_pos = _current_offset;
-    _current_offset += data_size;
-
-    return log_location{
+    log_location loc {
         .segment = _id,
-        .offset = current_pos,
+        .offset = _current_offset,
         .size = static_cast<uint32_t>(data_size)
     };
+
+    co_await do_write(loc, data);
+    _current_offset += data_size;
+    co_return loc;
 }
 
-future<> writeable_segment::write(log_location loc, bytes_view data) {
+future<> writeable_segment::do_write(log_location loc, bytes_view data) {
     const auto alignment = _file.disk_write_dma_alignment();
     const auto total = data.size();
     auto offset = absolute_offset(loc.offset);
@@ -561,6 +566,7 @@ class segment_manager_impl {
     static constexpr size_t segment_pool_size = 128;
 
     seg_ptr _active_segment;
+    seastar::semaphore _active_segment_write_sem{1};
     segment_pool _segment_pool;
     std::optional<shared_future<>> _switch_segment_fut;
     size_t _segment_seq_num{0};
@@ -876,28 +882,29 @@ future<> segment_manager_impl::write(write_buffer& wb) {
         throw std::runtime_error(fmt::format( "Write size {} exceeds segment size {}", data.size(), _cfg.segment_size));
     }
 
-    while (!_active_segment || !_active_segment->can_fit(data.size())) {
-        co_await request_segment_switch();
-    }
-
     {
+        auto sem_units = co_await get_units(_active_segment_write_sem, 1);
+
+        while (!_active_segment || !_active_segment->can_fit(data.size())) {
+            co_await request_segment_switch();
+        }
+
         seg_ptr seg = _active_segment;
         auto seg_holder = seg->hold();
         auto seg_ref = seg->ref();
         auto segment_seq_num = _segment_seq_num;
         auto write_op = _writes_phaser.start();
+        auto& desc = get_segment_descriptor(seg->id());
 
         // if we wrote a record to the segment but failed to write it to the separator, the segment should not be freed.
         auto write_to_separator_failed = defer([seg_ref] mutable {
             seg_ref.set_flush_failure();
         });
 
-        auto loc = seg->allocate(data.size());
-        auto& desc = get_segment_descriptor(loc);
-
         wb.write_header(desc.seg_gen);
 
-        co_await seg->write(loc, data);
+        auto loc = co_await seg->append(data);
+        sem_units.return_all();
 
         desc.on_write(wb.get_net_data_size(), wb.get_record_count());
 
@@ -932,15 +939,14 @@ future<> segment_manager_impl::write_full_segment(write_buffer& wb, compaction_g
     }
 
     seg_ptr seg = co_await _segment_pool.get_segment(source);
+    auto& desc = get_segment_descriptor(seg->id());
+
     _stats.segments_in_use++;
     logstor_logger.trace("Write full segment {} from {}", seg->id(), write_source_to_string(source));
 
-    auto loc = seg->allocate(data.size());
-    auto& desc = get_segment_descriptor(loc);
-
     wb.write_header(desc.seg_gen);
 
-    co_await seg->write(loc, data);
+    auto loc = co_await seg->append(data);
 
     desc.on_write(wb.get_net_data_size(), wb.get_record_count());
 
@@ -1152,13 +1158,13 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
         }
         auto bh = ser::deserialize_from_buffer(buffer_header_buf, std::type_identity<write_buffer::buffer_header>{});
 
-        // if buffer header is not valid, skip to next block
+        // if the buffer is invalid then skip the rest of the segment - buffer writes are sequential and serialized.
         if (bh.magic != write_buffer::buffer_header_magic) {
-            continue;
+            break;
         }
 
         if (bh.seg_gen != seg_gen) {
-            continue;
+            break;
         }
 
         // TODO crc, torn writes

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -392,6 +392,7 @@ private:
         bool running{false};
         shared_future<> completion{make_ready_future<>()};
         abort_source as;
+        int compaction_disabled_counter{0};
     };
     absl::flat_hash_map<compaction_group*, std::unique_ptr<group_compaction_state>> _groups;
 
@@ -418,6 +419,7 @@ private:
 
     void submit(compaction_group&) override;
     future<> stop_ongoing_compactions(compaction_group&) override;
+    future<compaction_reenabler> disable_compaction(replica::compaction_group&) override;
 
     std::vector<log_segment_id> select_segments_for_compaction(const segment_descriptor_hist&);
     future<> do_compact(compaction_group&, abort_source&);
@@ -1304,7 +1306,7 @@ void compaction_manager_impl::submit(compaction_group& cg) {
         state_ptr = std::make_unique<group_compaction_state>();
     }
     auto& state = *state_ptr;
-    if (state.running) {
+    if (state.running || state.compaction_disabled_counter > 0) {
         return;
     }
     state.running = true;
@@ -1327,6 +1329,26 @@ future<> compaction_manager_impl::stop_ongoing_compactions(compaction_group& cg)
     state.as.request_abort();
     co_await state.completion.get_future();
     _groups.erase(it);
+}
+
+future<compaction_reenabler> compaction_manager_impl::disable_compaction(compaction_group& cg) {
+    auto& state_ptr = _groups[&cg];
+    if (!state_ptr) {
+        state_ptr = std::make_unique<group_compaction_state>();
+    }
+    auto& state = *state_ptr;
+
+    ++state.compaction_disabled_counter;
+
+    // Wait for any ongoing compaction to finish before disabling
+    co_await state.completion.get_future();
+
+    co_return compaction_reenabler([this, &cg] {
+        auto it = _groups.find(&cg);
+        if (it != _groups.end()) {
+            --it->second->compaction_disabled_counter;
+        }
+    });
 }
 
 std::vector<log_segment_id> compaction_manager_impl::select_segments_for_compaction(const segment_descriptor_hist& segments) {

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -415,12 +415,13 @@ public:
     separator_buffer allocate_separator_buffer() override;
     future<> flush_separator_buffer(separator_buffer buf, compaction_group&) override;
 
-private:
-
     void submit(compaction_group&) override;
     future<> stop_ongoing_compactions(compaction_group&) override;
     future<compaction_reenabler> disable_compaction(replica::compaction_group&) override;
     compaction_reenabler disable_compaction_no_wait(replica::compaction_group&) override;
+    future<> split_compaction(replica::table&, compaction_group&, mutation_writer::classify_by_token_group) override;
+
+private:
 
     std::vector<log_segment_id> select_segments_for_compaction(const segment_descriptor_hist&);
     future<> do_compact(compaction_group&, abort_source&);
@@ -770,6 +771,7 @@ private:
     }
 
     friend class compaction_manager_impl;
+    friend struct compaction_buffer;
 };
 
 segment_manager_impl::segment_manager_impl(segment_manager_config config)
@@ -791,8 +793,9 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
     _free_segments.reserve(_max_segments);
 
     // pre-allocate write buffers for compaction
-    // currently there is only a single compaction running at a time
-    size_t compaction_buffer_count = 1;
+    // at most a single compaction/split running at a time
+    // and at most two buffers used at a time by split.
+    size_t compaction_buffer_count = 2;
     _available_compaction_buffers.reserve(compaction_buffer_count);
     _compaction_buffer_pool.reserve(compaction_buffer_count);
     for (size_t i = 0; i < compaction_buffer_count; ++i) {
@@ -1427,53 +1430,95 @@ future<> compaction_manager_impl::do_compact(compaction_group& cg, abort_source&
     });
 }
 
+// A single buffer used by compaction for rewriting records into new segments in a single compaction group.
+// `rewrite_record` append a record to the buffer and given it's current location, and
+// when the buffer is flushed it updates the index with the new location.
+// the buffer is flushed when the next record doesn't fit and on close().
+struct compaction_buffer {
+    segment_manager_impl& sm;
+    write_buffer* buf = nullptr;
+    compaction_group& cg;
+    std::vector<future<>> pending_updates;
+    size_t flush_count{0};
+
+    explicit compaction_buffer(segment_manager_impl& sm, compaction_group& cg)
+        : sm(sm), cg(cg)
+    {
+        if (sm._available_compaction_buffers.empty()) {
+            throw std::runtime_error("No available compaction buffers");
+        }
+        buf = sm._available_compaction_buffers.back();
+        sm._available_compaction_buffers.pop_back();
+    }
+
+    compaction_buffer(compaction_buffer&& o) noexcept
+        : sm(o.sm), buf(std::exchange(o.buf, nullptr)), cg(o.cg)
+        , pending_updates(std::move(o.pending_updates)), flush_count(o.flush_count) {}
+
+    ~compaction_buffer() {
+        if (buf) {
+            (void)buf->close().then([sm = &this->sm, buf = this->buf] {
+                buf->reset();
+                sm->_available_compaction_buffers.push_back(buf);
+            });
+        }
+    }
+
+    future<> flush() {
+        if (buf->has_data()) {
+            flush_count++;
+            co_await sm.write_full_segment(*buf, cg, write_source::compaction);
+            logstor_logger.trace("Compaction buffer flushed with {} bytes", buf->get_net_data_size());
+        }
+        co_await when_all_succeed(pending_updates.begin(), pending_updates.end());
+        co_await buf->close();
+        buf->reset();
+        pending_updates.clear();
+    }
+
+    future<> close() {
+        co_await flush();
+        sm._available_compaction_buffers.push_back(buf);
+        buf = nullptr;
+    }
+
+    // Rewrite a single live record into this buffer, updating the index atomically.
+    // Returns immediately after queuing the write; caller must co_await close()/flush()
+    // to ensure all pending updates complete.
+    future<> rewrite_record(primary_index& index, log_location read_location, log_record record,
+                             size_t& records_rewritten, size_t& records_skipped) {
+        if (!index.is_record_alive(record.key, read_location)) {
+            records_skipped++;
+            co_return;
+        }
+
+        auto key = record.key;
+        log_record_writer writer(std::move(record));
+
+        if (!buf->can_fit(writer)) {
+            co_await flush();
+        }
+
+        auto write_and_update_index = buf->write(std::move(writer)).then_unpack(
+                [this, &index, key = std::move(key), read_location, &records_rewritten, &records_skipped]
+                (log_location new_location, seastar::gate::holder op) {
+
+            if (index.update_record_location(key, read_location, new_location)) {
+                sm.free_record(read_location);
+                records_rewritten++;
+            } else {
+                // another write updated this key
+                sm.free_record(new_location);
+                records_skipped++;
+            }
+        });
+
+        pending_updates.push_back(std::move(write_and_update_index));
+    }
+};
+
 future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::vector<log_segment_id> segments) {
     logstor_logger.trace("Starting compaction of segments {} in compaction group {}:{}", segments, cg.schema()->id(), cg.group_id());
-
-    struct compaction_buffer {
-        segment_manager_impl& sm;
-        write_buffer* buf = nullptr;
-        compaction_group& cg;
-        std::vector<future<>> pending_updates;
-        size_t flush_count{0};
-
-        explicit compaction_buffer(segment_manager_impl& sm, compaction_group& cg)
-            : sm(sm), cg(cg)
-        {
-            if (sm._available_compaction_buffers.empty()) {
-                throw std::runtime_error("No available compaction buffers");
-            }
-            buf = sm._available_compaction_buffers.back();
-            sm._available_compaction_buffers.pop_back();
-        }
-
-        ~compaction_buffer() {
-            if (buf) {
-                (void)buf->close().then([sm = &this->sm, buf = this->buf] {
-                    buf->reset();
-                    sm->_available_compaction_buffers.push_back(buf);
-                });
-            }
-        }
-
-        future<> flush() {
-            if (buf->has_data()) {
-                flush_count++;
-                co_await sm.write_full_segment(*buf, cg, write_source::compaction);
-                logstor_logger.trace("Compaction buffer flushed with {} bytes", buf->get_net_data_size());
-            }
-            co_await when_all_succeed(pending_updates.begin(), pending_updates.end());
-            co_await buf->close();
-            buf->reset();
-            pending_updates.clear();
-        }
-
-        future<> close() {
-            co_await flush();
-            sm._available_compaction_buffers.push_back(buf);
-            buf = nullptr;
-        }
-    };
 
     compaction_buffer cb(_sm, cg);
 
@@ -1483,38 +1528,8 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
     auto& index = cg.get_logstor_index();
 
     co_await _sm.for_each_record(segments,
-            [this, &index, &records_rewritten, &records_skipped, &cb]
-            (log_location read_location, log_record record) -> future<> {
-
-        if (!index.is_record_alive(record.key, read_location)) {
-            records_skipped++;
-            _stats.compaction_records_skipped++;
-            co_return;
-        }
-
-        auto key = record.key;
-        log_record_writer writer(std::move(record));
-
-        if (!cb.buf->can_fit(writer)) {
-            co_await cb.flush();
-        }
-
-        // write the record and then update the index with the new location
-        auto write_and_update_index = cb.buf->write(std::move(writer)).then_unpack(
-                [this, &index, key = std::move(key), read_location, &records_rewritten, &records_skipped]
-                (log_location new_location, seastar::gate::holder op) {
-
-            if (index.update_record_location(key, read_location, new_location)) {
-                _sm.free_record(read_location);
-                records_rewritten++;
-            } else {
-                // another write updated this key
-                _sm.free_record(new_location);
-                records_skipped++;
-            }
-        });
-
-        cb.pending_updates.push_back(std::move(write_and_update_index));
+            [&index, &records_rewritten, &records_skipped, &cb] (log_location read_location, log_record record) -> future<> {
+        co_await cb.rewrite_record(index, read_location, std::move(record), records_rewritten, records_skipped);
     });
 
     co_await cb.close();
@@ -1523,13 +1538,14 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
                        records_rewritten, records_skipped, segments.size(), cb.flush_count);
 
     // wait for read operations that use the old locations
-    co_await cg.get_logstor_index().await_pending_reads();
+    co_await index.await_pending_reads();
 
     // Free the compacted segments
     auto& ss = cg.logstor_segments();
     for (auto seg_id : segments) {
         logstor_logger.trace("Free segment {} by compaction", seg_id);
-        ss.remove_segment(_sm.get_segment_descriptor(seg_id));
+        auto& desc = _sm.get_segment_descriptor(seg_id);
+        ss.remove_segment(desc);
         _sm.free_segment(seg_id);
     }
 
@@ -1545,6 +1561,96 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
 void compaction_manager_impl::controller::update(size_t segment_write_count, size_t new_segments) {
     float new_overhead = static_cast<float>(segment_write_count) / std::max<size_t>(1, new_segments);
     _compaction_overhead = 0.8 * _compaction_overhead + 0.2 * new_overhead;
+}
+
+future<> compaction_manager_impl::split_compaction(replica::table& t, compaction_group& src, mutation_writer::classify_by_token_group classifier) {
+    static constexpr size_t batch_size = 32;
+
+    // Disable compaction on src for the duration of the split.
+    // This waits for any running compaction on src to finish first.
+    auto compaction_disable_guard = co_await disable_compaction(src);
+
+    auto& src_segments = src.logstor_segments();
+    auto& index = t.logstor_index();
+
+    while (!src_segments._segments.empty()) {
+        // Collect candidate IDs without yielding to avoid iterator invalidation.
+        std::vector<log_segment_id> candidates;
+        candidates.reserve(batch_size);
+        for (const auto& cand_desc : src_segments._segments) {
+            candidates.push_back(_sm.desc_to_segment_id(cand_desc));
+            if (candidates.size() == batch_size) {
+                break;
+            }
+        }
+
+        // For each candidate, check whether it already belongs to a single group (fast path)
+        // or straddles the split boundary (slow path).
+        // Fast-path segments are moved to the correct child group immediately.
+        // Slow-path segments are collected into a batch for rewriting.
+        std::vector<log_segment_id> batch;
+        batch.reserve(candidates.size());
+        for (auto cand_seg_id : candidates) {
+            auto cand_hdr = co_await _sm.read_segment_header(cand_seg_id);
+            if (!cand_hdr || !std::holds_alternative<segment_header::full>(cand_hdr->v)) {
+                on_internal_error(logstor_logger, format("Invalid segment header for segment {} during split compaction", cand_seg_id));
+            }
+            auto& cand_seg_hdr = std::get<segment_header::full>(cand_hdr->v);
+            if (classifier(cand_seg_hdr.first_token) == classifier(cand_seg_hdr.last_token)) {
+                // Fast path: segment already belongs to a single group.
+                // Remove from src and add to the correct child group.
+                logstor_logger.trace("Fast path split segment {} with token range [{}, {}]", cand_seg_id, cand_seg_hdr.first_token, cand_seg_hdr.last_token);
+                auto& cand_desc = _sm.get_segment_descriptor(cand_seg_id);
+                src_segments.remove_segment(cand_desc);
+                if (!t.add_logstor_segment(cand_seg_id, cand_desc, cand_seg_hdr.first_token, cand_seg_hdr.last_token) || cand_desc.owner == &src_segments) {
+                    on_internal_error(logstor_logger, format("Failed to add segment {} to table {} during split", cand_seg_id, t.schema()->id()));
+                }
+            } else {
+                batch.push_back(cand_seg_id);
+            }
+        }
+
+        if (batch.empty()) {
+            continue;
+        }
+
+        // Slow path: rewrite live records from straddling segments into two compaction_buffers
+        // (one per target group). Both buffers write back into src; the next outer loop
+        // iteration will fast-path the resulting single-group segments to the correct child group.
+
+        // Acquire _compaction_sem to be mutually exclusive with background compaction.
+        auto sem_units = co_await get_units(_compaction_sem, 1);
+
+        std::array<compaction_buffer, 2> bufs{compaction_buffer{_sm, src}, compaction_buffer{_sm, src}};
+
+        size_t records_rewritten = 0;
+        size_t records_skipped = 0;
+
+        co_await _sm.for_each_record(batch,
+                [&index, &classifier, &bufs, &records_rewritten, &records_skipped] (log_location read_location, log_record record) -> future<> {
+            auto& cb = bufs[classifier(record.key.dk.token())];
+            co_await cb.rewrite_record(index, read_location, std::move(record), records_rewritten, records_skipped);
+        });
+
+        for (auto& cb : bufs) {
+            co_await cb.close();
+        }
+
+        logstor_logger.debug("Split compaction: {} records rewritten, {} skipped from {} segments",
+                             records_rewritten, records_skipped, batch.size());
+
+        // All records are safely written to new segments in src.
+        // Await pending reads before freeing the source segments.
+        co_await index.await_pending_reads();
+
+        // Remove and free the source segments of this batch.
+        for (auto seg_id : batch) {
+            logstor_logger.trace("Free segment {} by split", seg_id);
+            auto& desc = _sm.get_segment_descriptor(seg_id);
+            src_segments.remove_segment(desc);
+            _sm.free_segment(seg_id);
+        }
+    }
 }
 
 separator_buffer compaction_manager_impl::allocate_separator_buffer() {

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -12,12 +12,14 @@
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/rwlock.hh>
+#include <seastar/core/fstream.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/shared_ptr.hh>
 #include "bytes_fwd.hh"
 #include "mutation_writer/token_group_based_splitting_writer.hh"
 #include "replica/logstor/write_buffer.hh"
+#include "replica/logstor/compaction.hh"
 #include "types.hh"
 #include "utils/updateable_value.hh"
 
@@ -77,6 +79,12 @@ struct table_segment_stats {
     }
 };
 
+struct segment_snapshot {
+    log_segment_id segment_id;
+    segment_ref seg_ref;
+    noncopyable_function<future<seastar::input_stream<char>>(const file_input_stream_options&)> source;
+};
+
 class segment_stream_sink {
 public:
     virtual ~segment_stream_sink() = default;
@@ -128,8 +136,7 @@ public:
 
     future<> await_pending_writes();
 
-    // Create an input stream to read a segment (for sending to remote node)
-    future<seastar::input_stream<char>> create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts);
+    future<utils::chunked_vector<segment_snapshot>> make_snapshot(compaction_group& cg);
 
     // Create an output stream to write a segment (for receiving from remote node)
     // Allocates a new local segment and returns an output stream for writing to the segment.

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -16,6 +16,7 @@
 #include <seastar/core/queue.hh>
 #include <seastar/core/shared_ptr.hh>
 #include "bytes_fwd.hh"
+#include "mutation_writer/token_group_based_splitting_writer.hh"
 #include "replica/logstor/write_buffer.hh"
 #include "types.hh"
 #include "utils/updateable_value.hh"
@@ -23,6 +24,7 @@
 namespace replica {
 
 class database;
+class table;
 
 namespace logstor {
 

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -77,6 +77,15 @@ struct table_segment_stats {
     }
 };
 
+class segment_stream_sink {
+public:
+    virtual ~segment_stream_sink() = default;
+    virtual log_segment_id segment_id() const noexcept = 0;
+    virtual future<output_stream<char>> output() = 0;
+    virtual future<> close() = 0;
+    virtual future<> abort() = 0;
+};
+
 class segment_manager_impl;
 class log_index;
 
@@ -118,6 +127,13 @@ public:
     size_t get_memory_usage() const;
 
     future<> await_pending_writes();
+
+    // Create an input stream to read a segment (for sending to remote node)
+    future<seastar::input_stream<char>> create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts);
+
+    // Create an output stream to write a segment (for receiving from remote node)
+    // Allocates a new local segment and returns an output stream for writing to the segment.
+    future<std::unique_ptr<segment_stream_sink>> create_segment_output_stream(replica::database&);
 
     friend class segment_manager_impl;
 

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -97,14 +97,11 @@ public:
     future<> start();
     future<> stop();
 
-    future<log_location> write(write_buffer& wb);
+    future<> write(write_buffer& wb);
 
     future<log_record> read(log_location location);
 
     void free_record(log_location location);
-
-    future<> for_each_record(const std::vector<log_segment_id>& segments,
-                            std::function<future<>(log_location, log_record)> callback);
 
     compaction_manager& get_compaction_manager() noexcept;
     const compaction_manager& get_compaction_manager() const noexcept;

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 #include "write_buffer.hh"
+#include "dht/token.hh"
 #include "segment_manager.hh"
 #include "bytes_fwd.hh"
 #include "logstor.hh"
@@ -33,12 +34,12 @@ void log_record_writer::write(ostream& out) const {
 
 // write_buffer
 
-write_buffer::write_buffer(size_t buffer_size, bool with_record_copy)
+write_buffer::write_buffer(size_t buffer_size, segment_kind kind)
         : _buffer_size(buffer_size)
         , _buffer(seastar::allocate_aligned_buffer<char>(buffer_size, 4096))
-        , _with_record_copy(with_record_copy)
+        , _segment_kind(kind)
 {
-    if (_with_record_copy) {
+    if (with_record_copy()) {
         _records_copy.reserve(_buffer_size / 100);
     }
     reset();
@@ -47,9 +48,14 @@ write_buffer::write_buffer(size_t buffer_size, bool with_record_copy)
 void write_buffer::reset() {
     _stream = seastar::simple_memory_output_stream(_buffer.get(), _buffer_size);
     _header_stream = _stream.write_substream(buffer_header_size);
+    if (with_segment_header()) {
+        _segment_header_stream = _stream.write_substream(segment_header_size);
+    }
     _buffer_header = {};
     _net_data_size = 0;
     _record_count = 0;
+    _min_token = std::nullopt;
+    _max_token = std::nullopt;
     _written = {};
     _records_copy.clear();
     _write_gate = {};
@@ -62,7 +68,7 @@ future<> write_buffer::close() {
 }
 
 size_t write_buffer::get_max_write_size() const noexcept {
-    return _buffer_size - (buffer_header_size + record_header_size);
+    return _buffer_size - (header_size() + record_header_size);
 }
 
 bool write_buffer::can_fit(size_t data_size) const noexcept {
@@ -73,7 +79,7 @@ bool write_buffer::can_fit(size_t data_size) const noexcept {
 }
 
 bool write_buffer::has_data() const noexcept {
-    return offset_in_buffer() > buffer_header_size;
+    return offset_in_buffer() > header_size();
 }
 
 future<log_location_with_holder> write_buffer::write(log_record_writer writer, compaction_group* cg, seastar::gate::holder cg_holder) {
@@ -95,6 +101,12 @@ future<log_location_with_holder> write_buffer::write(log_record_writer writer, c
 
     _net_data_size += data_size;
     _record_count++;
+    if (!_min_token || writer.record().key.dk.token() < *_min_token) {
+        _min_token = writer.record().key.dk.token();
+    }
+    if (!_max_token || writer.record().key.dk.token() > *_max_token) {
+        _max_token = writer.record().key.dk.token();
+    }
 
     // Add padding to align record
     pad_to_alignment(record_alignment);
@@ -107,7 +119,7 @@ future<log_location_with_holder> write_buffer::write(log_record_writer writer, c
         };
     };
 
-    if (_with_record_copy) {
+    if (with_record_copy()) {
         _records_copy.push_back(record_in_buffer {
             .writer = std::move(writer),
             .offset_in_buffer = data_offset_in_buffer,
@@ -138,14 +150,26 @@ void write_buffer::pad_to_alignment(size_t alignment) {
 }
 
 void write_buffer::finalize(size_t alignment) {
-    _buffer_header.data_size = static_cast<uint32_t>(offset_in_buffer() - buffer_header_size);
+    _buffer_header.data_size = static_cast<uint32_t>(offset_in_buffer() - header_size());
     pad_to_alignment(alignment);
 }
 
-void write_buffer::write_header(segment_generation seg_gen) {
+void write_buffer::write_header(segment_generation seg_gen, std::optional<table_id> table) {
     _buffer_header.magic = buffer_header_magic;
     _buffer_header.seg_gen = seg_gen;
+    _buffer_header.kind = _segment_kind;
+
     ser::serialize<buffer_header>(_header_stream, _buffer_header);
+
+    if (_segment_kind == segment_kind::full) {
+        segment_header seg_hdr {
+            .table = table.value(),
+            .first_token = _min_token.value_or(dht::minimum_token()),
+            .last_token = _max_token.value_or(dht::minimum_token()),
+        };
+
+        ser::serialize<segment_header>(_segment_header_stream, seg_hdr);
+    }
 }
 
 future<> write_buffer::complete_writes(log_location base_location) {
@@ -161,7 +185,7 @@ future<> write_buffer::abort_writes(std::exception_ptr ex) {
 }
 
 std::vector<write_buffer::record_in_buffer>& write_buffer::records() {
-    if (!_with_record_copy) {
+    if (!with_record_copy()) {
         on_internal_error(logstor_logger, "requesting records but the write buffer has no record copy enabled");
     }
     return _records_copy;
@@ -185,7 +209,7 @@ buffered_writer::buffered_writer(segment_manager& sm, seastar::scheduling_group 
         , _flush_sg(flush_sg) {
     _ring.reserve(ring_size);
     for (size_t i = 0; i < ring_size; ++i) {
-        _ring.emplace_back(_sm.get_segment_size(), true);
+        _ring.emplace_back(_sm.get_segment_size(), segment_kind::mixed);
     }
 }
 

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -128,14 +128,6 @@ future<log_location_with_holder> write_buffer::write(log_record_writer writer, c
     });
 }
 
-future<log_location> write_buffer::write_no_holder(log_record_writer writer) {
-    // write and leave the gate immediately after the write.
-    // use carefully when the gate it not needed.
-    return write(std::move(writer)).then_unpack([] (log_location loc, seastar::gate::holder op) {
-        return loc;
-    });
-}
-
 void write_buffer::pad_to_alignment(size_t alignment) {
     auto current_pos = offset_in_buffer();
     auto next_pos = align_up(current_pos, alignment);

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -172,6 +172,18 @@ void write_buffer::write_header(segment_generation seg_gen, std::optional<table_
     }
 }
 
+void write_buffer::write_empty_header(ostream& out, segment_generation seg_gen) {
+    buffer_header hdr;
+    hdr.magic = buffer_header_magic;
+    hdr.data_size = 0;
+    hdr.seg_gen = seg_gen;
+    hdr.kind = segment_kind::mixed;
+    hdr.reserved1 = 0;
+    hdr.reserved2 = 0;
+
+    ser::serialize<buffer_header>(out, hdr);
+}
+
 future<> write_buffer::complete_writes(log_location base_location) {
     _written.set_value(base_location);
     co_await close();

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -19,6 +19,7 @@
 #include "idl/logstor.dist.impl.hh"
 #include <seastar/core/align.hh>
 #include <seastar/core/aligned_buffer.hh>
+#include "utils/crc.hh"
 
 namespace replica::logstor {
 
@@ -87,6 +88,9 @@ future<log_location_with_holder> write_buffer::write(log_record_writer writer, c
 
     if (!can_fit(data_size)) {
         throw std::runtime_error(fmt::format("Write size {} exceeds buffer size {}", data_size, _stream.size()));
+    }
+    if (data_size == 0) {
+        throw std::runtime_error("Cannot write empty record");
     }
 
     auto rh = record_header {
@@ -158,6 +162,9 @@ void write_buffer::write_header(segment_generation seg_gen, std::optional<table_
     _buffer_header.magic = buffer_header_magic;
     _buffer_header.seg_gen = seg_gen;
     _buffer_header.kind = _segment_kind;
+    _buffer_header.version = current_version;
+
+    _buffer_header.crc = _buffer_header.calculate_crc();
 
     ser::serialize<buffer_header>(_header_stream, _buffer_header);
 
@@ -178,10 +185,27 @@ void write_buffer::write_empty_header(ostream& out, segment_generation seg_gen) 
     hdr.data_size = 0;
     hdr.seg_gen = seg_gen;
     hdr.kind = segment_kind::mixed;
-    hdr.reserved1 = 0;
-    hdr.reserved2 = 0;
+    hdr.version = current_version;
+
+    hdr.crc = hdr.calculate_crc();
 
     ser::serialize<buffer_header>(out, hdr);
+}
+
+bool write_buffer::validate_header(const write_buffer::buffer_header& bh) {
+    if (bh.magic != write_buffer::buffer_header_magic) {
+        return false;
+    }
+
+    if (bh.calculate_crc() != bh.crc) {
+        return false;
+    }
+
+    if (bh.version != current_version) {
+        return false;
+    }
+
+    return true;
 }
 
 future<> write_buffer::complete_writes(log_location base_location) {
@@ -212,6 +236,16 @@ size_t write_buffer::estimate_required_segments(size_t net_data_size, size_t rec
 
     return align_up(total_size, segment_size) / segment_size;
 
+}
+
+uint32_t write_buffer::buffer_header::calculate_crc() const {
+    utils::crc32 c;
+    c.process_le(magic);
+    c.process_le(data_size);
+    c.process_le(seg_gen.value());
+    c.process_le(static_cast<uint8_t>(kind));
+    c.process_le(version);
+    return c.get();
 }
 
 // buffered_writer

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -182,25 +182,18 @@ size_t write_buffer::estimate_required_segments(size_t net_data_size, size_t rec
 
 buffered_writer::buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg)
         : _sm(sm)
-        , _available_buffers(num_flushing_buffers)
         , _flush_sg(flush_sg) {
-
-    _buffers.reserve(num_flushing_buffers + 1);
-    for (size_t i = 0; i < num_flushing_buffers + 1; ++i) {
-        _buffers.emplace_back(_sm.get_segment_size(), true);
-    }
-
-    _active_buffer = active_buffer {
-        .buf = &_buffers[0],
-    };
-
-    for (size_t i = 1; i < num_flushing_buffers + 1; ++i) {
-        _available_buffers.push(&_buffers[i]);
+    _ring.reserve(ring_size);
+    for (size_t i = 0; i < ring_size; ++i) {
+        _ring.emplace_back(_sm.get_segment_size(), true);
     }
 }
 
 future<> buffered_writer::start() {
     logstor_logger.info("Starting write buffer");
+    _consumer = with_gate(_async_gate, [this] {
+        return consumer_loop();
+    });
     co_return;
 }
 
@@ -210,7 +203,14 @@ future<> buffered_writer::stop() {
     }
     logstor_logger.info("Stopping write buffer");
 
+    // Wake the consumer so it can observe the closing gate and exit.
+    _tail_can_advance.broadcast();
+    // Wake any writer blocked waiting for a free ring slot.
+    _head_can_advance.broadcast();
+
     co_await _async_gate.close();
+    co_await std::move(_consumer);
+
     logstor_logger.info("Write buffer stopped");
 }
 
@@ -219,52 +219,66 @@ future<log_location_with_holder> buffered_writer::write(log_record record, compa
 
     log_record_writer writer(std::move(record));
 
-    if (writer.size() > _active_buffer.buf->get_max_write_size()) {
-        throw std::runtime_error(fmt::format("Write size {} exceeds buffer size {}", writer.size(), _active_buffer.buf->get_max_write_size()));
+    if (writer.size() > head_buf().get_max_write_size()) {
+        throw std::runtime_error(fmt::format("Write size {} exceeds buffer size {}", writer.size(), head_buf().get_max_write_size()));
     }
 
-    // Check if write fits in current buffer
-    while (!_active_buffer.buf->can_fit(writer)) {
-        co_await _buffer_switched.wait();
+    // Wait until the head buffer can fit this write.
+    while (!head_buf().can_fit(writer)) {
+        // Capture the current head before waiting.  Multiple concurrent writers
+        // can all reach this point; only the first one to proceed actually
+        // advances _head — the rest see _head != current_head and simply
+        // re-check the (already advanced) head buffer.
+        auto current_head = _head;
+        while (ring_full() && !_async_gate.is_closed()) {
+            co_await _head_can_advance.wait();
+        }
+        _async_gate.check();
+        if (_head == current_head) {
+            ++_head;
+            // Wake other writers that are also waiting for a new head buffer.
+            _head_can_advance.broadcast();
+        }
     }
 
-    // Write to buffer at current position
-    auto fut = _active_buffer.buf->write(std::move(writer), cg, std::move(cg_holder));
+    auto fut = head_buf().write(std::move(writer), cg, std::move(cg_holder));
 
-    // Trigger flush for the active buffer if not in progress
-    if (!std::exchange(_active_buffer.flush_requested, true)) {
-        (void)with_gate(_async_gate, [this] {
-            return switch_buffer().then([this] (write_buffer* old_buf) mutable {
-                return with_scheduling_group(_flush_sg, [this, old_buf] mutable {
-                    return flush(old_buf);
-                });
-            });
-        });
-    }
+    // Wake the consumer: there is now data at the tail.
+    _tail_can_advance.broadcast();
 
     co_return co_await std::move(fut);
 }
 
-future<write_buffer*> buffered_writer::switch_buffer() {
-    // Wait for and get the next available buffer
-    auto new_buf = co_await _available_buffers.pop_eventually();
+future<> buffered_writer::consumer_loop() {
+    while (true) {
+        // Wait for something to flush at the tail.
+        while (!_async_gate.is_closed() && !tail_buf().has_data()) {
+            co_await _tail_can_advance.wait();
+        }
 
-    auto next_active_buffer = active_buffer {
-        .buf = std::move(new_buf),
-    };
+        if (!tail_buf().has_data()) {
+            // Gate is closing and tail is empty — we are done.
+            break;
+        }
 
-    auto old_active_buffer = std::exchange(_active_buffer, std::move(next_active_buffer));
-    _buffer_switched.broadcast();
+        // If head == tail, the head buffer is still being written to.  Seal it
+        // by advancing the head to give writers a fresh slot.
+        if (_head == _tail) {
+            ++_head;
+            // Wake writers that may be waiting for a new head slot.
+            _head_can_advance.broadcast();
+        }
 
-    co_return std::move(old_active_buffer.buf);
-}
+        co_await with_scheduling_group(_flush_sg, [this] {
+            return _sm.write(tail_buf());
+        });
 
-future<> buffered_writer::flush(write_buffer* buf) {
-    co_await _sm.write(*buf);
+        tail_buf().reset();
+        ++_tail;
 
-    // Return the flushed buffer to the available queue
-    buf->reset();
-    _available_buffers.push(std::move(buf));
+        // A slot has been freed: wake any writer waiting to advance the head.
+        _head_can_advance.broadcast();
+    }
 }
 
 }

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -219,6 +219,8 @@ public:
         return s;
     }
 
+    static void write_empty_header(ostream& out, segment_generation seg_gen);
+
 private:
 
     const char* data() const noexcept { return _buffer.get(); }

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -97,14 +97,17 @@ public:
 
     static constexpr uint32_t buffer_header_magic = 0x4c475342;
     static constexpr size_t record_alignment = 8;
+    static constexpr uint8_t current_version = 1;
 
     struct buffer_header {
         uint32_t magic;
         uint32_t data_size; // size of all records data following the buffer_header
         segment_generation seg_gen;
         segment_kind kind;
-        uint8_t reserved1;
-        uint32_t reserved2;
+        uint8_t version;
+        uint32_t crc;
+
+        uint32_t calculate_crc() const;
     };
     static constexpr size_t buffer_header_size =
         2 * sizeof(uint32_t)
@@ -221,6 +224,8 @@ public:
 
     static void write_empty_header(ostream& out, segment_generation seg_gen);
 
+    static bool validate_header(const buffer_header& bh);
+
 private:
 
     const char* data() const noexcept { return _buffer.get(); }
@@ -315,8 +320,8 @@ struct serializer<replica::logstor::write_buffer::buffer_header> {
         serializer<uint32_t>::write(out, h.data_size);
         serializer<replica::logstor::segment_generation>::write(out, h.seg_gen);
         serializer<uint8_t>::write(out, static_cast<uint8_t>(h.kind));
-        serializer<uint8_t>::write(out, h.reserved1);
-        serializer<uint32_t>::write(out, h.reserved2);
+        serializer<uint8_t>::write(out, h.version);
+        serializer<uint32_t>::write(out, h.crc);
     }
     template <typename Input>
     static replica::logstor::write_buffer::buffer_header read(Input& in) {
@@ -325,8 +330,8 @@ struct serializer<replica::logstor::write_buffer::buffer_header> {
         h.data_size = serializer<uint32_t>::read(in);
         h.seg_gen = serializer<replica::logstor::segment_generation>::read(in);
         h.kind = static_cast<replica::logstor::segment_kind>(serializer<uint8_t>::read(in));
-        h.reserved1 = serializer<uint8_t>::read(in);
-        h.reserved2 = serializer<uint32_t>::read(in);
+        h.version = serializer<uint8_t>::read(in);
+        h.crc = serializer<uint32_t>::read(in);
         return h;
     }
     template <typename Input>

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -174,12 +174,6 @@ public:
         return write(std::move(writer), nullptr, {});
     }
 
-    // Write a record to the buffer.
-    // Returns a future that will be resolved with the log location once flushed.
-    // If there are follow-up operations to the write such as index updates then consider
-    // using write_with_holder instead to keep the write buffer open until those operations are complete.
-    future<log_location> write_no_holder(log_record_writer);
-
     static size_t estimate_required_segments(size_t net_data_size, size_t record_count, size_t segment_size);
 
 private:

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -17,8 +17,11 @@
 #include <seastar/core/queue.hh>
 #include <seastar/core/simple-stream.hh>
 #include <seastar/core/shared_future.hh>
+#include "schema/schema_fwd.hh"
 #include "types.hh"
 #include "serializer.hh"
+#include "idl/uuid.dist.hh"
+#include "idl/uuid.dist.impl.hh"
 
 namespace replica {
 
@@ -61,6 +64,11 @@ public:
 
 using log_location_with_holder = std::tuple<log_location, seastar::gate::holder>;
 
+enum class segment_kind : uint8_t {
+    mixed = 0,
+    full = 1,
+};
+
 // Manages a single aligned buffer for accumulating records and writing
 // them to the segment manager.
 //
@@ -80,11 +88,12 @@ public:
 
     using ostream = seastar::simple_memory_output_stream;
 
-    // buffer: buffer_header | record_1 | ... | record_n | 0-padding
+    // buffer: buffer_header | (segment_header)? | record_1 | ... | record_n | 0-padding
     // record: record_header | record_data | 0-padding
     //
-    // buffer_header and record are aligned by record_alignment
-    // buffer_header and record_header have explicit sizes and serialization below
+    // buffer_header, segment_header and record are aligned by record_alignment
+    // they have explicit sizes and serialization below
+    // segment_header exists when the segment_kind is segment_kind::full.
 
     static constexpr uint32_t buffer_header_magic = 0x4c475342;
     static constexpr size_t record_alignment = 8;
@@ -93,12 +102,27 @@ public:
         uint32_t magic;
         uint32_t data_size; // size of all records data following the buffer_header
         segment_generation seg_gen;
-        uint16_t reserved1;
+        segment_kind kind;
+        uint8_t reserved1;
         uint32_t reserved2;
     };
-    static constexpr size_t buffer_header_size = 3 * sizeof(uint32_t) + sizeof(uint16_t) + sizeof(segment_generation::underlying);
-
+    static constexpr size_t buffer_header_size =
+        2 * sizeof(uint32_t)
+        + sizeof(segment_generation::underlying)
+        + sizeof(std::underlying_type_t<segment_kind>)
+        + sizeof(uint8_t)
+        + sizeof(uint32_t);
     static_assert(buffer_header_size % record_alignment == 0, "Buffer header size must be aligned by record_alignment");
+
+    struct segment_header {
+        table_id table;
+        dht::token first_token;
+        dht::token last_token;
+    };
+    static constexpr size_t segment_header_size =
+        sizeof(table_id)
+        + 2 * sizeof(int64_t);
+    static_assert(segment_header_size % record_alignment == 0, "Segment header size must be aligned by record_alignment");
 
     struct record_header {
         uint32_t data_size; // size of the record data following the record_header
@@ -111,12 +135,16 @@ private:
 
     size_t _buffer_size;
     aligned_buffer_type _buffer;
+    segment_kind _segment_kind;
     seastar::simple_memory_output_stream _stream;
     buffer_header _buffer_header;
     seastar::simple_memory_output_stream _header_stream;
+    seastar::simple_memory_output_stream _segment_header_stream;
 
     size_t _net_data_size{0};
     size_t _record_count{0};
+    std::optional<dht::token> _min_token;
+    std::optional<dht::token> _max_token;
 
     shared_promise<log_location> _written;
 
@@ -131,12 +159,11 @@ private:
         seastar::gate::holder cg_holder;
     };
 
-    bool _with_record_copy;
     std::vector<record_in_buffer> _records_copy;
 
 public:
 
-    write_buffer(size_t buffer_size, bool with_record_copy);
+    write_buffer(size_t buffer_size, segment_kind kind);
 
     void reset();
 
@@ -176,11 +203,28 @@ public:
 
     static size_t estimate_required_segments(size_t net_data_size, size_t record_count, size_t segment_size);
 
+    bool with_record_copy() const noexcept {
+        return _segment_kind == segment_kind::mixed;
+    }
+
+    bool with_segment_header() const noexcept {
+        return _segment_kind == segment_kind::full;
+    }
+
+    size_t header_size() const noexcept {
+        size_t s = buffer_header_size;
+        if (with_segment_header()) {
+            s += segment_header_size;
+        }
+        return s;
+    }
+
 private:
 
     const char* data() const noexcept { return _buffer.get(); }
 
-    void write_header(segment_generation);
+    // table is set for segment_kind::full
+    void write_header(segment_generation seg_gen, std::optional<table_id> table);
 
     // get all write records in the buffer.
     // with_record_copy must be to true when creating the write_buffer.
@@ -268,7 +312,8 @@ struct serializer<replica::logstor::write_buffer::buffer_header> {
         serializer<uint32_t>::write(out, h.magic);
         serializer<uint32_t>::write(out, h.data_size);
         serializer<replica::logstor::segment_generation>::write(out, h.seg_gen);
-        serializer<uint16_t>::write(out, h.reserved1);
+        serializer<uint8_t>::write(out, static_cast<uint8_t>(h.kind));
+        serializer<uint8_t>::write(out, h.reserved1);
         serializer<uint32_t>::write(out, h.reserved2);
     }
     template <typename Input>
@@ -277,7 +322,8 @@ struct serializer<replica::logstor::write_buffer::buffer_header> {
         h.magic = serializer<uint32_t>::read(in);
         h.data_size = serializer<uint32_t>::read(in);
         h.seg_gen = serializer<replica::logstor::segment_generation>::read(in);
-        h.reserved1 = serializer<uint16_t>::read(in);
+        h.kind = static_cast<replica::logstor::segment_kind>(serializer<uint8_t>::read(in));
+        h.reserved1 = serializer<uint8_t>::read(in);
         h.reserved2 = serializer<uint32_t>::read(in);
         return h;
     }
@@ -286,8 +332,33 @@ struct serializer<replica::logstor::write_buffer::buffer_header> {
         serializer<uint32_t>::skip(in);
         serializer<uint32_t>::skip(in);
         serializer<replica::logstor::segment_generation>::skip(in);
-        serializer<uint16_t>::skip(in);
+        serializer<uint8_t>::skip(in);
+        serializer<uint8_t>::skip(in);
         serializer<uint32_t>::skip(in);
+    }
+};
+
+template <>
+struct serializer<replica::logstor::write_buffer::segment_header> {
+    template <typename Output>
+    static void write(Output& out, const replica::logstor::write_buffer::segment_header& h) {
+        serializer<table_id>::write(out, h.table);
+        serializer<int64_t>::write(out, h.first_token.raw());
+        serializer<int64_t>::write(out, h.last_token.raw());
+    }
+    template <typename Input>
+    static replica::logstor::write_buffer::segment_header read(Input& in) {
+        replica::logstor::write_buffer::segment_header h;
+        h.table = serializer<table_id>::read(in);
+        h.first_token = dht::token::from_int64(serializer<int64_t>::read(in));
+        h.last_token = dht::token::from_int64(serializer<int64_t>::read(in));
+        return h;
+    }
+    template <typename Input>
+    static void skip(Input& in) {
+        serializer<table_id>::skip(in);
+        serializer<int64_t>::skip(in);
+        serializer<int64_t>::skip(in);
     }
 };
 

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -197,24 +197,48 @@ private:
     friend class compaction_manager_impl;
 };
 
-// Manages multiple buffers, a single active buffer and multiple flushing buffers.
-// When switch is requested for the active buffer, it waits for a flushing buffer to
-// become available, and continuing to accumulate writes until then.
+// Manages a fixed-size circular ring of write_buffers.
+//
+// Writers append to the head buffer.  A single consumer coroutine drains the
+// tail.  The head advances when the current head buffer is full (can't fit the
+// next write) or when the consumer seals it.  Writers wait if the ring is full
+// (all buffers are pending flush).
 class buffered_writer {
-    static constexpr size_t num_flushing_buffers = 4;
+    // Number of buffers in the ring.  Must be >= 2 (one head + at least one
+    // that can be in-flight with the consumer).
+    static constexpr size_t ring_size = 5;
 
     segment_manager& _sm;
-
-    struct active_buffer {
-        write_buffer* buf;
-        bool flush_requested{false};
-    } _active_buffer;
-
-    std::vector<write_buffer> _buffers;
-    seastar::queue<write_buffer*> _available_buffers;
-    seastar::gate _async_gate;
-    seastar::condition_variable _buffer_switched;
     seastar::scheduling_group _flush_sg;
+
+    // The ring of buffers, indexed modulo ring_size.
+    std::vector<write_buffer> _ring;
+
+    // Monotonically increasing indices; the actual slot is idx % ring_size.
+    // _head: next slot writers append to.
+    // _tail: next slot the consumer will flush.
+    // Invariant: _head >= _tail && _head - _tail < ring_size.
+    size_t _head{0};
+    size_t _tail{0};
+
+    // Notified when _tail advances (a slot becomes free for the head to move into)
+    // or when the head buffer is switched.
+    seastar::condition_variable _head_can_advance;
+
+    // Notified when data is written to the head buffer (consumer may wake up).
+    seastar::condition_variable _tail_can_advance;
+
+    seastar::gate _async_gate;
+
+    // The single flush-consumer fiber, running for the lifetime of the writer.
+    future<> _consumer{make_ready_future<>()};
+
+    write_buffer& head_buf() noexcept { return _ring[_head % ring_size]; }
+    write_buffer& tail_buf() noexcept { return _ring[_tail % ring_size]; }
+
+    // The ring is full when all ring_size slots are occupied. Advancing the
+    // head further would make the new head slot collide with the tail slot.
+    bool ring_full() const noexcept { return _head - _tail == ring_size - 1; }
 
 public:
     explicit buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg);
@@ -228,9 +252,8 @@ public:
     future<log_location_with_holder> write(log_record, compaction_group* cg = nullptr, seastar::gate::holder cg_holder = {});
 
 private:
-    future<write_buffer*> switch_buffer();
-    future<> flush(write_buffer*);
-
+    // The flush consumer loop.
+    future<> consumer_loop();
 };
 
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -20,9 +20,11 @@
 #include <seastar/json/json_elements.hh>
 
 #include "dht/decorated_key.hh"
+#include "readers/mutation_reader.hh"
 #include "replica/database.hh"
 #include "replica/data_dictionary_impl.hh"
 #include "replica/compaction_group.hh"
+#include "replica/logstor/compaction.hh"
 #include "replica/query_state.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/sstable_set.hh"
@@ -797,6 +799,7 @@ class tablet_storage_group_manager final : public storage_group_manager {
     std::optional<utils::phased_barrier::operation> _pending_merge_fiber_work;
     // Holds compaction reenabler which disables compaction temporarily during tablet merge
     std::vector<background_merge_guard> _compaction_reenablers_for_merging;
+    std::vector<logstor::compaction_reenabler> _compaction_reenablers_for_logstor_merging;
 private:
     const schema_ptr& schema() const {
         return _t.schema();
@@ -2340,6 +2343,15 @@ compaction_group::merge_sstables_from(compaction_group& group) {
 }
 
 future<>
+compaction_group::merge_logstor_segments_from(compaction_group& group) {
+    if (!_t.uses_logstor()) {
+        co_return;
+    }
+    auto permit = co_await _t.get_sstable_list_permit();
+    co_await _logstor_segments->merge(*group._logstor_segments);
+}
+
+future<>
 compaction_group::update_sstable_sets_on_compaction_completion(compaction::compaction_completion_desc desc) {
     // Build a new list of _sstables: We remove from the existing list the
     // tables we compacted (by now, there might be more sstables flushed
@@ -3341,6 +3353,7 @@ future<> tablet_storage_group_manager::merge_completion_fiber() {
             auto cf_name = schema()->cf_name();
             // Enable compaction after merge is done.
             auto cres = std::exchange(_compaction_reenablers_for_merging, {});
+            auto logstor_cres = std::exchange(_compaction_reenablers_for_logstor_merging, {});
             co_await for_each_storage_group_gently([ks_name, cf_name] (storage_group& sg) -> future<> {
                 auto main_group = sg.main_compaction_group();
                 tlogger.debug("Merge compaction groups for table={}.{} group_id={} range={} started",
@@ -3359,6 +3372,7 @@ future<> tablet_storage_group_manager::merge_completion_fiber() {
                         co_await sleep(std::chrono::seconds(60));
                     }
                     co_await main_group->merge_sstables_from(*group);
+                    co_await main_group->merge_logstor_segments_from(*group);
                 }
                 co_await sg.remove_empty_merging_groups();
                 tlogger.debug("Merge compaction groups for table={}.{} group_id={} range={} finished",
@@ -3403,6 +3417,9 @@ void tablet_storage_group_manager::handle_tablet_merge_completion(locator::effec
         for (auto& view : new_cg->all_views()) {
             auto cre = _t.get_compaction_manager().stop_and_disable_compaction_no_wait(*view, "tablet merging");
             _compaction_reenablers_for_merging.push_back(background_merge_guard{std::move(cre), old_erm});
+        }
+        if (_t.uses_logstor()) {
+            _compaction_reenablers_for_logstor_merging.push_back(_t.get_logstor_compaction_manager().disable_compaction_no_wait(*new_cg));
         }
         auto new_sg = make_lw_shared<storage_group>(std::move(new_cg));
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2135,7 +2135,9 @@ uint64_t compaction_group::live_disk_space_used() const noexcept {
 }
 
 sstables::file_size_stats compaction_group::live_disk_space_used_full_stats() const noexcept {
-    return _main_sstables->get_file_size_stats() + _maintenance_sstables->get_file_size_stats();
+    auto logstor_size = logstor_disk_space_used();
+    return _main_sstables->get_file_size_stats() + _maintenance_sstables->get_file_size_stats()
+        + sstables::file_size_stats{logstor_size, logstor_size};
 }
 
 uint64_t storage_group::live_disk_space_used() const {
@@ -3070,7 +3072,10 @@ future<> compaction_group::stop(sstring reason) noexcept {
 }
 
 bool compaction_group::empty() const noexcept {
-    return _memtables->empty() && live_sstable_count() == 0 && _sstable_add_gate.get_count() == 0;
+    return _memtables->empty() && live_sstable_count() == 0 && _sstable_add_gate.get_count() == 0
+        && (_logstor_segments ? _logstor_segments->empty() : true)
+        && (_logstor_separator ? _logstor_separator->empty() : true)
+        && _separator_flushes.empty();
 }
 
 const schema_ptr& compaction_group::schema() const {
@@ -4748,7 +4753,8 @@ future<> table::apply(const mutation& m, db::rp_handle&& h, db::timeout_clock::t
     auto holder = cg.async_gate().hold();
 
     if (_logstor) [[unlikely]] {
-        return _logstor->write(m, cg, std::move(holder));
+        auto ss_holder = cg.sstable_add_gate().hold();
+        return _logstor->write(m, cg, std::move(ss_holder));
     }
 
     return dirty_memory_region_group().run_when_memory_available([this, &m, h = std::move(h), &cg, holder = std::move(holder)] () mutable {
@@ -4767,7 +4773,8 @@ future<> table::apply(const frozen_mutation& m, schema_ptr m_schema, db::rp_hand
     auto holder = cg.async_gate().hold();
 
     if (_logstor) [[unlikely]] {
-        return _logstor->write(m.unfreeze(m_schema), cg, std::move(holder));
+        auto ss_holder = cg.sstable_add_gate().hold();
+        return _logstor->write(m.unfreeze(m_schema), cg, std::move(ss_holder));
     }
 
     return dirty_memory_region_group().run_when_memory_available([this, &m, m_schema = std::move(m_schema), h = std::move(h), &cg, holder = std::move(holder)]() mutable {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -738,6 +738,9 @@ public:
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const override {
         return get_compaction_group();
     }
+    compaction_group& compaction_group_for_logstor_segment(logstor::log_segment_id seg_id, dht::token first_token, dht::token last_token) const override {
+        return get_compaction_group();
+    }
     size_t log2_storage_groups() const override {
         return 0;
     }
@@ -918,7 +921,9 @@ public:
     compaction_group& compaction_group_for_token(dht::token token) const override;
     utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const override;
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const override;
+    compaction_group& compaction_group_for_token_range(sstring desc, dht::token first_token, dht::token last_token) const;
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const override;
+    compaction_group& compaction_group_for_logstor_segment(logstor::log_segment_id seg_id, dht::token first_token, dht::token last_token) const override;
 
     size_t log2_storage_groups() const override {
         return log2ceil(tablet_map().tablet_count());
@@ -1320,9 +1325,38 @@ compaction_group& table::compaction_group_for_key(partition_key_view key, const 
     return _sg_manager->compaction_group_for_key(key, s);
 }
 
+compaction_group& tablet_storage_group_manager::compaction_group_for_token_range(sstring desc, dht::token first_token, dht::token last_token) const {
+    auto first_id = storage_group_of(first_token);
+    auto last_id = storage_group_of(last_token);
+
+    auto tablet_desc = [this] (locator::tablet_id id) {
+        return format("{} (replica set: {})", id, tablet_map().get_tablet_info(id).replicas);
+    };
+
+    if (first_id != last_id) {
+        on_internal_error(tlogger, format("Unable to load {} that belongs to tablets {} and {}",
+                                          desc,
+                                          tablet_desc(locator::tablet_id(first_id)),
+                                          tablet_desc(locator::tablet_id(last_id))));
+    }
+
+    try {
+        auto& sg = storage_group_for_id(first_id);
+        return *sg.select_compaction_group(
+                first_token,
+                last_token,
+                tablet_map());
+    } catch (std::out_of_range& e) {
+        on_internal_error(tlogger, format("Unable to load {} of tablet {}, due to {}",
+                                          desc,
+                                          tablet_desc(locator::tablet_id(first_id)),
+                                          e.what()));
+    }
+}
+
 compaction_group& tablet_storage_group_manager::compaction_group_for_sstable(const sstables::shared_sstable& sst) const {
-    auto first_id = storage_group_of(sst->get_first_decorated_key().token());
-    auto last_id = storage_group_of(sst->get_last_decorated_key().token());
+    auto first_token = sst->get_first_decorated_key().token();
+    auto last_token = sst->get_last_decorated_key().token();
 
     auto sstable_desc = [] (const sstables::shared_sstable& sst) {
         auto& identifier_opt = sst->sstable_identifier();
@@ -1332,33 +1366,21 @@ compaction_group& tablet_storage_group_manager::compaction_group_for_sstable(con
                       identifier_opt ? identifier_opt->to_sstring() : "unknown",
                       originating_host_id_opt ? originating_host_id_opt->to_sstring() : "unknown");
     };
-    auto tablet_desc = [this] (locator::tablet_id id) {
-        return format("{} (replica set: {})", id, tablet_map().get_tablet_info(id).replicas);
-    };
 
-    if (first_id != last_id) {
-        on_internal_error(tlogger, format("Unable to load SSTable {} that belongs to tablets {} and {}",
-                                          sstable_desc(sst),
-                                          tablet_desc(locator::tablet_id(first_id)),
-                                          tablet_desc(locator::tablet_id(last_id))));
-    }
+    return compaction_group_for_token_range(sstable_desc(sst), first_token, last_token);
+}
 
-    try {
-        auto& sg = storage_group_for_id(first_id);
-        return *sg.select_compaction_group(
-                sst->get_first_decorated_key().token(),
-                sst->get_last_decorated_key().token(),
-                tablet_map());
-    } catch (std::out_of_range& e) {
-        on_internal_error(tlogger, format("Unable to load SSTable {} of tablet {}, due to {}",
-                                          sstable_desc(sst),
-                                          tablet_desc(locator::tablet_id(first_id)),
-                                          e.what()));
-    }
+compaction_group& tablet_storage_group_manager::compaction_group_for_logstor_segment(logstor::log_segment_id seg_id, dht::token first_token, dht::token last_token) const {
+    auto desc = format("logstor segment {}", seg_id);
+    return compaction_group_for_token_range(std::move(desc), first_token, last_token);
 }
 
 compaction_group& table::compaction_group_for_sstable(const sstables::shared_sstable& sst) const {
     return _sg_manager->compaction_group_for_sstable(sst);
+}
+
+compaction_group& table::compaction_group_for_logstor_segment(logstor::log_segment_id seg_id, dht::token first_token, dht::token last_token) const {
+    return _sg_manager->compaction_group_for_logstor_segment(seg_id, first_token, last_token);
 }
 
 future<> table::parallel_foreach_compaction_group(std::function<future<>(compaction_group&)> action) {
@@ -1630,13 +1652,16 @@ table::update_cache(compaction_group& cg, lw_shared_ptr<memtable> m, std::vector
     }
 }
 
-bool table::add_logstor_segment(logstor::segment_descriptor& seg_desc, dht::token first_token, dht::token last_token) {
-    auto& cg = compaction_group_for_token(first_token);
-    if (&cg != &compaction_group_for_token(last_token)) {
+bool table::add_logstor_segment(logstor::log_segment_id seg_id, logstor::segment_descriptor& seg_desc, dht::token first_token, dht::token last_token) {
+    dht::token_range tr(first_token, last_token);
+    if (storage_groups_for_token_range(tr).size() == 1) {
+        auto& cg = compaction_group_for_logstor_segment(seg_id, first_token, last_token);
+        cg.add_logstor_segment(seg_desc);
+        return true;
+    } else {
+        // the segment doesn't fit in a single storage group. need to write to separator.
         return false;
     }
-    cg.add_logstor_segment(seg_desc);
-    return true;
 }
 
 logstor::separator_buffer& table::get_logstor_separator_buffer(dht::token token, size_t write_size) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1086,6 +1086,10 @@ future<> compaction_group::split(compaction::compaction_type_options::split opt,
         co_await cm.perform_offstrategy(*view, tablet_split_task_info);
         co_await cm.perform_split_compaction(*view, opt, tablet_split_task_info);
     }
+
+    if (_t.uses_logstor()) {
+        co_await get_logstor_compaction_manager().split_compaction(_t, *this, opt.classifier);
+    }
 }
 
 future<> compaction_group::discard_logstor_segments() {
@@ -1135,6 +1139,7 @@ future<> storage_group::split(compaction::compaction_type_options::split opt, ta
         }
         auto holder = cg->async_gate().hold();
         co_await cg->flush();
+        co_await cg->flush_separator();
         co_await cg->split(opt, tablet_split_task_info);
     }
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1124,6 +1124,12 @@ logstor::separator_buffer& compaction_group::get_separator_buffer(size_t write_s
     return *_logstor_separator;
 }
 
+future<utils::chunked_vector<logstor::segment_snapshot>> compaction_group::take_logstor_snapshot() {
+    auto compaction_disable_guard = co_await get_logstor_compaction_manager().disable_compaction(*this);
+    auto snp = co_await get_logstor_segment_manager().make_snapshot(*this);
+    co_return std::move(snp);
+}
+
 future<> storage_group::split(compaction::compaction_type_options::split opt, tasks::task_info tablet_split_task_info) {
     if (set_split_mode()) {
         co_return;
@@ -1161,6 +1167,24 @@ lw_shared_ptr<const sstables::sstable_set> storage_group::make_sstable_set() con
         underlying.emplace_back(cg->make_sstable_set());
     }
     return make_lw_shared(sstables::make_compound_sstable_set(schema, std::move(underlying)));
+}
+
+future<utils::chunked_vector<logstor::segment_snapshot>> storage_group::take_logstor_snapshot() const {
+    if (_split_ready_groups.empty() && _merging_groups.empty()) {
+        co_return co_await _main_cg->take_logstor_snapshot();
+    }
+    utils::chunked_vector<logstor::segment_snapshot> snp;
+    for (const auto& cg : _merging_groups) {
+        if (!cg->empty()) {
+            auto cg_snp = co_await cg->take_logstor_snapshot();
+            snp.insert(snp.end(), std::make_move_iterator(cg_snp.begin()), std::make_move_iterator(cg_snp.end()));
+        }
+    }
+    for (const auto& cg : _split_ready_groups) {
+        auto cg_snp = co_await cg->take_logstor_snapshot();
+        snp.insert(snp.end(), std::make_move_iterator(cg_snp.begin()), std::make_move_iterator(cg_snp.end()));
+    }
+    co_return std::move(snp);
 }
 
 lw_shared_ptr<const sstables::sstable_set> table::sstable_set_for_tombstone_gc(const compaction_group& cg) const {
@@ -1471,6 +1495,23 @@ future<utils::chunked_vector<sstables::shared_sstable>> table::take_sstable_set_
         result.push_back(sst);
     });
     co_return result;
+}
+
+future<utils::chunked_vector<logstor::segment_snapshot>> table::take_logstor_snapshot(dht::token_range tr) {
+    utils::chunked_vector<logstor::segment_snapshot> snp;
+    for (auto& sg : storage_groups_for_token_range(tr)) {
+        co_await sg->flush_separator();
+
+        auto deletion_guard = co_await get_sstable_list_permit();
+
+        auto sg_snp = co_await sg->take_logstor_snapshot();
+        snp.insert(snp.end(), std::make_move_iterator(sg_snp.begin()), std::make_move_iterator(sg_snp.end()));
+    }
+    co_return std::move(snp);
+}
+
+future<std::unique_ptr<logstor::segment_stream_sink>> table::create_logstor_segment_sink(replica::database& db) {
+    return get_logstor_segment_manager().create_segment_output_stream(db);
 }
 
 future<utils::chunked_vector<sstables::entry_descriptor>>
@@ -4314,6 +4355,12 @@ future<> compaction_group::flush() noexcept {
 future<> storage_group::flush() noexcept {
     for (auto& cg : compaction_groups_immediate()) {
         co_await cg->flush();
+    }
+}
+
+future<> storage_group::flush_separator() noexcept {
+    for (auto& cg : compaction_groups_immediate()) {
+        co_await cg->flush_separator();
     }
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -218,17 +218,6 @@ table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
 }
 
 mutation_reader
-table::make_logstor_mutation_reader(schema_ptr s,
-                                   reader_permit permit,
-                                   const dht::partition_range& pr,
-                                   const query::partition_slice& slice,
-                                   tracing::trace_state_ptr trace_state,
-                                   streamed_mutation::forwarding fwd,
-                                   mutation_reader::forwarding fwd_mr) const {
-    return _logstor->make_reader(std::move(s), logstor_index(), std::move(permit), pr, slice, std::move(trace_state));
-}
-
-mutation_reader
 table::make_mutation_reader(schema_ptr s,
                            reader_permit permit,
                            const dht::partition_range& range,
@@ -241,7 +230,7 @@ table::make_mutation_reader(schema_ptr s,
     }
 
     if (_logstor) [[unlikely]] {
-        return make_logstor_mutation_reader(s, std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr);
+        return _logstor->make_reader(s, logstor_index(), std::move(permit), range, slice, std::move(trace_state));
     }
 
     std::vector<mutation_reader> readers;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5406,6 +5406,11 @@ future<> compaction_group::cleanup() {
     co_await _t._cache.invalidate(std::move(updater), p_range);
     _t._cache.refresh_snapshot();
 
+    if (_t.uses_logstor()) {
+        co_await _t.logstor_index().erase(p_range);
+        co_await discard_logstor_segments();
+    }
+
     co_await _t.delete_sstables_atomically(permit, _sstables_compacted_but_not_deleted);
     // Clearing sstables_compacted_but_not_deleted only on success allows a retry caused
     // by a failure during deletion to still find the sstables, despite they were removed

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4702,7 +4702,13 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
             }
         });
 
-        if (trinfo->transition != locator::tablet_transition_kind::intranode_migration && _feature_service.file_stream && _db.local().get_config().enable_file_stream()) {
+        auto& table = _db.local().find_column_family(tablet.table);
+        const bool file_stream_enabled = _feature_service.file_stream && _db.local().get_config().enable_file_stream();
+        if (table.uses_logstor() && !file_stream_enabled) {
+            throw std::runtime_error(fmt::format("Table {}.{} uses logstor, which requires file streaming to be enabled", table.schema()->ks_name(), table.schema()->cf_name()));
+        }
+
+        if (file_stream_enabled && (trinfo->transition != locator::tablet_transition_kind::intranode_migration || table.uses_logstor())) {
             co_await utils::get_local_injector().inject("migration_streaming_wait", [] (auto& handler) {
                 rtlogger.info("migration_streaming_wait: start");
                 return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(2));

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -813,6 +813,7 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
     if (files.empty()) {
         co_return resp;
     }
+    co_await utils::get_local_injector().inject("wait_before_tablet_stream_files_after_snapshot", utils::wait_for_message(std::chrono::seconds(60)));
     auto ops_start_time = std::chrono::steady_clock::now();
     auto files_nr = files.size();
     size_t stream_bytes = co_await tablet_stream_files(ms, std::move(files), req.targets, req.table, req.ops_id, req.topo_guard);

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -130,6 +130,86 @@ lw_shared_ptr<tablet_stream_status> get_tablet_stream(file_stream_id ops_id) {
     return status;
 }
 
+using foreign_segment_sink = foreign_ptr<std::unique_ptr<replica::logstor::segment_stream_sink>>;
+using foreign_os = foreign_ptr<std::unique_ptr<output_stream<char>>>;
+
+struct foreign_data_sink : public data_sink_impl {
+    sharded<replica::database>& db;
+    shard_id target_shard;
+    foreign_os out;
+
+    foreign_data_sink(sharded<replica::database>& db, shard_id target_shard, foreign_os out)
+        : db(db), target_shard(target_shard), out(std::move(out)) {}
+
+    future<> put(std::span<temporary_buffer<char>> data) override {
+        // Copy buffers since they'll be moved to another shard
+        // TODO write directly from this shard to the file of the target shard?
+        std::vector<temporary_buffer<char>> bufs;
+        bufs.reserve(data.size());
+        for (auto& buf : data) {
+            if (!buf.empty()) {
+                temporary_buffer<char> copy(buf.size());
+                std::copy_n(buf.get(), buf.size(), copy.get_write());
+                bufs.push_back(std::move(copy));
+            }
+        }
+
+        co_await db.invoke_on(target_shard, [this, bufs = std::move(bufs)] (replica::database& db) -> future<> {
+            for (auto& buf : bufs) {
+                co_await out->write(buf.get(), buf.size());
+            }
+        });
+    }
+
+    future<> close() override {
+        co_await db.invoke_on(target_shard, [this] (replica::database&) -> future<> {
+            return out->close();
+        });
+    }
+};
+
+class logstor_sink {
+    sharded<replica::database>& _db;
+    table_id _tid;
+    shard_id _target_shard;
+    foreign_segment_sink _segment_sink;
+
+public:
+    logstor_sink(sharded<replica::database>& db, table_id tid, shard_id target_shard, foreign_segment_sink target_sink)
+        : _db(db), _tid(tid), _target_shard(target_shard), _segment_sink(std::move(target_sink)) {}
+
+    future<output_stream<char>> output(const file_open_options&, const file_output_stream_options&) {
+        auto foreign_out = co_await _db.invoke_on(_target_shard, [this] (replica::database& db) -> future<foreign_os> {
+            auto out = co_await _segment_sink->output();
+            co_return make_foreign(std::make_unique<output_stream<char>>(std::move(out)));
+        });
+        auto ds = std::make_unique<foreign_data_sink>(_db, _target_shard, std::move(foreign_out));
+        auto out = output_stream<char>(data_sink(std::move(ds)), file_stream_buffer_size);
+        co_return std::move(out);
+    }
+
+    future<> close() {
+        return _db.invoke_on(_target_shard, [this] (replica::database& db) -> future<> {
+            return _segment_sink->close();
+        });
+    }
+
+    future<> abort() {
+        return _db.invoke_on(_target_shard, [this] (replica::database& db) -> future<> {
+            return _segment_sink->abort();
+        });
+    }
+};
+
+future<logstor_sink> make_logstor_sink(sharded<replica::database>& db, table_id tid, shard_id target_shard) {
+    auto sink = co_await db.invoke_on(target_shard, [tid] (replica::database& db) -> future<foreign_segment_sink> {
+        auto& table = db.find_column_family(tid);
+        auto segment_sink = co_await table.create_logstor_segment_sink(db);
+        co_return make_foreign(std::move(segment_sink));
+    });
+    co_return logstor_sink(db, tid, target_shard, std::move(sink));
+}
+
 static void may_inject_error(const streaming::stream_blob_meta& meta, bool may_inject, const sstring& error) {
     if (may_inject) {
         if (rand() % 500 == 0) {
@@ -172,7 +252,8 @@ future<> stream_blob_handler(replica::database& db,
 
         // Reject any file_ops that is not support by this node
         if (meta.fops != streaming::file_ops::stream_sstables &&
-            meta.fops != streaming::file_ops::load_sstables) {
+            meta.fops != streaming::file_ops::load_sstables &&
+            meta.fops != streaming::file_ops::stream_logstor_segments) {
             auto msg = format("fstream[{}] Unsupported file_ops={} peer={} file={}",
                     meta.ops_id, int(meta.fops), from, meta.filename);
             blogger.warn("{}", msg);
@@ -352,29 +433,52 @@ future<> stream_blob_handler(replica::database& db, db::view::view_building_work
         stream_options.write_behind = file_stream_write_behind;
 
         auto& table = db.find_column_family(meta.table);
-        auto& sstm = table.get_sstables_manager();
-        // SSTable will be only sealed when added to the sstable set, so we make sure unsplit sstables aren't
-        // left sealed on the table directory.
-        sstables::sstable_stream_sink_cfg cfg { .last_component = meta.fops == file_ops::load_sstables,
-                                                .leave_unsealed = true };
-        auto sstable_sink = sstables::create_stream_sink(table.schema(), sstm, table.get_storage_options(), sstable_state(meta), meta.filename, cfg);
-        auto out = co_await sstable_sink->output(foptions, stream_options);
-        co_return output_result{
-            [sstable_sink = std::move(sstable_sink), &meta, &db, &vbw](store_result res) -> future<> {
-                if (res != store_result::ok) {
-                    co_await sstable_sink->abort();
-                    co_return;
-                }
-                auto sst = co_await sstable_sink->close();
-                if (sst) {
-                    blogger.debug("stream_sstables[{}] Loading sstable {} on shard {}", meta.ops_id, sst->toc_filename(), meta.dst_shard_id);
-                    auto desc = sst->get_descriptor(sstables::component_type::TOC);
-                    sst = {};
-                    co_await load_sstable_for_tablet(meta.ops_id, db, vbw, meta.table, sstable_state(meta), std::move(desc), meta.dst_shard_id);
-                }
-            },
-            std::move(out)
-        };
+        if (meta.fops == file_ops::stream_sstables || meta.fops == file_ops::load_sstables) {
+            auto& sstm = table.get_sstables_manager();
+            // SSTable will be only sealed when added to the sstable set, so we make sure unsplit sstables aren't
+            // left sealed on the table directory.
+            sstables::sstable_stream_sink_cfg cfg { .last_component = meta.fops == file_ops::load_sstables,
+                                                    .leave_unsealed = true };
+            auto sstable_sink = sstables::create_stream_sink(table.schema(), sstm, table.get_storage_options(), sstable_state(meta), meta.filename, cfg);
+            auto out = co_await sstable_sink->output(foptions, stream_options);
+            co_return output_result{
+                [sstable_sink = std::move(sstable_sink), &meta, &db, &vbw](store_result res) -> future<> {
+                    if (res != store_result::ok) {
+                        co_await sstable_sink->abort();
+                        co_return;
+                    }
+                    auto sst = co_await sstable_sink->close();
+                    if (sst) {
+                        blogger.debug("stream_sstables[{}] Loading sstable {} on shard {}", meta.ops_id, sst->toc_filename(), meta.dst_shard_id);
+                        auto desc = sst->get_descriptor(sstables::component_type::TOC);
+                        sst = {};
+                        co_await load_sstable_for_tablet(meta.ops_id, db, vbw, meta.table, sstable_state(meta), std::move(desc), meta.dst_shard_id);
+                    }
+                },
+                std::move(out)
+            };
+        } else if (meta.fops == file_ops::stream_logstor_segments) {
+            blogger.debug("stream_logstor_segments[{}] Creating logstor segment stream sink on shard {}", meta.ops_id, meta.dst_shard_id);
+            auto& sharded_db = db.container();
+            auto target_shard = meta.dst_shard_id;
+            auto table_id = meta.table;
+
+            auto sink = co_await make_logstor_sink(sharded_db, table_id, target_shard);
+            auto out = co_await sink.output(foptions, stream_options);
+
+            co_return output_result{
+                [sink = std::move(sink)](store_result res) mutable -> future<> {
+                    if (res != store_result::ok) {
+                        co_await sink.abort();
+                        co_return;
+                    }
+                    co_await sink.close();
+                },
+                std::move(out)
+            };
+        } else {
+            throw std::runtime_error(format("Unexpected file_ops={} in stream_blob_handler", int(meta.fops)));
+        }
     });
 }
 
@@ -638,68 +742,85 @@ tablet_stream_files(netw::messaging_service& ms, std::list<stream_blob_info> sou
 future<stream_files_response> tablet_stream_files_handler(replica::database& db, netw::messaging_service& ms, streaming::stream_files_request req) {
     stream_files_response resp;
     auto& table = db.find_column_family(req.table);
-    auto sstables = co_await table.take_storage_snapshot(req.range);
-    co_await utils::get_local_injector().inject("order_sstables_for_streaming", [&sstables] (auto& handler) -> future<> {
-        if (sstables.size() == 3) {
-            // make sure the sstables are ordered so that the sstable containing shadowed data is streamed last
-            const std::string_view shadowed_file = handler.template get<std::string_view>("shadowed_file").value();
-            for (int index: {0, 1}) {
-                if (sstables[index].sst->component_basename(component_type::Data) == shadowed_file) {
-                    std::swap(sstables[index], sstables[2]);
-                }
-            }
-        }
-        return make_ready_future<>();
-    });
     auto files = std::list<stream_blob_info>();
-
-    auto& sst_gen = table.get_sstable_generation_generator();
     auto reader = co_await db.obtain_reader_permit(table, "tablet_file_streaming", db::no_timeout, {});
 
-    for (auto& sst_snapshot : sstables) {
-        auto& sst = sst_snapshot.sst;
-        // stable state (across files) is a must for load to work on destination
-        auto sst_state = sst->state();
-
-        auto sources = co_await create_stream_sources(sst_snapshot, reader);
-        auto newgen = fmt::to_string(sst_gen());
-
-        for (auto&& s : sources) {
-            auto oldname = s->component_basename();
-            auto newname = get_sstable_name_with_generation(req.ops_id, oldname, newgen);
-
-            blogger.debug("fstream[{}] Get name oldname={}, newname={}", req.ops_id, oldname, newname);
-
+    if (table.uses_logstor()) {
+        auto segments = co_await table.take_logstor_snapshot(req.range);
+        for (auto& seg : segments) {
             auto& info = files.emplace_back();
-            info.fops = file_ops::stream_sstables;
-            info.sstable_state = sst_state;
-            info.filename = std::move(newname);
-            info.source = [s = std::move(s)](const file_input_stream_options& options) {
-                return s->input(options);
+            info.filename = format("logstor_segment_{}", seg.segment_id); // used only for logging
+            info.fops = file_ops::stream_logstor_segments;
+            info.source = [seg = std::move(seg)](const file_input_stream_options& options) {
+                return seg.source(options);
             };
         }
-        // ensure we mark the end of each component sequence.
-        if (!files.empty()) {
-            files.back().fops = file_ops::load_sstables;
+        blogger.debug("stream_logstor_segments[{}] Started sending segment_nr={} range={}",
+                req.ops_id, segments.size(), req.range);
+    } else {
+        auto sstables = co_await table.take_storage_snapshot(req.range);
+        co_await utils::get_local_injector().inject("order_sstables_for_streaming", [&sstables] (auto& handler) -> future<> {
+            if (sstables.size() == 3) {
+                // make sure the sstables are ordered so that the sstable containing shadowed data is streamed last
+                const std::string_view shadowed_file = handler.template get<std::string_view>("shadowed_file").value();
+                for (int index: {0, 1}) {
+                    if (sstables[index].sst->component_basename(component_type::Data) == shadowed_file) {
+                        std::swap(sstables[index], sstables[2]);
+                    }
+                }
+            }
+            return make_ready_future<>();
+        });
+
+        auto& sst_gen = table.get_sstable_generation_generator();
+
+        for (auto& sst_snapshot : sstables) {
+            auto& sst = sst_snapshot.sst;
+            // stable state (across files) is a must for load to work on destination
+            auto sst_state = sst->state();
+
+            auto sources = co_await create_stream_sources(sst_snapshot, reader);
+            auto newgen = fmt::to_string(sst_gen());
+
+            for (auto&& s : sources) {
+                auto oldname = s->component_basename();
+                auto newname = get_sstable_name_with_generation(req.ops_id, oldname, newgen);
+
+                blogger.debug("fstream[{}] Get name oldname={}, newname={}", req.ops_id, oldname, newname);
+
+                auto& info = files.emplace_back();
+                info.fops = file_ops::stream_sstables;
+                info.sstable_state = sst_state;
+                info.filename = std::move(newname);
+                info.source = [s = std::move(s)](const file_input_stream_options& options) {
+                    return s->input(options);
+                };
+            }
+            // ensure we mark the end of each component sequence.
+            if (!files.empty()) {
+                files.back().fops = file_ops::load_sstables;
+            }
         }
+        auto sstable_nr = sstables.size();
+        // Release reference to sstables to be streamed here. Since one sstable is streamed at a time,
+        // a sstable - that has been compacted - can have its space released from disk right after
+        // that sstable's content has been fully streamed.
+        sstables.clear();
+
+        blogger.debug("stream_sstables[{}] Started sending sstable_nr={} files_nr={} files={} range={}",
+                req.ops_id, sstable_nr, files.size(), files, req.range);
     }
     if (files.empty()) {
         co_return resp;
     }
-    auto sstable_nr = sstables.size();
-    // Release reference to sstables to be streamed here. Since one sstable is streamed at a time,
-    // a sstable - that has been compacted - can have its space released from disk right after
-    // that sstable's content has been fully streamed.
-    sstables.clear();
-    blogger.debug("stream_sstables[{}] Started sending sstable_nr={} files_nr={} files={} range={}",
-            req.ops_id, sstable_nr, files.size(), files, req.range);
     auto ops_start_time = std::chrono::steady_clock::now();
     auto files_nr = files.size();
     size_t stream_bytes = co_await tablet_stream_files(ms, std::move(files), req.targets, req.table, req.ops_id, req.topo_guard);
     resp.stream_bytes = stream_bytes;
     auto duration = std::chrono::steady_clock::now() - ops_start_time;
-    blogger.info("stream_sstables[{}] Finished sending sstable_nr={} files_nr={} range={} stream_bytes={} stream_time={} stream_bw={}",
-            req.ops_id, sstable_nr, files_nr, req.range, stream_bytes, duration, get_bw(stream_bytes, ops_start_time));
+    blogger.info("stream_{}[{}] Finished sending files_nr={} range={} stream_bytes={} stream_time={} stream_bw={}",
+            table.uses_logstor() ? "logstor_segments" : "sstables",
+            req.ops_id, files_nr, req.range, stream_bytes, duration, get_bw(stream_bytes, ops_start_time));
     co_return resp;
 }
 

--- a/streaming/stream_blob.hh
+++ b/streaming/stream_blob.hh
@@ -44,6 +44,7 @@ using file_stream_id = utils::tagged_uuid<struct file_stream_id_tag>;
 enum class file_ops : uint16_t {
     stream_sstables,
     load_sstables,
+    stream_logstor_segments,
 };
 
 // For STREAM_BLOB verb

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -370,7 +370,7 @@ async def test_compaction(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_drop_table(manager: ManagerClient):
     """
-    Test log compaction by creating dead data and verifying space reclamation.
+    Test that DROP TABLE works properly with logstor tables.
     """
     cmdline = ['--logger-log-level', 'logstor=trace']
     cfg = {'enable_logstor': True, 'experimental_features': ['logstor']}

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -12,7 +12,7 @@ from test.cluster.util import new_test_keyspace
 from cassandra.protocol import ConfigurationException
 import pytest
 import logging
-
+from test.pylib.tablets import get_tablet_count, get_tablet_replica
 from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
@@ -457,3 +457,286 @@ async def test_trigger_separator_flush(manager: ManagerClient):
             pk = 0
             value = f"value_{i}_" + ('x' * (value_size - 20))
             await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, '{value}')")
+
+@pytest.mark.asyncio
+async def test_tablet_split_trigger_by_size(manager: ManagerClient):
+    """
+    Test that a logstor table automatically splits tablets when the data size
+    exceeds --target-tablet-size-in-bytes.
+
+    The split threshold is set to 300KB (~2 segments at 128KB each).
+    Writing 5 keys with ~100KB values fills 5 segments (~640KB total), which
+    exceeds the threshold and should trigger an automatic split.
+    After the split, all data must remain readable.
+    """
+    cmdline = [
+        '--logger-log-level', 'logstor=debug',
+        '--logger-log-level', 'load_balancer=debug',
+        '--target-tablet-size-in-bytes', '300000',
+        '--smp=1',
+    ]
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        'enable_logstor': True,
+        'experimental_features': ['logstor'],
+    }
+    servers = [await manager.server_add(cmdline=cmdline, config=cfg)]
+    cql = manager.get_cql()
+
+    s0_log = await manager.server_open_log(servers[0].server_id)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        assert await get_tablet_count(manager, servers[0], ks, 'test') == 1
+
+        s0_mark = await s0_log.mark()
+
+        # Write 5 keys with ~100KB values to fill 5 segments (~640KB total).
+        # This exceeds the 300KB target and should trigger a split.
+        value = 'x' * (100 * 1024)
+        for i in range(5):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{value}')")
+
+        # Flush to assign segments to compaction groups so their size is
+        # visible to tablet load stats.
+        await manager.api.logstor_flush(servers[0].ip_addr)
+
+        await s0_log.wait_for('Detected tablet split for table', from_mark=s0_mark, timeout=60)
+        await asyncio.sleep(1)
+
+        # Verify all data is accessible after the split
+        for i in range(5):
+            rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test WHERE pk = {i}")
+            assert len(rows) == 1, f"Key {i} not found after tablet split"
+            assert rows[0].v == value, f"Wrong value for key {i} after tablet split"
+
+@pytest.mark.asyncio
+async def test_tablet_split_and_merge(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'table=debug',
+        '--logger-log-level', 'load_balancer=debug',
+        '--logger-log-level', 'logstor=trace',
+        '--smp', '1'
+    ]
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        'enable_logstor': True, 'experimental_features': ['logstor']
+    }
+    servers = [await manager.server_add(config=cfg, cmdline=cmdline)]
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1 AND storage_engine='logstor';")
+
+        total_keys = 10
+        keys = range(total_keys)
+        insert = cql.prepare(f"INSERT INTO {ks}.test(pk, c) VALUES(?, ?)")
+        await asyncio.gather(*[cql.run_async(insert, [pk, random.randbytes(30*1024)]) for pk in keys])
+
+        async def check():
+            logger.info("Checking table")
+            cql = manager.get_cql()
+            rows = await cql.run_async(f"SELECT * FROM {ks}.test;")
+            assert len(rows) == len(keys)
+
+        await check()
+
+        await manager.api.logstor_flush(servers[0].ip_addr)
+
+        tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
+        assert tablet_count == 1
+
+        s0_log = await manager.server_open_log(servers[0].server_id)
+        s0_mark = await s0_log.mark()
+        await cql.run_async(f"ALTER TABLE {ks}.test WITH tablets={{'min_tablet_count': 4}}")
+        await s0_log.wait_for('Detected tablet split for table', from_mark=s0_mark)
+
+        async def tablet_split_finished():
+            tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
+            if tablet_count >= 4:
+                return True
+        await wait_for(tablet_split_finished, time.time() + 60)
+
+        await check()
+
+        s0_mark = await s0_log.mark()
+        await cql.run_async(f"ALTER TABLE {ks}.test WITH tablets={{'min_tablet_count': 1}}")
+        await s0_log.wait_for('Detected tablet merge for table', from_mark=s0_mark)
+
+        async def tablet_merge_finished():
+            tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
+            if tablet_count == 1:
+                return True
+        await wait_for(tablet_merge_finished, time.time() + 60)
+
+        await check()
+
+@pytest.mark.asyncio
+async def test_tablet_migration(manager: ManagerClient):
+    """
+    Test tablet migration
+    """
+    cmdline = ['--logger-log-level', 'logstor=trace', '--logger-log-level', 'stream_blob=trace','--smp=1']
+    cfg = {'enable_logstor': True, 'experimental_features': ['logstor']}
+    s1 = await manager.server_add(cmdline=cmdline, config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+    servers = [s1]
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        nrows = 20
+        value = 'x' * (30 * 1024)
+        for i in range(nrows):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{i}_{value}')")
+
+        s2 = await manager.server_add(cmdline=cmdline, config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+        servers.append(s2)
+        cql, hosts = await manager.get_ready_cql(servers)
+
+        # migrate one tablet to the other node
+        h1 = await manager.get_host_id(s1.server_id)
+        h2 = await manager.get_host_id(s2.server_id)
+        tablet_token = 0
+        await manager.api.move_tablet(servers[0].ip_addr, ks, "test", h1, 0, h2, 0, tablet_token)
+
+        for i in range(nrows):
+            rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test WHERE pk = {i}")
+            assert len(rows) == 1, f"Expected 1 row for key {i} after tablet migration, but got {len(rows)}"
+            assert rows[0].v == f"{i}_{value}", f"Expected value '{i}_{value}' for key {i} after tablet migration, but got {rows[0].v}"
+
+@pytest.mark.asyncio
+async def test_tablet_intranode_migration(manager: ManagerClient):
+    """
+    Test tablet intranode migration
+    """
+    cmdline = ['--logger-log-level', 'logstor=trace', '--logger-log-level', 'stream_blob=trace','--smp=2']
+    cfg = {'enable_logstor': True, 'experimental_features': ['logstor']}
+    s1 = await manager.server_add(cmdline=cmdline, config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+    servers = [s1]
+    cql, _ = await manager.get_ready_cql(servers)
+
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        nrows = 20
+        value = 'x' * (30 * 1024)
+        for i in range(nrows):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{i}_{value}')")
+
+        tablet_token = 0
+        replica = await get_tablet_replica(manager, s1, ks, 'test', tablet_token)
+        h1 = replica[0]
+        src_shard = replica[1]
+        dst_shard = 1 - src_shard
+
+        # migrate one tablet to the other shard
+        await manager.api.move_tablet(servers[0].ip_addr, ks, "test", h1, src_shard, h1, dst_shard, tablet_token)
+
+        for i in range(nrows):
+            rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test WHERE pk = {i}")
+            assert len(rows) == 1, f"Expected 1 row for key {i} after tablet migration, but got {len(rows)}"
+            assert rows[0].v == f"{i}_{value}", f"Expected value '{i}_{value}' for key {i} after tablet migration, but got {rows[0].v}"
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tablet_migration_with_compaction(manager: ManagerClient):
+    """
+    Test that tablet migration is correct when compaction runs concurrently on the source.
+    Verifies that data migrated to the destination is intact even when segments are freed
+    by compaction while they are being streamed.
+
+    Uses an injection to pause migration after the snapshot of segments is taken
+    but before they are streamed, then triggers compaction to free dead
+    segments, then unpauses streaming to verify data survives.
+
+    This test:
+    1. Writes several segments with overwrites to create dead data suitable for compaction
+    2. Flushes to assign all segments to the tablet's compaction group
+    3. Enables the injection
+    4. Starts intranode tablet migration asynchronously
+    5. Waits for the injection to be hit (snapshot taken, streaming paused)
+    6. Triggers and waits for compaction to free dead segments
+    7. Releases the injection to let streaming proceed
+    8. Verifies all data is correct on the destination after migration
+    """
+    cmdline = ['--logger-log-level', 'logstor=trace', '--logger-log-level', 'stream_blob=trace', '--smp=2']
+    cfg = {'enable_logstor': True, 'experimental_features': ['logstor']}
+    s1 = await manager.server_add(cmdline=cmdline, config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+    servers = [s1]
+    cql, _ = await manager.get_ready_cql(servers)
+
+    inj = 'wait_before_tablet_stream_files_after_snapshot'
+
+    await manager.disable_tablet_balancing()
+
+    s1_log = await manager.server_open_log(s1.server_id)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        value_size = 30 * 1024
+        nrows = 20
+        expected = {}
+
+        # Write nrows unique keys to fill several segments
+        for i in range(nrows):
+            value = f"v{i}_" + ('a' * (value_size - 4))
+            expected[i] = value
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{value}')")
+
+        # Overwrite the first half of the keys multiple times to accumulate dead segments
+        dead_value = 'b' * value_size
+        for _ in range(4):
+            for i in range(nrows // 2):
+                await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{dead_value}')")
+
+        # Write the final expected values for the overwritten keys
+        for i in range(nrows // 2):
+            value = f"final{i}_" + ('c' * (value_size - 9))
+            expected[i] = value
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{value}')")
+
+        # Flush to assign all segments to the tablet's compaction group before migration
+        await manager.api.logstor_flush(s1.ip_addr)
+
+        # Find which shard owns the tablet and pick the other shard as destination
+        tablet_token = 0
+        replica = await get_tablet_replica(manager, s1, ks, 'test', tablet_token)
+        h1 = replica[0]
+        src_shard = replica[1]
+        dst_shard = 1 - src_shard
+
+        # Enable the injection that pauses streaming after the snapshot is taken
+        await manager.api.enable_injection(s1.ip_addr, inj, one_shot=True)
+        log_mark = await s1_log.mark()
+
+        # Start migration in the background; it will pause at the injection point
+        migration_task = asyncio.ensure_future(
+            manager.api.move_tablet(servers[0].ip_addr, ks, "test", h1, src_shard, h1, dst_shard, tablet_token)
+        )
+
+        # Wait until streaming has taken the snapshot and is paused at the injection
+        await s1_log.wait_for(f'{inj}: waiting for message', from_mark=log_mark)
+
+        # Trigger compaction while streaming is paused; the snapshot holds segment refs so
+        # compaction can compact and free dead segments without affecting the in-flight data
+        await manager.api.logstor_compaction(s1.ip_addr)
+        await manager.api.logstor_flush(s1.ip_addr)
+
+        # Release the injection to let streaming proceed
+        await manager.api.message_injection(s1.ip_addr, inj)
+        await migration_task
+
+        # Verify all data is correct on the destination after migration with concurrent compaction
+        for pk, expected_v in expected.items():
+            rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test WHERE pk = {pk}")
+            assert len(rows) == 1, f"Key {pk} not found after migration with concurrent compaction"
+            assert rows[0].v == expected_v, f"Key {pk} has wrong value after migration with concurrent compaction"

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -177,7 +177,9 @@ async def test_parallel_big_writes(manager: ManagerClient):
             assert rows[0].v == f"{i}-{large_value}"
 
 @pytest.mark.asyncio
-async def test_recovery_basic(manager: ManagerClient):
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.parametrize("fail_separator_flush", [False, True], ids=["normal", "fail_separator_flush"])
+async def test_recovery_basic(manager: ManagerClient, fail_separator_flush: bool):
     """
     Test that logstor data persists across server restarts.
 
@@ -193,6 +195,9 @@ async def test_recovery_basic(manager: ManagerClient):
     cfg = {'enable_logstor': True, 'experimental_features': ['logstor']}
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
     cql = manager.get_cql()
+
+    if fail_separator_flush:
+        await manager.api.enable_injection(servers[0].ip_addr, "fail_flush_separator_buffer", one_shot=False)
 
     async with new_test_keyspace(manager, "") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
@@ -412,6 +417,19 @@ async def test_drop_table(manager: ManagerClient):
         assert rows[0].v == 'new_value', f"Expected value 'new_value' for key 1 after new insert, but got {rows[0].v}"
 
         # verify test2 again
+        for i in range(20):
+            rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test2 WHERE pk = {i}")
+            assert len(rows) == 1, f"Expected 1 row for key {i} in test2 after all operations, but got {len(rows)}"
+            assert rows[0].v == value, f"Expected value of size {value_size} for key {i} in test2 after all operations, but got {len(rows[0].v)}"
+
+        # now test recovery after drop table.
+        await cql.run_async(f"DROP TABLE {ks}.test1")
+
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_start(servers[0].server_id)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        # verify test2
         for i in range(20):
             rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test2 WHERE pk = {i}")
             assert len(rows) == 1, f"Expected 1 row for key {i} in test2 after all operations, but got {len(rows)}"


### PR DESCRIPTION
implement tablet split, tablet merge and tablet migration for tables that use the experimental logstor storage engine.

* tablet merge simply merges the histograms of segments of one compaction group with another.
* for tablet split we take the segments from the source compaction group, read them and write all live records to separate segments according to the split classifier, and move separated segments to the target compaction groups.
* for tablet migration we use stream_blob, similarly to file streaming of sstables. we add a new op type for streaming a logstor segment. on the source we take a snapshot of the segments with an input stream that reads the segment, and on the target we create a sink that allocates a new segment on the target shard and writes to it.
* we also do some improvements for recovery and loading of segments. we add a segment header that contains useful information for non-mixed segments, such as the table and token range.

Refs SCYLLADB-770

no backport - still a new and experimental feature