### PR TITLE
test/cluster: fix race in test_insert_failure_standalone audit log query

### DIFF
--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -17,6 +17,7 @@ import socket
 import socketserver
 import tempfile
 import threading
+import time
 import uuid
 from collections import namedtuple
 from contextlib import contextmanager
@@ -35,6 +36,7 @@ from test.cluster.dtest.tools.data import rows_to_list, run_in_parallel
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
+from test.pylib.util import wait_for as wait_for_async
 
 logger = logging.getLogger(__name__)
 
@@ -1347,7 +1349,13 @@ class CQLAuditTester(AuditTester):
             conn = await self.manager.get_cql_exclusive(srv)
             stmt = SimpleStatement("INSERT INTO ks.test1 (k, v1) VALUES (1000, 1000)", consistency_level=ConsistencyLevel.THREE)
             conn.execute(stmt)
-            audit_node_ips = await self.get_audit_partitions_for_operation(session, stmt.query_string)
+            # The audit log entry may not be visible immediately after the
+            # insert, so retry with exponential backoff until it appears.
+            audit_node_ips = await wait_for_async(
+                lambda: self.get_audit_partitions_for_operation(session, stmt.query_string),
+                deadline=time.time() + 10,
+                period=0.05,
+                label=f"audit entry for node {index}")
             node_to_audit_nodes[index] = set(audit_node_ips)
 
         all_addresses = set(srv.ip_addr for srv in servers)


### PR DESCRIPTION
get_audit_partitions_for_operation() returns None when no audit log rows are found. In _test_insert_failure_doesnt_report_success_assign_nodes, this None is passed to set(), causing TypeError: 'NoneType' object is not iterable.

The audit log entry may not yet be visible immediately after executing the INSERT, so use wait_for() from test.pylib.util with exponential backoff to poll until the entry appears. Import it as wait_for_async to avoid shadowing the existing wait_for from test.cluster.dtest.dtest_class, which has a different signature (timeout vs deadline).

Fixes SCYLLADB-1330

Test isn't in any branch, so no backport is needed.