### PR TITLE
test_lwt_fencing_upgrade: fix quorum failure due to gossip lag

### DIFF
--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -438,6 +438,7 @@ async def test_lwt_fencing_upgrade(manager: ManagerClient, scylla_2025_1: Scylla
                 await wait_for(all_hosts_are_alive, deadline=time.time() + 60, period=0.1)
             logger.info(f"Upgrading {s.server_id}")
             await manager.server_change_version(s.server_id, scylla_binary)
+            await manager.server_sees_others(s.server_id, 2, interval=60.0)
 
         logger.info("Done upgrading servers")
 


### PR DESCRIPTION
If `lwt_workload()` sends an update immediately after a rolling restart, the coordinator might still see a replica as down due to gossip lagging behind. Concurrently restarting another node leaves only one available replica, failing the `LOCAL_QUORUM` requirement for learn or eventually consistent `sp::query()` in `sp::cas()` and resulting in a `mutation_write_failure_exception`.

We fix this problem by waiting for the restarted server to see 2 other peers. The `server_change_version()` doesn't do that by default -- it passes `wait_others=0` to `server_start()`.

Fixes SCYLLADB-1136

backport: doesn't seem worth the efforts -- it's very hard to reproduce, I never managed to reproduce it locally. We could do the backport if we see the actual failure in previous versions.