### PR TITLE
docs: add missing rack value for internode_compression parameter

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -488,6 +488,7 @@ sstable_format: ms
 # compressed.
 # can be:  all  - all traffic is compressed
 #          dc   - traffic between different datacenters is compressed
+#          rack - traffic between different racks is compressed
 #          none - nothing is compressed.
 # internode_compression: none
 

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -181,6 +181,7 @@ internode_compression controls whether traffic between nodes is compressed.
 
 * all  - all traffic is compressed.
 * dc   - traffic between different datacenters is compressed.
+* rack - traffic between different racks is compressed.
 * none - nothing is compressed (default).
 
 Configuring TLS/SSL in scylla.yaml


### PR DESCRIPTION
The rack option was fully implemented in the code but omitted from both docs/operating-scylla/admin.rst and conf/scylla.yaml comments.

Scylla Cloud clusters have `internode_compression` set to `rack` for all Scylla clusters >=2026.1.0.
https://github.com/scylladb/siren/pull/15603

~~(!) I assume none backport label is required, but would be happy if reviewing person could confirm on that~~

Edit by @annastuchlik:
If ScyllaDB Cloud clusters running 2026.1 have this option configured, I think this PR should be backported, at the minimum, to branch-2026.1.