### PR TITLE
Enable vnodes-to-tablets migrations with arbitrary tokens

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1723,6 +1723,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/view_schema_test.cc',
     'test/boost/virtual_reader_test.cc',
     'test/boost/virtual_table_test.cc',
+    'test/boost/vnodes_to_tablets_migration_test.cc',
     'tools/schema_loader.cc',
     'tools/read_mutation.cc',
     'test/lib/expr_test_utils.cc',

--- a/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
+++ b/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
@@ -53,9 +53,6 @@ Limitations
 
 The current migration procedure has the following limitations:
 
-* The total number of **vnode tokens** in the cluster must be a **power of two**
-  and the tokens must be **evenly spaced** across the token ring. This is
-  verified automatically when starting the migration.
 * **No schema changes** during the migration. Do not create, alter, or drop
   tables in the migrating keyspace until the migration is finished.
 * **No topology changes** during the migration. Do not add, remove, decommission,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3912,13 +3912,6 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
             throw std::runtime_error(fmt::format("Keyspace {} has no tables to migrate. To use tablets, recreate the keyspace with tablets enabled", ks_name));
         }
 
-        const auto& tm = get_token_metadata();
-        const auto& sorted_tokens = tm.sorted_tokens();
-        size_t tablet_count = sorted_tokens.size();
-        if (!std::has_single_bit(tablet_count)) {
-            throw std::runtime_error(fmt::format("Table migration requires vnodes to be a power of two. Current value: {}", tablet_count));
-        }
-
         auto topology = co_await get_system_keyspace().load_topology_state({});
         for (const auto& [server_id, replica_state]: topology.normal_nodes) {
             if (replica_state.storage_mode) {
@@ -3948,15 +3941,32 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
 
         // Build a tablet_map from vnode token boundaries.
         //
-        // The map contains one tablet per vnode. The replicas of each tablet are
-        // the same as the replicas of the corresponding vnode. Shards are assigned
-        // in round-robin fashion per node so that tablets are evenly distributed
-        // within each node.
+        // The map contains one tablet per vnode, plus one extra tablet for the
+        // wrap-around range (last_vnode_token, MAX_TOKEN] when
+        // last_vnode_token != MAX_TOKEN. Each tablet has the same replicas as
+        // the corresponding vnode. Shards are assigned in round-robin fashion
+        // per node so that tablets are evenly distributed within each node.
         // (FIXME: we should consider tablet sizes as well)
         //
         // This map will serve as a template for per-table tablet map mutations.
         // Each table in the keyspace receives its own tablet map, but all maps
         // have identical tablet boundaries and replica placement.
+
+        const auto& tm = get_token_metadata();
+        const auto& sorted_tokens = tm.sorted_tokens();
+
+        utils::chunked_vector<dht::raw_token> last_tokens;
+        size_t tablet_count = sorted_tokens.size();
+        last_tokens.reserve(tablet_count + 1); // +1 for possible wrapping tablet
+        for (const auto& t : sorted_tokens) {
+            last_tokens.emplace_back(t);
+        }
+        // Add an extra tablet for the wrapping range if needed.
+        auto needs_wrapping_tablet = sorted_tokens.back() != dht::token::last();
+        if (needs_wrapping_tablet) {
+            last_tokens.emplace_back(dht::token::last());
+            tablet_count++;
+        }
 
         slogger.info("Building tablet maps for tables in keyspace {} with {} tablet(s)", ks_name, tablet_count);
 
@@ -3971,18 +3981,16 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
 
         auto erm = ks.get_static_effective_replication_map();
 
-        locator::tablet_map tmap(tablet_count);
+        locator::tablet_map tmap(std::move(last_tokens));
         for (size_t i = 0; i < tablet_count; ++i) {
             auto tablet = locator::tablet_id(i);
-            auto vnode_replica_hosts = erm->get_natural_replicas(sorted_tokens[i], true);
+            auto vnode_token = needs_wrapping_tablet && i == tablet_count - 1 ? tmap.get_last_token(locator::tablet_id{0}) : tmap.get_last_token(tablet);
+            auto vnode_replica_hosts = erm->get_natural_replicas(vnode_token, true);
             locator::tablet_replica_set tablet_replicas;
             for (auto host : vnode_replica_hosts) {
                 tablet_replicas.push_back(locator::tablet_replica{host, next_shard_for[host]()});
             }
             tmap.set_tablet(tablet, locator::tablet_info(std::move(tablet_replicas)));
-            if (tmap.get_last_token(tablet) != sorted_tokens[i]) {
-                throw std::runtime_error(fmt::format("vnode token {} is not aligned; cannot be used as tablet boundary (expected: {})", sorted_tokens[i], tmap.get_last_token(tablet)));
-            }
         }
 
         // Build tablet map mutations for all tables and persist them to group0 (system.tablets)

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3928,45 +3928,6 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
             }
         }
 
-        // Stateful lambdas for round-robin shard assignment per node.
-        std::unordered_map<locator::host_id, std::function<shard_id()>> next_shard_for;
-        tm.for_each_token_owner([&] (const locator::node& node) {
-            auto host = node.host_id();
-            next_shard_for[host] = [num_shards = node.get_shard_count(), idx = 0u]() mutable {
-                return shard_id(idx++ % num_shards);
-            };
-        });
-
-        slogger.info("Building tablet maps for tables in keyspace {} with {} tablet(s)", ks_name, tablet_count);
-
-        // Build a tablet_map from vnode token boundaries.
-        //
-        // The map contains one tablet per vnode. The replicas of each tablet are
-        // the same as the replicas of the corresponding vnode. Shards are assigned
-        // in round-robin fashion per node so that tablets are evenly distributed
-        // within each node.
-        // (FIXME: we should consider tablet sizes as well)
-        //
-        // This map will serve as a template for per-table tablet map mutations.
-        // Each table in the keyspace receives its own tablet map, but all maps
-        // have identical tablet boundaries and replica placement.
-
-        auto erm = ks.get_static_effective_replication_map();
-
-        locator::tablet_map tmap(tablet_count);
-        for (size_t i = 0; i < tablet_count; ++i) {
-            auto tablet = locator::tablet_id(i);
-            auto vnode_replica_hosts = erm->get_natural_replicas(sorted_tokens[i], true);
-            locator::tablet_replica_set tablet_replicas;
-            for (auto host : vnode_replica_hosts) {
-                tablet_replicas.push_back(locator::tablet_replica{host, next_shard_for[host]()});
-            }
-            tmap.set_tablet(tablet, locator::tablet_info(std::move(tablet_replicas)));
-            if (tmap.get_last_token(tablet) != sorted_tokens[i]) {
-                throw std::runtime_error(fmt::format("vnode token {} is not aligned; cannot be used as tablet boundary (expected: {})", sorted_tokens[i], tmap.get_last_token(tablet)));
-            }
-        }
-
         std::vector<std::pair<table_id, sstring>> tables_to_migrate;
 
         for (const auto& [name, schema] : cf_meta_data) {
@@ -3983,6 +3944,45 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         if (tables_to_migrate.empty()) {
             slogger.info("All tables in keyspace {} already use tablets, nothing to do", ks_name);
             co_return;
+        }
+
+        // Build a tablet_map from vnode token boundaries.
+        //
+        // The map contains one tablet per vnode. The replicas of each tablet are
+        // the same as the replicas of the corresponding vnode. Shards are assigned
+        // in round-robin fashion per node so that tablets are evenly distributed
+        // within each node.
+        // (FIXME: we should consider tablet sizes as well)
+        //
+        // This map will serve as a template for per-table tablet map mutations.
+        // Each table in the keyspace receives its own tablet map, but all maps
+        // have identical tablet boundaries and replica placement.
+
+        slogger.info("Building tablet maps for tables in keyspace {} with {} tablet(s)", ks_name, tablet_count);
+
+        // Stateful lambdas for round-robin shard assignment per node.
+        std::unordered_map<locator::host_id, std::function<shard_id()>> next_shard_for;
+        tm.for_each_token_owner([&] (const locator::node& node) {
+            auto host = node.host_id();
+            next_shard_for[host] = [num_shards = node.get_shard_count(), idx = 0u]() mutable {
+                return shard_id(idx++ % num_shards);
+            };
+        });
+
+        auto erm = ks.get_static_effective_replication_map();
+
+        locator::tablet_map tmap(tablet_count);
+        for (size_t i = 0; i < tablet_count; ++i) {
+            auto tablet = locator::tablet_id(i);
+            auto vnode_replica_hosts = erm->get_natural_replicas(sorted_tokens[i], true);
+            locator::tablet_replica_set tablet_replicas;
+            for (auto host : vnode_replica_hosts) {
+                tablet_replicas.push_back(locator::tablet_replica{host, next_shard_for[host]()});
+            }
+            tmap.set_tablet(tablet, locator::tablet_info(std::move(tablet_replicas)));
+            if (tmap.get_last_token(tablet) != sorted_tokens[i]) {
+                throw std::runtime_error(fmt::format("vnode token {} is not aligned; cannot be used as tablet boundary (expected: {})", sorted_tokens[i], tmap.get_last_token(tablet)));
+            }
         }
 
         // Build tablet map mutations for all tables and persist them to group0 (system.tablets)

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -389,6 +389,7 @@ add_scylla_test(combined_tests
     view_schema_test.cc
     virtual_reader_test.cc
     virtual_table_test.cc
+    vnodes_to_tablets_migration_test.cc
   LIBRARIES
     cql3
     idl

--- a/test/boost/vnodes_to_tablets_migration_test.cc
+++ b/test/boost/vnodes_to_tablets_migration_test.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/test_case.hh>
+#include <seastar/util/bool_class.hh>
+
+#include "db/config.hh"
+#include "test/lib/cql_test_env.hh"
+#include "locator/tablets.hh"
+#include "service/storage_service.hh"
+
+using aligned_last_token = bool_class<class aligned_last_token_tag>;
+
+BOOST_AUTO_TEST_SUITE(vnodes_to_tablets_migration_test)
+
+// Verify creation of extra tablet for wrap-around vnodes.
+//
+// Tablets cannot wrap around the token ring as vnodes do; the last token of
+// the last tablet must always be MAX_TOKEN. So, when we build the tablet map,
+// if a wrap-around vnode exists (i.e., the last vnode token is not MAX_TOKEN),
+// it needs to be split into two tablets: (last_vnode_token, last_token()] and
+// [first_token(), first_vnode_token].
+static future<> test_migration_tablet_boundaries(aligned_last_token aligned) {
+    std::vector<int64_t> tokens{-7686143364045646507, 0, 7158264828641642373}; // some random tokens
+    if (aligned) {
+        tokens.back() = dht::last_token().raw();
+    }
+
+    cql_test_config cfg;
+    auto initial_token = fmt::format("{}", fmt::join(tokens, ", "));
+    cfg.db_config->initial_token.set(std::move(initial_token));
+
+    return do_with_cql_env_thread([tokens, aligned] (cql_test_env& e) {
+        auto ks_name = sstring("test_migration_ks");
+        e.execute_cql(format("CREATE KEYSPACE {} "
+                "WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} "
+                "AND tablets = {{'enabled': false}}", ks_name)).get();
+
+        e.execute_cql(format("CREATE TABLE {}.t (pk int PRIMARY KEY)", ks_name)).get();
+        auto tid = e.local_db().find_schema(ks_name, "t")->id();
+
+        e.get_storage_service().local().prepare_for_tablets_migration(ks_name).get();
+
+        auto& stm = e.local_db().get_shared_token_metadata();
+        auto& tmap = stm.get()->tablets().get_tablet_map(tid);
+
+        auto expected = std::vector<dht::token>{};
+        for (const auto& t : tokens) {
+            expected.push_back(dht::token(t));
+        }
+        if (!aligned) {
+            expected.push_back(dht::last_token());
+        }
+
+        auto actual = std::vector<dht::token>{};
+        for (size_t i = 0; i < tmap.tablet_count(); ++i) {
+            actual.push_back(tmap.get_last_token(locator::tablet_id(i)));
+        }
+        BOOST_TEST_INFO("actual: " << fmt::format("{}", fmt::join(actual, ", ")));
+        BOOST_TEST_INFO("expected: " << fmt::format("{}", fmt::join(expected, ", ")));
+        BOOST_REQUIRE_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+    }, cfg);
+}
+
+// When the last vnode token != MAX_TOKEN, the wrap-around vnode is split
+// into two tablets. Expect one more tablet than vnodes.
+SEASTAR_TEST_CASE(test_unaligned_last_token) {
+    return test_migration_tablet_boundaries(aligned_last_token::no);
+}
+
+// When the last vnode token == MAX_TOKEN, no split is needed.
+// Expect exactly one tablet per vnode.
+SEASTAR_TEST_CASE(test_aligned_last_token) {
+    return test_migration_tablet_boundaries(aligned_last_token::yes);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -10,7 +10,6 @@ import pytest
 import asyncio
 import logging
 import subprocess
-from collections import defaultdict
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
 from test.pylib.tablets import get_tablet_count, get_all_tablet_replicas
@@ -21,20 +20,9 @@ from test.cluster.util import new_test_keyspace, reconnect_driver
 
 logger = logging.getLogger(__name__)
 
-def calculate_powof2_tokens(num_nodes: int, tokens_per_node: int) -> dict[int, list[int]]:
-    exp = 0
-    while 2**exp < num_nodes * tokens_per_node:
-        exp += 1
-    n = 2**exp
-    new_tokens_combined = [int(i * 2**64 // n - 2**63 - 1) for i in range(1, n+1)]
-    calculated_new_tokens = defaultdict(list)
-    new_server_id = 1
-    for i, t in enumerate(new_tokens_combined):
-        calculated_new_tokens[new_server_id  + (i % num_nodes)].append(t)
-    for s, tokens in calculated_new_tokens.items():
-        calculated_new_tokens[s] = sorted(tokens)
-    logger.debug(f"{calculated_new_tokens=}")
-    return calculated_new_tokens
+# Largest token that can be associated with a partition key (int64 max).
+# The tablet map always ends at this token to cover the full ring.
+MAX_TOKEN = 2**63 - 1
 
 
 def get_sstable_token_ranges(scylla_path: str, scylla_yaml: str, sstable_data_files: list[str]) -> list[tuple[int, int]]:
@@ -84,15 +72,24 @@ def sstable_range_within_vnode(first_token: int, last_token: int, vnode_boundari
     Returns:
         True if both first_token and last_token fall within the same vnode range.
     """
-    def find_owning_vnode(token: int) -> int:
-        """Return the index of the vnode that owns this token."""
-        for i, boundary in enumerate(vnode_boundaries):
-            if token <= boundary:
-                return i
-        # Token is above the last boundary, wraps to vnode 0
-        return 0
+    for token in vnode_boundaries:
+        if first_token < token <= last_token:
+            return False
+    return True
 
-    return find_owning_vnode(first_token) == find_owning_vnode(last_token)
+
+async def get_all_vnode_tokens(cql) -> list[int]:
+    """Return a sorted list of all vnode token boundaries across all nodes.
+
+    Queries the tokens column in system.topology, which contains the tokens
+    for every node in the cluster.
+    """
+    rows = await cql.run_async("SELECT tokens FROM system.topology WHERE key = 'topology'")
+    tokens = []
+    for row in rows:
+        if row.tokens:
+            tokens.extend(int(t) for t in row.tokens)
+    return sorted(tokens)
 
 
 async def verify_data_integrity(cql, ks, table, num_keys, cl=ConsistencyLevel.QUORUM):
@@ -134,7 +131,7 @@ async def test_migration(manager: ManagerClient):
     """Verify vnodes-to-tablets migration for a single table on a single-node cluster.
 
     Steps:
-    1. Start a single node with multiple shards and power-of-2 aligned vnodes.
+    1. Start a single node with multiple shards and random vnodes.
     2. Create a vnode table and inject data.
     3. Start the migration by creating a tablet map for the table.
        - Verify that the tablet map was created and tablet tokens match vnode tokens.
@@ -149,15 +146,16 @@ async def test_migration(manager: ManagerClient):
     tokens_per_node = 16
     num_keys = 5000
 
-    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} power-of-2 aligned tokens")
-    tokens = calculate_powof2_tokens(num_nodes=1, tokens_per_node=tokens_per_node)
-    token_list = tokens[1]  # server_id 1
-    initial_token = ','.join([str(t) for t in token_list])
-    servers = (await manager.servers_add(1, cmdline=['--smp', str(num_shards), '--initial-token', initial_token, '--logger-log-level', 'compaction=debug']))
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} random tokens")
+    cfg = {'num_tokens': tokens_per_node}
+    servers = await manager.servers_add(1, cmdline=['--smp', str(num_shards), '--logger-log-level', 'compaction=debug'], config=cfg)
     server = servers[0]
     host_id = await manager.get_host_id(server.server_id)
 
     cql, _ = await manager.get_ready_cql(servers)
+
+    vnode_boundaries = await get_all_vnode_tokens(cql)
+    logger.info(f"Vnode boundaries ({len(vnode_boundaries)} tokens): {vnode_boundaries}")
 
     logger.info("Creating keyspace and table with vnodes")
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
@@ -180,17 +178,11 @@ async def test_migration(manager: ManagerClient):
         scylla_yaml = os.path.join(node_workdir, "conf", "scylla.yaml")
         table_data_dir = glob.glob(os.path.join(node_workdir, "data", ks, "test-*"))[0]
         pre_migration_sstables = glob.glob(os.path.join(table_data_dir, "*-Data.db"))
-        logger.info(f"Pre-migration SSTable count: {len(pre_migration_sstables)}")
         assert len(pre_migration_sstables) == num_shards * num_flushes
-
-        logger.info("Verifying that at least one pre-migration SSTable spans multiple vnode ranges (ensures that resharding will have work to do)")
-        vnode_boundaries = sorted(token_list)
         pre_migration_ranges = get_sstable_token_ranges(scylla_path, scylla_yaml, pre_migration_sstables)
         cross_vnode_count = sum(1 for first, last in pre_migration_ranges
                                 if not sstable_range_within_vnode(first, last, vnode_boundaries))
         logger.info(f"Pre-migration: {cross_vnode_count}/{len(pre_migration_ranges)} SSTables span multiple vnodes")
-        assert cross_vnode_count >= 1, \
-            "Expected at least one pre-migration SSTable to span multiple vnode ranges, but none was found. The test is malformed."
 
         logger.info("Verifying migration status before starting migration")
         await verify_migration_status(manager, server, ks, expected_status='vnodes', expected_node_statuses={})
@@ -204,18 +196,20 @@ async def test_migration(manager: ManagerClient):
             expected_node_statuses={host_id: ('vnodes', 'vnodes')})
 
         logger.info("Verifying that the tablet map was created")
+        expected_tablet_tokens = vnode_boundaries if vnode_boundaries[-1] == MAX_TOKEN else vnode_boundaries + [MAX_TOKEN]
+        expected_tablet_count = len(expected_tablet_tokens)
         tablet_count = await get_tablet_count(manager, server, ks, 'test')
-        assert tablet_count == tokens_per_node, \
-            f"Expected {tokens_per_node} tablet(s), got {tablet_count}"
+        assert tablet_count == expected_tablet_count, \
+            f"Expected {expected_tablet_count} tablet(s), got {tablet_count}"
 
         tablet_replicas = await get_all_tablet_replicas(manager, server, ks, 'test')
-        assert len(tablet_replicas) == tokens_per_node, \
-            f"Expected {tokens_per_node} tablet replica entries, got {len(tablet_replicas)}"
+        assert len(tablet_replicas) == expected_tablet_count, \
+            f"Expected {expected_tablet_count} tablet replica entries, got {len(tablet_replicas)}"
 
-        logger.info("Verifying that tablet tokens match vnode tokens")
+        logger.info("Verifying that tablet tokens match vnode tokens plus max token")
         tablet_tokens = sorted([tr.last_token for tr in tablet_replicas])
-        assert tablet_tokens == vnode_boundaries, \
-            f"Tablet tokens {tablet_tokens} do not match vnode tokens {vnode_boundaries}"
+        assert tablet_tokens == expected_tablet_tokens, \
+            f"Tablet tokens {tablet_tokens} do not match expected {expected_tablet_tokens}"
 
         logger.info("Verifying data integrity after building tablet map and before resharding")
         await verify_data_integrity(cql, ks, "test", num_keys)
@@ -282,7 +276,7 @@ async def test_migration_rollback(manager: ManagerClient):
     cleared.
 
     Steps:
-    1. Start a single node with multiple shards and power-of-2 aligned vnodes.
+    1. Start a single node with multiple shards and random vnodes.
     2. Create a vnode table and inject data.
     3. Start the migration by creating a tablet map for the table.
     4. Mark the node for upgrade and restart (triggers resharding).
@@ -297,15 +291,16 @@ async def test_migration_rollback(manager: ManagerClient):
     tokens_per_node = 16
     num_keys = 5000
 
-    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} power-of-2 aligned tokens")
-    tokens = calculate_powof2_tokens(num_nodes=1, tokens_per_node=tokens_per_node)
-    token_list = tokens[1]  # server_id 1
-    initial_token = ','.join([str(t) for t in token_list])
-    servers = (await manager.servers_add(1, cmdline=['--smp', str(num_shards), '--initial-token', initial_token, '--logger-log-level', 'compaction=debug']))
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} random tokens")
+    cfg = {'num_tokens': tokens_per_node}
+    servers = await manager.servers_add(1, cmdline=['--smp', str(num_shards), '--logger-log-level', 'compaction=debug'], config=cfg)
     server = servers[0]
     host_id = await manager.get_host_id(server.server_id)
 
     cql, _ = await manager.get_ready_cql(servers)
+
+    vnode_boundaries = await get_all_vnode_tokens(cql)
+    logger.info(f"Vnode boundaries ({len(vnode_boundaries)} tokens): {vnode_boundaries}")
 
     logger.info("Creating keyspace and table with vnodes")
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
@@ -324,9 +319,10 @@ async def test_migration_rollback(manager: ManagerClient):
         await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
 
         logger.info("Verifying that the tablet map was created")
+        expected_tablet_count = len(vnode_boundaries) if vnode_boundaries[-1] == MAX_TOKEN else len(vnode_boundaries) + 1
         tablet_count = await get_tablet_count(manager, server, ks, 'test')
-        assert tablet_count == tokens_per_node, \
-            f"Expected {tokens_per_node} tablet(s), got {tablet_count}"
+        assert tablet_count == expected_tablet_count, \
+            f"Expected {expected_tablet_count} tablet(s), got {tablet_count}"
 
         logger.info("Marking node for tablets migration")
         await manager.api.upgrade_node_to_tablets(server.ip_addr)
@@ -396,7 +392,7 @@ async def test_migration_multinode(manager: ManagerClient):
     """Verify vnodes-to-tablets migration for a single table on a multi-node cluster with rolling restarts.
 
     Steps:
-    1. Start a 2-node cluster with RF=2, multiple shards, and power-of-2 aligned vnodes.
+    1. Start a 2-node cluster with RF=2, multiple shards, and random vnodes.
     2. Create a vnode table and inject data at CL=QUORUM.
     3. Create tablet map — verify one tablet replica per node, tablet tokens match vnode tokens.
     4. Rolling restart — for each node: mark for upgrade, verify intended_storage_mode
@@ -409,18 +405,14 @@ async def test_migration_multinode(manager: ManagerClient):
     tokens_per_node = 64
     num_keys = 1000
 
-    logger.info(f"Starting {num_nodes} nodes with {num_shards} shards each, ~{tokens_per_node} power-of-2 aligned tokens per node")
-    calculated_tokens = calculate_powof2_tokens(num_nodes=num_nodes, tokens_per_node=tokens_per_node)
-    total_vnodes = sum(len(t) for t in calculated_tokens.values())
-    logger.info(f"Total vnodes: {total_vnodes}")
+    logger.info(f"Starting {num_nodes} nodes with {num_shards} shards each, {tokens_per_node} random tokens per node")
 
     servers = []
-    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1}
-    for i, tokens in calculated_tokens.items():
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': tokens_per_node}
+    for i in range(1, num_nodes + 1):
         cmdline = [
             '--smp', str(num_shards),
             '--logger-log-level', 'compaction=debug',
-            f"--initial-token={','.join([str(t) for t in tokens])}",
         ]
         servers.append(await manager.server_add(cmdline=cmdline, property_file={"dc": "dc1", "rack": f"rack{i}"}, config=cfg))
 
@@ -428,6 +420,10 @@ async def test_migration_multinode(manager: ManagerClient):
 
     server_to_host_map = {s.server_id: await manager.get_host_id(s.server_id) for s in servers}
     host_ids = set(server_to_host_map.values())
+
+    all_vnode_tokens = await get_all_vnode_tokens(cql)
+    total_vnodes = len(all_vnode_tokens)
+    logger.info(f"Total vnodes: {total_vnodes}")
 
     logger.info(f"Creating keyspace and table with vnodes (RF={num_nodes})")
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {num_nodes}}} AND tablets = {{'enabled': false}}") as ks:
@@ -447,14 +443,15 @@ async def test_migration_multinode(manager: ManagerClient):
             expected_node_statuses={host_id: ('vnodes', 'vnodes') for host_id in host_ids})
 
         logger.info("Verifying tablet map")
+        expected_tablet_tokens = all_vnode_tokens if all_vnode_tokens[-1] == MAX_TOKEN else all_vnode_tokens + [MAX_TOKEN]
+        expected_tablet_count = len(expected_tablet_tokens)
         tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
-        assert len(tablet_replicas) == total_vnodes, \
-            f"Expected {total_vnodes} tablets, got {len(tablet_replicas)}"
+        assert len(tablet_replicas) == expected_tablet_count, \
+            f"Expected {expected_tablet_count} tablets, got {len(tablet_replicas)}"
 
-        all_vnode_tokens = sorted([t for tokens in calculated_tokens.values() for t in tokens])
         tablet_tokens = sorted([tr.last_token for tr in tablet_replicas])
-        assert tablet_tokens == all_vnode_tokens, \
-            f"Tablet tokens do not match vnode tokens"
+        assert tablet_tokens == expected_tablet_tokens, \
+            f"Tablet tokens do not match expected tokens"
 
         for tr in tablet_replicas:
             replica_hosts = set(r[0] for r in tr.replicas)
@@ -534,13 +531,10 @@ async def test_migration_multinode(manager: ManagerClient):
         await verify_data_integrity(cql, ks, "test", total_keys)
 
 
-async def setup_single_node_with_powof2_tokens(manager: ManagerClient):
-    """Start a single node with power-of-2 aligned tokens for migration error tests."""
-    tokens_per_node = 16
-    tokens = calculate_powof2_tokens(num_nodes=1, tokens_per_node=tokens_per_node)
-    token_list = tokens[1]
-    initial_token = ','.join([str(t) for t in token_list])
-    server = await manager.server_add(cmdline=['--smp', '2', '--initial-token', initial_token])
+async def setup_single_node(manager: ManagerClient):
+    """Start a single node with random tokens for migration error tests."""
+    cfg = {'num_tokens': 16}
+    server = await manager.server_add(cmdline=['--smp', '2'], config=cfg)
     cql, _ = await manager.get_ready_cql([server])
     return server, cql
 
@@ -548,7 +542,7 @@ async def setup_single_node_with_powof2_tokens(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_migration_nonexistent_keyspace(manager: ManagerClient):
     """Verify that migration APIs fail on a non-existent keyspace."""
-    server, cql = await setup_single_node_with_powof2_tokens(manager)
+    server, cql = await setup_single_node(manager)
 
     with pytest.raises(HTTPError, match="Can't find a keyspace"):
         await manager.api.create_vnode_tablet_migration(server.ip_addr, "ks")
@@ -561,7 +555,7 @@ async def test_migration_nonexistent_keyspace(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_migration_already_tablets(manager: ManagerClient):
     """Verify that starting migration on a keyspace that already uses tablets fails."""
-    server, cql = await setup_single_node_with_powof2_tokens(manager)
+    server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks_tablets:
         with pytest.raises(HTTPError, match="already uses tablets"):
@@ -571,7 +565,7 @@ async def test_migration_already_tablets(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_migration_empty_keyspace(manager: ManagerClient):
     """Verify that starting migration on a keyspace with no tables fails."""
-    server, cql = await setup_single_node_with_powof2_tokens(manager)
+    server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks_empty:
         with pytest.raises(HTTPError, match="has no tables to migrate"):
@@ -581,7 +575,7 @@ async def test_migration_empty_keyspace(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_migration_finalize_without_migration(manager: ManagerClient):
     """Verify that finalizing migration without starting one first fails."""
-    server, cql = await setup_single_node_with_powof2_tokens(manager)
+    server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks_vnodes:
         await cql.run_async(f"CREATE TABLE {ks_vnodes}.t (pk int PRIMARY KEY)")
@@ -592,7 +586,7 @@ async def test_migration_finalize_without_migration(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_migration_upgrade_without_migration(manager: ManagerClient):
     """Verify that upgrading a node to tablets without an active migration fails."""
-    server, cql = await setup_single_node_with_powof2_tokens(manager)
+    server, cql = await setup_single_node(manager)
 
     with pytest.raises(HTTPError, match="no migration is in progress"):
         await manager.api.upgrade_node_to_tablets(server.ip_addr)
@@ -601,7 +595,7 @@ async def test_migration_upgrade_without_migration(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_migration_overlapping_migrations(manager: ManagerClient):
     """Verify that starting a second migration while one is already in progress fails."""
-    server, cql = await setup_single_node_with_powof2_tokens(manager)
+    server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks1:
         await cql.run_async(f"CREATE TABLE {ks1}.t (pk int PRIMARY KEY)")
@@ -622,7 +616,7 @@ async def test_migration_overlapping_migrations(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_migration_finalize_before_upgrade(manager: ManagerClient):
     """Verify that finalizing migration before the node has finished upgrading fails."""
-    server, cql = await setup_single_node_with_powof2_tokens(manager)
+    server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY)")
@@ -644,11 +638,9 @@ async def test_migration_multiple_keyspaces(manager: ManagerClient):
     num_shards = 3
     tokens_per_node = 16
 
-    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} power-of-2 aligned tokens")
-    tokens = calculate_powof2_tokens(num_nodes=1, tokens_per_node=tokens_per_node)
-    token_list = tokens[1]
-    initial_token = ','.join([str(t) for t in token_list])
-    servers = await manager.servers_add(1, cmdline=['--smp', str(num_shards), '--initial-token', initial_token])
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} random tokens")
+    cfg = {'num_tokens': tokens_per_node}
+    servers = await manager.servers_add(1, cmdline=['--smp', str(num_shards)], config=cfg)
     server = servers[0]
     host_id = await manager.get_host_id(server.server_id)
 


### PR DESCRIPTION
This PR removes the power-of-two token constraint from vnodes-to-tablets migrations, allowing clusters with randomly generated tokens to migrate without manual token reassignment.

Previously, migrations required vnode tokens to be a power of two and aligned. In practice, these conditions are not met with Scylla's default random token assignment, so the constraint is a blocker for real-world use. With the introduction of arbitrary tablet boundaries in PR #28459, the tablet layer can now support arbitrary tablet boundaries. This PR builds on that capability to allow arbitrary vnode tokens during migration.

When the highest vnode token does not coincide with the end of the token ring, the vnode wraps around, but tablets do not support that. This is handled by splitting it into two tablets: one covering the tail end of the ring and one covering the beginning.

Testing has been updated accordingly: existing cluster tests now use randomly generated tokens instead of precomputed power-of-two values, and a new Boost test validates the wrap-around tablet boundary logic.

Fixes SCYLLADB-724.

New feature, no backport is needed.