### PR TITLE
schema: Avoid copies in column_mapping::operator==

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -131,12 +131,12 @@ bool operator==(const column_mapping_entry& lhs, const column_mapping_entry& rhs
 }
 
 bool operator==(const column_mapping& lhs, const column_mapping& rhs) {
-    const auto& lhs_columns = lhs.columns(), rhs_columns = rhs.columns();
+    const auto& lhs_columns = lhs.columns(), &rhs_columns = rhs.columns();
     if (lhs_columns.size() != rhs_columns.size()) {
         return false;
     }
     for (size_t i = 0, end = lhs_columns.size(); i < end; ++i) {
-        const column_mapping_entry& lhs_entry = lhs_columns[i], rhs_entry = rhs_columns[i];
+        const column_mapping_entry& lhs_entry = lhs_columns[i], &rhs_entry = rhs_columns[i];
         if (lhs_entry != rhs_entry) {
             return false;
         }


### PR DESCRIPTION
In a multi-declarator declaration, the & ref-qualifier is part of each individual declarator, not the shared type specifier. So:

    const auto& a = x(), b = y();

declares 'a' as a reference but 'b' as a value, silently copying y(). The same applies to:

    const T& a = v[i], b = v[j];

Both operator== lines had this pattern, causing an unnecessary copy of the column vector and an unnecessary copy of each entry on every call.

Fix by repeating & on the second declarator in both lines.

Small optimization that doesn't affect correctness. Not backporting