### PR TITLE
token_metadata: Clear _topology_change_info gently

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -367,6 +367,8 @@ future<> token_metadata_impl::clear_gently() noexcept {
     co_await utils::clear_gently(_sorted_tokens);
     co_await _topology.clear_gently();
     co_await _tablets.clear_gently();
+    co_await utils::clear_gently(_topology_change_info);
+    _topology_change_info.reset();
     co_return;
 }
 


### PR DESCRIPTION
clear_gently() (introduced in 322aa2f8b5) clears all token_metadata_impl members using co_await to avoid reactor stalls on large data structures.

_topology_change_info (introduced in 10bf8c7901) was added later and not included in clear_gently().

update_topology_change_info() already uses utils::clear_gently() when replacing the value, so it looks reasonable to apply the same pattern in clear_gently().

Codeflow improvement, probably not worth backporting