### PR TITLE
test: fix NoHostAvailable race in collect_mutations

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -17,7 +17,7 @@ from test.cluster.object_store.conftest import format_tuples
 from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace
 from test.pylib.rest_client import read_barrier
 from test.pylib.util import unique_name, wait_all
-from cassandra.cluster import ConsistencyLevel
+from cassandra.cluster import ConsistencyLevel, NoHostAvailable
 from collections import defaultdict
 from test.pylib.util import wait_for
 from test.pylib.rest_client import HTTPError
@@ -636,7 +636,20 @@ async def collect_mutations(cql, server, manager, ks, cf):
     host = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 30)
     await read_barrier(manager.api, server.ip_addr)  # scylladb/scylladb#18199
     ret = defaultdict(list)
-    for frag in await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({ks}.{cf})", host=host[0]):
+    # The driver may transiently tear down and rebuild the connection pool for a
+    # host during a token map rebuild (triggered by topology/status change events).
+    # A single unguarded run_async(..., host=...) can therefore hit a brief window
+    # where no pool exists and throw NoHostAvailable even though the node is up.
+    # Retry with the same 30-second deadline to ride out the transient.
+    async def run_query():
+        try:
+            frags = await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({ks}.{cf})", host=host[0])
+            return frags
+        except NoHostAvailable:
+            logging.info(f"Driver temporarily lost connection to {server.ip_addr}, retrying")
+            return None
+    frags = await wait_for(run_query, time.time() + 30)
+    for frag in frags:
         ret[frag.pk].append({'mutation_source': frag.mutation_source, 'partition_region': frag.partition_region, 'node': server.ip_addr})
     return ret
 


### PR DESCRIPTION
## Summary

- `collect_mutations` in `test/cluster/object_store/test_backup.py` called `cql.run_async(..., host=host[0])` with no retry.
- The Python driver can transiently tear down and rebuild its connection pool for a host while rebuilding the token map in response to concurrent `TOPOLOGY_CHANGE` / `STATUS_CHANGE` events. If the query lands in that brief teardown window, the driver throws `NoHostAvailable` immediately — even though the node itself is fully up.
- This is what caused the flaky failure in `test_refresh_with_streaming_scopes[topology_rf_validity0]`: the log shows `"Host 127.97.149.4:9042 is now marked up"` at `15:35:16.441`, immediately followed by `"Removed connection pool for <Host: 127.97.149.4:9042>"` at `15:35:16.445`, and the query crash at `15:35:16.447` — a ~1 ms window.

## Fix

Wrap the `run_async` call in a `wait_for` retry loop (same 30-second deadline used elsewhere in the test), catching `NoHostAvailable` and retrying until the driver re-establishes the pool after the token-map rebuild completes.

```python
# before
for frag in await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({ks}.{cf})", host=host[0]):
    ...

# after
async def run_query():
    try:
        frags = await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({ks}.{cf})", host=host[0])
        return frags
    except NoHostAvailable:
        logging.info(f"Driver temporarily lost connection to {server.ip_addr}, retrying")
        return None
frags = await wait_for(run_query, time.time() + 30)
for frag in frags:
    ...
```

## Fixes

Fixes SCYLLADB-559: `test_refresh_with_streaming_scopes[topology_rf_validity0]` failed with `NoHostAvailable`