### PR TITLE
test: fix flaky test_timeout_is_applied_on_lookup by using eventually_true

### DIFF
--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -906,9 +906,13 @@ SEASTAR_THREAD_TEST_CASE(test_timeout_is_applied_on_lookup) {
     BOOST_REQUIRE(entry.permit.timeout() == new_timeout);
     BOOST_REQUIRE(!entry.permit.get_abort_exception());
 
-    sleep(ttl_timeout_test_timeout * 2).get();
+    // Don't waste time retrying before the timeout is up
+    sleep(ttl_timeout_test_timeout).get();
 
-    BOOST_REQUIRE(entry.permit.get_abort_exception());
+    eventually_true([&entry] {
+        return bool(entry.permit.get_abort_exception());
+    });
+
     BOOST_REQUIRE_THROW(std::rethrow_exception(entry.permit.get_abort_exception()), seastar::named_semaphore_timed_out);
 }
 


### PR DESCRIPTION
## Summary

- Fix flaky `test_timeout_is_applied_on_lookup` which fails on slow/overloaded CI machines (aarch64/release) because the lowres_clock timer hasn't fired after the fixed 2x sleep.
- Replace the fixed sleep with `sleep(1x)` + `eventually_true()` (exponential backoff), matching the pattern already used in `test_time_based_cache_eviction` in the same file.

Backport: flaky test improvement, no backport

Fixes: SCYLLADB-1311