### PR TITLE
lwt, vector: write to CDC when vector index is enabled.

### DIFF
--- a/schema/caching_options.hh
+++ b/schema/caching_options.hh
@@ -30,6 +30,9 @@ class caching_options {
     friend class schema;
     caching_options();
 public:
+    // do not used schema.cdc_options().enabled(), use cdc::cdc_enabled(schema)
+    // instead. This is because cdc_enabled() also checks for CDC being enabled
+    // by a vector index.
     bool enabled() const {
         return _enabled;
     }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2664,7 +2664,7 @@ future<> paxos_response_handler::learn_decision(lw_shared_ptr<paxos::proposal> d
     // We use the first path for CDC mutations (if present) and the latter for "paxos mutations".
     // Attempts to send both kinds of mutations in one shot caused an infinite loop.
     future<> f_cdc = make_ready_future<>();
-    if (_schema->cdc_options().enabled()) {
+    if (cdc::cdc_enabled(*_schema)) {
         auto update_mut = decision->update.unfreeze(_schema);
         const auto base_tbl_id = update_mut.column_family_id();
         utils::chunked_vector<mutation> update_mut_vec{std::move(update_mut)};

--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -424,6 +424,54 @@ def test_try_enable_vector_search_with_cdc_disabled(scylla_only, cql, test_keysp
         assert alter_cdc(cql, table, {'enabled': True})
         assert create_index(cql, test_keyspace, table, "v")
 
+# When a vector index is created on a table, writes to it should appear in the
+# CDC log, even though CDC was never explicitly enabled. This should be true
+# both for regular writes and writes using LWT.
+# This is a regression test for SCYLLADB-1342, where LWT writes forgot to update
+# the CDC log.
+def test_vector_index_writes_appear_in_cdc_log(cql, test_keyspace, scylla_only, skip_without_tablets):
+    schema = "p int primary key, v vector<float, 3>"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        _, table_name = table.split('.')
+        cdc_log_table = f"{test_keyspace}.{table_name}_scylla_cdc_log"
+
+        # Creating a vector index auto-enables CDC on the table.
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
+
+        # Confirm that traditional CDC was *not* enabled, but the CDC log
+        # table was created (SELECT from it generates no error).
+        cdc_opts = cql.execute(f"SELECT cdc FROM system_schema.scylla_tables WHERE keyspace_name = '{test_keyspace}' AND table_name = '{table_name}'").one().cdc
+        assert not cdc_opts or cdc_opts.get('enabled') != 'true'
+        cql.execute(f"SELECT * FROM {cdc_log_table}")
+
+        # A regular write should appear in the CDC log
+        cql.execute(f"INSERT INTO {table} (p, v) VALUES (1, [1.0, 2.0, 3.0])")
+        rows_after_regular = list(cql.execute(f"SELECT * FROM {cdc_log_table}"))
+        assert len(rows_after_regular) > 0
+
+        # A successful LWT write should appear in the CDC log (reproduces
+        # SCYLLADB-1342)
+        cql.execute(f"INSERT INTO {table} (p, v) VALUES (2, [4.0, 5.0, 6.0]) IF NOT EXISTS")
+        rows_after_lwt = list(cql.execute(f"SELECT * FROM {cdc_log_table} ALLOW FILTERING"))
+        assert len(rows_after_lwt) > len(rows_after_regular)
+
+        # An unsuccessful LWT write should not appear in the CDC log.
+        # p=2 already exists, so this IF NOT EXISTS will not be applied.
+        cql.execute(f"INSERT INTO {table} (p, v) VALUES (2, [7.0, 8.0, 9.0]) IF NOT EXISTS")
+        rows_after_failed_lwt = list(cql.execute(f"SELECT * FROM {cdc_log_table} ALLOW FILTERING"))
+        assert len(rows_after_failed_lwt) == len(rows_after_lwt)
+
+        # Above we tested sucessful LWT writes using INSERT. Verify the same
+        # also for UPDATE and DELETE.
+        # A successful LWT UPDATE (p=1 exists) should appear in the CDC log.
+        cql.execute(f"UPDATE {table} SET v = [0.1, 0.2, 0.3] WHERE p = 1 IF EXISTS")
+        rows_after_lwt_update = list(cql.execute(f"SELECT * FROM {cdc_log_table} ALLOW FILTERING"))
+        assert len(rows_after_lwt_update) > len(rows_after_failed_lwt)
+
+        # A successful LWT DELETE (p=2 exists) should appear in the CDC log.
+        cql.execute(f"DELETE FROM {table} WHERE p = 2 IF EXISTS")
+        rows_after_lwt_delete = list(cql.execute(f"SELECT * FROM {cdc_log_table} ALLOW FILTERING"))
+        assert len(rows_after_lwt_delete) > len(rows_after_lwt_update)
 
 # This test reproduces VECTOR-179.
 # It performs a vector search with tracing enabled. An exception is expected


### PR DESCRIPTION
The vector-search feature introduced the somewhat confusing feature of enabling CDC without explicitly enabling CDC: When a vector index is enabled on a table, CDC is "enabled" for it even if the user didn't ask to enable CDC.

For this, write-path code began to use a new cdc_enabled() function instead of checking schema.cdc_options.enabled() directly.  This cdc_enabled() function checks if either this enabled() is true, or has_vector_index() is true.

Unfortunately, some specific code paths in LWT writes continued to use cdc_options.enabled() instead of the new cdc_enabled(). This means that if a vector index is used and a vector is written using an LWT write, the new value is not indexed.

This patch fixes this bug. It also adds a regression test that fails before this patch and passes afterwards - the new test verifies that when a table has a vector index (but no explicit CDC enabled), the CDC log is updated both after regular writes and after successful LWT writes.
    
This patch was also tested in the context of the upcoming vector-search-for-Alternator pull request, which has a test reproducing this bug (Alternator uses LWT frequently, so this is very important there). It will also be tested by the vector-store test suite ("validator").


Fixes SCYLLADB-1342