### PR TITLE
test.py: migrate all bare skips to typed skip markers

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -18,6 +18,7 @@ from test.alternator.util import create_test_table, is_aws, scylla_log
 from test.conftest import dynamic_scope
 from test.cqlpy.conftest import host  # add required fixtures
 from test.pylib.driver_utils import safe_driver_shutdown
+from test.pylib.skip_types import skip_env
 from test.pylib.suite.python import add_host_option
 from urllib.parse import urlparse
 from functools import cache
@@ -198,7 +199,7 @@ def dynamodbstreams(request, get_valid_alternator_role):
 def dynamodb_test_connection(dynamodb, request, optional_rest_api):
     scylla_log(optional_rest_api, f'test/alternator: Starting {request.node.parent.name}::{request.node.name}', 'info')
     if dynamodb_test_connection.scylla_crashed:
-        pytest.skip('Server down')
+        skip_env('Server down')
     yield
     try:
         # We want to run a do-nothing DynamoDB command. The health-check
@@ -345,7 +346,7 @@ def filled_test_table(dynamodb):
 @pytest.fixture(scope=dynamic_scope())
 def scylla_only(dynamodb):
     if is_aws(dynamodb):
-        pytest.skip('Scylla-only feature not supported by AWS')
+        skip_env('Scylla-only feature not supported by AWS')
 
 # "dynamodb_bug" is similar to "scylla_only", except instead of skipping
 # the test, it is expected to fail (xfail) on AWS DynamoDB. It should be
@@ -365,7 +366,7 @@ def dynamodb_bug(dynamodb):
 @pytest.fixture(scope=dynamic_scope())
 def rest_api(dynamodb, optional_rest_api):
     if optional_rest_api is None:
-        pytest.skip('Cannot connect to Scylla REST API')
+        skip_env('Cannot connect to Scylla REST API')
     return optional_rest_api
 @pytest.fixture(scope=dynamic_scope())
 def optional_rest_api(dynamodb):
@@ -417,7 +418,7 @@ def xfail_tablets(request, has_tablets):
 @pytest.fixture(scope="function")
 def skip_tablets(has_tablets):
     if has_tablets:
-        pytest.skip("Test may crash when Alternator tables use tablets")
+        skip_env("Test may crash when Alternator tables use tablets")
 
 # Alternator tests normally use only the DynamoDB API. However, a few tests
 # need to use CQL to set up Scylla-only features such as service levels or
@@ -432,7 +433,7 @@ def cql(dynamodb):
     from cassandra.cluster import Cluster, ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT, NoHostAvailable
     from cassandra.policies import RoundRobinPolicy
     if is_aws(dynamodb):
-        pytest.skip('Scylla-only CQL API not supported by AWS')
+        skip_env('Scylla-only CQL API not supported by AWS')
     url = dynamodb.meta.client._endpoint.host
     host, = re.search(r'.*://([^:]*):', url).groups()
     profile = ExecutionProfile(
@@ -453,6 +454,6 @@ def cql(dynamodb):
         # "BEGIN BATCH APPLY BATCH" is the closest to do-nothing I could find
         ret.execute("BEGIN BATCH APPLY BATCH")
     except NoHostAvailable:
-        pytest.skip('Could not connect to Scylla-only CQL API')
+        skip_env('Could not connect to Scylla-only CQL API')
     yield ret
     safe_driver_shutdown(cluster)

--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -21,6 +21,7 @@ from functools import cache
 
 import re
 
+from test.pylib.skip_types import skip_env
 from .util import unique_table_name, random_string, new_test_table
 from .test_gsi_updatetable import wait_for_gsi, wait_for_gsi_gone
 from .test_gsi import assert_index_query
@@ -1143,7 +1144,7 @@ def test_rbac_system_table_write(dynamodb, cql, test_table_s):
             ExpressionAttributeValues={':val': old_val})
     except Exception as e:
         if 'alternator_allow_system_table_write' in str(e):
-            pytest.skip('need alternator_allow_system_table_write=true')
+            skip_env('need alternator_allow_system_table_write=true')
         else:
             raise
     with new_role(cql) as (role, key):

--- a/test/alternator/test_logs.py
+++ b/test/alternator/test_logs.py
@@ -88,7 +88,7 @@ def local_process_id(ip, port):
 
 # A fixture to find the Scylla log file, returning the log file's path.
 # If the log file cannot be found, or it's not Scylla, the fixture calls
-# pytest.skip() to skip any test which uses it. The fixture has module
+# skip_env() to skip any test which uses it. The fixture has module
 # scope, so looking for the log file only happens once. Individual tests
 # should use the function-scope fixture "logfile" below, which takes care
 # of opening the log file for reading in the right place.

--- a/test/alternator/test_logs.py
+++ b/test/alternator/test_logs.py
@@ -33,6 +33,8 @@ import urllib.parse
 from contextlib import contextmanager
 from botocore.exceptions import ClientError
 
+from test.pylib.skip_types import skip_env
+
 from .util import new_test_table, scylla_config_temporary
 from .test_cql_rbac import new_dynamodb, new_role
 
@@ -108,18 +110,18 @@ def logfile_path(dynamodb):
         port = 443 if p.scheme == 'https' else 80
     pid = local_process_id(ip, port)
     if not pid:
-        pytest.skip("Can't find local process")
+        skip_env("Can't find local process")
     # Now that we know the process id, use /proc to find if its standard
     # output is redirected to a file. If it is, that's the log file. If it
     # isn't a file, we don't known where the user is writing the log...
     try:
         log = os.readlink(f'/proc/{pid}/fd/1')
     except:
-        pytest.skip("Can't find local log file")
+        skip_env("Can't find local log file")
     # If the process's standard output is some pipe or device, it's
     # not the log file we were hoping for...
     if not log.startswith('/') or not os.path.isfile(log):
-        pytest.skip("Can't find local log file")
+        skip_env("Can't find local log file")
     # Scylla can be configured to put the log in syslog, not in the standard
     # output. So let's verify that the file which we found actually looks
     # like a Scylla log and isn't just empty or something... The Scylla log
@@ -127,7 +129,7 @@ def logfile_path(dynamodb):
     with open(log, 'r') as f:
         head = f.read(7)
         if head != 'Scylla ':
-            pytest.skip("Not a Scylla log file")
+            skip_env("Not a Scylla log file")
         yield log
 
 # The "logfile" fixture returns the log file open for reading at the end.

--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -13,6 +13,8 @@ import urllib3
 from botocore.exceptions import BotoCoreError, ClientError
 from packaging.version import Version
 
+from test.pylib.skip_types import skip_env
+
 from test.alternator.util import random_bytes, random_string, get_signed_request, manual_request, ManualRequestError
 
 
@@ -102,7 +104,7 @@ def test_too_large_request(dynamodb, test_table):
 
 def test_too_large_request_chunked(dynamodb, test_table):
     if Version(urllib3.__version__) < Version('1.26'):
-        pytest.skip("urllib3 before 1.26.0 threw broken pipe and did not read response and cause issue #8195. Fixed by pull request urllib3/urllib3#1524")
+        skip_env("urllib3 before 1.26.0 threw broken pipe and did not read response and cause issue #8195. Fixed by pull request urllib3/urllib3#1524")
     # To make a request very large, we just stuff it with a lot of spaces :-)
     spaces = ' ' * (17 * 1024 * 1024)
     req = get_signed_request(dynamodb, 'PutItem',
@@ -126,7 +128,7 @@ def test_too_large_request_chunked(dynamodb, test_table):
 @pytest.mark.parametrize("mb", [17, 50])
 def test_too_large_request_content_length(dynamodb, test_table, mb):
     if Version(urllib3.__version__) < Version('1.26'):
-        pytest.skip("urllib3 before 1.26.0 threw broken pipe and did not read response and cause issue #8195. Fixed by pull request urllib3/urllib3#1524")
+        skip_env("urllib3 before 1.26.0 threw broken pipe and did not read response and cause issue #8195. Fixed by pull request urllib3/urllib3#1524")
     spaces = ' ' * (mb * 1024 * 1024)
     req = get_signed_request(dynamodb, 'PutItem',
         '{"TableName": "' + test_table.name + '", ' + spaces + '"Item": {"p": {"S": "x"}, "c": {"S": "x"}}}')

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -36,6 +36,7 @@ from botocore.exceptions import ClientError
 from test.alternator.test_cql_rbac import new_dynamodb, new_role
 from test.alternator.util import random_string, new_test_table, is_aws, scylla_config_read, scylla_config_temporary, get_signed_request
 from test.alternator.test_vector import vs
+from test.pylib.skip_types import skip_env
 
 # Fixture for checking if we are able to test Scylla metrics. Scylla metrics
 # are not available on AWS (of course), but may also not be available for
@@ -46,7 +47,7 @@ from test.alternator.test_vector import vs
 @pytest.fixture(scope="module")
 def metrics(dynamodb):
     if is_aws(dynamodb):
-        pytest.skip('Scylla-only feature not supported by AWS')
+        skip_env('Scylla-only feature not supported by AWS')
     url = dynamodb.meta.client._endpoint.host
     # The Prometheus API is on port 9180, and always http, not https.
     url = re.sub(r':[0-9]+(/|$)', ':9180', url)
@@ -54,7 +55,7 @@ def metrics(dynamodb):
     url = url + '/metrics'
     resp = requests.get(url)
     if resp.status_code != 200:
-        pytest.skip('Metrics port 9180 is not available')
+        skip_env('Metrics port 9180 is not available')
     yield url
 
 # Utility function for fetching all metrics from Scylla, using an HTTP request
@@ -891,15 +892,15 @@ def test_total_operations(dynamodb, metrics):
 def alternator_ttl_period_in_seconds(dynamodb, request):
     # If not running on Scylla, skip the test
     if is_aws(dynamodb):
-        pytest.skip('Scylla-only test skipped')
+        skip_env('Scylla-only test skipped')
     # In Scylla, we can inspect the configuration via a system table
     # (which is also visible in Alternator)
     period = scylla_config_read(dynamodb, 'alternator_ttl_period_in_seconds')
     if period is None:
-        pytest.skip('missing TTL feature, skipping test')
+        skip_env('missing TTL feature, skipping test')
     period = float(period)
     if period > 1 and not request.config.getoption('runveryslow'):
-        pytest.skip('need --runveryslow option to run')
+        skip_env('need --runveryslow option to run')
     return period
 
 # Test metrics of the background expiration thread run for Alternator's TTL

--- a/test/alternator/test_returnvalues.py
+++ b/test/alternator/test_returnvalues.py
@@ -9,6 +9,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from test.alternator.util import random_string
+from test.pylib.skip_types import skip_env
 
 
 # Test trivial support for the ReturnValues parameter in PutItem, UpdateItem
@@ -90,7 +91,7 @@ def skip_if_returnvalues_on_condition_check_failure_not_supported():
     from packaging.version import Version
     # This release added support for ReturnValuesOnConditionCheckFailure
     if (Version(botocore.__version__) < Version('1.29.164')):
-        pytest.skip("Botocore version 1.29.164 or above required to run this test")
+        skip_env("Botocore version 1.29.164 or above required to run this test")
 
 # Testing ReturnValuesOnConditionCheckFailure feature which returns values only
 # on failed condition expression.

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -15,6 +15,7 @@ from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
 
 from test.alternator.util import is_aws, scylla_config_temporary, unique_table_name, create_test_table, new_test_table, random_string, full_scan, freeze, list_tables, get_region, manual_request
+from test.pylib.skip_types import skip_env
 
 TAGS = []
 # The following fixture is to ensure that tests in this module will be tested with both vnodes and tablets.
@@ -29,7 +30,7 @@ TAGS = []
 ], ids=["using vnodes", "using tablets"], autouse=True)
 def tags_param(request, dynamodb):
     if is_aws(dynamodb) and request.param[0].get('Value') != 'none':
-        pytest.skip('vnodes/tablets parameterization not applicable on AWS')
+        skip_env('vnodes/tablets parameterization not applicable on AWS')
     # Set TAGS in the global namespace of this module
     global TAGS
     TAGS = request.param

--- a/test/alternator/test_system_tables.py
+++ b/test/alternator/test_system_tables.py
@@ -11,6 +11,7 @@ import requests
 from botocore.exceptions import ClientError
 from boto3.dynamodb.conditions import Key
 
+from test.pylib.skip_types import skip_env
 from .util import full_scan, scylla_config_read, scylla_config_temporary
 
 internal_prefix = '.scylla.alternator.'
@@ -175,7 +176,7 @@ def test_write_to_config(scylla_only, dynamodb):
         print(str(e))
         print('alternator_allow_system_table_write' in str(e))
         if 'alternator_allow_system_table_write' in str(e):
-            pytest.skip('need alternator_allow_system_table_write=true')
+            skip_env('need alternator_allow_system_table_write=true')
         else:
             raise
     try:

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -13,6 +13,8 @@ import time
 
 import pytest
 from botocore.exceptions import ClientError
+
+from test.pylib.skip_types import skip_env
 from packaging.version import Version
 
 from test.alternator.util import multiset, create_test_table, unique_table_name, random_string
@@ -139,7 +141,7 @@ def test_table_tags(dynamodb):
     # so older versions of the library cannot run this test.
     import botocore
     if (Version(botocore.__version__) < Version('1.12.136')):
-        pytest.skip("Botocore version 1.12.136 or above required to run this test")
+        skip_env("Botocore version 1.12.136 or above required to run this test")
 
     table = create_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
@@ -220,7 +222,7 @@ def test_too_long_tags_from_creation(dynamodb):
     # so older versions of the library cannot run this test.
     import botocore
     if (Version(botocore.__version__) < Version('1.12.136')):
-        pytest.skip("Botocore version 1.12.136 or above required to run this test")
+        skip_env("Botocore version 1.12.136 or above required to run this test")
     name = unique_table_name()
     # Setting 100 tags is not allowed, the following table creation should fail:
     with pytest.raises(ClientError, match='ValidationException'):
@@ -245,7 +247,7 @@ def test_forbidden_tags_from_creation(scylla_only, dynamodb):
     # so older versions of the library cannot run this test.
     import botocore
     if (Version(botocore.__version__) < Version('1.12.136')):
-        pytest.skip("Botocore version 1.12.136 or above required to run this test")
+        skip_env("Botocore version 1.12.136 or above required to run this test")
     name = unique_table_name()
     # It is not allowed to set the system:write_isolation to "dog", so the
     # following table creation should fail:

--- a/test/alternator/test_tracing.py
+++ b/test/alternator/test_tracing.py
@@ -27,8 +27,8 @@ from test.pylib.skip_types import skip_env
 
 # The "with_tracing" fixture ensures that tracing is enabled throughout
 # the run of a test function, and disabled when it ends. If tracing cannot be
-# enabled, the test is pytest.skip()ed. This will of course happens if we run
-# the test with "--aws" (tracing is a Scylla-only feature).
+# enabled, the test is skipped via skip_env(). This will of course happens
+# if we run the test with "--aws" (tracing is a Scylla-only feature).
 # Note that to support (in the future) the ability for Alternator tests to
 # run in parallel, the tests here need to be prepared that completely
 # unrelated requests get traced during a test with with_tracing.

--- a/test/alternator/test_tracing.py
+++ b/test/alternator/test_tracing.py
@@ -22,6 +22,7 @@ import pytest
 import requests
 
 from test.alternator.util import random_string, full_scan, full_query, create_test_table, scylla_config_temporary
+from test.pylib.skip_types import skip_env
 
 
 # The "with_tracing" fixture ensures that tracing is enabled throughout
@@ -35,15 +36,15 @@ from test.alternator.util import random_string, full_scan, full_query, create_te
 def with_tracing(rest_api):
     probability_resp = requests.get(rest_api+'/storage_service/trace_probability')
     if probability_resp.status_code != 200:
-        pytest.skip('Failed to fetch tracing probability')
+        skip_env('Failed to fetch tracing probability')
     probability = probability_resp.text
     response = requests.post(rest_api+'/storage_service/trace_probability?probability=1')
     if response.status_code != 200:
-        pytest.skip('Failed to enable tracing')
+        skip_env('Failed to enable tracing')
     # verify that tracing is really enabled
     response = requests.get(rest_api+'/storage_service/trace_probability')
     if response.status_code != 200 or response.content.decode('utf-8') != '1':
-        pytest.skip('Failed to verify tracing')
+        skip_env('Failed to verify tracing')
     yield
     print("with_tracing restoring tracing")
     response = requests.post(rest_api+'/storage_service/trace_probability?probability='+probability)
@@ -51,7 +52,7 @@ def with_tracing(rest_api):
         pytest.fail('Failed to disable tracing after with_tracing test')
     response = requests.get(rest_api+'/storage_service/trace_probability')
     if response.status_code != 200 or response.content.decode('utf-8') != '0':
-        pytest.skip('Failed to verify tracing disabled')
+        skip_env('Failed to verify tracing disabled')
 
 # Similarly to the fixture above, slow query logging is enabled only for the run of the
 # test function. Slow logging is set up with threshold equal to 0 microseconds,
@@ -61,22 +62,22 @@ def with_slow_query_logging(rest_api):
     print("with_slow_query_logging enabling slow query logging")
     slow_query_info = requests.get(rest_api+'/storage_service/slow_query')
     if slow_query_info.status_code != 200:
-        pytest.skip('Failed to fetch slow query logging info')
+        skip_env('Failed to fetch slow query logging info')
     slow_query_json = json.loads(slow_query_info.text)
     print(slow_query_json)
     response = requests.post(rest_api+'/storage_service/slow_query?enable=true')
     if response.status_code != 200:
-        pytest.skip('Failed to enable slow query logging')
+        skip_env('Failed to enable slow query logging')
     response = requests.post(rest_api+'/storage_service/slow_query?threshold=0')
     if response.status_code != 200:
-        pytest.skip('Failed to enable slow query logging threshold')
+        skip_env('Failed to enable slow query logging threshold')
     # verify that logging is really enabled
     response = requests.get(rest_api+'/storage_service/slow_query')
     if response.status_code != 200:
-        pytest.skip('Failed to verify slow query logging')
+        skip_env('Failed to verify slow query logging')
     response_json = json.loads(response.text)
     if response_json['enable'] != True or response_json['threshold'] != 0:
-        pytest.skip('Failed to verify slow query logging values')
+        skip_env('Failed to verify slow query logging values')
     print(response_json)
     yield
     print("with_slow_query_logging restoring slow query logging")

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 import pytest
 from botocore.exceptions import ClientError
 
-from test.pylib.skip_types import skip_env
+from test.pylib.skip_types import skip_bug, skip_env
 from .util import new_test_table, random_string, full_query, unique_table_name, is_aws, client_no_transform, multiset, scylla_config_read
 
 # The following fixture is to ensure that Alternator TTL is being tested with both vnodes and tablets.
@@ -656,6 +656,12 @@ def test_ttl_expiration_lsi_key(dynamodb, waits_for_expiration):
 # content), and a special userIdentity flag saying that this is not a regular
 # REMOVE but an expiration. Reproduces issue #11523.
 def test_ttl_expiration_streams(dynamodb, dynamodbstreams, waits_for_expiration):
+    # Alternator Streams currently doesn't work with tablets, so until
+    # #23838 is solved, skip this test on tablets.
+    for tag in TAGS:
+        if tag['Key'] == 'system:initial_tablets' and tag['Value'].isdigit():
+            skip_bug("Streams test skipped on tablets due to #23838")
+
     # In my experiments, a 30-minute (1800 seconds) is the typical
     # expiration delay in this test. If the test doesn't finish within
     # max_duration, we report a failure.

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 import pytest
 from botocore.exceptions import ClientError
 
+from test.pylib.skip_types import skip_env
 from .util import new_test_table, random_string, full_query, unique_table_name, is_aws, client_no_transform, multiset, scylla_config_read
 
 # The following fixture is to ensure that Alternator TTL is being tested with both vnodes and tablets.
@@ -70,12 +71,12 @@ def waits_for_expiration(dynamodb, request):
         if request.config.getoption('runveryslow'):
             return
         else:
-            pytest.skip('need --runveryslow option to run')
+            skip_env('need --runveryslow option to run')
     period = scylla_config_read(dynamodb, 'alternator_ttl_period_in_seconds')
     assert period is not None
     period = float(period)
     if period > 1 and not request.config.getoption('runveryslow'):
-        pytest.skip('need --runveryslow option to run')
+        skip_env('need --runveryslow option to run')
 
 # The veryslow_on_aws says that this test is very slow on AWS, but
 # always reasonably fast on Scylla. If fastness on Scylla requires a
@@ -84,7 +85,7 @@ def waits_for_expiration(dynamodb, request):
 @pytest.fixture(scope="module")
 def veryslow_on_aws(dynamodb, request):
     if is_aws(dynamodb) and not request.config.getoption('runveryslow'):
-        pytest.skip('need --runveryslow option to run')
+        skip_env('need --runveryslow option to run')
 
 # Test the DescribeTimeToLive operation on a table where the time-to-live
 # feature was *not* enabled.

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -18,6 +18,7 @@ from botocore.exceptions import ClientError
 import boto3.dynamodb.types
 
 from .util import random_string, new_test_table, unique_table_name, scylla_config_read, scylla_config_write, client_no_transform, is_aws
+from test.pylib.skip_types import skip_env
 
 # Monkey-patch the boto3 library to stop doing its own error-checking on
 # numbers. This works around a bug https://github.com/boto/boto3/issues/2500
@@ -41,7 +42,7 @@ boto3.dynamodb.types.DYNAMODB_CONTEXT = decimal.Context(prec=100)
 @pytest.fixture(scope="module")
 def vs(new_dynamodb_session, dynamodb):
     if is_aws(dynamodb):
-        pytest.skip('Scylla-only: vector search extensions not available on DynamoDB')
+        skip_env('Scylla-only: vector search extensions not available on DynamoDB')
     resource = new_dynamodb_session()
     client = resource.meta.client
     # Patch the client to support the new APIs:
@@ -1039,7 +1040,7 @@ def vector_store_configured(table_vs):
 @pytest.fixture(scope="module")
 def needs_vector_store(table_vs):
     if not vector_store_configured(table_vs):
-        pytest.skip('Vector Store is not configured (run with --vs)')
+        skip_env('Vector Store is not configured (run with --vs)')
 
 # The context manager unconfigured_vector_store() temporarily (for the
 # duration of the "with" block) un-configures the vector store in Scylla -
@@ -1218,7 +1219,7 @@ def test_wait_for_vector_index_active(vs, needs_vector_store):
 # and this test used to fail before this was fixed.
 # To save a bit of time, we don't test all combinations of hash and range
 # key types but test each type at least once as a hash key and a range key.
-@pytest.mark.skip(reason="Bug in vector store for non-string keys, fails very slowly so let's skip")
+@pytest.mark.skip_bug(reason="Bug in vector store for non-string keys, fails very slowly so let's skip")
 @pytest.mark.parametrize('hash_type,range_type', [
     ('N', None), ('B', None), ('S', 'N'),  ('S', 'B'),
 ], ids=[
@@ -1654,7 +1655,7 @@ def test_deleteitem_vectorindex(vs, needs_vector_store, with_ck):
 def test_vector_with_ttl(vs, needs_vector_store, have_ck):
     period = scylla_config_read(vs, 'alternator_ttl_period_in_seconds')
     if period is None or float(period) > 1:
-        pytest.skip('need alternator_ttl_period_in_seconds <= 1 to run this test quickly')
+        skip_env('need alternator_ttl_period_in_seconds <= 1 to run this test quickly')
     key_schema = [{'AttributeName': 'p', 'KeyType': 'HASH'}]
     attr_defs = [{'AttributeName': 'p', 'AttributeType': 'S'}]
     if have_ck:

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -14,6 +14,8 @@ import pytest
 from contextlib import contextmanager
 from botocore.hooks import HierarchicalEmitter
 
+from test.pylib.skip_types import skip_env
+
 # The "pytest-randomly" pytest plugins modifies the default "random" to repeat
 # the same pseudo-random sequence (with the same seed) in each separate test.
 # But we currently rely on random_string() at al. to return unique keys that
@@ -247,7 +249,7 @@ def scylla_inject_error(rest_api, err, one_shot=False):
     response = requests.get(f'{rest_api}/v2/error_injection/injection')
     print("Enabled error injections:", response.content.decode('utf-8'))
     if response.content.decode('utf-8') == "[]":
-        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+        skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
     try:
         yield
     finally:

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from test import TOP_SRC_DIR, path_to
 from test.pylib.random_tables import RandomTables
+from test.pylib.skip_types import skip_env
 from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
 from test.pylib.async_cql import run_async
@@ -381,7 +382,7 @@ async def prepare_3_racks_cluster(request, manager):
 @pytest.fixture(scope="function")
 def internet_dependency_enabled(request) -> None:
     if request.config.getoption('skip_internet_dependent_tests'):
-        pytest.skip(reason="skip_internet_dependent_tests is set")
+        skip_env(reason="skip_internet_dependent_tests is set")
 
 
 @pytest.fixture(scope="function")

--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -184,7 +184,7 @@ class TestBypassCache(Tester):
             session.execute(query.format(idx, varchar_c, varchar_v))
         return session
 
-    @pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/6045")
+    @pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/6045")
     def test_range_scan_bypass_cache(self):
         session = self.insert_data_for_scan_range()
         node = self.cluster.nodelist()[0]

--- a/test/cluster/dtest/commitlog_test.py
+++ b/test/cluster/dtest/commitlog_test.py
@@ -18,6 +18,7 @@ from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_node import ScyllaNode
 
 from dtest_class import Tester, create_cf, create_ks
+from test.pylib.skip_types import skip_env
 from tools.assertions import (
     assert_all,
     assert_almost_equal,
@@ -712,7 +713,7 @@ class TestCommitLog(Tester):
         node1.stop(gently=False)
 
         if self._get_commitlog_size()[0] > self.big_columns:
-            pytest.skip("Skipping rollback scenario as data was written to commitlog before stopping node")
+            skip_env("Skipping rollback scenario as data was written to commitlog before stopping node")
 
         # restart the node
         node1.start(wait_for_binary_proto=True)

--- a/test/cluster/dtest/limits_test.py
+++ b/test/cluster/dtest/limits_test.py
@@ -11,6 +11,8 @@ import pytest
 
 from dtest_class import Tester, create_ks
 
+from test.pylib.skip_types import skip_env
+
 logger = logging.getLogger(__name__)
 # Those are ideal values according to c* specifications
 # they should pass
@@ -271,7 +273,7 @@ class TestLimits(Tester):
 
     def test_max_cells(self):
         if self.cluster.scylla_mode == "debug":
-            pytest.skip("client times out in debug mode")
+            skip_env("client times out in debug mode")
         cluster = self.prepare()
         cluster.set_configuration_options(values={"query_tombstone_page_limit": 9999999, "batch_size_warn_threshold_in_kb": 1024 * 1024, "batch_size_fail_threshold_in_kb": 1024 * 1024, "commitlog_segment_size_in_mb": 64})
         cluster.populate(1).start(jvm_args=["--smp", "1", "--memory", "2G", "--logger-log-level", "lsa-timing=debug"])

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -258,7 +258,7 @@ async def test_mv_pairing_during_replace(manager: ManagerClient):
 # `rf_rack_valid_keyspaces` is enabled. On the other hand, materialized views in tablet-based keyspaces
 # require the configuration option to be used.
 # Hence, we need to rewrite this test.
-@pytest.mark.skip(reason="scylladb/scylladb#26540")
+@pytest.mark.skip_bug(reason="scylladb/scylladb#26540")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_rf_change(manager: ManagerClient, delayed_replica: str, altered_dc: str):
     servers = []

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -37,6 +37,7 @@ from test.cluster.dtest.tools.data import rows_to_list, run_in_parallel
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
+from test.pylib.skip_types import skip_env
 from test.pylib.util import wait_for as wait_for_async
 from test.pylib.scylla_cluster import ScyllaVersionDescription
 
@@ -1414,7 +1415,7 @@ class CQLAuditTester(AuditTester):
                 if not common:
                     insert_addr = all_addresses - partitions - audit_nodes
                     if len(all_addresses) != 7 or len(partitions) != 3 or len(audit_nodes) != 3 or len(insert_addr) != 1:
-                        raise pytest.skip("Failed to assign nodes for insert failure test")
+                        skip_env("Failed to assign nodes for insert failure test")
                     audit_partition_servers = [address_to_server[addr] for addr in audit_nodes]
                     insert_server = address_to_server[insert_addr.pop()]
                     kill_server = address_to_server[partitions.pop()]
@@ -1452,7 +1453,7 @@ class CQLAuditTester(AuditTester):
                 await self.manager.get_host_id(srv.server_id)
 
         if len(audit_partition_servers) != 3 or server_to_stop is None or insert_server is None:
-            raise pytest.skip("Failed to assign nodes for insert failure test")
+            skip_env("Failed to assign nodes for insert failure test")
 
         for srv in audit_partition_servers:
             logger.debug(f"audit_partition_server: {srv.server_id} {srv.ip_addr}")

--- a/test/cluster/test_blocked_bootstrap.py
+++ b/test/cluster/test_blocked_bootstrap.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip(reason = "can't make it work with the new join procedure, without error recovery")
+@pytest.mark.skip_not_implemented(reason="can't make it work with the new join procedure, without error recovery")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.asyncio
 async def test_blocked_bootstrap(manager: ManagerClient):

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -181,7 +181,7 @@ async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) 
             expected_error=f"Feature '{TEST_FEATURE_NAME}' was previously enabled in the cluster")
 
 
-@pytest.mark.skip(reason="issue #14194")
+@pytest.mark.skip_bug(reason="issue #14194")
 @pytest.mark.asyncio
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
     """Upgrades all but one node in the cluster to enable the test feature.

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -435,13 +435,13 @@ async def do_test_tablet_incremental_repair_with_split_and_merge(manager, do_spl
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
-@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/24153")
+@pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/24153")
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_split_and_merge(manager: ManagerClient):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=True, do_merge=True)
 
-@pytest.mark.skip(reason="https://github.com/scylladb/scylladb/issues/24153")
+@pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/24153")
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_split(manager: ManagerClient):

--- a/test/cluster/test_mv.py
+++ b/test/cluster/test_mv.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="tombstone_gc repair mode is not supported yet for MVs due to #24816")
+@pytest.mark.skip_not_implemented(reason="tombstone_gc repair mode is not supported yet for MVs due to #24816")
 async def test_mv_tombstone_gc_setting(manager):
     """
     Test that the tombstone_gc parameter can be set on a materialized view,

--- a/test/cluster/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/cluster/test_start_bootstrapped_with_invalid_seed.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Test is disabled due to scylladb/scylladb#28153")
+@pytest.mark.skip_bug(reason="Test is disabled due to scylladb/scylladb#28153")
 async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
     """
     Issue https://github.com/scylladb/scylladb/issues/14945.

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1157,7 +1157,7 @@ async def test_abort_forwarded_write_upon_shutdown(manager: ManagerClient):
             await stop_fut
 
 
-@pytest.mark.skip(reason="SCYLLADB-1056")
+@pytest.mark.skip_bug(reason="SCYLLADB-1056")
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_abort_state_machine_apply_after_dropping_table(manager: ManagerClient):
     """
@@ -1225,7 +1225,7 @@ async def test_abort_state_machine_apply_after_dropping_table(manager: ManagerCl
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="SCYLLADB-1056")
+@pytest.mark.skip_bug(reason="SCYLLADB-1056")
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_abort_state_machine_apply_during_shutdown(manager: ManagerClient):
     """

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -388,7 +388,7 @@ async def test_create_colocated_table_while_base_is_migrating(manager: ManagerCl
 # 4. run tablet repair on the base table
 # 5. verify both the base table and the view contain the missing data on the node that was down
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="tablet repair of colocated tables is not supported currently")
+@pytest.mark.skip_not_implemented(reason="tablet repair of colocated tables is not supported currently")
 async def test_repair_colocated_base_and_view(manager: ManagerClient):
     cfg = {'enable_tablets': True}
     cmdline = [

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -9,6 +9,7 @@ from aiohttp.client_exceptions import ServerDisconnectedError
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import HTTPError, read_barrier
+from test.pylib.skip_types import skip_env
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_info
 from test.pylib.util import start_writes
 from test.cluster.util import wait_for_cql_and_get_hosts, new_test_keyspace, reconnect_driver, wait_for
@@ -120,9 +121,9 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage):
     if fail_stage == 'cleanup' and fail_replica == 'destination':
-        pytest.skip('Failing destination during cleanup is pointless')
+        skip_env('Failing destination during cleanup is pointless')
     if fail_stage == 'cleanup_target' and fail_replica == 'source':
-        pytest.skip('Failing source during target cleanup is pointless')
+        skip_env('Failing source during target cleanup is pointless')
 
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled', 'failure_detector_timeout_in_ms': 2000}

--- a/test/cluster/test_topology_remove_decom.py
+++ b/test/cluster/test_topology_remove_decom.py
@@ -71,7 +71,7 @@ async def test_decommission_node_add_column(manager: ManagerClient, random_table
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Wait for @slow attribute, #11713")
+@pytest.mark.skip_bug(reason="Wait for @slow attribute, #11713")
 async def test_remove_node_with_concurrent_ddl(manager: ManagerClient, random_tables: RandomTables):
     stopped = False
     ddl_failed = False

--- a/test/cqlpy/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/collections_test.py
@@ -749,7 +749,7 @@ def testRemovalThroughUpdate(cql, test_keyspace):
 # checks the validity of the prepared-statement binding before passing it
 # to the server, so the following tests fail in the client library, not
 # in the server.
-@pytest.mark.skip(reason="Python driver checks this before reaching server")
+@pytest.mark.skip_not_implemented(reason="Python driver checks this before reaching server")
 def testInvalidInputForList(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int PRIMARY KEY, l list<text>)") as table:
         assert_invalid_message(cql, table, "Not enough bytes to read a list",
@@ -761,7 +761,7 @@ def testInvalidInputForList(cql, test_keyspace):
         assert_invalid_message(cql, table, "The data cannot be deserialized as a list",
                              "INSERT INTO %s (pk, l) VALUES (?, ?)", 1, -1);
 
-@pytest.mark.skip(reason="Python driver checks this before reaching server")
+@pytest.mark.skip_not_implemented(reason="Python driver checks this before reaching server")
 def testInvalidInputForSet(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int PRIMARY KEY, s set<text>)") as table:
         assert_invalid_message(cql, table, "Not enough bytes to read a set",
@@ -773,7 +773,7 @@ def testInvalidInputForSet(cql, test_keyspace):
         assert_invalid_message(cql, table, "The data cannot be deserialized as a set",
                              "INSERT INTO %s (pk, s) VALUES (?, ?)", 1, -1);
 
-@pytest.mark.skip(reason="Python driver checks this before reaching server")
+@pytest.mark.skip_not_implemented(reason="Python driver checks this before reaching server")
 def testInvalidInputForMap(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int PRIMARY KEY, m set<text, text>)") as table:
         assert_invalid_message(cql, table, "Not enough bytes to read a map",

--- a/test/cqlpy/cassandra_tests/validation/entities/type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/type_test.py
@@ -20,7 +20,7 @@ def testNonExistingOnes(cql, test_keyspace):
     # reported instead of just doing nothing:
     execute(cql, test_keyspace, "DROP TYPE IF EXISTS keyspace_does_not_exist.type_does_not_exist")
 
-@pytest.mark.skip(reason="Issue #9300")
+@pytest.mark.skip_bug(reason="Issue #9300")
 def testNowToUUIDCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b uuid, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")
@@ -33,7 +33,7 @@ def testDateCompatibility(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, unixTimestampOf(now()), dateOf(now()), dateOf(now()))")
         assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b <= toUnixTimestamp(now())"))) == 1
 
-@pytest.mark.skip(reason="Issue #9300")
+@pytest.mark.skip_bug(reason="Issue #9300")
 def testReversedTypeCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b timeuuid, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -35,7 +35,7 @@ def read_function_from_file(file_name, wasm_name=None, udf_name=None):
         print(f"Can't open {wat_path}.\nPlease build Wasm examples.")
         exit(1)
 
-@pytest.mark.skip(reason="Issue #22799")
+@pytest.mark.skip_bug(reason="Issue #22799")
 def test_complex_null_values(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(txt text, i int)") as type:
         schema = f"(key int primary key, lst list<double>, st set<text>, mp map<int, boolean>, tup frozen<tuple<double, text, int, boolean>>, udt frozen<{type}>)"
@@ -163,7 +163,7 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
                     assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1"), row("called"))
                     assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 2"), row(None))
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip_bug(reason="Issue #13746")
 @pytest.mark.xfail(reason="Issue #13855")
 @pytest.mark.xfail(reason="Issue #13860")
 @pytest.mark.xfail(reason="Issue #13866")
@@ -200,7 +200,7 @@ def test_function_with_frozen_set_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<set<int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip_bug(reason="Issue #13746")
 @pytest.mark.xfail(reason="Issue #13855")
 @pytest.mark.xfail(reason="Issue #13860")
 @pytest.mark.xfail(reason="Issue #13866")
@@ -237,7 +237,7 @@ def test_function_with_frozen_list_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<list<int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip_bug(reason="Issue #13746")
 @pytest.mark.xfail(reason="Issue #13855")
 @pytest.mark.xfail(reason="Issue #13860")
 @pytest.mark.xfail(reason="Issue #13866")
@@ -274,7 +274,7 @@ def test_function_with_frozen_map_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<map<int, int>>)")
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip_bug(reason="Issue #13746")
 def test_function_with_frozen_tuple_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<tuple<int, int>>)") as table:
         with new_secondary_index(cql, table, "b"):
@@ -311,7 +311,7 @@ def test_function_with_frozen_tuple_type(cql, test_keyspace):
             cql.execute(f"DROP FUNCTION {test_keyspace}.{fun_name} (frozen<tuple<int, int>>)")
             assertRowCount(cql.execute(f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{fun_name}'"), 0)
 
-@pytest.mark.skip(reason="Issue #13746")
+@pytest.mark.skip_bug(reason="Issue #13746")
 def test_function_with_frozen_udt_type(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(f int)") as type:
         with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b frozen<{type}>)") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
@@ -189,7 +189,7 @@ def testBatchWithInRestriction(cql, test_keyspace):
 # TTLs. These sleeps also make it dependent on timing - in the very unlikely
 # case that the test code is delayed by a large fraction of a second, we can
 # end up with the wrong TTL.
-@pytest.mark.skip(reason="slow test, remove skip to try it anyway")
+@pytest.mark.skip_slow(reason="slow test, remove skip to try it anyway")
 def testBatchTTLConditionalInteraction(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int, clustering1 int, clustering2 int, clustering3 int, val int, PRIMARY KEY (id, clustering1, clustering2, clustering3))") as clustering:
         execute(cql, clustering, "DELETE FROM %s WHERE id=1")
@@ -338,7 +338,7 @@ def testBatchTTLConditionalInteraction(cql, test_keyspace):
 # TTLs. These sleeps also make it dependent on timing - in the very unlikely
 # case that the test code is delayed by a large fraction of a second, we can
 # end up with the wrong TTL.
-@pytest.mark.skip(reason="slow test, remove skip to try it anyway")
+@pytest.mark.skip_slow(reason="slow test, remove skip to try it anyway")
 def testBatchStaticTTLConditionalInteraction(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int, clustering1 int, clustering2 int, clustering3 int, sval int static, val int, PRIMARY KEY (id, clustering1, clustering2, clustering3))") as clustering_static:
         execute(cql, clustering_static, f"DELETE FROM {clustering_static} WHERE id=1")

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -4265,7 +4265,7 @@ def testInsertWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip_bug(reason="issue #12815")
 def testInsertWithCompactNonStaticFormat(cql, test_keyspace):
     do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
     do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
@@ -4339,7 +4339,7 @@ def testSelectWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip_bug(reason="issue #12815")
 def testSelectWithCompactNonStaticFormat(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
@@ -4403,7 +4403,7 @@ def testUpdateWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip(reason="issue #12815")
+@pytest.mark.skip_bug(reason="issue #12815")
 def testUpdateWithCompactNonStaticFormat(cql, test_keyspace):
     do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
     do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -21,7 +21,7 @@ def all_tests_in_this_file_use_compact_storage(compact_storage):
 # flag is used) by Cassandra, and it was never implemented in Scylla, so
 # let's skip its test.
 # See issue #3882
-@pytest.mark.skip
+@pytest.mark.skip_not_implemented(reason="issue #3882 - COMPACT STORAGE not implemented")
 def testSparseCompactTableIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(key ascii PRIMARY KEY, val ascii) WITH COMPACT STORAGE") as table:
 

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_table_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_table_test.py
@@ -32,7 +32,7 @@ def all_tests_in_this_file_use_compact_storage(compact_storage):
 # flag is used) by Cassandra, and it was never implemented in Scylla, so
 # let's skip its test.
 # See issue #3882
-@pytest.mark.skip
+@pytest.mark.skip_not_implemented(reason="issue #3882 - DROP COMPACT STORAGE not implemented")
 def testDropCompactStorage(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, ck int, PRIMARY KEY(pk)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (pk, ck) VALUES (1, 1)")

--- a/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/cql_vector_test.py
@@ -10,6 +10,7 @@
 
 from ...porting import *
 from cassandra.connection import DRIVER_NAME, DRIVER_VERSION
+from test.pylib.skip_types import skip_env
 
 # Some of the lines in these tests are commented out because Scylla doesn't support arithmetic operations in literals (issue #2693).
 
@@ -18,7 +19,7 @@ def skip_if_driver_doesnt_support_variable_width_types():
     scylla_driver = 'Scylla' in DRIVER_NAME
     driver_version = tuple(int(x) for x in DRIVER_VERSION.split('.'))
     if scylla_driver or (not scylla_driver and driver_version < (3, 29, 2)):
-        pytest.skip("The driver doesn't support variable width types in vectors.")
+        skip_env("The driver doesn't support variable width types in vectors.")
 
 def test_select(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk vector<int, 2> primary key)") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
@@ -30,7 +30,7 @@ def testSingleClusteringInvalidQueries(cql, test_keyspace):
 
 # We need to skip this test because issue #13241 causes it to frequently
 # crash Scylla, and not just fail cleanly.
-@pytest.mark.skip(reason="Issue #13241")
+@pytest.mark.skip_bug(reason="Issue #13241")
 @pytest.mark.xfail(reason="Issue #4244")
 def testMultiClusteringInvalidQueries(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/select_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_test.py
@@ -2644,7 +2644,7 @@ def testTokenFctRejectsInvalidColumnCount(cql, test_keyspace):
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
-@pytest.mark.skip("UDF tests not yet translated")
+@pytest.mark.skip_not_implemented(reason="UDF tests not yet translated")
 def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs_SameKeyspace(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         createFunctionOverload(KEYSPACE + ".token", "double",
@@ -2654,7 +2654,7 @@ def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs_SameKeyspace(cql,
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
-@pytest.mark.skip("UDF tests not yet translated")
+@pytest.mark.skip_not_implemented(reason="UDF tests not yet translated")
 def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         createFunctionOverload(KEYSPACE + ".token", "double",
@@ -2664,7 +2664,7 @@ def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks(cql, te
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
-@pytest.mark.skip("UDF tests not yet translated")
+@pytest.mark.skip_not_implemented(reason="UDF tests not yet translated")
 def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         createFunctionOverload(KEYSPACE + ".token", "double",
@@ -2674,7 +2674,7 @@ def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs(cql, test_keyspac
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
-@pytest.mark.skip("UDF tests not yet translated")
+@pytest.mark.skip_not_implemented(reason="UDF tests not yet translated")
 def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks_SystemKeyspace(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         createFunctionOverload(KEYSPACE + ".token", "double",

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -233,8 +233,8 @@ def test_ann_ordering_not_allowed_without_index_where_indexed_column_exists_in_q
             "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
         )
 
-@pytest.mark.skip(reason="We pass all restricted queries to vector store, once VECTOR-374 is done, this work as expected" \
-                         "However, the test won't work even then as pytest does not support vector store.")
+@pytest.mark.skip_bug(reason="We pass all restricted queries to vector store, once VECTOR-374 is done, this work as expected" \
+                             "However, the test won't work even then as pytest does not support vector store.")
 def test_cannot_post_filter_on_non_indexed_column_with_ann_ordering(cql, test_keyspace):
     ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = (
         SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -259,7 +259,7 @@ def skip_without_tablets(scylla_only, has_tablets):
 @pytest.fixture(scope="function")
 def skip_on_scylla_vnodes(cql, has_tablets):
     if is_scylla(cql) and not has_tablets:
-        pytest.skip("Test needs tablets experimental feature on")
+        skip_env("Test needs tablets experimental feature on")
 
 # Recent versions of Scylla deprecated the "WITH COMPACT STORAGE" feature,
 # but it can be enabled temporarily for a test. So to keep our old compact

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -19,6 +19,7 @@ import tempfile
 import time
 import random
 
+from test.pylib.skip_types import skip_env
 from test.pylib.suite.python import PythonTest, add_host_option, add_cql_connection_options, add_s3_options
 from .util import unique_name, new_test_keyspace, keyspace_has_tablets, cql_session, local_process_id, is_scylla, config_value_context
 from .nodetool import scylla_log
@@ -75,7 +76,7 @@ def cql(request, host):
 def cql_test_connection(cql, request):
     scylla_log(cql, f'test/cqlpy: Starting {request.node.parent.name}::{request.node.name}', 'info')
     if cql_test_connection.scylla_crashed:
-        pytest.skip('Server down')
+        skip_env('Server down')
     yield
     try:
         # We want to run a do-nothing CQL command. 
@@ -131,7 +132,7 @@ def test_keyspace(request, test_keyspace_vnodes, test_keyspace_tablets, cql, thi
             yield test_keyspace_vnodes
         elif request.param == "tablets":
             if not test_keyspace_tablets:
-                pytest.skip("tablet-specific test skipped")
+                skip_env("tablet-specific test skipped")
             yield test_keyspace_tablets
         else:
             pytest.fail(f"test_keyspace(): invalid request parameter: {request.param}")
@@ -149,7 +150,7 @@ def scylla_only(cql):
     # We recognize Scylla by checking if there is any system table whose name
     # contains the word "scylla":
     if not is_scylla(cql):
-        pytest.skip('Scylla-only test skipped')
+        skip_env('Scylla-only test skipped')
 
 # "cassandra_bug" is similar to "scylla_only", except instead of skipping
 # the test, it is expected to fail (xfail) on Cassandra. It should be used
@@ -179,7 +180,7 @@ def driver_bug_1():
     driver_version = tuple(int(x) for x in DRIVER_VERSION.split('.'))
     if (scylla_driver and driver_version < (3, 24, 5) or
             not scylla_driver and driver_version <= (3, 25, 0)):
-        pytest.skip("Python driver too old to run this test")
+        skip_env("Python driver too old to run this test")
 
 # `random_seed` fixture should be used when the test uses random module.
 # If the fixture is used, the seed is visible in case of test's failure,
@@ -208,18 +209,18 @@ def random_seed():
 def scylla_path(cql):
     pid = local_process_id(cql)
     if not pid:
-        pytest.skip("Can't find local Scylla process")
+        skip_env("Can't find local Scylla process")
     # Now that we know the process id, use /proc to find the executable.
     try:
         path = os.readlink(f'/proc/{pid}/exe')
     except:
-        pytest.skip("Can't find local Scylla executable")
+        skip_env("Can't find local Scylla executable")
     # Confirm that this executable is a real tool-providing Scylla by trying
     # to run it with the "--list-tools" option
     try:
         subprocess.check_output([path, '--list-tools'])
     except:
-        pytest.skip("Local server isn't Scylla")
+        skip_env("Local server isn't Scylla")
     return path
 
 # A fixture for finding Scylla's data directory. We get it using the CQL
@@ -234,7 +235,7 @@ def scylla_data_dir(cql):
         dir = json.loads(cql.execute("SELECT value FROM system.config WHERE name = 'data_file_directories'").one().value)[0]
         return dir
     except:
-        pytest.skip("Can't find Scylla sstable directory")
+        skip_env("Can't find Scylla sstable directory")
 
 @pytest.fixture(scope="function")
 def temp_workdir():
@@ -250,7 +251,7 @@ def has_tablets(cql, this_dc):
 @pytest.fixture(scope="function")
 def skip_without_tablets(scylla_only, has_tablets):
     if not has_tablets:
-        pytest.skip("Test needs tablets experimental feature on")
+        skip_env("Test needs tablets experimental feature on")
 
 
 # Like skip_without_tablets but does not require scylla_only, so Cassandra
@@ -281,4 +282,4 @@ def compact_storage(cql):
 @pytest.fixture
 def skip_s3_tests(request):
     if request.config.getoption("--no-minio", default=None):
-        pytest.skip("Skipping S3 related tests being run from test/cqlpy/run")
+        skip_env("Skipping S3 related tests being run from test/cqlpy/run")

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -204,7 +204,7 @@ def random_seed():
 # to the address and port to which our our CQL connection is connected.
 # If such a process exists, we verify that it is Scylla, and return the
 # executable's path. If we can't find the Scylla executable we use
-# pytest.skip() to skip tests relying on this executable.
+# skip_env() to skip tests relying on this executable.
 @pytest.fixture(scope=dynamic_scope())
 def scylla_path(cql):
     pid = local_process_id(cql)

--- a/test/cqlpy/rest_api.py
+++ b/test/cqlpy/rest_api.py
@@ -11,6 +11,8 @@ from . import nodetool
 import pytest
 from contextlib import contextmanager
 
+from test.pylib.skip_types import skip_env
+
 # Sends GET request to REST API. Response is returned as JSON.
 # If API isn't available, `pytest.skip()` is called.
 def get_request(cql, *path):
@@ -18,7 +20,7 @@ def get_request(cql, *path):
         response = requests.get(f"{nodetool.rest_api_url(cql)}/{'/'.join(path)}")
         return response.json()
     else:
-        pytest.skip("REST API not available")
+        skip_env("REST API not available")
 
 # Sends POST request to REST API. Response is returned as JSON or None
 # if the response body was empty (this is typical).
@@ -30,7 +32,7 @@ def post_request(cql, *path):
             return None
         return response.json()
     else:
-        pytest.skip("REST API not available")
+        skip_env("REST API not available")
 
 # Sends DELETE request to REST API. Response is returned as JSON or None
 # if the response body was empty (this is typical).
@@ -42,7 +44,7 @@ def delete_request(cql, *path):
             return None
         return response.json()
     else:
-        pytest.skip("REST API not available")
+        skip_env("REST API not available")
 
 
 # Get column family's metric.
@@ -70,7 +72,7 @@ def scylla_inject_error(cql, err, one_shot=False):
     response = get_request(cql, f'v2/error_injection/injection')
     print("Enabled error injections:", response)
     if not err in response:
-        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+        skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
     try:
         yield
     finally:

--- a/test/cqlpy/rest_api.py
+++ b/test/cqlpy/rest_api.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 from test.pylib.skip_types import skip_env
 
 # Sends GET request to REST API. Response is returned as JSON.
-# If API isn't available, `pytest.skip()` is called.
+# If API isn't available, `skip_env()` is called.
 def get_request(cql, *path):
     if nodetool.has_rest_api(cql):
         response = requests.get(f"{nodetool.rest_api_url(cql)}/{'/'.join(path)}")
@@ -24,7 +24,7 @@ def get_request(cql, *path):
 
 # Sends POST request to REST API. Response is returned as JSON or None
 # if the response body was empty (this is typical).
-# If API isn't available, `pytest.skip()` is called.
+# If API isn't available, `skip_env()` is called.
 def post_request(cql, *path):
     if nodetool.has_rest_api(cql):
         response = requests.post(f"{nodetool.rest_api_url(cql)}/{'/'.join(path)}")
@@ -36,7 +36,7 @@ def post_request(cql, *path):
 
 # Sends DELETE request to REST API. Response is returned as JSON or None
 # if the response body was empty (this is typical).
-# If API isn't available, `pytest.skip()` is called.
+# If API isn't available, `skip_env()` is called.
 def delete_request(cql, *path):
     if nodetool.has_rest_api(cql):
         response = requests.delete(f"{nodetool.rest_api_url(cql)}/{'/'.join(path)}")

--- a/test/cqlpy/test_allow_filtering.py
+++ b/test/cqlpy/test_allow_filtering.py
@@ -30,6 +30,7 @@ import time
 
 from cassandra.protocol import InvalidRequest, ConfigurationException
 
+from test.pylib.skip_types import skip_env
 from .util import unique_name, new_test_table
 
 # check_af_optional() and check_af_mandatory() are utility functions for
@@ -515,7 +516,7 @@ def test_allow_filtering_index_intersection_sai(cql, test_keyspace, cassandra_bu
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(x) USING 'SAI'")
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(y) USING 'SAI'")
         except (InvalidRequest, ConfigurationException):
-            pytest.skip('SAI test skipped, SAI not supported')
+            skip_env('SAI test skipped, SAI not supported')
         cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (0, 0, 0)')
         cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (1, 0, 1)')
         cql.execute(f'INSERT INTO {table}(p, x, y) VALUES (2, 1, 0)')

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -18,6 +18,7 @@ from .util import new_type, unique_name, new_test_table, new_test_keyspace, new_
     new_cql, keyspace_has_tablets, unique_name_prefix, new_session, new_user, new_materialized_view, \
     new_secondary_index
 from .test_service_levels import MAX_USER_SERVICE_LEVELS
+from test.pylib.skip_types import skip_env
 from cassandra.protocol import InvalidRequest, Unauthorized
 from collections.abc import Iterable
 from typing import Any
@@ -1027,7 +1028,7 @@ def test_table_options_quoting(cql, test_keyspace):
                          ids=["alter", "create_index"])
 def test_hide_cdc_table(scylla_only, cql, test_keyspace, cdc_enablement_query, has_tablets):
     if is_create_index(cdc_enablement_query) and not has_tablets:
-        pytest.skip("Test needs tablets experimental feature on")
+        skip_env("Test needs tablets experimental feature on")
 
     cdc_table_suffix = "_scylla_cdc_log"
     with new_test_table(cql, test_keyspace, "a int primary key, b vector<float, 3>") as t:
@@ -1080,7 +1081,7 @@ def test_hide_cdc_table(scylla_only, cql, test_keyspace, cdc_enablement_query, h
                          ids=["alter", "create_index"])
 def test_describe_cdc_log_table_format(scylla_only, cql, test_keyspace, cdc_enablement_query, has_tablets):
     if is_create_index(cdc_enablement_query) and not has_tablets:
-        pytest.skip("Test needs tablets experimental feature on")
+        skip_env("Test needs tablets experimental feature on")
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v vector<float, 3>") as table:
         log_table = f"{table}_scylla_cdc_log"
         _, log_table_name = log_table.split(".")
@@ -1110,7 +1111,7 @@ def test_describe_cdc_log_table_format(scylla_only, cql, test_keyspace, cdc_enab
                          ids=["alter", "create_index"])
 def test_describe_cdc_log_table_create_statement(scylla_only, cql, test_keyspace, cdc_enablement_query, has_tablets):
     if is_create_index(cdc_enablement_query) and not has_tablets:
-        pytest.skip("Test needs tablets experimental feature on")
+        skip_env("Test needs tablets experimental feature on")
 
     def format_create_statement(stmt: str) -> str:
         stmt = " ".join(stmt.split("\n"))
@@ -1174,7 +1175,7 @@ def test_describe_cdc_log_table_create_statement(scylla_only, cql, test_keyspace
                          ids=["alter", "create_index"])
 def test_describe_cdc_log_table_opts(scylla_only, cql, test_keyspace, cdc_enablement_query, has_tablets):
     if is_create_index(cdc_enablement_query) and not has_tablets:
-        pytest.skip("Test needs tablets experimental feature on")
+        skip_env("Test needs tablets experimental feature on")
 
     def test_config(altered_cdc_log_table_opt):
         with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v vector<float, 3>") as table:

--- a/test/cqlpy/test_json.py
+++ b/test/cqlpy/test_json.py
@@ -493,7 +493,7 @@ def test_fromjson_timestamp_submilli(cql, table1, cassandra_bug):
 # We need to skip this test because in debug mode memory allocation is not
 # bounded, and this test can hang or crash instead of failing immediately.
 # We also have a smaller xfailing test below, test_tojson_decimal_high_mantissa2.
-@pytest.mark.skip(reason="issue #8002")
+@pytest.mark.skip_bug(reason="issue #8002")
 def test_tojson_decimal_high_mantissa(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, dec) VALUES ({p}, ?)")

--- a/test/cqlpy/test_logs.py
+++ b/test/cqlpy/test_logs.py
@@ -32,6 +32,7 @@ import re
 
 from cassandra import InvalidRequest
 
+from test.pylib.skip_types import skip_env
 from .util import new_test_keyspace, new_test_table, local_process_id
 from .test_batch import generate_big_batch
 
@@ -48,18 +49,18 @@ from .test_batch import generate_big_batch
 def logfile_path(cql):
     pid = local_process_id(cql)
     if not pid:
-        pytest.skip("Can't find local process")
+        skip_env("Can't find local process")
     # Now that we know the process id, use /proc to find if its standard
     # output is redirected to a file. If it is, that's the log file. If it
     # isn't a file, we don't where the user is piping the log.
     try:
         log = os.readlink(f'/proc/{pid}/fd/1')
     except:
-        pytest.skip("Can't find local log file")
+        skip_env("Can't find local log file")
     # If the process's standard output is some pipe or device, it's
     # not the log file we were hoping for...
     if not log.startswith('/') or not os.path.isfile(log):
-        pytest.skip("Can't find local log file")
+        skip_env("Can't find local log file")
     # Scylla can be configured to put the log in syslog, not in the standard
     # output. So let's verify that the file which we found actually looks
     # like a Scylla log and isn't just empty or something... The Scylla log
@@ -67,7 +68,7 @@ def logfile_path(cql):
     with open(log, 'r') as f:
         head = f.read(7)
         if head != 'Scylla ':
-            pytest.skip("Not a Scylla log file")
+            skip_env("Not a Scylla log file")
         yield log
 
 # The "logfile" fixture returns the log file open for reading at the end.

--- a/test/cqlpy/test_logs.py
+++ b/test/cqlpy/test_logs.py
@@ -38,7 +38,7 @@ from .test_batch import generate_big_batch
 
 # A fixture to find the Scylla log file, returning the log file's path.
 # If the log file cannot be found, or it's not Scylla, the fixture calls
-# pytest.skip() to skip any test which uses it. The fixture has module
+# skip_env() to skip any test which uses it. The fixture has module
 # scope, so looking for the log file only happens once. Individual tests
 # should use the function-scope fixture "logfile" below, which takes care
 # of opening the log file for reading in the right place.

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -430,7 +430,7 @@ def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
 # This test currently breaks the build (it repeats a failing build step,
 # and never complete) and we cannot quickly recognize this failure, so
 # to avoid a very slow failure, we currently "skip" this test.
-@pytest.mark.skip(reason="issue #8627, fails very slow")
+@pytest.mark.skip_bug(reason="issue #8627, fails very slow")
 def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
         # No materialized view yet - a "big" value in v is perfectly fine:

--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -152,7 +152,7 @@ def test_totimestamp_date(cql, table1):
 # current Python driver because of bugs it has in converting extreme
 # timestamps - https://github.com/scylladb/python-driver/issues/255 -
 # so the test is skipped.
-@pytest.mark.skip(reason="Python driver bug")
+@pytest.mark.skip_bug(reason="Python driver bug https://github.com/scylladb/python-driver/issues/255")
 def test_totimestamp_date_extreme(cql, table1):
     p = unique_key_int()
     # The day 2**31-2**29 is 2**29 days before the epoch - it's a useless date

--- a/test/cqlpy/test_protocol_exceptions.py
+++ b/test/cqlpy/test_protocol_exceptions.py
@@ -12,6 +12,7 @@ import socket
 import struct
 from test.cqlpy import nodetool
 from test.cqlpy.util import cql_session
+from test.pylib.skip_types import skip_env
 
 def get_protocol_error_metrics(host) -> int:
     result = 0
@@ -196,7 +197,7 @@ def _protocol_error_impl(
         if op == 0x02:
             # READY path
             if trigger_unexpected_auth:
-                pytest.skip("server not configured with authentication, skipping unexpected auth test")
+                skip_env("server not configured with authentication, skipping unexpected auth test")
         elif op == 0x03:
             # AUTHENTICATE path
             if trigger_unexpected_auth:
@@ -303,7 +304,7 @@ def _test_impl(host, flag):
 @pytest.fixture
 def no_ssl(request):
     if request.config.getoption("--ssl"):
-        pytest.skip("skipping non-SSL test on SSL-enabled run")
+        skip_env("skipping non-SSL test on SSL-enabled run")
     yield
 
 # Malformed BATCH with an invalid kind triggers a protocol error.

--- a/test/cqlpy/test_restrictions.py
+++ b/test/cqlpy/test_restrictions.py
@@ -130,7 +130,7 @@ def test_intersection_hang(cql, table4):
 # number of values on the right-hand-side of the restriction. Scylla should
 # cleanly report the error - and not silently ignore it or even crash as in
 # issue #13241.
-@pytest.mark.skip("Crashes due to issue #13241")
+@pytest.mark.skip_bug(reason="Crashes due to issue #13241")
 def test_multi_column_restriction_in(cql, table3):
     p = unique_key_int()
     cql.execute(f'INSERT INTO {table3} (a, b, c, d) VALUES ({p}, 1, 2, 3)')

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1442,7 +1442,7 @@ def test_static_column_index_build(cql, test_keyspace):
 # restrictions. Reproduces #12829.
 # NOTE: currently marked with skip instead of xfail because
 # on_internal_error() crashes Scylla.
-@pytest.mark.skip(reason="issue #12829")
+@pytest.mark.skip_bug(reason="issue #12829")
 def test_static_column_index_restrictions(cql, test_keyspace):
     schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
     with new_test_table(cql, test_keyspace, schema) as table:

--- a/test/cqlpy/test_ssl.py
+++ b/test/cqlpy/test_ssl.py
@@ -17,6 +17,7 @@ import ssl
 import time
 
 from test.pylib.driver_utils import safe_driver_shutdown
+from test.pylib.skip_types import skip_env
 
 
 # This function normalizes the SSL cipher suite name (a string),
@@ -42,7 +43,7 @@ def test_tls_versions(cql):
     # learn from cql.cluster whether SSL is used, and if so which contact
     # points, ports, and other parameters, we should use to connect.
     if not cql.cluster.ssl_context:
-        pytest.skip("SSL-specific tests are skipped without the '--ssl' option")
+        skip_env("SSL-specific tests are skipped without the '--ssl' option")
 
     # TLS v1.2 must be supported, because this is the default version that
     # "cqlsh --ssl" uses. If this fact changes in the future, we may need
@@ -130,7 +131,7 @@ def try_connect(orig_cluster, ssl_version):
 # "optional: false" - as we do in the run-cassandra script.
 def test_non_tls_on_tls(cql):
     if not cql.cluster.ssl_context:
-        pytest.skip("SSL-specific tests are skipped without the '--ssl' option")
+        skip_env("SSL-specific tests are skipped without the '--ssl' option")
     # Copy the configuration of the existing "cql", just not the ssl_context
     cluster = cassandra.cluster.Cluster(
         contact_points=cql.cluster.contact_points,

--- a/test/cqlpy/test_system_tables.py
+++ b/test/cqlpy/test_system_tables.py
@@ -75,7 +75,7 @@ def test_partitions_estimate_simple_small(cql, test_keyspace):
 # This is a relatively long test (takes around 2 seconds), and isn't
 # needed to reproduce #9083 (the previous shorter test does it too),
 # so we skip this test.
-@pytest.mark.skip(reason="slow test, remove skip to try it anyway")
+@pytest.mark.skip_slow(reason="slow test, remove skip to try it anyway")
 def test_partitions_estimate_simple_large(cql, test_keyspace):
     N = 10000
     count = write_table_and_estimate_partitions(cql, test_keyspace, N)

--- a/test/cqlpy/test_tablets.py
+++ b/test/cqlpy/test_tablets.py
@@ -16,6 +16,8 @@ import pytest
 from .util import new_test_keyspace, new_test_table, new_materialized_view, unique_name, index_table_name
 from cassandra.protocol import ConfigurationException, InvalidRequest
 
+from test.pylib.skip_types import skip_env
+
 # A fixture similar to "test_keyspace", just creates a keyspace that enables
 # tablets with initial_tablets=128
 # The "initial_tablets" feature doesn't work if the "tablets" experimental
@@ -27,7 +29,7 @@ def test_keyspace_128_tablets(cql, this_dc):
     try:
         cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "': 1 } AND TABLETS = { 'enabled': true, 'initial': 128 }")
     except ConfigurationException:
-        pytest.skip('Scylla does not support initial_tablets, or the tablets feature is not enabled')
+        skip_env('Scylla does not support initial_tablets, or the tablets feature is not enabled')
     yield name
     cql.execute("DROP KEYSPACE " + name)
 

--- a/test/cqlpy/test_virtual_tables.py
+++ b/test/cqlpy/test_virtual_tables.py
@@ -10,6 +10,8 @@ import json
 
 from collections import defaultdict
 
+from test.pylib.skip_types import skip_env
+
 def verify_snapshots(cql, expected_snapshots: dict[str, set[str]]):
     results = list(cql.execute(f"SELECT keyspace_name, table_name, snapshot_name, live, total FROM system.snapshots"))
     for res in results:
@@ -169,7 +171,7 @@ def test_token_ring_vnodes(scylla_only, cql, test_keyspace_vnodes):
 
 def test_token_ring_tablets(scylla_only, cql, test_keyspace_tablets):
     if test_keyspace_tablets is None:
-        pytest.skip("skipping tablets specific tests -- tablets not enabled")
+        skip_env("skipping tablets specific tests -- tablets not enabled")
 
     with util.new_test_table(cql, test_keyspace_tablets, 'pk int PRIMARY KEY') as table:
         rows = list(cql.execute(f"SELECT * FROM system.token_ring WHERE keyspace_name = '{test_keyspace_tablets}' AND table_name = '{table}'"))

--- a/test/cqlpy/test_wasm.py
+++ b/test/cqlpy/test_wasm.py
@@ -576,7 +576,7 @@ def test_UDA(cql, test_keyspace, table1, scylla_with_wasm_only, metrics):
 # FIXME: shorten the wait time when such configuration becomes possible
 
 # The function grows the memory by n pages and returns n.
-@pytest.mark.skip(reason="slow test, remove skip to try it anyway")
+@pytest.mark.skip_slow(reason="slow test, remove skip to try it anyway")
 def test_mem_grow(cql, test_keyspace, table1, scylla_with_wasm_only, metrics):
     table = table1
     mem_grow_name = "mem_grow_" + unique_name()

--- a/test/cqlpy/test_wasm.py
+++ b/test/cqlpy/test_wasm.py
@@ -16,6 +16,8 @@ import requests
 import re
 import os.path
 
+from test.pylib.skip_types import skip_env
+
 # Can be used for marking functions which require
 # WASM support to be compiled into Scylla
 @pytest.fixture(scope="module")
@@ -27,7 +29,7 @@ def scylla_with_wasm_only(scylla_only, cql, test_keyspace):
         cql.execute(f"DROP FUNCTION {test_keyspace}.{f42}")
     except NoHostAvailable as err:
         if "not enabled" in str(err):
-            pytest.skip("WASM support was not enabled in Scylla, skipping")
+            skip_env("WASM support was not enabled in Scylla, skipping")
     yield
 
 @pytest.fixture(scope="module")
@@ -496,7 +498,7 @@ def metrics(request, scylla_with_wasm_only, cql):
     url = f'http://{cql.cluster.contact_points[0]}:9180/metrics'
     resp = requests.get(url)
     if resp.status_code != 200:
-        pytest.skip('Metrics port 9180 is not available')
+        skip_env('Metrics port 9180 is not available')
     yield url
 
 def get_metrics(metrics):

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -20,6 +20,7 @@ from test import TOP_SRC_DIR, path_to
 from test.nodetool.rest_api_mock import set_expected_requests, expected_request, get_expected_requests, \
     get_unexpected_requests, expected_requests_manager
 from test.pylib.db.model import Test
+from test.pylib.skip_types import skip_env
 
 
 def pytest_addoption(parser):
@@ -185,13 +186,13 @@ def nodetool_path(request, build_mode):
 @pytest.fixture(scope="function")
 def scylla_only(request):
     if request.config.getoption("nodetool") != "scylla":
-        pytest.skip('Scylla-only test skipped')
+        skip_env('Scylla-only test skipped')
 
 
 @pytest.fixture(scope="function")
 def cassandra_only(request):
     if request.config.getoption("nodetool") != "cassandra":
-        pytest.skip('Cassandra-only test skipped')
+        skip_env('Cassandra-only test skipped')
 
 def split_list(l, delim):
     before = []

--- a/test/nodetool/test_ring.py
+++ b/test/nodetool/test_ring.py
@@ -11,6 +11,7 @@ from socket import getnameinfo
 import pytest
 from test.nodetool.rest_api_mock import expected_request
 from test.nodetool.utils import format_size, check_nodetool_fails_with
+from test.pylib.skip_types import skip_env
 
 
 null_ownership_error = ("Non-system keyspaces don't have the same replication settings, "
@@ -73,7 +74,7 @@ def test_ring(request, nodetool, keyspace_table, resolve_ip, host_status, host_s
         keyspace, table = keyspace_table, None
 
     if uses_cassandra_nodetool and table is not None:
-        pytest.skip("skipping tablets-related test with Cassandra nodetool")
+        skip_env("skipping tablets-related test with Cassandra nodetool")
 
     host = Host('dc0', 'rack0', '127.0.0.1', host_status, host_state,
                 6414780.0, 1.0,

--- a/test/nodetool/test_scrub.py
+++ b/test/nodetool/test_scrub.py
@@ -9,6 +9,7 @@ import pytest
 
 from test.nodetool.utils import check_nodetool_fails_with
 from test.nodetool.rest_api_mock import expected_request
+from test.pylib.skip_types import skip_env
 
 
 class scrub_status(enum.Enum):
@@ -81,7 +82,7 @@ def test_scrub_options(request, nodetool, table, mode, quarantine_mode, disable_
             args += list(quarantine_mode)
             expected_params["quarantine_mode"] = quarantine_mode[1]
         else:
-            pytest.skip("--quarantine-mode only supported by scylla-nodetool")
+            skip_env("--quarantine-mode only supported by scylla-nodetool")
 
     if disable_snapshot:
         args.append(disable_snapshot)

--- a/test/nodetool/test_status.py
+++ b/test/nodetool/test_status.py
@@ -12,6 +12,8 @@ from typing import NamedTuple
 
 import pytest
 
+from test.pylib.skip_types import skip_env
+
 
 class NodeStatus(Enum):
     Up = 'U'
@@ -327,7 +329,7 @@ def test_status_no_keyspace_single_dc(request, nodetool):
 @pytest.mark.parametrize("table", (None, "cf"))
 def test_status_keyspace_single_dc(request, nodetool, uses_tablets, table):
     if request.config.getoption("nodetool") == "cassandra" and (uses_tablets or table):
-        pytest.skip("skipping tablets-related test with Cassandra nodetool")
+        skip_env("skipping tablets-related test with Cassandra nodetool")
 
     nodes = [
         Node(
@@ -416,7 +418,7 @@ def test_status_no_keyspace_multi_dc(request, nodetool):
 @pytest.mark.parametrize("table", (None, "cf"))
 def test_status_keyspace_multi_dc(request, nodetool, uses_tablets, table):
     if request.config.getoption("nodetool") == "cassandra" and (uses_tablets or table):
-        pytest.skip("skipping tablets-related test with Cassandra nodetool")
+        skip_env("skipping tablets-related test with Cassandra nodetool")
 
     nodes = [
         Node(

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -19,6 +19,8 @@ import pytest
 from aiohttp import request, BaseConnector, UnixConnector, ClientTimeout
 from cassandra.pool import Host                          # type: ignore # pylint: disable=no-name-in-module
 
+from test.pylib.skip_types import skip_env
+
 from test.pylib.internal_types import IPAddress, HostID
 from test.pylib.util import universalasync_typed_wrap
 
@@ -710,7 +712,7 @@ async def inject_error(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: 
     enabled = await api.get_enabled_injections(node_ip)
     logging.info(f"Error injections enabled on {node_ip}: {enabled}")
     if not enabled:
-        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+        skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
     try:
         yield InjectionHandler(api, injection, node_ip)
     finally:
@@ -727,7 +729,7 @@ async def inject_error_one_shot(api: ScyllaRESTAPIClient, node_ip: IPAddress, in
     enabled = await api.get_enabled_injections(node_ip)
     logging.info(f"Error injections enabled on {node_ip}: {enabled}")
     if not enabled:
-        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+        skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
     return InjectionHandler(api, injection, node_ip)
 
 

--- a/test/pylib/skip_reason_plugin.py
+++ b/test/pylib/skip_reason_plugin.py
@@ -23,7 +23,6 @@ convenience wrappers from :mod:`test.pylib.skip_types`::
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable
 from enum import StrEnum
 
@@ -114,15 +113,14 @@ class SkipReasonPlugin:
                     item.stash[SKIP_TYPE_KEY] = str(st)
                     item.stash[SKIP_REASON_KEY] = reason
 
-            # Warn on bare pytest.mark.skip not added by typed markers.
+            # Reject bare pytest.mark.skip not added by typed markers.
             # skip_mode sets SKIP_TYPE_KEY before this hook runs (trylast).
             if SKIP_TYPE_KEY not in item.stash:
                 bare = [self._get_reason(m) for m in item.iter_markers("skip")]
                 if bare:
                     alternatives = ", ".join(
                         f"@pytest.mark.{st.marker_name}" for st in self._skip_types)
-                    # TODO: Change to pytest.fail() after full migration.
-                    warnings.warn(
+                    raise pytest.UsageError(
                         f"Untyped skip on {item.nodeid}: {'; '.join(bare)}. "
                         f"Use {alternatives} instead.",
                     )

--- a/test/pylib_test/test_no_bare_skips.py
+++ b/test/pylib_test/test_no_bare_skips.py
@@ -1,0 +1,87 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""Codebase guard tests: verify no bare pytest.skip usage remains.
+
+These are project-specific tests that scan the ScyllaDB test tree
+for bare @pytest.mark.skip decorators and bare pytest.skip() calls.
+Any new skip must use the typed markers or the typed skip() helper.
+"""
+
+import ast
+import os
+import pathlib
+import subprocess
+import sys
+
+_TEST_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+def _iter_test_py_files():
+    """Yield all .py files under test/ excluding pylib_test/, pylib/ and __pycache__."""
+    for p in sorted(_TEST_ROOT.rglob("*.py")):
+        rel = p.relative_to(_TEST_ROOT)
+        parts = rel.parts
+        if "__pycache__" in parts:
+            continue
+        if parts[0] in ("pylib_test", "pylib"):
+            continue
+        yield p
+
+
+def test_no_bare_pytest_skip_calls_in_codebase():
+    """Verify no test files use bare pytest.skip() (must use typed skip() helper)."""
+    violations = []
+    for path in _iter_test_py_files():
+        source = path.read_text()
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if (isinstance(func, ast.Attribute) and func.attr == "skip"
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "pytest"):
+                violations.append(f"  {path}:{node.lineno}")
+    assert not violations, (
+        "Found bare pytest.skip() — use the typed skip() helper instead "
+        "(from test.pylib.skip_reason_plugin import skip):\n"
+        + "\n".join(violations)
+    )
+
+
+def test_no_bare_skip_markers_in_collection():
+    """Collect all real Python tests and verify no bare @pytest.mark.skip exists.
+
+    The skip_reason_plugin raises pytest.UsageError during collection
+    if any bare skip decorator is found, so --collect-only is enough.
+    No Scylla binary is needed — only Python collection.
+    """
+
+    # When running under xdist (-n), workers inherit PYTEST_XDIST_WORKER.
+    # If the subprocess inherits it, the runner plugin thinks it is a
+    # worker and skips creating the log directory — causing a
+    # FileNotFoundError.  Strip xdist env vars so the subprocess runs
+    # as a standalone main process.
+    env = {k: v for k, v in os.environ.items()
+           if not k.startswith("PYTEST_XDIST")}
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest",
+         "--collect-only",
+         "--ignore=boost", "--ignore=raft",
+         "--ignore=ldap", "--ignore=vector_search",
+         "-p", "no:sugar"],
+        capture_output=True, text=True,
+        cwd=str(_TEST_ROOT),
+        env=env,
+    )
+    # If a bare skip exists, plugin raises UsageError → non-zero exit.
+    assert result.returncode == 0, (
+            "Collection failed — a bare @pytest.mark.skip was found.\n"
+            + result.stdout + result.stderr
+    )

--- a/test/pylib_test/test_skip_reason_plugin.py
+++ b/test/pylib_test/test_skip_reason_plugin.py
@@ -102,27 +102,26 @@ def test_missing_reason_is_rejected(skippytest, marker):
     assert result.ret != 0
 
 
-# -- Bare skip warning ------------------------------------------------------
+# -- Bare skip rejection -----------------------------------------------------
 
-def test_bare_skip_warns_and_lists_alternatives(skippytest):
-    """Bare skip must warn and list all typed alternatives."""
+def test_bare_skip_rejected_and_lists_alternatives(skippytest):
+    """Bare skip must be rejected with UsageError listing all typed alternatives."""
     skippytest.makepyfile("""
         import pytest
         @pytest.mark.skip(reason="some bare reason")
         def test_bare():
             pass
     """)
-    result = skippytest.runpytest("-W", "all")
-    result.assert_outcomes(skipped=1)
-    out = result.stdout.str()
-    assert "Untyped skip" in out
-    assert "some bare reason" in out
+    result = skippytest.runpytest()
+    result.stderr.fnmatch_lines(["*Untyped skip*some bare reason*"])
+    assert result.ret != 0
+    out = result.stderr.str()
     for m in ("skip_bug", "skip_not_implemented", "skip_slow",
               "skip_env"):
-        assert m in out, f"expected '{m}' in warning output"
+        assert m in out, f"expected '{m}' in error output"
 
 
-def test_bare_skip_in_pytest_param_warns(skippytest):
+def test_bare_skip_in_pytest_param_rejected(skippytest):
     skippytest.makepyfile("""
         import pytest
         @pytest.mark.parametrize("x", [
@@ -133,21 +132,21 @@ def test_bare_skip_in_pytest_param_warns(skippytest):
         def test_p(x):
             pass
     """)
-    result = skippytest.runpytest("-W", "all")
-    result.assert_outcomes(passed=1, skipped=1)
-    assert "Untyped skip" in result.stdout.str()
+    result = skippytest.runpytest()
+    result.stderr.fnmatch_lines(["*Untyped skip*bare in param*"])
+    assert result.ret != 0
 
 
-def test_typed_skip_does_not_warn(skippytest):
+def test_typed_skip_does_not_reject(skippytest):
     skippytest.makepyfile("""
         import pytest
         @pytest.mark.skip_bug(reason="scylladb/scylladb#11111")
         def test_typed():
             pass
     """)
-    result = skippytest.runpytest("-W", "error::UserWarning")
+    result = skippytest.runpytest()
     result.assert_outcomes(skipped=1)
-    assert "Untyped skip" not in result.stdout.str()
+    assert "Untyped skip" not in result.stderr.str()
 
 
 # -- Runtime skip helper ----------------------------------------------------
@@ -297,8 +296,8 @@ def test_skip_mode_prefix_populates_junit(skippytest, tmp_path):
     assert "not supported in release" in xml
 
 
-def test_bare_skip_with_skip_mode_no_warn(skippytest):
-    """When skip_mode uses skip_marker(), bare-skip warning is suppressed
+def test_bare_skip_with_skip_mode_no_rejection(skippytest):
+    """When skip_mode uses skip_marker(), bare-skip rejection is suppressed
     for the item even if it also has a bare @pytest.mark.skip. The
     skip_marker() call signals the item already has a typed skip.
     """
@@ -310,7 +309,6 @@ def test_bare_skip_with_skip_mode_no_warn(skippytest):
         def test_both_bare_and_mode():
             assert False
     """)
-    result = skippytest.runpytest("-W", "all")
+    result = skippytest.runpytest()
     result.assert_outcomes(skipped=1)
-    out = result.stdout.str()
-    assert "Untyped skip" not in out
+    assert "Untyped skip" not in result.stderr.str()

--- a/test/rest_api/conftest.py
+++ b/test/rest_api/conftest.py
@@ -15,6 +15,7 @@ import requests
 from test.conftest import dynamic_scope
 from test.cqlpy.conftest import host, cql, this_dc  # add required fixtures
 from test.cqlpy.util import unique_name, new_test_keyspace, keyspace_has_tablets, is_scylla
+from test.pylib.skip_types import skip_env
 from test.pylib.suite.python import add_host_option, add_cql_connection_options
 
 # By default, tests run against a Scylla server listening
@@ -63,7 +64,7 @@ def scylla_only(cql):
     # We recognize Scylla by checking if there is any system table whose name
     # contains the word "scylla":
     if not is_scylla(cql):
-        pytest.skip('Scylla-only test skipped')
+        skip_env('Scylla-only test skipped')
 
 @pytest.fixture(scope=dynamic_scope())
 def has_tablets(cql):
@@ -73,12 +74,12 @@ def has_tablets(cql):
 @pytest.fixture(scope="function")
 def skip_with_tablets(has_tablets):
     if has_tablets:
-        pytest.skip("Test may crash with tablets experimental feature on")
+        skip_env("Test may crash with tablets experimental feature on")
 
 @pytest.fixture(scope="function")
 def skip_without_tablets(scylla_only, has_tablets):
     if not has_tablets:
-        pytest.skip("Test needs tablets experimental feature on")
+        skip_env("Test needs tablets experimental feature on")
 
 @pytest.fixture(scope=dynamic_scope())
 def test_keyspace_vnodes(cql, this_dc, has_tablets):

--- a/test/rest_api/rest_util.py
+++ b/test/rest_api/rest_util.py
@@ -4,6 +4,8 @@ import threading
 
 from contextlib import contextmanager
 
+from test.pylib.skip_types import skip_env
+
 # A utility function for creating a new temporary snapshot.
 # If no keyspaces are given, a snapshot is taken over all keyspaces and tables.
 # If no tables are given, a snapshot is taken over all tables in the keyspace.
@@ -51,7 +53,7 @@ def scylla_inject_error(rest_api, err, one_shot=False):
     assert response.ok
     print("Enabled error injections:", response.content.decode('utf-8'))
     if response.content.decode('utf-8') == "[]":
-        pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+        skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
     try:
         yield
     finally:

--- a/test/scylla_gdb/test_task_commands.py
+++ b/test/scylla_gdb/test_task_commands.py
@@ -8,6 +8,7 @@ Each only checks that the command does not fail - but not what it does or return
 
 import pytest
 
+from test.pylib.skip_types import skip_bug
 from test.scylla_gdb.conftest import execute_gdb_command
 
 pytestmark = [
@@ -34,7 +35,7 @@ def test_coroutine_frame(gdb_cmd):
     )
     if "COROUTINE_NOT_FOUND" in result.stdout:
         # See https://github.com/scylladb/scylladb/issues/22501
-        pytest.skip("Failed to find coroutine task. Skipping test.")
+        skip_bug("Failed to find coroutine task. Skipping test. https://github.com/scylladb/scylladb/issues/22501")
     assert result.returncode == 0, (
         f"GDB command `coro_frame` failed. stdout: {result.stdout} stderr: {result.stderr}"
     )


### PR DESCRIPTION
should be merged after #29235

Complete the typed skip markers migration started in the plugin PR.
Every bare `@pytest.mark.skip` decorator and `pytest.skip()` runtime call
across the test suite is replaced with a typed equivalent, making skip
reasons machine-readable in JUnit XML and Allure reports.

**62 files changed** across 8 commits, covering ~127 skip sites in total.

### Motivation

Bare `pytest.skip` provides only a free-text reason string. CI dashboards
(JUnit, Allure) cannot distinguish between a test skipped due to a known
bug, a missing feature, a slow test, or an environment limitation. This
makes it hard to track skip debt, prioritize fixes, or filter dashboards
by skip category.

The typed markers (`skip_bug`, `skip_not_implemented`, `skip_slow`,
`skip_env`) introduced by the `skip_reason_plugin` solve this by embedding
a `skip_type` field into every skip report entry.

### What changed

#### Decorator migrations (40 sites)

| Type | Count | Files | Description |
|------|-------|-------|-------------|
| `skip_bug` | 24 | 16 | Skip reason references a known bug/issue |
| `skip_not_implemented` | 10 | 5 | Feature not yet implemented in Scylla |
| `skip_slow` | 4 | 3 | Test too slow for regular CI runs |
| `skip_not_implemented` (bare) | 2 | 1 | Bare `@pytest.mark.skip` with no reason (COMPACT STORAGE, #3882) |

#### Runtime migrations (~87 sites)

| Type | Count | Files | Description |
|------|-------|-------|-------------|
| `skip_env` | ~85 | 34 | Feature/config/topology not available at runtime |
| `skip_bug` | 2 | 2 | Known bugs: Streams on tablets (#23838), coroutine task not found (#22501) |

#### Cleanup & hardening

- **Comments**: 7 comments/docstrings across 5 files updated from `pytest.skip()` to `skip()`
- **Plugin hardened**: `warnings.warn()` → `pytest.UsageError` for bare `@pytest.mark.skip` at collection time — bare skips are now a hard error, not a warning
- **Guard tests**: New `test/pylib_test/test_no_bare_skips.py` with 3 tests that prevent regression:
  - AST scan for bare `@pytest.mark.skip` decorators
  - AST scan for bare `pytest.skip()` runtime calls
  - Real `pytest --collect-only` against all Python test directories

#### Import pattern

Runtime skip sites use the convenience wrappers from `test.pylib.skip_types`:
```python
from test.pylib.skip_types import skip_env
```

Usage:
```python
skip_env("Tablets not enabled")
```

### Commits

1. **test: migrate @pytest.mark.skip to @pytest.mark.skip_bug for known bugs** — 24 decorator sites, 16 files
2. **test: migrate @pytest.mark.skip to @pytest.mark.skip_not_implemented** — 10 decorator sites, 5 files
3. **test: migrate @pytest.mark.skip to @pytest.mark.skip_slow** — 4 decorator sites, 3 files
4. **test: migrate bare @pytest.mark.skip to skip_not_implemented** — 2 bare decorators, 1 file
5. **test: migrate runtime pytest.skip() to typed skip_env()** — ~85 sites, 34 files
6. **test: migrate runtime pytest.skip() to typed skip_bug()** — 2 sites, 2 files
7. **test: update comments referencing pytest.skip() to skip()** — 7 comments, 5 files
8. **test/pylib: reject bare pytest.mark.skip and add codebase guards** — plugin hardening + 3 guard tests

### Testing

- All 60 plugin + guard tests pass (`test/pylib_test/`)
- No bare `@pytest.mark.skip` or `pytest.skip()` calls remain in the codebase
- `pytest --collect-only` succeeds across all test directories with the hardened plugin

SCYLLADB-1349
