### PR TITLE
Restrict tombstone GC sstable set to repaired sstables for tombstone_gc=repair mode

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -240,7 +240,7 @@ static max_purgeable get_max_purgeable_timestamp(const compaction_group_view& ta
     // and if the memtable also contains the key we're calculating max purgeable timestamp for.
     // First condition helps to not penalize the common scenario where memtable only contains
     // newer data.
-    if (memtable_min_timestamp <= compacting_max_timestamp && table_s.memtable_has_key(dk)) {
+    if (!table_s.skip_memtable_for_tombstone_gc() && memtable_min_timestamp <= compacting_max_timestamp && table_s.memtable_has_key(dk)) {
         timestamp = memtable_min_timestamp;
         source = max_purgeable::timestamp_source::memtable_possibly_shadowing_data;
     }

--- a/compaction/compaction_group_view.hh
+++ b/compaction/compaction_group_view.hh
@@ -39,6 +39,9 @@ public:
     virtual future<lw_shared_ptr<const sstables::sstable_set>> main_sstable_set() const = 0;
     virtual future<lw_shared_ptr<const sstables::sstable_set>> maintenance_sstable_set() const = 0;
     virtual lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const = 0;
+    // Returns true when tombstone GC considers only the repaired sstable set, meaning the
+    // memtable does not need to be consulted (its data is always newer than any GC-eligible tombstone).
+    virtual bool skip_memtable_for_tombstone_gc() const noexcept = 0;
     virtual std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point compaction_time) const = 0;
     virtual const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept = 0;
     virtual compaction_strategy& get_compaction_strategy() const noexcept = 0;

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -240,6 +240,9 @@ future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::
             _progress_tracker->on_sstable_registration(sst);
         }
 
+        utils::get_local_injector().inject("view_update_generator_pause_before_processing",
+                utils::wait_for_message(std::chrono::minutes(5))).get();
+
         // Generate view updates from staging sstables
         auto start_time = db_clock::now();
         auto [result, input_size] = generate_updates_from_staging_sstables(table, sstables);

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -269,6 +269,10 @@ public:
     // Gets the view a sstable currently belongs to.
     compaction::compaction_group_view& view_for_sstable(const sstables::shared_sstable& sst) const;
     utils::small_vector<compaction::compaction_group_view*, 3> all_views() const;
+    // Returns true iff v is the repaired view of this compaction group.
+    bool is_repaired_view(const compaction::compaction_group_view* v) const noexcept;
+    // Returns an sstable set containing only repaired sstables (those classified as repaired).
+    lw_shared_ptr<sstables::sstable_set> make_repaired_sstable_set() const;
 
     seastar::condition_variable& get_staging_done_condition() noexcept {
         return _staging_done_condition;
@@ -404,6 +408,8 @@ public:
 
     // Make an sstable set spanning all sstables in the storage_group
     lw_shared_ptr<const sstables::sstable_set> make_sstable_set() const;
+    // Like make_sstable_set(), but restricted to repaired sstables only across all compaction groups.
+    lw_shared_ptr<const sstables::sstable_set> make_repaired_sstable_set() const;
 
     future<utils::chunked_vector<logstor::segment_snapshot>> take_logstor_snapshot() const;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -757,6 +757,10 @@ private:
     // groups during tablet split with overlapping token range, and we need to include them all in a single
     // sstable set to allow safe tombstone gc.
     lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc(const compaction_group&) const;
+    // Like sstable_set_for_tombstone_gc(), but restricted to repaired sstables only across all compaction
+    // groups of the same tablet (storage group).  Used by the tombstone_gc=repair optimization to avoid
+    // scanning unrepaired sstables when looking for GC-blocking shadows.
+    lw_shared_ptr<const sstables::sstable_set> make_repaired_sstable_set_for_tombstone_gc(const compaction_group&) const;
 
     bool cache_enabled() const {
         return _config.enable_cache && _schema->caching_options().enabled();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1203,9 +1203,33 @@ future<utils::chunked_vector<logstor::segment_snapshot>> storage_group::take_log
     co_return std::move(snp);
 }
 
+lw_shared_ptr<const sstables::sstable_set> storage_group::make_repaired_sstable_set() const {
+    if (_split_ready_groups.empty() && _merging_groups.empty()) {
+        return _main_cg->make_repaired_sstable_set();
+    }
+    const auto& schema = _main_cg->_t.schema();
+    std::vector<lw_shared_ptr<sstables::sstable_set>> underlying;
+    underlying.reserve(1 + _merging_groups.size() + _split_ready_groups.size());
+    underlying.emplace_back(_main_cg->make_repaired_sstable_set());
+    for (const auto& cg : _merging_groups) {
+        if (!cg->empty()) {
+            underlying.emplace_back(cg->make_repaired_sstable_set());
+        }
+    }
+    for (const auto& cg : _split_ready_groups) {
+        underlying.emplace_back(cg->make_repaired_sstable_set());
+    }
+    return make_lw_shared(sstables::make_compound_sstable_set(schema, std::move(underlying)));
+}
+
 lw_shared_ptr<const sstables::sstable_set> table::sstable_set_for_tombstone_gc(const compaction_group& cg) const {
     auto& sg = storage_group_for_id(cg.group_id());
     return sg.make_sstable_set();
+}
+
+lw_shared_ptr<const sstables::sstable_set> table::make_repaired_sstable_set_for_tombstone_gc(const compaction_group& cg) const {
+    auto& sg = storage_group_for_id(cg.group_id());
+    return sg.make_repaired_sstable_set();
 }
 
 bool tablet_storage_group_manager::all_storage_groups_split() {
@@ -3000,8 +3024,46 @@ public:
     future<lw_shared_ptr<const sstables::sstable_set>> maintenance_sstable_set() const override {
         return make_sstable_set_for_this_view(_cg.maintenance_sstables(), [this] { return *_cg.make_maintenance_sstable_set(); });
     }
+private:
+    // Returns true when tombstone GC is restricted to the repaired set:
+    // tombstone_gc=repair mode and this view is the repaired view.
+    //
+    // The optimization is safe for materialized view tables as well as base tables.
+    // The key invariant for MV: MV tablet repair calls flush_hints() before
+    // take_storage_snapshot().  flush_hints() creates a sync point that covers BOTH
+    // _hints_manager (base mutations) AND _hints_for_views_manager (view mutations).
+    // It waits until all pending hints — including any D_view hint stored in
+    // _hints_for_views_manager while the target node was down — have been replayed
+    // to the target node.  Only then is take_storage_snapshot() called, which flushes
+    // the MV memtable and captures D_view in the repairing sstable.  After repair
+    // completes, D_view is in the repaired set.
+    //
+    // If a subsequent base repair later replays a D_base hint that causes another
+    // D_view write (same key and timestamp), it is a no-op duplicate: the original
+    // D_view already in the repaired set still prevents T_mv from being purged.
+    //
+    // USING TIMESTAMP with timestamps predating (gc_before + propagation_delay) is
+    // explicitly UB and excluded from the safety argument.
+    bool is_tombstone_gc_repaired_only() const noexcept {
+        return _cg.is_repaired_view(this) &&
+               _t.schema()->tombstone_gc_options().mode() == tombstone_gc_mode::repair;
+    }
+public:
     lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const override {
+        // Optimization: when tombstone_gc=repair and this is the repaired view, only check
+        // repaired sstables. The repair ordering guarantee ensures that by the time a tombstone
+        // becomes GC-eligible (repair_time committed to Raft), any data it shadows has already
+        // been promoted from repairing to repaired. Unrepaired data always has timestamps newer
+        // than any GC-eligible tombstone (legitimate writes; USING TIMESTAMP abuse is UB).
+        // For all other tombstone_gc modes this invariant does not hold, so we fall through to
+        // the full storage-group set.
+        if (is_tombstone_gc_repaired_only()) {
+            return _t.make_repaired_sstable_set_for_tombstone_gc(_cg);
+        }
         return _t.sstable_set_for_tombstone_gc(_cg);
+    }
+    bool skip_memtable_for_tombstone_gc() const noexcept override {
+        return is_tombstone_gc_repaired_only();
     }
     std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point query_time) const override {
         return compaction::get_fully_expired_sstables(*this, sstables, query_time);
@@ -5417,6 +5479,21 @@ compaction::compaction_group_view& compaction_group::as_view_for_static_sharding
 
 compaction::compaction_group_view& compaction_group::view_for_unrepaired_data() const {
     return *_unrepaired_view;
+}
+
+bool compaction_group::is_repaired_view(const compaction::compaction_group_view* v) const noexcept {
+    return v == _repaired_view.get();
+}
+
+lw_shared_ptr<sstables::sstable_set> compaction_group::make_repaired_sstable_set() const {
+    auto set = make_lw_shared<sstables::sstable_set>(make_main_sstable_set());
+    auto sstables_repaired_at = get_sstables_repaired_at();
+    for (auto& sst : *_main_sstables->all()) {
+        if (repair::is_repaired(sstables_repaired_at, sst)) {
+            set->insert(sst);
+        }
+    }
+    return set;
 }
 
 compaction::compaction_group_view& compaction_group::view_for_sstable(const sstables::shared_sstable& sst) const {

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -104,6 +104,7 @@ public:
     virtual future<lw_shared_ptr<const sstables::sstable_set>> main_sstable_set() const override { co_return make_lw_shared<const sstables::sstable_set>(_main_set); }
     virtual future<lw_shared_ptr<const sstables::sstable_set>> maintenance_sstable_set() const override { co_return make_lw_shared<const sstables::sstable_set>(_maintenance_set); }
     virtual lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const override { return make_lw_shared<const sstables::sstable_set>(_main_set); }
+    virtual bool skip_memtable_for_tombstone_gc() const noexcept override { return false; }
     virtual std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point compaction_time) const override { return {}; }
     virtual const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept override { return _compacted_undeleted_sstables; }
     virtual compaction::compaction_strategy& get_compaction_strategy() const noexcept override { return _compaction_strategy; }

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -5,10 +5,11 @@
 #
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.repair import load_tablet_sstables_repaired_at, create_table_insert_data_for_repair
+from test.pylib.repair import load_tablet_sstables_repaired_at, load_tablet_repair_time, create_table_insert_data_for_repair
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.tasks.task_manager_client import TaskManagerClient
 from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, new_test_keyspace, new_test_table, trigger_stepdown
+from test.pylib.util import wait_for_cql_and_get_hosts
 
 from cassandra.query import ConsistencyLevel
 
@@ -1050,3 +1051,262 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
         f"on servers[1] after restart lost the being_repaired markers during the race window. " \
         f"They are UNREPAIRED on servers[0] and servers[2] (classification divergence). " \
         f"Wrongly promoted (first 10): {sorted(wrongly_promoted)[:10]}"
+
+# ----------------------------------------------------------------------------
+# Tombstone GC safety tests
+#
+# These tests verify that incremental repair with tombstone_gc=repair never
+# causes data resurrection via premature tombstone GC.  The key invariant is:
+#
+#   mark_sstable_as_repaired() completes on ALL replicas BEFORE the coordinator
+#   commits repair_time to Raft.  Therefore, by the time gc_before advances and
+#   a tombstone T becomes GC-eligible, any data D that T shadows has already
+#   been promoted from the repairing set to the repaired set.  Tombstone GC
+#   running on the repaired set will always see D there and will prevent T from
+#   being purged prematurely.
+#
+# Three scenarios are tested:
+#
+# 1. Basic ordering guarantee: D arrives via hint flush at the start of repair,
+#    is captured in the repairing snapshot, and is promoted to repaired before
+#    repair_time advances.  GC then runs on the repaired set; T must not be
+#    purged while D is still present.
+#
+# 2. Hints flush failure: hints flush times out on one replica so D is not
+#    delivered during that repair.  repair_time must NOT advance (the guard in
+#    repair that skips the repair_history update when hints_batchlog_flushed is
+#    false).  Therefore T does not become GC-eligible from this repair, and no
+#    resurrection can occur even though D is not yet on that replica.
+#
+# 3. Propagation delay: D is written with an old USING TIMESTAMP (simulating a
+#    write that arrives within the propagation delay window).  T is written
+#    later with a higher timestamp.  Repair runs, D is captured in repairing
+#    (delivered via hint flush), T is in repaired.  After repair completes D is
+#    in repaired too.  GC on the repaired set must not purge T because D has a
+#    lower timestamp but is visible.
+# ----------------------------------------------------------------------------
+
+async def _setup_tombstone_gc_cluster(manager, *, tablets=2, extra_cmdline=None):
+    """Create a 3-node cluster with a tombstone_gc=repair table and return
+    (servers, cql, hosts, ks, table_id, logs).
+
+    Uses propagation_delay_in_seconds=0 so that tombstones become GC-eligible
+    immediately after repair_time is committed (T.deletion_time < repair_time = gc_before),
+    allowing the tests to actually exercise the GC eligibility path without sleeping.
+    """
+    cmdline = ['--logger-log-level', 'repair=debug']
+    if extra_cmdline:
+        cmdline += extra_cmdline
+    servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(
+        manager, nr_keys=0, cmdline=cmdline, tablets=tablets,
+        disable_flush_cache_time=True)
+    # Lower propagation_delay to 0 so gc_before = repair_time, making tombstones
+    # GC-eligible immediately after a successful repair rather than 1h later.
+    await cql.run_async(
+        f"ALTER TABLE {ks}.test WITH tombstone_gc = {{'mode': 'repair', 'propagation_delay_in_seconds': '0'}}"
+    )
+    logs = [await manager.server_open_log(s.server_id) for s in servers]
+    return servers, cql, hosts, ks, table_id, logs
+
+
+async def _trigger_repaired_compaction(manager, server, ks):
+    """Force a compaction that operates on the repaired sstable set."""
+    await manager.api.keyspace_compaction(server.ip_addr, ks, "test")
+
+
+async def _assert_key_visible(cql, ks, key, hosts, *, msg=""):
+    """Assert that key is readable on every replica (by querying each host directly)."""
+    for h in hosts:
+        rows = await cql.run_async(
+            f"SELECT pk FROM {ks}.test WHERE pk = {key}",
+            host=h)
+        assert rows, f"Key {key} not found on host {h} after tombstone GC compaction. {msg}"
+
+
+async def _assert_key_deleted(cql, ks, key, hosts, *, msg=""):
+    """Assert that key is not visible (tombstone wins) on every replica."""
+    for h in hosts:
+        rows = await cql.run_async(
+            f"SELECT pk FROM {ks}.test WHERE pk = {key}",
+            host=h)
+        assert not rows, f"Key {key} unexpectedly visible on host {h} — data resurrection! {msg}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tombstone_gc_no_resurrection_basic_ordering(manager: ManagerClient):
+    """Verify that the ordering guarantee prevents premature tombstone GC.
+
+    With propagation_delay=0, gc_before = repair_time.  T.deletion_time (wall-clock
+    time of DELETE, just before repair starts) < repair_time = gc_before, so T IS
+    GC-eligible after repair.  D (CQL timestamp=1) is in the repaired set because it
+    was captured in the repairing snapshot and promoted before repair_time was committed.
+    Compaction on the repaired set must NOT purge T because D (min_live_timestamp=1)
+    makes T non-purgeable (T.timestamp=2 > max_purgeable=1).
+
+    Scenario:
+      - D written at ts=1 to all replicas, flushed.
+      - T (row deletion, ts=2) written to all replicas, flushed.
+      - Repair runs: both D and T move repairing → repaired.  repair_time advances.
+      - gc_before = repair_time > T.deletion_time  →  T is GC-eligible.
+      - Repaired compaction must NOT purge T because D (in repaired) prevents it.
+      - Key must remain deleted.
+    """
+    servers, cql, hosts, ks, table_id, logs = await _setup_tombstone_gc_cluster(manager)
+
+    # D at ts=1, T at ts=2 (T wins over D, correctly deletes the row).
+    key = 42
+    await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({key}, 1) USING TIMESTAMP 1")
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+
+    await cql.run_async(f"DELETE FROM {ks}.test USING TIMESTAMP 2 WHERE pk = {key}")
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+
+    # Both D and T captured in repairing, then promoted to repaired.  repair_time advances.
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all", incremental_mode='incremental')
+
+    # With propagation_delay=0: gc_before = repair_time > T.deletion_time → T is GC-eligible.
+    # Compaction on the repaired set: D is also in repaired (promoted before repair_time
+    # was committed), so max_purgeable = D.timestamp = 1 < T.timestamp = 2 → T not purgeable.
+    for s in servers:
+        await _trigger_repaired_compaction(manager, s, ks)
+
+    # T must not have been GC'd; key must remain deleted (not resurrected).
+    await _assert_key_deleted(cql, ks, key, hosts,
+                              msg="T was prematurely GC'd on repaired compaction (D in repaired should prevent it)")
+
+    logger.info("test_tombstone_gc_no_resurrection_basic_ordering: PASSED")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tombstone_gc_no_resurrection_hints_flush_failure(manager: ManagerClient):
+    """Verify that repair_time stays at epoch when hints flush fails, so tombstones
+    are never GC-eligible after such a repair and data resurrection cannot occur.
+
+    With propagation_delay=0, gc_before = repair_time.  When hints flush fails,
+    repair_time is set to epoch (gc_clock::time_point{}) by the repair framework
+    (flush_time stays at epoch because hints_batchlog_flushed=False).  Therefore
+    gc_before = epoch, T.deletion_time ≈ now >> epoch, T is never GC-eligible, and
+    compaction cannot purge T regardless of what is in the repaired set.
+
+    Scenario:
+      - D and T written to all replicas and flushed.
+      - Repair runs with injection that makes hints flush fail on servers[2].
+      - repair_time must stay at epoch (guard: hints_batchlog_flushed=False).
+      - Compaction on the repaired set: T not GC-eligible → key stays deleted.
+    """
+    servers, cql, hosts, ks, table_id, logs = await _setup_tombstone_gc_cluster(manager)
+
+    key = 99
+
+    # Write D at ts=1 and T at ts=2 to all nodes so everyone has the tombstone.
+    await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({key}, 1) USING TIMESTAMP 1")
+    await cql.run_async(f"DELETE FROM {ks}.test USING TIMESTAMP 2 WHERE pk = {key}")
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+
+    # Read the initial repair_time so we can verify it doesn't meaningfully advance.
+    initial_repair_times = await load_tablet_repair_time(cql, hosts, table_id)
+
+    # Inject: make batchlog manager appear uninitialized on servers[2] so hints flush fails.
+    await manager.api.enable_injection(servers[2].ip_addr, "repair_flush_hints_batchlog_handler_bm_uninitialized", one_shot=False)
+
+    try:
+        # Repair warns about hints flush failure but continues (repair.cc outer catch).
+        # flush_time stays at epoch so repair_time will be set to epoch in system.tablets.
+        await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all", incremental_mode='incremental')
+    except Exception:
+        pass  # repair may report failure; we care about side-effects only
+    finally:
+        await manager.api.disable_injection(servers[2].ip_addr, "repair_flush_hints_batchlog_handler_bm_uninitialized")
+
+    # repair_time must NOT have advanced to a meaningful time (it stays at epoch when
+    # hints flush fails, so gc_before = epoch and T is never GC-eligible).
+    new_repair_times = await load_tablet_repair_time(cql, hosts, table_id)
+    for token, old_time in initial_repair_times.items():
+        new_time = new_repair_times.get(token)
+        assert new_time == old_time or new_time is None, \
+            f"repair_time advanced for token {token} despite hints flush failure: " \
+            f"{old_time} → {new_time}"
+
+    # Trigger compaction on the repaired set; T is not GC-eligible (gc_before = epoch).
+    for s in servers:
+        await _trigger_repaired_compaction(manager, s, ks)
+
+    # Key must remain deleted (T not GC'd).
+    await _assert_key_deleted(cql, ks, key, hosts,
+                              msg="T was prematurely GC'd despite hints flush failure (repair_time should be epoch)")
+
+    logger.info("test_tombstone_gc_no_resurrection_hints_flush_failure: PASSED")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tombstone_gc_no_resurrection_propagation_delay(manager: ManagerClient):
+    """Verify the ordering guarantee when D arrives via hint flush just before repair.
+
+    D has an old CQL timestamp (ts_d = now - 2h) simulating a write that was delayed
+    by the propagation window.  T has a higher CQL timestamp (ts_t = now - 90min) so T
+    correctly shadows D.  With propagation_delay=0, T becomes GC-eligible as soon as
+    repair_time is committed (T.deletion_time < repair_time = gc_before).
+
+    The invariant being tested: mark_sstable_as_repaired() runs on all replicas BEFORE
+    the coordinator commits repair_time to Raft.  So when gc_before advances (repair_time
+    committed), D is already in the repaired set on all replicas.  Repaired compaction
+    must NOT purge T because D (min_live_timestamp = ts_d < ts_t) is present there.
+
+    Scenario:
+      - servers[2] stopped; D and T written (go to hints on coordinator for servers[2]).
+      - D and T flushed on servers[0] and servers[1].
+      - servers[2] restarted.
+      - Repair: hints flush delivers D and T to servers[2] before the repairing snapshot.
+        mark_sstable_as_repaired() promotes D and T to repaired on servers[2].
+        repair_time then committed.  gc_before = repair_time > T.deletion_time.
+      - Repaired compaction: D (ts_d) in repaired prevents T (ts_t > ts_d) from being GC'd.
+      - Key must remain deleted.
+    """
+    servers, cql, hosts, ks, table_id, logs = await _setup_tombstone_gc_cluster(
+        manager, extra_cmdline=['--hinted-handoff-enabled', '1'])
+
+    # Stop servers[2] so writes to it are queued as hints on the coordinator.
+    await manager.server_stop_gracefully(servers[2].server_id)
+
+    key = 77
+    # CQL USING TIMESTAMP is in microseconds since epoch.
+    now_us = int(time.time() * 1e6)
+    ts_d = now_us - int(2 * 3600 * 1e6)    # 2 hours ago (CQL µs timestamp)
+    ts_t = now_us - int(90 * 60 * 1e6)      # 90 minutes ago (CQL µs timestamp); ts_t > ts_d
+
+    # D and T go to servers[0] and servers[1] directly; servers[2] gets hints queued.
+    await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({key}, 1) USING TIMESTAMP {ts_d}")
+    await cql.run_async(f"DELETE FROM {ks}.test USING TIMESTAMP {ts_t} WHERE pk = {key}")
+
+    for s in [servers[0], servers[1]]:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+
+    # Restart servers[2]; D and T are not on its disk yet.
+    await manager.server_start(servers[2].server_id)
+    await manager.servers_see_each_other(servers)
+    await reconnect_driver(manager)
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    # Repair: hints flush sends D and T to servers[2] before the repairing snapshot.
+    # After row sync, mark_sstable_as_repaired() promotes D and T to repaired on servers[2].
+    # Only then does the coordinator commit repair_time to Raft.
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all", incremental_mode='incremental')
+
+    # With propagation_delay=0: gc_before = repair_time > T.deletion_time → T is GC-eligible.
+    # But D (ts_d < ts_t) is already in repaired on servers[2], so max_purgeable = ts_d
+    # < ts_t = T.timestamp → T is NOT purgeable.
+    for s in servers:
+        await _trigger_repaired_compaction(manager, s, ks)
+
+    # Key must remain deleted (T not GC'd, D not resurrected).
+    await _assert_key_deleted(cql, ks, key, hosts,
+                              msg="Data resurrection: T was GC'd despite D being present in repaired set")
+
+    logger.info("test_tombstone_gc_no_resurrection_propagation_delay: PASSED")

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -11,7 +11,7 @@ from test.cluster.tasks.task_manager_client import TaskManagerClient
 from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, new_test_keyspace, new_test_table, trigger_stepdown
 from test.pylib.util import wait_for_cql_and_get_hosts
 
-from cassandra.query import ConsistencyLevel
+from cassandra.query import ConsistencyLevel, SimpleStatement
 
 import pytest
 import asyncio
@@ -1217,9 +1217,11 @@ async def test_tombstone_gc_no_resurrection_hints_flush_failure(manager: Manager
     try:
         # Repair warns about hints flush failure but continues (repair.cc outer catch).
         # flush_time stays at epoch so repair_time will be set to epoch in system.tablets.
-        await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all", incremental_mode='incremental')
+        # Use a short timeout: the call may never return because the topology coordinator
+        # keeps re-scheduling repairs when repair_time stays at epoch.
+        await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all", incremental_mode='incremental', timeout=30)
     except Exception:
-        pass  # repair may report failure; we care about side-effects only
+        pass  # repair may report failure or time out; we care about side-effects only
     finally:
         await manager.api.disable_injection(servers[2].ip_addr, "repair_flush_hints_batchlog_handler_bm_uninitialized")
 
@@ -1310,3 +1312,278 @@ async def test_tombstone_gc_no_resurrection_propagation_delay(manager: ManagerCl
                               msg="Data resurrection: T was GC'd despite D being present in repaired set")
 
     logger.info("test_tombstone_gc_no_resurrection_propagation_delay: PASSED")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tombstone_gc_mv_optimization_safe_via_hints(manager: ManagerClient):
+    """Verify the repaired-only tombstone GC optimization is safe for non-co-located MVs
+    when view hints deliver the shadowing row before the MV repair snapshot.
+
+    The optimization (sstable_set_for_tombstone_gc returns only repaired sstables) is
+    extended to materialized view tables.  For this to be safe, any D_view that could
+    shadow a GC-eligible T_mv in the repaired set must itself be in the repaired set by
+    the time repaired compaction runs.
+
+    The repair invariant that makes this safe: flush_hints() is called before
+    take_storage_snapshot() during tablet repair.  flush_hints() creates a sync point
+    covering BOTH _hints_manager (base mutations) AND _hints_for_views_manager (view
+    mutations).  It waits until ALL pending hints — including D_view entries stored in
+    hints_for_views_manager while the target node was down — have been replayed to the
+    target node before the repairing snapshot is taken.  D_view therefore lands in the
+    MV's repairing sstable and is promoted to repaired.  When a repaired compaction then
+    checks for shadows it finds D_view in the repaired set, keeping T_mv non-purgeable.
+
+    Scenario:
+      1. 3-node cluster, base table + MV with tombstone_gc=repair, propagation_delay=0,
+         SYNCHRONOUS_UPDATES=TRUE, 1 tablet (ensures single tablet for predictable placement).
+      2. Stop servers[2]; D_base(ts_d) and T_base(ts_t) written to servers[0] and servers[1].
+         View update dispatch: D_view(ts_d) and T_mv(ts_t) hints queued in
+         hints_for_views_manager for servers[2].
+      3. Flush servers[0] and servers[1] so the data is in sstables.
+      4. Start servers[2] (view hints still pending).
+      5. Run MV tablet repair: flush_hints() replays D_view + T_mv to servers[2] before
+         take_storage_snapshot(); both are captured in the repairing sstable and promoted
+         to repaired.  repair_time committed; gc_before = repair_time > T_mv.deletion_time.
+      6. Trigger repaired compaction on servers[2]'s MV.  With the optimization applied:
+         only repaired sstables are scanned for shadows; D_view (ts_d) is found there →
+         max_purgeable < ts_t → T_mv is NOT purged.
+      7. Assert: the MV row is NOT visible on servers[2] — T_mv preserved, no resurrection.
+    """
+    servers, cql, hosts, ks, table_id, logs = await _setup_tombstone_gc_cluster(
+        manager, tablets=1, extra_cmdline=['--hinted-handoff-enabled', '1'])
+
+    mv_name = "mv_test"
+    await cql.run_async(
+        f"CREATE MATERIALIZED VIEW {ks}.{mv_name} AS "
+        f"SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL "
+        f"PRIMARY KEY (c, pk) "
+        f"WITH SYNCHRONOUS_UPDATES = TRUE "
+        f"AND tombstone_gc = {{'mode': 'repair', 'propagation_delay_in_seconds': '0'}}"
+    )
+
+    # Stop servers[2] so it misses the base writes; view hints will be queued for it.
+    await manager.server_stop_gracefully(servers[2].server_id)
+
+    key = 99
+    c_val = 7
+    now_us = int(time.time() * 1e6)
+    ts_d = now_us - int(2 * 3600 * 1e6)   # 2 hours ago
+    ts_t = now_us - int(1 * 3600 * 1e6)   # 1 hour ago (ts_t > ts_d so T_mv shadows D_view)
+
+    # D_base and T_base go to servers[0] and servers[1] only.  servers[2] is down:
+    # S0/S1 dispatch D_view and T_mv to MV replicas; for servers[2] these are stored as
+    # view hints in hints_for_views_manager.
+    await cql.run_async(
+        f"INSERT INTO {ks}.test (pk, c) VALUES ({key}, {c_val}) USING TIMESTAMP {ts_d}"
+    )
+    await cql.run_async(
+        f"DELETE FROM {ks}.test USING TIMESTAMP {ts_t} WHERE pk = {key}"
+    )
+
+    for s in [servers[0], servers[1]]:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+
+    # Restart servers[2]; view hints (D_view + T_mv) are still pending.
+    await manager.server_start(servers[2].server_id)
+    await manager.servers_see_each_other(servers)
+    await reconnect_driver(manager)
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    # MV tablet repair:
+    #   flush_hints() → hints_for_views_manager replays D_view + T_mv to servers[2] before snapshot
+    #   take_storage_snapshot() flushes MV memtable → D_view + T_mv in repairing sstable
+    #   mark_sstable_as_repaired() → D_view + T_mv promoted to repaired
+    #   repair_time committed → gc_before = repair_time > T_mv.deletion_time → T_mv GC-eligible
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, mv_name, "all", incremental_mode='incremental')
+
+    # Repaired compaction on servers[2] MV with the optimization applied to MV:
+    # repaired set scanned → D_view(ts_d) found → max_purgeable = ts_d < ts_t → T_mv non-purgeable.
+    await manager.api.keyspace_compaction(servers[2].ip_addr, ks, mv_name)
+
+    # Query servers[2] directly (CL=ONE).  If T_mv was incorrectly GC'd, D_view would
+    # resurface and the row would be visible — that would be data resurrection.
+    stmt = SimpleStatement(
+        f"SELECT pk FROM {ks}.{mv_name} WHERE c = {c_val} AND pk = {key}",
+        consistency_level=ConsistencyLevel.ONE,
+    )
+    rows = await cql.run_async(stmt, host=hosts[2])
+    assert not rows, (
+        f"Data resurrection on servers[2] MV: (c={c_val}, pk={key}) visible after repaired "
+        f"compaction — T_mv was incorrectly GC'd, meaning D_view was NOT in the repaired set "
+        f"despite the hints-before-snapshot invariant. Optimization is broken for MV."
+    )
+
+    logger.info("test_tombstone_gc_mv_optimization_safe_via_hints: PASSED")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tombstone_gc_mv_safe_staging_processor_delay(manager: ManagerClient):
+    """Verify no resurrection when the view-update-generator staging processor is delayed
+    past the point where T_mv has been GC'd from the repaired set.
+
+    This test exercises the "staging delay" edge case in the tombstone GC optimization safety
+    analysis for materialized views.  The optimization (sstable_set_for_tombstone_gc returns
+    only repaired sstables) could in principle allow T_mv to be purged from the repaired set
+    BEFORE the staging processor has dispatched D_view to MV-on-servers[0].  The test verifies
+    that staging correctly generates a no-op in this situation — no D_view is dispatched — so
+    no resurrection occurs.
+
+    The safety mechanism that prevents resurrection here is the read-before-write performed by
+    stream_view_replica_updates (via as_mutation_source_excluding_staging()):
+      When the staging processor fires, it reads the CURRENT base-table state including T_base
+      (which was written to servers[0] AFTER base repair returned).  The view_update_builder
+      sees T_base as the existing partition tombstone, marks D_base as dead (ts_d < ts_t), and
+      generates NO view update.  D_view is therefore never dispatched to MV-on-servers[0].
+    Because D_view never reaches MV-on-servers[0], no resurrection can occur even if T_mv was
+    already GC'd from the repaired set when staging fires.
+
+    Scenario:
+      1. 3-node cluster, base table + MV, tombstone_gc=repair, propagation_delay=0,
+         SYNCHRONOUS_UPDATES=FALSE, hinted-handoff DISABLED (so no view hints are stored
+         for the offline node).
+      2. Stop servers[0].  D_base(ts_d) written to servers[1] only.
+         servers[1] dispatches D_view to MV replicas on servers[1] and servers[2].
+         MV-on-servers[0] receives nothing.
+      3. Flush servers[1] and servers[2].  Restart servers[0].
+      4. Enable view_update_generator_pause_before_processing injection on servers[0].
+      5. Run BASE table repair.  Row-sync detects servers[0] missing D_base and writes
+         it via the staging path (repair_writer → staging SSTable → view_update_generator).
+         The view_update_generator on servers[0] blocks BEFORE dispatching any view update.
+         Base repair returns without waiting for the staging processor.
+      6. T_base(ts_t > ts_d) written to all three nodes NOW (after base repair).
+         servers[0] dispatches T_mv directly to MV-on-servers[0]; all MV replicas get T_mv.
+      7. Flush all servers.
+      8. Run MV table repair.
+         flush_hints(): no view hints (hinted-handoff disabled) → no-op.
+         take_storage_snapshot(): MV-on-servers[0] has T_mv only; MV-on-servers[1/2] have
+         D_view + T_mv; the maybe_compact_for_streaming reader drops D_view (shadowed by T_mv)
+         → hashes equal → no row-sync needed.
+         repair_time committed; gc_before = repair_time > T_mv.deletion_time → T_mv GC-eligible.
+      9. Trigger repaired compaction on servers[0] MV.
+         Optimization: only repaired sstables scanned → no D_view → T_mv is GC-eligible → T_mv PURGED.
+     10. Assert: key NOT visible on servers[0] MV (T_mv purged, staging still blocked).
+     11. Release staging injection.  process_staging_sstables calls
+         stream_view_replica_updates with as_mutation_source_excluding_staging() to read the
+         base table.  T_base(ts_t) is present → D_base row marker (ts_d) expired by T_base →
+         view update is a no-op → D_view NOT dispatched.
+     12. Wait for "Processed ks.test" log line confirming staging completed.
+     13. Flush + compact MV on servers[0].  No D_view was written → nothing resurrects.
+     14. Assert: key still NOT visible on servers[0] MV.
+
+    The test demonstrates that the tombstone GC optimization is safe even when the staging
+    processor fires after T_mv has already been purged.
+    """
+    servers, cql, hosts, ks, table_id, logs = await _setup_tombstone_gc_cluster(
+        manager, tablets=1,
+        extra_cmdline=['--hinted-handoff-enabled', '0'])
+
+    mv_name = "mv_test"
+    await cql.run_async(
+        f"CREATE MATERIALIZED VIEW {ks}.{mv_name} AS "
+        f"SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL "
+        f"PRIMARY KEY (c, pk) "
+        f"WITH SYNCHRONOUS_UPDATES = FALSE "
+        f"AND tombstone_gc = {{'mode': 'repair', 'propagation_delay_in_seconds': '0'}}"
+    )
+
+    # Stop servers[0]; it will miss D_base and D_view (no hints, hinted-handoff disabled).
+    await manager.server_stop_gracefully(servers[0].server_id)
+
+    key = 77
+    c_val = 5
+    now_us = int(time.time() * 1e6)
+    ts_d = now_us - int(2 * 3600 * 1e6)   # 2 hours ago
+    ts_t = now_us - int(1 * 3600 * 1e6)   # 1 hour ago (ts_t > ts_d so T_mv shadows D_view)
+
+    # D_base written to servers[1] only (servers[0] is down, servers[2] will also
+    # receive a replica copy because tablet RF=3).  servers[1] dispatches D_view to
+    # MV replicas.  MV-on-servers[0] gets nothing.
+    await cql.run_async(
+        f"INSERT INTO {ks}.test (pk, c) VALUES ({key}, {c_val}) USING TIMESTAMP {ts_d}",
+        host=hosts[1])
+
+    for s in [servers[1], servers[2]]:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+
+    # Restart servers[0]; still no D_base on base or D_view on MV for servers[0].
+    await manager.server_start(servers[0].server_id)
+    await manager.servers_see_each_other(servers)
+    await reconnect_driver(manager)
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    # Block the staging processor on servers[0] BEFORE running base repair, so that
+    # the staged D_base (written by row-sync during base repair) never gets dispatched
+    # to MV-on-servers[0] until we explicitly release the injection.
+    await manager.api.enable_injection(
+        servers[0].ip_addr, "view_update_generator_pause_before_processing", one_shot=True)
+
+    # Base repair: row-sync detects servers[0] missing D_base → writes D_base to servers[0]
+    # via the staging path → staging sstable registered → view_update_generator BLOCKED.
+    # Base repair returns without waiting for staging to complete.
+    # NOTE: T_base has NOT been written yet, so D_base is not shadowed during repair
+    # hash computation; the hashes are unequal and row-sync fires as expected.
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all",
+                                    incremental_mode='incremental')
+
+    # T_base(ts_t) written to all nodes NOW — after base repair so staging is already blocked.
+    # servers[0] dispatches T_mv to MV-on-servers[0]; all MV replicas now have T_mv.
+    # D_view remains absent from MV-on-servers[0] (staging still blocked).
+    await cql.run_async(
+        f"DELETE FROM {ks}.test USING TIMESTAMP {ts_t} WHERE pk = {key}")
+
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+
+    # MV repair:
+    #   flush_hints() → no view hints (hinted-handoff disabled) → no-op.
+    #   take_storage_snapshot(): servers[0] MV has T_mv only; servers[1,2] MV have
+    #   D_view(ts_d) + T_mv(ts_t); the streaming compacting reader drops D_view (shadowed
+    #   by T_mv) → hashes equal → no row-sync → repair_time committed.
+    #   T_mv.deletion_time ≈ write time (step above); repair_time > deletion_time → GC-eligible.
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, mv_name, "all",
+                                    incremental_mode='incremental')
+
+    # Repaired compaction on servers[0] MV with staging still blocked:
+    #   sstable_set_for_tombstone_gc = only repaired sstables = {T_mv sstable}.
+    #   No D_view in repaired → T_mv is GC-eligible → T_mv PURGED.
+    await manager.api.keyspace_compaction(servers[0].ip_addr, ks, mv_name)
+
+    # T_mv has been purged; staging still blocked.  No resurrection yet.
+    stmt = SimpleStatement(
+        f"SELECT pk FROM {ks}.{mv_name} WHERE c = {c_val} AND pk = {key}",
+        consistency_level=ConsistencyLevel.ONE)
+    rows = await cql.run_async(stmt, host=hosts[0])
+    assert not rows, (
+        f"Unexpected resurrection on servers[0] MV after first compaction "
+        f"(c={c_val}, pk={key}) visible — T_mv was not GC'd or D_view was incorrectly present.")
+
+    # Release the staging processor.
+    # stream_view_replica_updates is called with as_mutation_source_excluding_staging() to
+    # read the current base table state.  T_base(ts_t) is present on servers[0] base table
+    # (written in step 6 above).  The view_update_builder sets _existing_partition_tombstone
+    # = T_base, applies it onto the D_base row (ts_d < ts_t → row marker expired), and
+    # generates a no-op view update.  D_view is NOT dispatched to MV-on-servers[0].
+    await manager.api.message_injection(
+        servers[0].ip_addr, "view_update_generator_pause_before_processing")
+
+    # Wait for staging processing to complete: view_update_generator logs
+    # "Processed ks.base_cf: N sstables" after generate_updates_from_staging_sstables returns.
+    # The staging sstable is registered for the BASE TABLE (test), not the MV.
+    await logs[0].wait_for(f"Processed {ks}.test")
+
+    # Flush and compact again.  No D_view was dispatched by staging → nothing new in MV.
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+    await manager.api.keyspace_compaction(servers[0].ip_addr, ks, mv_name)
+
+    rows = await cql.run_async(stmt, host=hosts[0])
+    assert not rows, (
+        f"Resurrection after staging on servers[0] MV: (c={c_val}, pk={key}) visible. "
+        f"The staging processor dispatched D_view despite T_base being present in the "
+        f"base table — the read-before-write safety mechanism failed.")
+
+    logger.info("test_tombstone_gc_mv_safe_staging_processor_delay: PASSED")

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -74,6 +74,7 @@ public:
     lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const override {
         return table().try_get_compaction_group_with_static_sharding()->main_sstables();
     }
+    bool skip_memtable_for_tombstone_gc() const noexcept override { return false; }
     std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point query_time) const override {
         return compaction::get_fully_expired_sstables(*this, sstables, query_time);
     }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -802,6 +802,7 @@ public:
     virtual future<lw_shared_ptr<const sstables::sstable_set>> main_sstable_set() const override { co_return make_lw_shared<const sstables::sstable_set>(_main_set); }
     virtual future<lw_shared_ptr<const sstables::sstable_set>> maintenance_sstable_set() const override { co_return make_lw_shared<const sstables::sstable_set>(_maintenance_set); }
     lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const override { return make_lw_shared<const sstables::sstable_set>(_main_set); }
+    virtual bool skip_memtable_for_tombstone_gc() const noexcept override { return false; }
     virtual std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point compaction_time) const override { return {}; }
     virtual const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept override { return _compacted_undeleted_sstables; }
     virtual compaction::compaction_strategy& get_compaction_strategy() const noexcept override { return _compaction_strategy; }


### PR DESCRIPTION
When tombstone_gc=repair, the repaired compaction view's sstable_set_for_tombstone_gc()
previously returned all sstables across all three views (unrepaired, repairing, repaired).
This is correct but unnecessarily expensive: the unrepaired and repairing sets are never
the source of a GC-blocking shadow when tombstone_gc=repair, for base tables.

The key ordering guarantee that makes this safe is:
- topology_coordinator sends send_tablet_repair RPC and waits for it to complete.
  Inside that RPC, mark_sstable_as_repaired() runs on all replicas, moving D from
  repairing → repaired (repaired_at stamped on disk).
- Only after the RPC returns does the coordinator commit repair_time + sstables_repaired_at
  to Raft.
- gc_before = repair_time - propagation_delay only advances once that Raft commit applies.

Therefore, when a tombstone T in the repaired set first becomes GC-eligible (its
deletion_time < gc_before), any data D it shadows is already in the repaired set on
every replica. This holds because:
- The memtable is flushed before the repairing snapshot is taken (take_storage_snapshot
  calls sg->flush()), capturing all data present at repair time.
- Hints and batchlog are flushed before the snapshot, ensuring remotely-hinted writes
  arrive before the snapshot boundary.
- Legitimate unrepaired data has timestamps close to 'now', always newer than any
  GC-eligible tombstone (USING TIMESTAMP to write backdated data is user error / UB).

Excluding the repairing and unrepaired sets from the GC shadow check cannot cause any
tombstone to be wrongly collected. The memtable check is also skipped for the same
reason: memtable data is either newer than the GC-eligible tombstone, or was flushed
into the repairing/repaired set before gc_before advanced.

Safety restriction — materialized views:
The optimization IS applied to materialized view tables. Two possible paths could inject
D_view into the MV's unrepaired set after MV repair: view hints and staging via the
view-update-generator. Both are safe:

(1) View hints: flush_hints() creates a sync point covering BOTH _hints_manager (base
mutations) AND _hints_for_views_manager (view mutations). It waits until ALL pending view
hints — including D_view entries queued in _hints_for_views_manager while the target MV
replica was down — have been replayed to the target node before take_storage_snapshot() is
called. D_view therefore lands in the MV's repairing sstable and is promoted to repaired.
When a repaired compaction then checks for shadows it finds D_view in the repaired set,
keeping T_mv non-purgeable.

(2) View-update-generator staging path: Base table repair can write a missing D_base to a
replica via a staging sstable. The view-update-generator processes the staging sstable
ASYNCHRONOUSLY: it may fire arbitrarily later, even after MV repair has committed
repair_time and T_mv has been GC'd from the repaired set. However, the staging processor
calls stream_view_replica_updates() which performs a READ-BEFORE-WRITE via
as_mutation_source_excluding_staging(): it reads the CURRENT base table state before
building the view update. If T_base was written to the base table (as it always is before
the base replica can be repaired and the MV tombstone can become GC-eligible), the
view_update_builder sees T_base as the existing partition tombstone. D_base's row marker
(ts_d < ts_t) is expired by T_base, so the view update is a no-op: D_view is never
dispatched to the MV replica. No resurrection can occur regardless of how long staging is
delayed.

A potential sub-edge-case is T_base being purged BEFORE staging fires (leaving D_base as
the sole survivor, so stream_view_replica_updates would dispatch D_view). This is blocked
by an additional invariant: for tablet-based tables, the repair writer stamps repaired_at
on staging sstables (repair_writer_impl::create_writer sets mark_as_repaired = true and
perform_component_rewrite writes repaired_at = sstables_repaired_at + 1 on every staging
sstable). After base repair commits sstables_repaired_at to Raft, the staging sstable
satisfies is_repaired(sstables_repaired_at, staging_sst) and therefore appears in
make_repaired_sstable_set(). Any subsequent base repair that advances sstables_repaired_at
further still includes the staging sstable (its repaired_at ≤ new sstables_repaired_at).
D_base in the staging sstable thus shadows T_base in every repaired compaction's shadow
check, keeping T_base non-purgeable as long as D_base remains in staging.

A base table hint also cannot bypass this. A base hint is replayed as a base mutation. The
resulting view update is generated synchronously on the base replica and sent to the MV
replica via _hints_for_views_manager (path 1 above), not via staging.

USING TIMESTAMP with timestamps predating (gc_before + propagation_delay) is explicitly
UB and excluded from the safety argument.

For tombstone_gc modes other than repair (timeout, immediate, disabled) the invariant
does not hold for base tables either, so the full storage-group set is returned.

The expected gain is reduced bloom filter and memtable key-lookup I/O during repaired
compactions: the unrepaired set is typically the largest (it holds all recent writes),
yet for tombstone_gc=repair it never influences GC decisions.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-231.