### PR TITLE
test.py: reduce timeout for one test

### DIFF
--- a/test.py
+++ b/test.py
@@ -181,7 +181,7 @@ def parse_cmd_line() -> argparse.Namespace:
                         help="Run only tests for given build mode(s)")
     parser.add_argument('--repeat', action="store", default="1", type=int,
                         help="number of times to repeat test execution")
-    parser.add_argument('--timeout', action="store", default="24000", type=int,
+    parser.add_argument('--timeout', action="store", default="3600", type=int,
                         help="timeout value for single test execution")
     parser.add_argument('--session-timeout', action="store", default="24000", type=int,
                         help="timeout value for test.py/pytest session execution")


### PR DESCRIPTION
Reduce the timeout for one test to 60 minutes. The longest test we had so far was ~10-15 minutes. So reducing this timeout is pretty safe and should help with hanging tests.

No backport, test framework config change only.