### PR TITLE
transport: improve memory accounting for big responses and slow network

### DIFF
--- a/service_permit.hh
+++ b/service_permit.hh
@@ -18,6 +18,13 @@ class service_permit {
     friend service_permit empty_service_permit();
 public:
     size_t count() const { return _permit ? _permit->count() : 0; };
+    // Merge additional semaphore units into this permit.
+    // Used to grow the permit after the actual resource cost is known.
+    void adopt(seastar::semaphore_units<>&& units) {
+        if (_permit) {
+            _permit->adopt(std::move(units));
+        }
+    }
 };
 
 inline service_permit make_service_permit(seastar::semaphore_units<>&& permit) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1260,7 +1260,16 @@ future<> cql_server::connection::process_request() {
                                                   message,
                                                   tracing::trace_state_ptr()));
                     } else {
-                        write_response(response_f.get(), std::move(mem_permit), _compression);
+                        auto response = response_f.get();
+                        // Account for response body size exceeding the initial estimate.
+                        auto resp_size = response->size();
+                        auto permit_size = mem_permit.count();
+                        if (resp_size > permit_size) {
+                            auto extra = resp_size - permit_size;
+                            auto extra_units = consume_units(_server._memory_available, extra);
+                            mem_permit.adopt(std::move(extra_units));
+                        }
+                        write_response(std::move(response), std::move(mem_permit), _compression);
                     }
                     _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave)] {});
                 } catch (...) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -272,6 +272,12 @@ void cql_sg_stats::register_metrics()
         }
     }
 
+    transport_metrics.emplace_back(
+            sm::make_gauge("cql_pending_response_memory", [this] { return _pending_response_memory; },
+                             sm::description("Holds the total memory in bytes consumed by responses waiting to be sent."),
+                             {{"scheduling_group_name", cur_sg_name}}).set_skip_when_empty()
+    );
+
     new_metrics.add_group("transport", std::move(transport_metrics));
     _metrics = std::exchange(new_metrics, {});
 }
@@ -1253,6 +1259,8 @@ future<> cql_server::connection::process_request() {
 
             future<> request_response_future = request_process_future.then_wrapped([this, buf = std::move(buf), mem_permit, leave = std::move(leave), stream] (future<foreign_ptr<std::unique_ptr<cql_server::response>>> response_f) mutable {
                 try {
+                    auto& sg_stats = _server.get_cql_sg_stats();
+                    size_t pending_response_size = 0;
                     if (response_f.failed()) {
                         const auto message = format("request processing failed, error [{}]", response_f.get_exception());
                         clogger.error("{}: {}", _client_state.get_remote_address(), message);
@@ -1269,9 +1277,13 @@ future<> cql_server::connection::process_request() {
                             auto extra_units = consume_units(_server._memory_available, extra);
                             mem_permit.adopt(std::move(extra_units));
                         }
+                        pending_response_size = resp_size;
+                        sg_stats._pending_response_memory += pending_response_size;
                         write_response(std::move(response), _compression);
                     }
-                    _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave), permit = std::move(mem_permit)] {});
+                    _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave), permit = std::move(mem_permit), &sg_stats, pending_response_size] {
+                        sg_stats._pending_response_memory -= pending_response_size;
+                    });
                 } catch (...) {
                     clogger.error("{}: request processing failed: {}",
                                   _client_state.get_remote_address(), std::current_exception());

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1269,9 +1269,9 @@ future<> cql_server::connection::process_request() {
                             auto extra_units = consume_units(_server._memory_available, extra);
                             mem_permit.adopt(std::move(extra_units));
                         }
-                        write_response(std::move(response), std::move(mem_permit), _compression);
+                        write_response(std::move(response), _compression);
                     }
-                    _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave)] {});
+                    _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave), permit = std::move(mem_permit)] {});
                 } catch (...) {
                     clogger.error("{}: request processing failed: {}",
                                   _client_state.get_remote_address(), std::current_exception());
@@ -2110,9 +2110,9 @@ cql_server::connection::make_client_routes_change_event(const event::client_rout
     return response;
 }
 
-void cql_server::connection::write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit, cql_compression compression)
+void cql_server::connection::write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, cql_compression compression)
 {
-    _ready_to_respond = _ready_to_respond.then([this, compression, response = std::move(response), permit = std::move(permit)] () mutable {
+    _ready_to_respond = _ready_to_respond.then([this, compression, response = std::move(response)] () mutable {
         cql_server::response& r = *response;
         auto del = make_deleter([response = std::move(response)] {});
         return r.write_message(_write_buf, _version, compression, std::move(del));

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -342,7 +342,7 @@ private:
 
         cql3::dialect get_dialect() const;
 
-        void write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit = empty_service_permit(), cql_compression compression = cql_compression::none);
+        void write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, cql_compression compression = cql_compression::none);
         
         void update_user_scheduling_group(const std::optional<auth::authenticated_user>& usr);
         void update_control_connection_scheduling_group();

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -144,6 +144,10 @@ struct cql_sg_stats {
     request_kind_stats& get_cql_opcode_stats(cql_binary_opcode op) { return _cql_requests_stats[static_cast<uint8_t>(op)]; }
     void register_metrics();
     void rename_metrics();
+
+    // Track total memory consumed by responses waiting to be sent.
+    // Incremented when a response is queued, decremented when the write completes.
+    int64_t _pending_response_memory = 0;
 private:
     bool _use_metrics = false;
     seastar::metrics::metric_groups _metrics;
@@ -246,8 +250,11 @@ public:
     service::endpoint_lifecycle_subscriber* get_lifecycle_listener() const noexcept;
     service::migration_listener* get_migration_listener() const noexcept;
     qos::qos_configuration_change_subscriber* get_qos_configuration_listener() const noexcept;
+    cql_sg_stats& get_cql_sg_stats() {
+        return scheduling_group_get_specific<cql_sg_stats>(_stats_key);
+    }
     cql_sg_stats::request_kind_stats& get_cql_opcode_stats(cql_binary_opcode op) {
-        return scheduling_group_get_specific<cql_sg_stats>(_stats_key).get_cql_opcode_stats(op);
+        return get_cql_sg_stats().get_cql_opcode_stats(op);
     }
 
     future<utils::chunked_vector<foreign_ptr<std::unique_ptr<client_data>>>> get_client_data();


### PR DESCRIPTION
After obtaining the CQL response, check if its actual size exceeds the initially acquired memory permit. If so, acquire additional semaphore units and adopt them into the permit, ensuring accurate memory accounting for large responses.

Additionally, move the permit into a .then() continuation so that the semaphore units are kept alive until write_message finishes, preventing premature release of memory permit. This is especially important with slow networks and big responses when buffers can accumulate and deplete a node's memory.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1306
Related https://scylladb.atlassian.net/browse/SCYLLADB-740

Backport: all supported versions