### PR TITLE
test/object_store: fix long test timeout caused by busy-spin in DockerizedServer.start()

### DIFF
--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -198,6 +198,8 @@ class GSServer(GSFront):
                 os.environ[k] = val
 
     def unpublish(self):
+        if not self.oldvars:
+            return
         for k in self.vars:
             v = self.oldvars[k]
             if v:

--- a/test/pylib/dockerized_service.py
+++ b/test/pylib/dockerized_service.py
@@ -86,6 +86,12 @@ class DockerizedServer:
                                 print(f'Got fail message: {line}')
                                 failed = True
                                 break
+                    if not done and not failed:
+                        # Yield to the event loop so that the asyncio.timeout()
+                        # above can fire if the deadline is reached. Without this,
+                        # the loop body is entirely synchronous and the event loop
+                        # is never resumed, causing the timeout to never trigger.
+                        await asyncio.sleep(0.1)
 
             if failed:
                 self.logfile.close()


### PR DESCRIPTION
The GS docker contained failed to start (possibly due to infra issue)
but this test handled it very poorly, resulting in 6 hour CI, ending
with timeout. This patch fixes the problems on the test logic end.

DockerizedServer.start() polls a log file waiting for the containerized
service to emit its startup message. The polling loop was entirely
synchronous -- no await points -- so the asyncio event loop was never
resumed while waiting. This meant the asyncio.timeout(120) context
manager could never fire its cancellation, causing the test to hang
until the outer pytest-timeout (24000s) killed it.

Fix this by adding await asyncio.sleep(0.1) at the bottom of the
polling loop, yielding control back to the event loop on each iteration
so the timeout can trigger as intended.

As a secondary fix, guard GSServer.unpublish() against being called
when publish() was never invoked (i.e. when start() failed before
reaching publish()). Previously this caused a confusing KeyError on
'GS_SERVER_ADDRESS_FOR_TEST' that masked the real timeout error.

Fixes: SCYLLADB-1105

Backport: the test was introduced in 31cc1160b4, needs backport to scylla-2026.1.