### PR TITLE
alternator/streams: Block tablet merges for Alternator Streams on tablet tables

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -15,6 +15,7 @@
 #include "auth/resource.hh"
 #include "cdc/log.hh"
 #include "cdc/cdc_options.hh"
+#include "cdc/cdc_extension.hh"
 #include "auth/service.hh"
 #include "cql3/cql3_type.hh"
 #include "db/config.hh"
@@ -1310,6 +1311,29 @@ static future<> mark_view_schemas_as_built(utils::chunked_vector<mutation>& out,
     }
 }
 
+// When Alternator Streams are requested on a tablet table, convert the
+// already-configured enabled=true CDC options into a deferred state:
+// - enabled=false: don't create the CDC log table yet
+// - enable_requested=true: persist the user's intent for the topology
+//   coordinator to finalize later
+// - tablet_merge_blocked=true: suppress tablet merges that would produce
+//   2-parent shards incompatible with the DynamoDB Streams API
+// The topology coordinator will finalize enablement once all pending merges
+// complete (see maybe_finalize_pending_stream_enables in cdc/generation.cc).
+//
+// Callers must ensure the builder already has CDC options with enabled=true.
+static void defer_enabling_streams_block_tablet_merges(schema_builder& builder) {
+    auto& exts = builder.get_extensions();
+    auto it = exts.find(cdc::cdc_extension::NAME);
+    throwing_assert(it != exts.end());
+    auto opts = dynamic_pointer_cast<cdc::cdc_extension>(it->second)->get_options();
+    throwing_assert(opts.enabled());
+    opts.enabled(false);
+    opts.enable_requested(true);
+    opts.tablet_merge_blocked(true);
+    builder.with_cdc_options(opts);
+}
+
 // Returns true if the given attribute name is already the target of any vector
 // index on the schema. Analogous to schema::has_index(), but looks up by the
 // indexed attribute name rather than the index name.
@@ -1838,15 +1862,21 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                 empty_request = false;
                 if (add_stream_options(*stream_specification, builder, p.local())) {
                     validate_cdc_log_name_length(builder.cf_name());
+                    // On tablet tables, defer stream enablement and block
+                    // tablet merges (see defer_enabling_streams_block_tablet_merges).
+                    bool uses_tablets = p.local().local_db().find_keyspace(tab->ks_name()).get_replication_strategy().uses_tablets();
+                    if (uses_tablets) {
+                        defer_enabling_streams_block_tablet_merges(builder);
+                    }
                 }
                 auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
                 if (stream_enabled && stream_enabled->IsBool()) {
                     if (stream_enabled->GetBool()) {
-                        if (tab->cdc_options().enabled()) {
+                        if (tab->cdc_options().enabled() || tab->cdc_options().enable_requested()) {
                             co_return api_error::validation("Table already has an enabled stream: TableName: " + tab->cf_name());
                         }
                     }
-                    else if (!tab->cdc_options().enabled()) {
+                    else if (!tab->cdc_options().enabled() && !tab->cdc_options().enable_requested()) {
                         co_return api_error::validation("Table has no stream to disable: TableName: " + tab->cf_name());
                     }
                 }

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -877,6 +877,8 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
         } else {
             status = "ENABLED";
         }
+    } else if (opts.enable_requested()) {
+        status = "ENABLING";
     }
 
     auto ttl = std::chrono::seconds(opts.ttl());
@@ -1544,6 +1546,7 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
 
         cdc::options opts;
         opts.enabled(true);
+        opts.tablet_merge_blocked(true);
         // cdc::delta_mode is ignored by Alternator, so aim for the least overhead.
         opts.set_delta_mode(cdc::delta_mode::keys);
         opts.ttl(std::chrono::duration_cast<std::chrono::seconds>(dynamodb_streams_max_window).count());
@@ -1581,21 +1584,27 @@ void executor::supplement_table_stream_info(rjson::value& descr, const schema& s
         stream_arn arn(cf.schema(), cdc::get_base_table(db.real_database(), *cf.schema()));
         rjson::add(descr, "LatestStreamArn", arn);
         rjson::add(descr, "LatestStreamLabel", rjson::from_string(stream_label(*cf.schema())));
-
-        auto stream_desc = rjson::empty_object();
-        rjson::add(stream_desc, "StreamEnabled", true);
-
-        auto mode = stream_view_type::KEYS_ONLY;
-        if (opts.preimage() && opts.postimage()) {
-            mode = stream_view_type::NEW_AND_OLD_IMAGES;
-        } else if (opts.preimage()) {
-            mode = stream_view_type::OLD_IMAGE;
-        } else if (opts.postimage()) {
-            mode = stream_view_type::NEW_IMAGE;
-        }
-        rjson::add(stream_desc, "StreamViewType", mode);
-        rjson::add(descr, "StreamSpecification", std::move(stream_desc));
+    } else if (!opts.enable_requested()) {
+        return;
     }
+    // For both enabled() and enable_requested():
+    // DynamoDB returns StreamEnabled=true in StreamSpecification even when
+    // the stream status is ENABLING (not yet fully active). We mirror this
+    // behavior: enable_requested means the user asked for streams but CDC
+    // is not yet finalized, so we still report StreamEnabled=true.
+    auto stream_desc = rjson::empty_object();
+    rjson::add(stream_desc, "StreamEnabled", true);
+
+    auto mode = stream_view_type::KEYS_ONLY;
+    if (opts.preimage() && opts.postimage()) {
+        mode = stream_view_type::NEW_AND_OLD_IMAGES;
+    } else if (opts.preimage()) {
+        mode = stream_view_type::OLD_IMAGE;
+    } else if (opts.postimage()) {
+        mode = stream_view_type::NEW_IMAGE;
+    }
+    rjson::add(stream_desc, "StreamViewType", mode);
+    rjson::add(descr, "StreamSpecification", std::move(stream_desc));
 }
 
 } // namespace alternator

--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -35,6 +35,15 @@ enum class image_mode : uint8_t {
 
 class options final {
     std::optional<bool> _enabled;
+    bool _enable_requested = false;
+    // When CDC is employed for the purpose of Alternator Streams and tablets are used,
+    // tablet merges need to be blocked due to limitations of DynamoDB Streams API.
+    // DynamoDB Streams allows to specify a single parent for a stream.
+    // In ScyllaDB, there is a one-to-one association between streams and tablets,
+    // so merging tablets means also merging streams. A merged stream has two parents and both
+    // need to be done reading from before reading from the newly merged tablet. This is impossible
+    // to be conveyed with DynamoDB Streams API and the result can be reordering of events in Streams.
+    bool _tablet_merge_blocked = false;
     image_mode _preimage = image_mode::off;
     bool _postimage = false;
     delta_mode _delta_mode = delta_mode::full;
@@ -48,6 +57,8 @@ public:
 
     bool enabled() const { return _enabled.value_or(false); }
     bool is_enabled_set() const { return _enabled.has_value(); }
+    bool enable_requested() const { return _enable_requested; }
+    bool tablet_merge_blocked() const { return _tablet_merge_blocked; }
     bool preimage() const { return _preimage != image_mode::off; }
     bool full_preimage() const { return _preimage == image_mode::full; }
     bool postimage() const { return _postimage; }
@@ -56,6 +67,17 @@ public:
     int ttl() const { return _ttl; }
 
     void enabled(bool b) { _enabled = b; }
+    // For the cases when enabling cannot be immediately enforced, like with Alternator Streams
+    // which is incompatible with tablet merges, we need to be able to defer actual enablement
+    // until any in-progress tablet merges complete. We expect that finalization happens
+    // promptly: on_update_column_family callback in topology_coordinator.cc wakes up
+    // the topology coordinator to run maybe_finalize_pending_stream_enables shortly
+    // after the DDL. However, there is SCYLLADB-1304
+    void enable_requested(bool b = true) { _enable_requested = b; }
+    // Persistent flag checked by the tablet allocator to suppress new merge
+    // decisions. Always set when Alternator Streams are enabled; inert on
+    // vnode tables.
+    void tablet_merge_blocked(bool b = true) { _tablet_merge_blocked = b; }
     void preimage(bool b) { preimage(b ? image_mode::on : image_mode::off); }
     void preimage(image_mode m) { _preimage = m; }
     void postimage(bool b) { _postimage = b; }

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -16,8 +16,11 @@
 #include "keys/keys.hh"
 #include "replica/database.hh"
 #include "db/system_keyspace.hh"
+#include "db/schema_tables.hh"
 #include "dht/token-sharding.hh"
 #include "locator/token_metadata.hh"
+#include "locator/tablets.hh"
+#include "schema/schema_builder.hh"
 #include "types/set.hh"
 #include "utils/assert.hh"
 #include "utils/error_injection.hh"
@@ -29,6 +32,7 @@
 #include "cdc/cdc_options.hh"
 #include "cdc/generation_service.hh"
 #include "cdc/log.hh"
+#include "service/migration_listener.hh"
 
 extern logging::logger cdc_log;
 
@@ -774,6 +778,61 @@ future<> generation_service::garbage_collect_cdc_streams(utils::chunked_vector<c
             muts.emplace_back(std::move(m));
         }
     }
+}
+
+future<utils::chunked_vector<canonical_mutation>> generation_service::maybe_finalize_pending_stream_enables(const locator::token_metadata& tm, api::timestamp_type ts) {
+    utils::chunked_vector<canonical_mutation> muts;
+
+    if (utils::get_local_injector().enter("delay_cdc_stream_finalization")) {
+        co_return std::move(muts);
+    }
+
+    co_await _db.get_tables_metadata().for_each_table_gently([&] (table_id id, lw_shared_ptr<replica::table> t) -> future<> {
+        auto s = t->schema();
+        if (!s->cdc_options().enable_requested()) {
+            co_return;
+        }
+
+        // Only tablet tables can have enable_requested set
+        if (!tm.tablets().has_tablet_map(id)) {
+            co_return;
+        }
+
+        auto& tmap = tm.tablets().get_tablet_map(id);
+        if (tmap.needs_merge()) {
+            cdc_log.debug("Table {}.{}: deferring stream enablement, tablet merge still in progress", s->ks_name(), s->cf_name());
+            co_return;
+        }
+
+        cdc_log.info("Table {}.{}: finalizing deferred stream enablement (no in-progress merges)", s->ks_name(), s->cf_name());
+
+        // Build a new schema with enabled=true, enable_requested=false
+        schema_builder builder(s);
+        cdc::options new_opts = s->cdc_options();
+        new_opts.enabled(true);
+        new_opts.enable_requested(false);
+        new_opts.tablet_merge_blocked(true);
+        builder.with_cdc_options(new_opts);
+        auto new_schema = builder.build();
+
+        // Generate the schema mutation (table metadata update only, no columns/indices changed)
+        utils::chunked_vector<mutation> schema_muts;
+        db::schema_tables::add_table_or_view_to_schema_mutation(new_schema, ts, false, schema_muts);
+
+        // Trigger the CDC migration listener hook which creates the CDC log table.
+        // This runs on_before_update_column_family listeners (including CDC's own
+        // listener that creates/updates the log table schema).
+        co_await seastar::async([&] {
+            _db.get_notifier().before_update_column_family(*new_schema, *s, schema_muts, ts);
+        });
+
+        for (auto& m : schema_muts) {
+            muts.emplace_back(canonical_mutation(m));
+            co_await coroutine::maybe_yield();
+        }
+    });
+
+    co_return std::move(muts);
 }
 
 } // namespace cdc

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -18,6 +18,7 @@ class system_keyspace;
 
 namespace locator {
 class tablet_map;
+class token_metadata;
 }
 
 namespace cdc {
@@ -63,6 +64,12 @@ public:
     future<> query_cdc_streams(table_id table, noncopyable_function<future<>(db_clock::time_point, const utils::chunked_vector<cdc::stream_id>& current, cdc::cdc_stream_diff)> f);
 
     future<> generate_tablet_resize_update(utils::chunked_vector<canonical_mutation>& muts, table_id table, const locator::tablet_map& new_tablet_map, api::timestamp_type ts);
+
+    // Check for tables with enable_requested CDC option and finalize their
+    // stream enablement if no in-progress tablet merges remain.
+    // Returns schema mutations that transition enable_requested -> enabled,
+    // including CDC log table creation side effects.
+    future<utils::chunked_vector<canonical_mutation>> maybe_finalize_pending_stream_enables(const locator::token_metadata& tm, api::timestamp_type ts);
 
     future<utils::chunked_vector<mutation>> garbage_collect_cdc_streams_for_table(table_id table, std::optional<std::chrono::seconds> ttl, api::timestamp_type ts);
     future<> garbage_collect_cdc_streams(utils::chunked_vector<canonical_mutation>& muts, api::timestamp_type ts);

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -465,6 +465,18 @@ cdc::options::options(const std::map<sstring, sstring>& map) {
             if (_ttl < 0) {
                 throw exceptions::configuration_exception("Invalid CDC option: ttl must be >= 0");
             }
+        } else if (key == "enable_requested") {
+            if (is_true || is_false) {
+                _enable_requested = is_true;
+            } else {
+                throw exceptions::configuration_exception("Invalid value for CDC option \"enable_requested\": " + p.second);
+            }
+        } else if (key == "tablet_merge_blocked") {
+            if (is_true || is_false) {
+                _tablet_merge_blocked = is_true;
+            } else {
+                throw exceptions::configuration_exception("Invalid value for CDC option \"tablet_merge_blocked\": " + p.second);
+            }
         } else {
             throw exceptions::configuration_exception("Invalid CDC option: " + p.first);
         }
@@ -472,7 +484,7 @@ cdc::options::options(const std::map<sstring, sstring>& map) {
 }
 
 std::map<sstring, sstring> cdc::options::to_map() const {
-    if (!is_enabled_set()) {
+    if (!is_enabled_set() && !_enable_requested) {
         return {};
     }
 
@@ -482,6 +494,8 @@ std::map<sstring, sstring> cdc::options::to_map() const {
         { "postimage", _postimage ? "true" : "false" },
         { "delta", fmt::format("{}", _delta_mode) },
         { "ttl", std::to_string(_ttl) },
+        { "enable_requested", enable_requested() ? "true" : "false" },
+        { "tablet_merge_blocked", _tablet_merge_blocked ? "true" : "false" },
     };
 }
 
@@ -490,7 +504,9 @@ sstring cdc::options::to_sstring() const {
 }
 
 bool cdc::options::operator==(const options& o) const {
-    return enabled() == o.enabled() && _preimage == o._preimage && _postimage == o._postimage && _ttl == o._ttl
+    return enabled() == o.enabled() && enable_requested() == o.enable_requested()
+            && _tablet_merge_blocked == o._tablet_merge_blocked
+            && _preimage == o._preimage && _postimage == o._postimage && _ttl == o._ttl
             && _delta_mode == o._delta_mode;
 }
 

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -97,6 +97,10 @@ speculative_retry::from_sstring(sstring str) {
     return speculative_retry(t, v);
 }
 
+bool schema::tablet_merges_forbidden() const {
+    return cdc_options().tablet_merge_blocked();
+}
+
 sstring to_sstring(column_kind k) {
     switch (k) {
     case column_kind::partition_key:  return "PARTITION_KEY";

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -804,6 +804,8 @@ public:
         return _raw._props.get_cdc_options();
     }
 
+    bool tablet_merges_forbidden() const;
+
     const ::tombstone_gc_options& tombstone_gc_options() const {
         return _raw._props.get_tombstone_gc_options();
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4291,6 +4291,9 @@ future<> storage_service::process_tablet_split_candidate(table_id table) noexcep
 
             if (co_await all_compaction_groups_split()) {
                 slogger.debug("All compaction groups of table {} are split ready.", table);
+                if (_topology_state_machine.on_tablet_split_ready) {
+                    _topology_state_machine.on_tablet_split_ready();
+                }
                 release_guard(std::move(guard));
                 break;
             } else {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include "cdc/cdc_options.hh"
 #include "cql3/statements/ks_prop_defs.hh"
 #include "db/system_keyspace.hh"
 #include "locator/tablets.hh"
@@ -2180,6 +2181,21 @@ public:
 
             resize_decision new_resize_decision;
             new_resize_decision.way = table_plan.resize_decision;
+
+            // Block merge decisions for Alternator tablet tables whose
+            // stream configuration forbids merges. Tablet merges produce
+            // 2 parents per child which is incompatible with the DynamoDB
+            // Streams API. If a merge is already in progress on the tmap,
+            // suppressing new_resize_decision here causes the existing
+            // revocation logic in tables_being_resized to cancel the merge.
+            if (new_resize_decision.is_merge()) {
+                auto [s, rs] = get_schema_and_rs(table);
+                if (s->tablet_merges_forbidden()) {
+                    lblogger.debug("Table {} ({}.{}): suppressing new merge decision because tablet merges are forbidden",
+                                   table, s->ks_name(), s->cf_name());
+                    new_resize_decision = {};
+                }
+            }
 
             table_size_desc size_desc {
                 .avg_tablet_size = *table_plan.avg_tablet_size,

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2782,6 +2782,21 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 guard = std::move(*guard_opt);
             }
 
+            // Check if any Alternator tables have deferred stream enablement
+            // that can now be finalized (no in-progress tablet merges).
+            {
+                auto tm = get_token_metadata_ptr();
+                auto cdc_muts = co_await _cdc_gens.maybe_finalize_pending_stream_enables(*tm, guard.write_timestamp());
+                if (!cdc_muts.empty()) {
+                    rtlogger.info("Finalizing deferred Alternator stream enablement for {} table(s)", cdc_muts.size());
+                    mixed_change change{std::move(cdc_muts)};
+                    group0_command g0_cmd = _group0.client().prepare_command(std::move(change), guard,
+                        "Finalize deferred Alternator stream enablement");
+                    co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), _as);
+                    co_return true;
+                }
+            }
+
             // If there is no other work, evaluate load and start tablet migration if there is imbalance.
             if (auto guard_opt = co_await maybe_start_tablet_migration(std::move(guard)); !guard_opt) {
                 co_return true;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -24,6 +24,7 @@
 #include <variant>
 
 #include "auth/service.hh"
+#include "cdc/cdc_options.hh"
 #include "cdc/generation.hh"
 #include "cdc/generation_service.hh"
 #include "cql3/statements/ks_prop_defs.hh"
@@ -4071,6 +4072,15 @@ public:
         , _async_gate("topology_coordinator")
     {
         _db.get_notifier().register_listener(this);
+        // When the delay_cdc_stream_finalization error injection is disabled
+        // (test releases it), wake the topology coordinator so it retries
+        // maybe_finalize_pending_stream_enables promptly.
+        utils::get_local_injector().register_on_disable("delay_cdc_stream_finalization", [this] {
+            _topo_sm.event.broadcast();
+        });
+        _topo_sm.on_tablet_split_ready = [this] {
+            trigger_load_stats_refresh();
+        };
     }
 
     future<> run();
@@ -4554,6 +4564,8 @@ future<> topology_coordinator::run() {
 
 future<> topology_coordinator::stop() {
     co_await _db.get_notifier().unregister_listener(this);
+    utils::get_local_injector().unregister_on_disable("delay_cdc_stream_finalization");
+    _topo_sm.on_tablet_split_ready = nullptr;
 
     // if topology_coordinator::run() is aborted either because we are not a
     // leader anymore, or we are shutting down as a leader, we have to handle

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <functional>
 #include <set>
 #include <unordered_set>
 #include <unordered_map>
@@ -268,6 +269,11 @@ struct topology_state_machine {
     topology_type _topology;
     condition_variable event;
     size_t reload_count = 0;
+
+    // Called by the tablet split monitor when all local storage groups
+    // for a table are split-ready, to trigger an early load stats
+    // refresh so the coordinator can finalize the resize promptly.
+    std::function<void()> on_tablet_split_ready;
 
     future<> await_not_busy();
     future<sstring> wait_for_request_completion(db::system_keyspace& sys_ks, utils::UUID id, bool require_entry);

--- a/test/alternator/test_streams_tablets.py
+++ b/test/alternator/test_streams_tablets.py
@@ -182,6 +182,7 @@ def run_parent_children_relationship_test(dynamodb, dynamodbstreams, rest_api, c
 # NOTE: this test assumes starting tablet count is bigger than one
 # NOTE: this test fails if `system:initial_tablets` is set to anything but 0 - maybe because 0 means start with some default
 #       while non-zero means start with this value, but never go any lower?
+@pytest.mark.xfail(reason="Tablet merges are blocked when Alternator Streams are enabled")
 def test_parent_children_merge(dynamodb, dynamodbstreams, rest_api, cql):
     def verify_parent_children_relationship_merge(root_shard_ids, shard_parents_map, shard_children_map):
         # shard_parents_map will contain both generations, so we strip original one
@@ -282,12 +283,12 @@ def test_parent_children_split(dynamodb, dynamodbstreams, rest_api, cql):
 #         of stream shards to be created. Each stream shard from previous generation will point
 #         to at least one stream shard in the next generation and never to some other generation.
 def test_parent_filtering(dynamodb, dynamodbstreams, rest_api, cql):
-    tablet_multipliers = [1, 2, 4, 8, 16, 8, 4, 2, 1]
+    # Only growing tablet count — merges are incompatible with Alternator Streams.
+    tablet_multipliers = [1, 2, 4, 8, 16]
 
     def verify_parent_children_relationship(root_shard_ids, shard_parents_map, shard_children_map):
-        # Verify the split/merge invariant: in a split all children point
-        # back to the same parent; in a merge the child may point to only one
-        # of its two parents, but both parents will have the child in their CHILD_SHARDS result.
+        # Verify the split invariant: all children point
+        # back to the same parent.
         #
         # First, build declared_children from the ParentShardId field recorded
         # in shard_parents_map, then compare against the CHILD_SHARDS filter
@@ -387,14 +388,12 @@ def test_parent_filtering(dynamodb, dynamodbstreams, rest_api, cql):
 #      - all written items are present in the stream (check count and then sorted content)
 #      - within each partition key, the records are in order of writes (check that `e` is monotonically increasing for each record)
 #      - the stream shard parent-child relationships are correct - stream shards create "generations" (all stream shards are split or merged at the same moment,
-#        when tablet count is changed). Every stream shard except first ones has a parent, but not every stream shard is being point to as a parent - when stream shard merge
-#        (let's say A & B merge into C), then next generation stream shard (C) has two parents (A & B), but the DynamoDB API allows to appoint only one - let's say A
-#        (the other one - B - will never be pointed to as a parent by anything else).
-#        NOTE: it's not the same as having no children - the stream shard (B) will have a child (C), but that child (C) will have it's sibling as parent (A).
+#        when tablet count is changed). Every stream shard except first ones has a parent.
 #        Then we try to walk the tree starting from every stream shard that is not pointed to as a parent. Depending on which generation that stream shard is in,
 #        the path will have different length.
 def test_get_records_with_alternating_tablets_count(dynamodb, dynamodbstreams, rest_api, cql):
-    tablet_multipliers = [1, 2, 4, 8, 16, 8, 4, 2, 1]
+    # Only growing tablet count — merges are incompatible with Alternator Streams.
+    tablet_multipliers = [1, 2, 4, 8, 16]
     writes_per_tablet_multiplier = 100
     partition_count = 32
 

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -30,6 +30,7 @@ import re
 from test.cluster.util import get_replication
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
+from test.pylib.rest_client import inject_error
 from test.pylib.tablets import get_all_tablet_replicas
 from test.pylib.tablets import get_tablet_replica
 
@@ -1393,3 +1394,135 @@ async def test_alternator_invalid_shard_for_lwt(manager: ManagerClient):
 
     stop_event.set()
     t.join()
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_deferred_stream_enablement_on_tablets(manager: ManagerClient):
+    """Test that enabling Alternator Streams on a tablet table uses deferred
+       enablement: the table goes through an ENABLING state (where the intent
+       is stored but CDC is not yet active) before the topology coordinator
+       finalizes it to ENABLED. While streams are active (ENABLING or ENABLED),
+       tablet merges must be blocked but splits must still be allowed. After
+       streams are disabled, merges must be allowed again.
+
+       The test exercises an elaborate sequence of tablet count changes:
+       in each of the ENABLING and ENABLED states, first a shrinkage is
+       attempted (must be blocked), then an increase (must succeed). After
+       disabling streams, a shrinkage is attempted (must succeed).
+    """
+    server = (await manager.servers_add(1, config=alternator_config))[0]
+    cql = manager.get_cql()
+    alternator = get_alternator(server.ip_addr)
+
+    async def get_table_id(ks, table_name):
+        rows = await cql.run_async(
+            f"SELECT id FROM system_schema.tables "
+            f"WHERE keyspace_name='{ks}' AND table_name='{table_name}'")
+        return rows[0].id
+
+    async def get_tablet_count(table_id):
+        rows = await cql.run_async(
+            f"SELECT tablet_count FROM system.tablets "
+            f"WHERE table_id={table_id} LIMIT 1")
+        return rows[0].tablet_count
+
+    async def set_tablet_target(ks, table_name, count):
+        """Set both min and max tablet count to force a specific target."""
+        await cql.run_async(
+            f'ALTER TABLE "{ks}"."{table_name}" '
+            f"WITH tablets = {{'min_tablet_count': {count}, 'max_tablet_count': {count}}}")
+
+    async def wait_for_tablet_count(table_id, expected_count):
+        """Wait for tablet count to reach exact expected_count."""
+        async def check():
+            count = await get_tablet_count(table_id)
+            if count == expected_count:
+                return count
+            return None
+        return await wait_for(check, time.time() + 60, period=0.1)
+
+    async def assert_tablet_count_stable(table_id, expected_count, duration=5):
+        """Assert tablet count stays at expected_count for duration seconds."""
+        deadline = time.time() + duration
+        while time.time() < deadline:
+            count = await get_tablet_count(table_id)
+            assert count == expected_count, \
+                f"Tablet count changed unexpectedly from {expected_count}"
+            await asyncio.sleep(0.1)
+
+    # === Phase 1: ENABLING state ===
+    # Hold finalization with an error injection so the table stays in
+    # ENABLING (enable_requested=true, enabled=false) state.
+    async with inject_error(manager.api, server.ip_addr, "delay_cdc_stream_finalization"):
+        table = alternator.create_table(
+            TableName=unique_table_name(),
+            Tags=[{'Key': 'system:initial_tablets', 'Value': '4'}],
+            BillingMode='PAY_PER_REQUEST',
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}])
+        try:
+            # create_table enables Streams immediately, so to test deferred
+            # Streams enablement, we need to use update_table.
+            table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'})
+            # Verify ENABLING state: StreamSpecification is present but
+            # LatestStreamArn is not (CDC log table does not exist yet).
+            desc = table.meta.client.describe_table(TableName=table.name)['Table']
+            assert 'StreamSpecification' in desc
+            assert desc['StreamSpecification']['StreamEnabled'] == True
+            assert desc['StreamSpecification']['StreamViewType'] == 'KEYS_ONLY'
+            assert 'LatestStreamArn' not in desc
+
+            # Double-enable must be rejected while ENABLING.
+            with pytest.raises(ClientError, match='ValidationException.*already has an enabled stream'):
+                table.update(StreamSpecification={
+                    'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'})
+
+            ks = f'alternator_{table.name}'
+            table_id = await get_table_id(ks, table.name)
+            count = await get_tablet_count(table_id)
+            assert count == 4
+
+            # Shrinkage attempt (ENABLING): must be BLOCKED.
+            # Setting target to 2 would normally trigger a merge (4 -> 2),
+            # but tablet_merge_blocked prevents it.
+            await set_tablet_target(ks, table.name, 2)
+            await assert_tablet_count_stable(table_id, 4, duration=5)
+
+            # Increase (ENABLING): must succeed (4 -> 8).
+            await set_tablet_target(ks, table.name, 8)
+            await wait_for_tablet_count(table_id, 8)
+        except:
+            table.delete()
+            raise
+    # <-- delay_cdc_stream_finalization disabled; finalization proceeds.
+
+    # === Phase 2: Transition to ENABLED ===
+    try:
+        async def check_stream_enabled():
+            desc = table.meta.client.describe_table(TableName=table.name)['Table']
+            if 'LatestStreamArn' in desc:
+                return True
+            return None
+        await wait_for(check_stream_enabled, time.time() + 60, period=0.1)
+
+        count = await get_tablet_count(table_id)
+        assert count == 8
+
+        # === Phase 3: ENABLED state ===
+        # Shrinkage attempt (ENABLED): must be BLOCKED.
+        await set_tablet_target(ks, table.name, 4)
+        await assert_tablet_count_stable(table_id, 8, duration=5)
+
+        # Increase (ENABLED): must succeed (8 -> 16).
+        await set_tablet_target(ks, table.name, 16)
+        await wait_for_tablet_count(table_id, 16)
+
+        # === Phase 4: Disable streams, merges must be unblocked ===
+        table.update(StreamSpecification={'StreamEnabled': False})
+
+        # Shrinkage (streams disabled): must SUCCEED (16 -> 8).
+        await set_tablet_target(ks, table.name, 8)
+        await wait_for_tablet_count(table_id, 8)
+    finally:
+        table.delete()
+        table.meta.client.get_waiter('table_not_exists').wait(TableName=table.name)

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -328,6 +328,11 @@ private:
     // Map enabled-injection-name -> is-one-shot
     std::unordered_map<std::string_view, injection_data> _enabled;
 
+    // Callbacks invoked when a specific injection is disabled.
+    // Registered independently of the injection being enabled, so
+    // the callback can be set up before the injection is ever activated.
+    std::unordered_map<sstring, std::function<void()>> _on_disable_callbacks;
+
     bool is_one_shot(const std::string_view& injection_name) const {
         const auto it = _enabled.find(injection_name);
         if (it == _enabled.end()) {
@@ -383,11 +388,19 @@ public:
     void disable(const std::string_view& injection_name) {
         errinj_logger.debug("Disabling injection \"{}\"", injection_name);
         _enabled.erase(injection_name);
+        if (auto it = _on_disable_callbacks.find(sstring(injection_name)); it != _on_disable_callbacks.end()) {
+            it->second();
+        }
     }
 
     void disable_all() {
         errinj_logger.debug("Disabling all injections");
-        _enabled.clear();
+        auto was_enabled = std::move(_enabled);
+        for (auto& [name, _] : was_enabled) {
+            if (auto it = _on_disable_callbacks.find(sstring(name)); it != _on_disable_callbacks.end()) {
+                it->second();
+            }
+        }
     }
 
     std::vector<sstring> enabled_injections() const {
@@ -395,6 +408,20 @@ public:
                 | std::views::filter([] (const auto& pair) { return !pair.second.is_ongoing_oneshot(); })
                 | std::views::keys
                 | std::ranges::to<std::vector<sstring>>();
+    }
+
+    // Register a callback that is invoked when a specific injection is
+    // disabled (via disable() or disable_all()).  The callback is stored
+    // independently of the injection being enabled, so it can be set up
+    // before the injection is ever activated and survives enable/disable
+    // cycles.  Only one callback per injection name is supported; a second
+    // registration for the same name replaces the previous one.
+    void register_on_disable(const sstring& injection_name, std::function<void()> callback) {
+        _on_disable_callbacks[injection_name] = std::move(callback);
+    }
+
+    void unregister_on_disable(const sstring& injection_name) {
+        _on_disable_callbacks.erase(injection_name);
     }
 
     // \brief Inject a lambda call
@@ -611,6 +638,12 @@ public:
 
     [[gnu::always_inline]]
     std::vector<sstring> enabled_injections() const { return {}; };
+
+    [[gnu::always_inline]]
+    void register_on_disable(const sstring&, std::function<void()>) {}
+
+    [[gnu::always_inline]]
+    void unregister_on_disable(const sstring&) {}
 
     // Inject a lambda call
     [[gnu::always_inline]]


### PR DESCRIPTION
DynamoDB Streams API can only convey a single parent per stream shard.
Tablet merges produce two parents, making them incompatible with
Alternator Streams. This series blocks tablet merges when streams are
active on a tablet table.

For CreateTable, a freshly created table has no pending merges, so
streams are enabled immediately with tablet merges blocked.

For UpdateTable on an existing table, stream enablement is deferred:
the user's intent is stored via `enable_requested`, tablet merges are
blocked (new merge decisions are suppressed and any active merge
decision is revoked), and the topology coordinator finalizes enablement
once no in-flight merges remain.

The topology coordinator is woken promptly on error injection release
and tablet split completion, reducing finalization latency from ~60s
to seconds.

`test_parent_children_merge` is marked xfail (merges are now blocked),
and downward (merge) steps are removed from `test_parent_filtering` and
`test_get_records_with_alternating_tablets_count`.

Not addressed here: using a topology request to preempt long-running
operations like repair (tracked in SCYLLADB-1304).

Refs SCYLLADB-461