### PR TITLE
test/pylib: add typed skip markers plugin

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -60,7 +60,7 @@ def pytest_collection_modifyitems(config, items):
     if config.getoption("--runveryslow"):
         # --runveryslow given in cli: do not skip veryslow tests
         return
-    skip_veryslow = pytest.mark.skip(reason="need --runveryslow option to run")
+    skip_veryslow = pytest.mark.skip_env(reason="need --runveryslow option to run")
     for item in items:
         if "veryslow" in item.keywords:
             item.add_marker(skip_veryslow)

--- a/test/alternator/test_https.py
+++ b/test/alternator/test_https.py
@@ -14,11 +14,13 @@ import urllib3
 import urllib.parse
 import ssl
 
+from test.pylib.skip_types import skip_env
+
 @pytest.fixture(scope="module")
 def https_url(dynamodb):
     url = dynamodb.meta.client._endpoint.host
     if not url.startswith('https://'):
-        pytest.skip("HTTPS-specific tests are skipped without the '--https' option")
+        skip_env("HTTPS-specific tests are skipped without the '--https' option")
     yield url
 
 # Test which TLS versions are supported. We require that both TLS 1.2 and 1.3

--- a/test/cluster/dtest/schema_management_test.py
+++ b/test/cluster/dtest/schema_management_test.py
@@ -196,7 +196,7 @@ class TestSchemaManagement(Tester):
         logger.debug("read and check data")
         run_stress("read")
 
-    @pytest.mark.skip("unimplemented")
+    @pytest.mark.skip_not_implemented(reason="unimplemented")
     def commitlog_replays_after_schema_change(self):
         """
         Commitlog can be replayed even though schema has been changed

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
     "use_tablets",
     [
         pytest.param(False, id="vnodes"),
-        pytest.param(True, id="tablets", marks=[pytest.mark.skip(reason="issue #20282"), pytest.mark.nightly]),
+        pytest.param(True, id="tablets", marks=[pytest.mark.skip_bug(reason="issue #20282"), pytest.mark.nightly]),
     ],
 )
 @pytest.mark.asyncio

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -117,7 +117,7 @@ async def test_tablet_repair_progress_split(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=True)
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/26844")
+@pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/26844")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress_merge(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_merge=True)
@@ -571,7 +571,7 @@ async def test_tablet_auto_repair_cfg_enable(manager: ManagerClient):
     # Check repair is executed
     await check_has_repair_time(cql, hosts[0:1], table_id)
 
-@pytest.mark.skip(reason="no per tablet support yet")
+@pytest.mark.skip_not_implemented(reason="no per tablet support yet")
 @pytest.mark.asyncio
 async def test_tablet_auto_repair_cfg_disable_per_table_enable(manager: ManagerClient):
     cmdline = ["--auto-repair-enabled-default", "0",  "--auto-repair-threshold-default-in-seconds", "1"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,14 +4,16 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
+import allure
 import pytest
 
 from test import TEST_RUNNER
 from test.pylib.report_plugin import ReportPlugin
+from test.pylib.skip_reason_plugin import SkipReasonPlugin
+from test.pylib.skip_types import SkipType
 
 
 pytest_plugins = []
-
 
 if TEST_RUNNER == "runpy":
     @pytest.fixture(scope="session")
@@ -23,3 +25,10 @@ else:
 
 def pytest_configure(config: pytest.Config) -> None:
     config.pluginmanager.register(ReportPlugin())
+
+    def _allure_report(skip_type: str, reason: str) -> None:
+        """Enrich Allure reports with skip type metadata."""
+        allure.dynamic.tag(f"skip_type:{skip_type}")
+        allure.dynamic.label("skip_type", skip_type)
+
+    config.pluginmanager.register(SkipReasonPlugin(SkipType, report_callback=_allure_report))

--- a/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
@@ -129,7 +129,7 @@ def testTimestampsOnUnsetColumnsWide(cql, test_keyspace):
                    [2, 2, None, None],
                    [3, 3, 3, 1])
 
-@pytest.mark.skip(reason="a very slow test (6 seconds), skipping it")
+@pytest.mark.skip_slow(reason="a very slow test (6 seconds), skipping it")
 def testTimestampAndTTLPrepared(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, i int, PRIMARY KEY (k, c))") as table:
         execute(cql, table, "INSERT INTO %s (k, c, i) VALUES (1, 1, 1) USING TIMESTAMP ? AND TTL ?;", 1, 5)
@@ -146,7 +146,7 @@ def testTimestampAndTTLPrepared(cql, test_keyspace):
         time.sleep(6)
         assert_empty(execute(cql, table, "SELECT k, c, i, writetime(i) FROM %s "))
 
-@pytest.mark.skip(reason="a very slow test (6 seconds), skipping it")
+@pytest.mark.skip_slow(reason="a very slow test (6 seconds), skipping it")
 def testTimestampAndTTLUpdatePrepared(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, i int, PRIMARY KEY (k, c))") as table:
         execute(cql, table, "UPDATE %s USING TIMESTAMP ? AND TTL ? SET i=1 WHERE k=1 AND c = 1 ;", 1, 5)

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -29,6 +29,7 @@ from _pytest.junitxml import xml_key
 
 from test import ALL_MODES, DEBUG_MODES, TEST_RUNNER, TOP_SRC_DIR, TESTPY_PREPARED_ENVIRONMENT, HOST_ID
 from test.pylib.scylla_cluster import merge_cmdline_options
+from test.pylib.skip_reason_plugin import skip_marker
 from test.pylib.suite.base import (
     SUITE_CONFIG_FILENAME,
     PYTEST_TESTS_LOGS_FOLDER,
@@ -473,7 +474,7 @@ def modify_pytest_item(item: pytest.Item) -> None:
             for mode in modes:
                 if mode == item.stash[BUILD_MODE]:
                     if platform_key is None or platform_key in platform.platform():
-                        item.add_marker(pytest.mark.skip(reason=reason))
+                        skip_marker(item, reason, skip_type="mode")
         try:
             __skip_test(*mark.args, **mark.kwargs)
         except TypeError as e:

--- a/test/pylib/skip_reason_plugin.py
+++ b/test/pylib/skip_reason_plugin.py
@@ -1,0 +1,157 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+"""Pytest plugin for typed skip markers.
+
+Framework-agnostic: the concrete skip types are provided by the
+project's ``conftest.py`` via :class:`SkipReasonPlugin`.
+
+Usage as decorator (after conftest.py registers the plugin)::
+
+    @pytest.mark.skip_bug(reason="scylladb/scylladb#12345")
+    @pytest.mark.skip_not_implemented(reason="no per tablet support yet")
+
+Usage at runtime (inside test body or fixture) — prefer the
+convenience wrappers from :mod:`test.pylib.skip_types`::
+
+    from test.pylib.skip_types import skip_env
+    skip_env("need --runveryslow option")
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable
+from enum import StrEnum
+
+import pytest
+
+# StashKeys to carry skip metadata from collection to reporting.
+SKIP_TYPE_KEY = pytest.StashKey[str]()
+SKIP_REASON_KEY = pytest.StashKey[str]()
+
+
+def skip(reason: str, skip_type: StrEnum):
+    """Skip the current test at runtime with a typed reason.
+
+    Use instead of bare ``pytest.skip()``.
+    The *skip_type* should be a :class:`~enum.StrEnum` member defined
+    by the project (e.g. ``SkipType.SKIP_ENV``).
+    """
+    pytest.skip(f"[{skip_type}] {reason}")
+
+
+def skip_marker(item: pytest.Item, reason: str, skip_type: str) -> None:
+    """Add a typed skip marker to an item during collection.
+
+    Use from ``pytest_collection_modifyitems`` hooks (e.g. runner.py's
+    ``skip_mode`` processing) to skip a test with full type metadata.
+    The caller does not need to know how the metadata is stored.
+    """
+    item.add_marker(pytest.mark.skip(reason=f"[{skip_type}] {reason}"))
+    item.stash[SKIP_TYPE_KEY] = skip_type
+    item.stash[SKIP_REASON_KEY] = reason
+
+
+class SkipReasonPlugin:
+    """Pytest plugin that converts typed skip markers into real skips
+    and enriches reports with skip metadata.
+
+    Args:
+        skip_types: A :class:`~enum.StrEnum` whose members define the
+            typed skip markers.  Each member's ``marker_name`` property
+            becomes the pytest marker name, and its value becomes the
+            tag written to reports.
+        report_callback: Optional callback invoked with
+            ``(skip_type, reason)`` for every skipped test that has
+            type metadata.
+    """
+
+    def __init__(
+        self,
+        skip_types: type[StrEnum],
+        *,
+        report_callback: Callable[[str, str], None] | None = None,
+    ) -> None:
+        self._skip_types = skip_types
+        self._report_callback = report_callback
+
+    @staticmethod
+    def _get_reason(mark: pytest.Mark) -> str:
+        """Extract reason from a marker (keyword or positional)."""
+        return mark.kwargs.get("reason") or (mark.args[0] if mark.args else "")
+
+    @staticmethod
+    def _parse_skip_type(longrepr) -> tuple[str, str] | None:
+        """Try to extract ``(skip_type, reason)`` from a ``[type] reason`` message.
+
+        Returns ``None`` when *longrepr* does not match the expected format.
+        """
+        text = longrepr[-1] if isinstance(longrepr, tuple) else str(longrepr)
+        text = text.removeprefix("Skipped: ")
+        if text.startswith("[") and "]" in text:
+            tag, _, reason = text[1:].partition("]")
+            return tag, reason.lstrip()
+        return None
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_collection_modifyitems(self, items: list[pytest.Item]) -> None:
+        """Apply typed markers and warn on bare skips."""
+        for item in items:
+            # Convert typed skip markers to real pytest.mark.skip.
+            for st in self._skip_types:
+                for mark in item.iter_markers(st.marker_name):
+                    reason = self._get_reason(mark)
+                    if not reason:
+                        raise pytest.UsageError(
+                            f"Marker @pytest.mark.{st.marker_name} on {item.nodeid} "
+                            f"requires a 'reason' argument."
+                        )
+                    item.add_marker(pytest.mark.skip(reason=f"[{st}] {reason}"))
+                    item.stash[SKIP_TYPE_KEY] = str(st)
+                    item.stash[SKIP_REASON_KEY] = reason
+
+            # Warn on bare pytest.mark.skip not added by typed markers.
+            # skip_mode sets SKIP_TYPE_KEY before this hook runs (trylast).
+            if SKIP_TYPE_KEY not in item.stash:
+                bare = [self._get_reason(m) for m in item.iter_markers("skip")]
+                if bare:
+                    alternatives = ", ".join(
+                        f"@pytest.mark.{st.marker_name}" for st in self._skip_types)
+                    # TODO: Change to pytest.fail() after full migration.
+                    warnings.warn(
+                        f"Untyped skip on {item.nodeid}: {'; '.join(bare)}. "
+                        f"Use {alternatives} instead.",
+                    )
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_makereport(self, item: pytest.Item):
+        """Enrich JUnit XML reports (and optionally custom reporters) with skip metadata."""
+        outcome = yield
+        report = outcome.get_result()
+
+        if not report.skipped:
+            return
+
+        skip_type = item.stash.get(SKIP_TYPE_KEY, None)
+        reason = item.stash.get(SKIP_REASON_KEY, "")
+
+        # Runtime skips (via skip()) don't set stash keys — parse from message.
+        if skip_type is None and report.longrepr:
+            parsed = self._parse_skip_type(report.longrepr)
+            if parsed is None:
+                return
+            skip_type, reason = parsed
+
+        if skip_type is None:
+            return
+
+        item.user_properties.append(("skip_type", skip_type))
+        if reason:
+            item.user_properties.append(("skip_reason", reason))
+
+        if self._report_callback is not None:
+            self._report_callback(skip_type, reason)

--- a/test/pylib/skip_types.py
+++ b/test/pylib/skip_types.py
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+"""ScyllaDB skip-type definitions and convenience wrappers.
+
+This module is the single source of truth for:
+* :class:`SkipType` — the enum of all typed skip categories.
+* Per-category runtime skip helpers (``skip_bug``, ``skip_env``, …)
+  that are thin wrappers around :func:`skip_reason_plugin.skip`.
+
+Import ``SkipType`` or the helpers from here instead of defining
+them in ``conftest.py``.
+
+Usage::
+
+    from test.pylib.skip_types import SkipType, skip_env
+
+    # As a runtime skip inside a test or fixture:
+    skip_env("HTTPS-specific tests need the '--https' option")
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from test.pylib.skip_reason_plugin import skip
+
+
+class SkipType(StrEnum):
+    """ScyllaDB-specific skip categories.
+
+    Each member name (lowercased) is the pytest marker, e.g.
+    ``SKIP_BUG`` → ``@pytest.mark.skip_bug``, tag ``"bug"``.
+    """
+
+    SKIP_BUG = "bug"
+    SKIP_NOT_IMPLEMENTED = "not_implemented"
+    SKIP_SLOW = "slow"
+    SKIP_ENV = "env"
+
+    @property
+    def marker_name(self) -> str:
+        return self.name.lower()
+
+
+# ── Convenience wrappers ────────────────────────────────────────────────
+# Each wrapper calls :func:`skip` with the appropriate ``SkipType``,
+# so callers never need to import ``SkipType`` separately.
+
+
+def skip_bug(reason: str) -> None:
+    """Runtime skip for a known bug.  *reason* should be an issue reference."""
+    skip(reason, skip_type=SkipType.SKIP_BUG)
+
+
+def skip_not_implemented(reason: str) -> None:
+    """Runtime skip for a feature that is not yet implemented."""
+    skip(reason, skip_type=SkipType.SKIP_NOT_IMPLEMENTED)
+
+
+def skip_slow(reason: str) -> None:
+    """Runtime skip for a test that is too slow for regular CI."""
+    skip(reason, skip_type=SkipType.SKIP_SLOW)
+
+
+def skip_env(reason: str) -> None:
+    """Runtime skip for a missing environment requirement."""
+    skip(reason, skip_type=SkipType.SKIP_ENV)

--- a/test/pylib_test/test_skip_reason_plugin.py
+++ b/test/pylib_test/test_skip_reason_plugin.py
@@ -1,0 +1,316 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+"""Tests for the skip_reason_plugin.
+
+Uses pytester to run sub-pytest processes that exercise the typed skip
+markers, bare-skip warnings, and report enrichment.
+"""
+
+import textwrap
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+
+# Base conftest that every sub-pytest process needs: define the enum,
+# configure the plugin, and register it.
+_BASE_CONFTEST = textwrap.dedent("""\
+    import enum
+    import pytest
+    from test.pylib.skip_reason_plugin import SkipReasonPlugin
+
+    class SkipType(enum.StrEnum):
+        SKIP_BUG = "bug"
+        SKIP_NOT_IMPLEMENTED = "not_implemented"
+        SKIP_SLOW = "slow"
+        SKIP_ENV = "env"
+        @property
+        def marker_name(self):
+            return self.name.lower()
+
+    def pytest_configure(config):
+        config.pluginmanager.register(SkipReasonPlugin(SkipType))
+""")
+
+
+@pytest.fixture
+def skippytest(pytester: pytest.Pytester) -> pytest.Pytester:
+    """Pytester with skip_reason_plugin loaded and sugar/xdist disabled."""
+    pytester.makeconftest(_BASE_CONFTEST)
+    pytester.makeini(
+        "[pytest]\n"
+        "addopts = -p no:sugar -p no:xdist\n"
+        "asyncio_default_fixture_loop_scope = session\n"
+    )
+    return pytester
+
+
+# -- Typed markers ----------------------------------------------------------
+
+@pytest.mark.parametrize("marker, skip_type, reason", [
+    ("skip_bug",             "bug",            "scylladb/scylladb#99999"),
+    ("skip_not_implemented", "not_implemented", "feature X not built yet"),
+    ("skip_slow",            "slow",            "takes 10 minutes"),
+    ("skip_env",             "env",             "need --special-flag"),
+], ids=["bug", "not_implemented", "slow", "env"])
+def test_typed_marker_skips_with_prefix(skippytest, marker, skip_type, reason):
+    skippytest.makepyfile(f"""
+        import pytest
+        @pytest.mark.{marker}(reason="{reason}")
+        def test_target():
+            assert False
+    """)
+    result = skippytest.runpytest("-rs")
+    result.assert_outcomes(skipped=1)
+    out = result.stdout.str()
+    assert f"[{skip_type}]" in out
+    assert reason in out
+
+
+def test_typed_marker_positional_reason(skippytest):
+    """Reason passed as a positional arg (not keyword) must also work."""
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip_bug("scylladb/scylladb#55555")
+        def test_positional():
+            assert False
+    """)
+    result = skippytest.runpytest("-rs")
+    result.assert_outcomes(skipped=1)
+    out = result.stdout.str()
+    assert "[bug]" in out
+    assert "scylladb/scylladb#55555" in out
+
+
+# -- Missing reason ---------------------------------------------------------
+
+@pytest.mark.parametrize("marker", ["skip_bug", "skip_not_implemented"])
+def test_missing_reason_is_rejected(skippytest, marker):
+    skippytest.makepyfile(f"""
+        import pytest
+        @pytest.mark.{marker}()
+        def test_no_reason():
+            pass
+    """)
+    result = skippytest.runpytest()
+    result.stderr.fnmatch_lines(["*requires a 'reason' argument*"])
+    assert result.ret != 0
+
+
+# -- Bare skip warning ------------------------------------------------------
+
+def test_bare_skip_warns_and_lists_alternatives(skippytest):
+    """Bare skip must warn and list all typed alternatives."""
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip(reason="some bare reason")
+        def test_bare():
+            pass
+    """)
+    result = skippytest.runpytest("-W", "all")
+    result.assert_outcomes(skipped=1)
+    out = result.stdout.str()
+    assert "Untyped skip" in out
+    assert "some bare reason" in out
+    for m in ("skip_bug", "skip_not_implemented", "skip_slow",
+              "skip_env"):
+        assert m in out, f"expected '{m}' in warning output"
+
+
+def test_bare_skip_in_pytest_param_warns(skippytest):
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.parametrize("x", [
+            pytest.param(1, id="ok"),
+            pytest.param(2, id="skipped",
+                         marks=[pytest.mark.skip(reason="bare in param")]),
+        ])
+        def test_p(x):
+            pass
+    """)
+    result = skippytest.runpytest("-W", "all")
+    result.assert_outcomes(passed=1, skipped=1)
+    assert "Untyped skip" in result.stdout.str()
+
+
+def test_typed_skip_does_not_warn(skippytest):
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip_bug(reason="scylladb/scylladb#11111")
+        def test_typed():
+            pass
+    """)
+    result = skippytest.runpytest("-W", "error::UserWarning")
+    result.assert_outcomes(skipped=1)
+    assert "Untyped skip" not in result.stdout.str()
+
+
+# -- Runtime skip helper ----------------------------------------------------
+
+def test_runtime_skip_helper(skippytest):
+    skippytest.makepyfile("""
+        from test.pylib.skip_reason_plugin import skip
+        from conftest import SkipType
+        def test_runtime():
+            skip("missing dependency", skip_type=SkipType.SKIP_ENV)
+    """)
+    result = skippytest.runpytest("-rs")
+    result.assert_outcomes(skipped=1)
+    out = result.stdout.str()
+    assert "[env]" in out
+    assert "missing dependency" in out
+
+
+def test_runtime_skip_populates_junit(skippytest, tmp_path):
+    """Runtime skip() must produce skip_type/skip_reason in JUnit XML."""
+    skippytest.makepyfile("""
+        from test.pylib.skip_reason_plugin import skip
+        from conftest import SkipType
+        def test_rt():
+            skip("no HTTPS", skip_type=SkipType.SKIP_ENV)
+    """)
+    xml_path = tmp_path / "report.xml"
+    result = skippytest.runpytest(f"--junitxml={xml_path}")
+    result.assert_outcomes(skipped=1)
+
+    xml = xml_path.read_text()
+    assert 'name="skip_type"' in xml
+    assert 'value="env"' in xml
+    assert "no HTTPS" in xml
+
+
+# -- JUnit XML enrichment ---------------------------------------------------
+
+def test_junit_xml_contains_skip_type(skippytest, tmp_path):
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip_bug(reason="scylladb/scylladb#77777")
+        def test_bug():
+            pass
+    """)
+    xml_path = tmp_path / "report.xml"
+    result = skippytest.runpytest(f"--junitxml={xml_path}")
+    result.assert_outcomes(skipped=1)
+
+    xml = xml_path.read_text()
+    assert 'name="skip_type"' in xml
+    assert 'value="bug"' in xml
+    assert 'name="skip_reason"' in xml
+    assert "scylladb/scylladb#77777" in xml
+
+
+def test_report_callback_is_invoked(pytester: pytest.Pytester, tmp_path):
+    """The report_callback passed to SkipReasonPlugin must be called for skipped tests."""
+    cb_path = tmp_path / "cb.txt"
+    pytester.makeconftest(textwrap.dedent(f"""\
+        import enum
+        import pytest
+        from pathlib import Path
+        from test.pylib.skip_reason_plugin import SkipReasonPlugin
+
+        class SkipType(enum.StrEnum):
+            SKIP_BUG = "bug"
+            @property
+            def marker_name(self):
+                return self.name.lower()
+
+        def _callback(skip_type, reason):
+            Path("{cb_path}").write_text(f"{{skip_type}}:{{reason}}")
+
+        def pytest_configure(config):
+            config.pluginmanager.register(SkipReasonPlugin(SkipType, report_callback=_callback))
+    """))
+    pytester.makeini(
+        "[pytest]\n"
+        "addopts = -p no:sugar -p no:xdist\n"
+        "asyncio_default_fixture_loop_scope = session\n"
+    )
+    pytester.makepyfile("""
+        import pytest
+        @pytest.mark.skip_bug(reason="scylladb/scylladb#44444")
+        def test_cb():
+            pass
+    """)
+    result = pytester.runpytest()
+    result.assert_outcomes(skipped=1)
+    assert cb_path.read_text() == "bug:scylladb/scylladb#44444"
+
+
+# -- Typed marker + skip_mode interaction -----------------------------------
+
+# Simulates runner.py's skip_mode: injects a skip marker and sets stash
+# keys via a conftest hook that runs before the plugin (no trylast).
+_SKIP_MODE_CONFTEST = _BASE_CONFTEST + textwrap.dedent("""\
+    from test.pylib.skip_reason_plugin import skip_marker
+    def pytest_collection_modifyitems(items):
+        for item in items:
+            if any(item.iter_markers("skip_mode")):
+                skip_marker(item, "not supported in release", skip_type="mode")
+""")
+
+
+def test_typed_marker_with_skip_mode_populates_junit(skippytest, tmp_path):
+    """When both a typed marker and skip_mode exist on the same test,
+    JUnit XML must contain the typed skip metadata regardless of which
+    skip marker pytest uses for -rs output.
+    """
+    skippytest.makeconftest(_SKIP_MODE_CONFTEST)
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip_bug(reason="scylladb/scylladb#26844")
+        @pytest.mark.skip_mode(mode="release", reason="no error injections")
+        def test_both():
+            assert False
+    """)
+    xml_path = tmp_path / "report.xml"
+    result = skippytest.runpytest(f"--junitxml={xml_path}")
+    result.assert_outcomes(skipped=1)
+
+    # JUnit XML must have the typed skip metadata.
+    xml = xml_path.read_text()
+    assert 'value="bug"' in xml
+    assert "scylladb/scylladb#26844" in xml
+
+
+def test_skip_mode_prefix_populates_junit(skippytest, tmp_path):
+    """When runner.py's skip_mode sets stash keys directly,
+    the report hook must populate JUnit XML with skip_type=mode.
+    """
+    skippytest.makeconftest(_SKIP_MODE_CONFTEST)
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip_mode(mode="release", reason="not supported in release")
+        def test_skip_mode_only():
+            assert False
+    """)
+    xml_path = tmp_path / "report.xml"
+    result = skippytest.runpytest(f"--junitxml={xml_path}")
+    result.assert_outcomes(skipped=1)
+
+    xml = xml_path.read_text()
+    assert 'value="mode"' in xml
+    assert "not supported in release" in xml
+
+
+def test_bare_skip_with_skip_mode_no_warn(skippytest):
+    """When skip_mode uses skip_marker(), bare-skip warning is suppressed
+    for the item even if it also has a bare @pytest.mark.skip. The
+    skip_marker() call signals the item already has a typed skip.
+    """
+    skippytest.makeconftest(_SKIP_MODE_CONFTEST)
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip(reason="some bare reason")
+        @pytest.mark.skip_mode(mode="release", reason="not supported in release")
+        def test_both_bare_and_mode():
+            assert False
+    """)
+    result = skippytest.runpytest("-W", "all")
+    result.assert_outcomes(skipped=1)
+    out = result.stdout.str()
+    assert "Untyped skip" not in out

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -32,7 +32,11 @@ markers =
     unstable: mark for unstable tests that may pass may fail, these tests will continue to run every night and generate up-to-date statistics with failures without failing the “Main” verification path(scylla-ci, Next), these tests will automatically apply non_gating marker
     non_gating: tests that are not run in CI/Next/Nightly verification, but can be run manually or on special job when needed
     nightly: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification
-    skip_mode: Can be used to mark a test to be skipped for a specific mode, e.g. dev. The reason to skip a test should be specified, used as a comment only.  Additionally, platform_key can be specified to limit the scope of the attribute to the specified platform. Example platform_key-s: [aarch64, x86_64]
+    skip_mode(mode, reason, platform_key=None): Skip test in a specific build mode (e.g. dev, debug, release).
+    skip_bug(reason): Skip due to a known bug (reason = issue reference).
+    skip_not_implemented(reason): Skip because the feature is not yet implemented.
+    skip_slow(reason): Skip because the test is too slow for regular CI.
+    skip_env(reason): Skip due to a missing environment requirement.
 
 norecursedirs = manual perf lib
 # Ignore warnings about HTTPS requests without certificate verification


### PR DESCRIPTION
Add skip_reason_plugin.py — a framework-agnostic pytest plugin that
provides typed skip markers (skip_bug, skip_not_implemented, skip_slow,
skip_env) so that the reason a test is skipped is machine-readable in
JUnit XML and Allure reports.  Bare untyped pytest.mark.skip now
triggers a warning (to become an error after full migration).  Runtime
skips via skip() are also enriched by parsing the [type] prefix from
the skip message.

The plugin is a class (SkipReasonPlugin) that receives the concrete
SkipType enum and an optional report_callback from conftest.py, keeping
it decoupled from allure and project-specific types.

Extract SkipType enum and convenience runtime skip wrappers (skip_bug,
skip_env, etc.) into test/pylib/skip_types.py so callers only need a
single import instead of importing both SkipType and skip() separately.
conftest.py imports SkipType from the new module and registers the
plugin instance unconditionally (for all test runners).

New files:
- test/pylib/skip_reason_plugin.py: core plugin — typed marker
  processing, bare-skip warnings, JUnit/Allure report enrichment
  (including runtime skip() parsing via _parse_skip_type helper)
- test/pylib/skip_types.py: SkipType enum and convenience wrappers
  (skip_bug, skip_not_implemented, skip_slow, skip_env)
- test/pylib_test/test_skip_reason_plugin.py: 17 pytester-based
  test functions (51 cases across 3 build modes) covering markers,
  warnings, reports, callbacks, and skip_mode interaction

Infrastructure changes:
- test/conftest.py: import SkipType from skip_types, register
  SkipReasonPlugin with allure report callback
- test/pylib/runner.py: set SKIP_TYPE_KEY/SKIP_REASON_KEY stash keys
  for skip_mode so the report hook can enrich JUnit/Allure with
  skip_type=mode without longrepr parsing
- test/pytest.ini: register typed marker definitions (required for
  --strict-markers even when plugin is not loaded)

Migrated test files (representative samples):
- test/cluster/test_tablet_repair_scheduler.py:
  skip -> skip_bug (https://github.com/scylladb/scylladb/issues/26844), skip -> skip_not_implemented
- test/cqlpy/.../timestamp_test.py: skip -> skip_slow
- test/cluster/dtest/schema_management_test.py: skip -> skip_not_implemented
- test/cluster/test_change_replication_factor_1_to_0.py: skip -> skip_bug (https://github.com/scylladb/scylladb/issues/20282)
- test/alternator/conftest.py: skip -> skip_env
- test/alternator/test_https.py: use skip_env() wrapper

Fixes SCYLLADB-79
