### PR TITLE
scripts/base36-uuid: dump date in UTC

### DIFF
--- a/scripts/base36-uuid.py
+++ b/scripts/base36-uuid.py
@@ -142,7 +142,7 @@ class TimeUuid:
         # need to translate the timestamp to the UNIX time
         unix_time = self.uuid.time - self.UNIX_EPOCH_SINCE_GREGORIAN_DAY0
         seconds, decimicro_seconds = divmod(unix_time, DECIMICRO_RATIO)
-        return datetime.datetime.fromtimestamp(seconds), decimicro_seconds
+        return datetime.datetime.fromtimestamp(seconds, tz=datetime.timezone.utc), decimicro_seconds
 
     def print_field(self, field: str, print_in_hex: bool) -> None:
         def print_num(n: int, bits: int) -> str:
@@ -186,7 +186,7 @@ def test_dencode_base36() -> None:
     assert timeuuid.encode_with_base36() == encoded_uuid
 
     timestamp, decimicro_seconds = timeuuid.timestamp
-    assert timestamp == datetime.datetime(2022, 5, 23, 18, 37, 52)
+    assert timestamp == datetime.datetime(2022, 5, 23, 10, 37, 52, tzinfo=datetime.timezone.utc)
     assert decimicro_seconds == 7040000
 
 


### PR DESCRIPTION
Previously, the timestamp decoded from a timeuuid was printed using the local timezone via datetime.fromtimestamp(), which produces different output depending on the machine's locale settings.

ScyllaDB logs are emitted in UTC by default. Printing the decoded date in UTC makes it straightforward to correlate SSTable identifiers with log entries without having to mentally convert timezones.

Also fix the embedded pytest assertion, which was accidentally correct only on machines in UTC+8 — it now uses an explicit UTC-aware datetime.

Enhancement, not backporting.