### PR TITLE
api: Fix enable_injection to accept case-insensitive bool parameter

### DIFF
--- a/api/error_injection.cc
+++ b/api/error_injection.cc
@@ -23,7 +23,7 @@ void set_error_injection(http_context& ctx, routes& r) {
 
     hf::enable_injection.set(r, [](std::unique_ptr<request> req) -> future<json::json_return_type> {
         sstring injection = req->get_path_param("injection");
-        bool one_shot = req->get_query_param("one_shot") == "True";
+        bool one_shot = strcasecmp(req->get_query_param("one_shot").c_str(), "true") == 0;
         auto params = co_await util::read_entire_stream_contiguous(*req->content_stream);
 
         const size_t max_params_size = 1024 * 1024;


### PR DESCRIPTION
Replace strict case-sensitive '== "True"' check with strcasecmp(..., "true") so that Python's str(True) -> "True" is properly recognized. Accepts any case variation of "true" ("True", "TRUE", etc.), with empty string defaulting to false.

Maintains backward compatibility with out-of-tree tests that rely on Python's bool stringification.

The goal is to reduce the number of distinct ways API handlers use to convert string http query parameters into bool variables. This place is the only one that simply compares param to "True".

Code cleanup, not backporting