### PR TITLE
test: fix flaky cache_algorithm_test by relaxing reads guard assertion

### DIFF
--- a/test/boost/cache_algorithm_test.cc
+++ b/test/boost/cache_algorithm_test.cc
@@ -123,8 +123,10 @@ SEASTAR_TEST_CASE(test_index_doesnt_flood_cache_in_small_partition_workload) {
                 uint64_t reads_after = e.local_db().row_cache_tracker().get_stats().reads_done;
                 uint64_t misses_after = get_misses();
                 if (get_misses() != misses_before) {
-                    // Cache misses are allowed only if they were done by something outside of the test.
-                    BOOST_REQUIRE_GT(reads_after, reads_expected);
+                    // Cache misses are allowed only if they can be explained by activity outside of the test.
+                    // We use GE rather than GT because cache eviction can also be triggered by
+                    // LSA memory pressure (e.g. from index page loading) without any extra reads.
+                    BOOST_REQUIRE_GE(reads_after, reads_expected);
                     if (retries < max_retries) {
                         ++retries;
                         testlog.warn("Detected extra cache misses (actual={}, expected={}, repeat={}, i={}), but they can be explained by extra reads (after={}, before={}, expected={}) done by something in the background, so retrying. (retries={})", misses_after, misses_before, repeat, i, reads_after, reads_before, reads_expected, retries);
@@ -213,8 +215,10 @@ SEASTAR_TEST_CASE(test_index_is_cached_in_big_partition_workload) {
         uint64_t reads_after = e.local_db().row_cache_tracker().get_stats().reads_done;
         uint64_t misses_after = get_misses();
         if (misses_after != misses_before) {
-            // Cache misses are allowed only if they were done by something outside of the test.
-            BOOST_REQUIRE_GT(reads_after, reads_expected);
+            // Cache misses are allowed only if they can be explained by activity outside of the test.
+            // We use GE rather than GT because cache eviction can also be triggered by
+            // LSA memory pressure (e.g. from index page loading) without any extra reads.
+            BOOST_REQUIRE_GE(reads_after, reads_expected);
             if (retries < max_retries) {
                 ++retries;
                 testlog.warn("Detected extra cache misses (actual={}, expected={}), but they can be explained by extra reads (after={}, before={}, expected={}) done by something in the background, so retrying. (retries={})", misses_after, misses_before, reads_after, reads_before, reads_expected, retries);


### PR DESCRIPTION
The cache algorithm tests use a reads counter guard to verify that cache misses during the hot-subset re-read phase can be explained by background activity. The guard used BOOST_REQUIRE_GT(reads_after, reads_expected), which requires strictly more reads than expected.

However, cache eviction can also be triggered by LSA memory pressure (e.g. from index page loading via allocating_section::on_alloc_failure) without any extra reads being started. In that case reads_after == reads_expected, causing the GT assertion to fail before the retry logic is reached.

Change BOOST_REQUIRE_GT to BOOST_REQUIRE_GE to allow the test to retry when eviction happens without background reads. The test still catches real algorithmic failures because a truly broken cache algorithm would cause misses on every retry, exhausting all 100 retries.

Fixes scylladb/scylladb#1244

Requires backports to 2026.1 and 2025.4 at least (CI hit it there)