### PR TITLE
test: protect populate_range in row_cache_test from bad_alloc

### DIFF
--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -2644,7 +2644,10 @@ SEASTAR_TEST_CASE(test_exception_safety_of_update_from_memtable) {
                 return rd;
             };
 
-            populate_range(cache, population_range);
+            {
+                memory::scoped_critical_alloc_section dfg;
+                populate_range(cache, population_range);
+            }
             auto rd1_v1 = assert_that(make_reader(population_range));
             mutation_reader_opt snap;
             auto close_snap = defer([&snap] {


### PR DESCRIPTION
When test_exception_safety_of_update_from_memtable was converted from manual fail_after()/catch to with_allocation_failures() in 74db08165d, the populate_range() call ended up inside the failure injection scope without a scoped_critical_alloc_section guard. The other two tests converted in the same commit (test_exception_safety_of_transitioning... and test_exception_safety_of_partition_scan) were correctly guarded.

Without the guard, the allocation failure injector can sometimes target an allocation point inside the cleanup path of populate_range(). In a rare corner case, this triggers a bad_alloc in a noexcept context (reader_concurrency_semaphore::stop()), causing std::terminate.

Fixes SCYLLADB-1346

It's an old CI bug, better backport it to 2026.1, 2025.4, 2025.1 branches.