### PR TITLE
encryption: improve error message when KMS host is not configured

### DIFF
--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -380,7 +380,7 @@ public:
     }
 
     template<typename HostType, typename CacheType, typename ConfigType>
-    shared_ptr<HostType> get_host(const sstring& host, CacheType& cache, const ConfigType& config_map) {
+    shared_ptr<HostType> get_host(const sstring& host, CacheType& cache, const ConfigType& config_map, std::string_view config_entry_name) {
         auto& host_cache = cache[this_shard_id()];
         auto it = host_cache.find(host);
         if (it != host_cache.end()) {
@@ -394,23 +394,26 @@ public:
             return result;
         }
 
-        throw std::invalid_argument("No such host: " + host);
+        throw std::invalid_argument(fmt::format(
+            "Encryption host \"{}\" is not defined in scylla.yaml. "
+            "Make sure it is listed under the \"{}\" section.",
+            host, config_entry_name));
     }
 
     shared_ptr<kmip_host> get_kmip_host(const sstring& host) override {
-        return get_host<kmip_host>(host, _per_thread_kmip_host_cache, _cfg->kmip_hosts());
+        return get_host<kmip_host>(host, _per_thread_kmip_host_cache, _cfg->kmip_hosts(), "kmip_hosts");
     }
 
     shared_ptr<kms_host> get_kms_host(const sstring& host) override {
-        return get_host<kms_host>(host, _per_thread_kms_host_cache, _cfg->kms_hosts());
+        return get_host<kms_host>(host, _per_thread_kms_host_cache, _cfg->kms_hosts(), "kms_hosts");
     }
 
     shared_ptr<gcp_host> get_gcp_host(const sstring& host) override {
-        return get_host<gcp_host>(host, _per_thread_gcp_host_cache, _cfg->gcp_hosts());
+        return get_host<gcp_host>(host, _per_thread_gcp_host_cache, _cfg->gcp_hosts(), "gcp_hosts");
     }
 
     shared_ptr<azure_host> get_azure_host(const sstring& host) override {
-        return get_host<azure_host>(host, _per_thread_azure_host_cache, _cfg->azure_hosts());
+        return get_host<azure_host>(host, _per_thread_azure_host_cache, _cfg->azure_hosts(), "azure_hosts");
     }
 
 

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -1423,7 +1423,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_azure_provider_with_no_host, local_azure_kms_wrap
         co_await test_provider("'key_provider': 'AzureKeyProviderFactory', 'azure_host': 'azure_test', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", tmp, yaml)
         , std::invalid_argument
         , [](const std::invalid_argument& e) {
-            return sstring(e.what()).find("No such host") != sstring::npos;
+            return sstring(e.what()).find("is not defined in scylla.yaml") != sstring::npos;
         }
     );
 }


### PR DESCRIPTION
When an SSTable was encrypted with a KMS host that is not present in scylla.yaml, the error thrown was:

    std::invalid_argument (No such host: <host-name>)

This message is very obscure in general, and especially confusing when encountered while using the scylla-sstable tool: it gives no indication that the SSTable is encrypted, that a KMS host lookup is involved, or what the user needs to do to fix the problem.

Replace it with a message that names the missing host and points directly to the relevant scylla.yaml section:

    Encryption host "<host-name>" is not defined in scylla.yaml. Make sure it is listed under the appropriate key provider section (kmip_hosts/kms_hosts/gcp_hosts/azure_hosts).

The wording is intentionally kept neutral (not framed as an SSTable tool problem) because the same code path is exercised by production ScyllaDB when a node's configuration no longer contains a host referenced by an existing data file (e.g. after a config rollback or when restoring data from a different cluster). The production use-case takes precedence, but the message is equally actionable from the tool.

Backport: improvement, no backport