### PR TITLE
scylla-gdb.py: fix small_vector.__len__()

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -3600,7 +3600,7 @@ class small_vector(object):
         self.ref = ref
 
     def __len__(self):
-        return self.ref['_begin'] - self.ref['_end']
+        return self.ref['_end'] - self.ref['_begin']
 
     def __iter__(self):
         e = self.ref['_begin']


### PR DESCRIPTION
start - end will result in negative length, rejected by the python runtime. Use the correct end - start to calculate length.

Backport: scylla-gdb.py minor bugfix, no backport