### PR TITLE
alternator: fix flaky test_update_condition_unused_entries_short_circuit

### DIFF
--- a/test/cluster/dtest/alternator_tests.py
+++ b/test/cluster/dtest/alternator_tests.py
@@ -273,6 +273,30 @@ class TesterAlternator(BaseAlternator):
         logger.info("Testing and validating an update query using key condition expression")
         logger.info(f"ConditionExpression update of short circuit is: {conditional_update_short_circuit}")
         dc2_table.update_item(**conditional_update_short_circuit)
+        # Wait for cross-DC replication to reach both live DC1 nodes
+        # before stopping dc2_node.  The LWT commit uses LOCAL_QUORUM,
+        # which only guarantees DC2 persistence; replication to DC1 is
+        # async background work.  Without this wait, stopping dc2_node
+        # can drop in-flight RPCs to DC1 while CAS mutations don't
+        # store hints.  We must confirm both live DC1 replicas have the
+        # data so that the later ConsistentRead=True (LOCAL_QUORUM)
+        # read on restarted node1 is guaranteed to succeed.
+        # See https://scylladb.atlassian.net/browse/SCYLLADB-1267
+        dc1_live_nodes = [
+            node for node in self.cluster.nodelist()
+            if node.data_center == node1.data_center and node.server_id != node1.server_id
+        ]
+        dc1_live_tables = [self.get_table(table_name=TABLE_NAME, node=node) for node in dc1_live_nodes]
+        wait_for(
+            lambda: all(
+                t.get_item(
+                    Key={self._table_primary_key: new_pk_val}, ConsistentRead=False
+                ).get("Item", {}).get("c") == 3
+                for t in dc1_live_tables
+            ),
+            timeout=60,
+            text="Waiting for cross-DC replication of conditional update to both live DC1 nodes",
+        )
         dc2_node.stop()
         node1.start()
 


### PR DESCRIPTION
## Summary
- Wait for cross-DC replication to complete on both live DC1 nodes
  before stopping dc2_node in the test, fixing the race condition
  that caused intermittent failures.

The LWT commit uses `LOCAL_QUORUM`, which only guarantees persistence
in the coordinator's DC. Replication to the remote DC is async
background work, and CAS mutations don't store hints. Stopping
`dc2_node` immediately after `update_item()` returns could drop
in-flight RPCs to DC1, leaving it without the mutation.

The fix polls both live DC1 nodes (with `ConsistentRead=False`) after
the write to confirm cross-DC replication completed before proceeding
to stop `dc2_node`. Both nodes must have the data so that the later
`ConsistentRead=True` (`LOCAL_QUORUM`) read on restarted `node1` is
guaranteed to succeed.

Fixes SCYLLADB-1267