### PR TITLE
locator/tablets: Fix missing selector value in error messages

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1269,7 +1269,7 @@ private:
                     return info->next;
                 }
             }
-            on_internal_error(tablet_logger, format("Invalid replica selector", static_cast<int>(info->writes)));
+            on_internal_error(tablet_logger, format("Invalid write replica selector: {}", static_cast<int>(info->writes)));
         });
         tablet_logger.trace("get_replicas_for_write({}): table={}, tablet={}, replicas={}", search_token, _table, tablet, replicas);
         return replicas;
@@ -1296,7 +1296,7 @@ private:
             case write_replica_set_selector::next:
                 return {};
         }
-        on_internal_error(tablet_logger, format("Invalid replica selector", static_cast<int>(info->writes)));
+        on_internal_error(tablet_logger, format("Invalid write replica selector: {}", static_cast<int>(info->writes)));
     }
 
     host_id_vector_replica_set get_for_reading_helper(const token& search_token) const {
@@ -1314,7 +1314,7 @@ private:
                     return info->next;
                 }
             }
-            on_internal_error(tablet_logger, format("Invalid replica selector", static_cast<int>(info->reads)));
+            on_internal_error(tablet_logger, format("Invalid read replica selector: {}", static_cast<int>(info->reads)));
         });
         tablet_logger.trace("get_endpoints_for_reading({}): table={}, tablet={}, replicas={}", search_token, _table, tablet, replicas);
         return to_host_set(replicas);


### PR DESCRIPTION
Some on_internal_error() calls have the selector argument to a format string with no placeholder for it in the format string.

"While at it", disambiguate selector type in the message text.

Improving error reporting. Doesn't seem to had happened before, so not worth backporting