### PR TITLE
sstables: handle null parse_assert messages

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -641,6 +641,7 @@ scylla_tests = set([
     'test/boost/sstable_move_test',
     'test/boost/sstable_mutation_test',
     'test/boost/sstable_partition_index_cache_test',
+    'test/boost/sstable_parse_assert_test',
     'test/boost/sstable_resharding_test',
     'test/boost/sstable_test',
     'test/boost/stall_free_test',

--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -29,6 +29,9 @@ public:
 };
 
 [[noreturn]] void on_parse_error(sstring message, std::optional<component_name> filename);
+[[noreturn]] inline void on_parse_error(const char* message, std::optional<component_name> filename) {
+    on_parse_error(message ? sstring(message) : sstring(), filename);
+}
 [[noreturn, gnu::noinline]] void on_bti_parse_error(uint64_t pos);
 
 // Use this instead of SCYLLA_ASSERT() or assert() in code that is used while parsing SSTables.

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -248,6 +248,8 @@ add_scylla_test(sstable_mutation_test
   KIND SEASTAR)
 add_scylla_test(sstable_partition_index_cache_test
   KIND SEASTAR)
+add_scylla_test(sstable_parse_assert_test
+  KIND SEASTAR)
 add_scylla_test(sstable_resharding_test
   KIND SEASTAR)
 add_scylla_test(sstable_test

--- a/test/boost/sstable_parse_assert_test.cc
+++ b/test/boost/sstable_parse_assert_test.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include <seastar/testing/on_internal_error.hh>
+
+#include "sstables/exceptions.hh"
+#include "test/lib/exception_utils.hh"
+#include "test/lib/scylla_test_case.hh"
+
+using namespace sstables;
+
+SEASTAR_THREAD_TEST_CASE(parse_assert_without_message_is_null_safe) {
+    seastar::testing::scoped_no_abort_on_internal_error no_abort;
+
+    BOOST_REQUIRE_EXCEPTION(
+            [] {
+                parse_assert(false);
+            }(),
+            malformed_sstable_exception, exception_predicate::message_equals("parse_assert() failed"));
+}
+
+SEASTAR_THREAD_TEST_CASE(on_parse_error_null_message_is_null_safe) {
+    seastar::testing::scoped_no_abort_on_internal_error no_abort;
+
+    BOOST_REQUIRE_EXCEPTION(
+            [] {
+                on_parse_error(static_cast<const char*>(nullptr), {});
+            }(),
+            malformed_sstable_exception, exception_predicate::message_equals("parse_assert() failed"));
+}


### PR DESCRIPTION
## Summary
- make `sstables::on_parse_error()` handle nullable `const char*` messages so `parse_assert(false)` raises `malformed_sstable_exception` instead of crashing on `strlen(nullptr)`
- add a dedicated `sstable_parse_assert_test` regression target covering both `parse_assert(false)` and direct `on_parse_error(nullptr, {})`
- register the new test in both `test/boost/CMakeLists.txt` and `configure.py`
- keep `sstables/exceptions.hh` formatting aligned with upstream style in a follow-up independent cleanup commit

## Validation
- `./tools/toolchain/dbuild ./configure.py --mode debug --compiler-cache none`
- `./tools/toolchain/dbuild ninja build/debug/test/boost/sstable_parse_assert_test_g`
- `./tools/toolchain/dbuild ./build/debug/test/boost/sstable_parse_assert_test_g --run_test=parse_assert_without_message_is_null_safe`
- `./tools/toolchain/dbuild ./build/debug/test/boost/sstable_parse_assert_test_g --run_test=on_parse_error_null_message_is_null_safe`

FIXES: CUSTOMER-279