### PR TITLE
repair: fix quadratic complexity when loading repair history

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3764,7 +3764,32 @@ future<> repair_service::load_history() {
 
         rlogger.info("Loading repair history for keyspace={}, table={}, table_uuid={}",
                 table->schema()->ks_name(), table->schema()->cf_name(), table_uuid);
-        co_await _sys_ks.local().get_repair_history(table_uuid, [this] (const auto& entry) -> future<> {
+
+        // Collect entries into batches and flush each batch via a single
+        // copy-on-write update, avoiding O(N²) complexity when there are many
+        // repair history entries (SCYLLADB-104).  The batch size is bounded to
+        // limit peak memory usage: the repair history table currently has no
+        // bound on the number of entries and can grow large.
+        static constexpr size_t max_batch_size = 1000;
+        std::vector<shared_tombstone_gc_state::repair_time_update> updates;
+        updates.reserve(max_batch_size);
+
+        auto flush = [&] () -> future<> {
+            if (updates.empty()) {
+                co_return;
+            }
+            try {
+                co_await get_db().invoke_on_all([table_uuid, &updates] (replica::database& local_db) {
+                    auto& gc_state = local_db.get_compaction_manager().get_shared_tombstone_gc_state();
+                    gc_state.batch_update_repair_time(table_uuid, updates);
+                });
+            } catch (...) {
+                rlogger.warn("Failed to update repair history time for table_uuid={}: {}", table_uuid, std::current_exception());
+            }
+            updates.clear();
+        };
+
+        co_await _sys_ks.local().get_repair_history(table_uuid, [this, &updates, &flush] (const auto& entry) -> future<> {
             get_repair_module().check_in_shutdown();
             auto start = entry.range_start == std::numeric_limits<int64_t>::min() ? dht::minimum_token() : dht::token::from_int64(entry.range_start);
             auto end = entry.range_end == std::numeric_limits<int64_t>::min() ? dht::maximum_token() : dht::token::from_int64(entry.range_end);
@@ -3772,16 +3797,13 @@ future<> repair_service::load_history() {
             auto repair_time = to_gc_clock(entry.ts);
             rlogger.debug("Loading repair history for keyspace={}, table={}, table_uuid={}, repair_time={}, range={}",
                     entry.ks, entry.cf, entry.table_uuid, entry.ts, range);
-            try {
-                co_await get_db().invoke_on_all([table_uuid = entry.table_uuid, range, repair_time] (replica::database& local_db) {
-                    auto& gc_state = local_db.get_compaction_manager().get_shared_tombstone_gc_state();
-                    gc_state.update_repair_time(table_uuid, range, repair_time);
-                });
-            } catch (...) {
-                rlogger.warn("Failed to update repair history time for keyspace={}, table={}, range={}, repair_time={}",
-                        entry.ks, entry.cf, range, repair_time);
+            updates.emplace_back(range, repair_time);
+            if (updates.size() >= max_batch_size) {
+                co_await flush();
             }
         });
+
+        co_await flush();
     }));
   } catch (const abort_requested_exception&) {
     // Ignore

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -241,6 +241,24 @@ void shared_tombstone_gc_state::update_repair_time(table_id id, const dht::token
     });
 }
 
+void shared_tombstone_gc_state::batch_update_repair_time(table_id id, std::span<const repair_time_update> updates) {
+    if (updates.empty()) {
+        return;
+    }
+    mutate_repair_history([id, updates] (per_table_history_maps& maps) {
+        auto [it, inserted] = maps.try_emplace(id, lw_shared_ptr<repair_history_map>(nullptr));
+        if (inserted || !it->second) {
+            it->second = seastar::make_lw_shared<repair_history_map>();
+        } else {
+            // Single COW copy of the per-table interval map for all updates.
+            it->second = seastar::make_lw_shared<repair_history_map>(*it->second);
+        }
+        for (const auto& [range, repair_time] : updates) {
+            *it->second += std::make_pair(locator::token_metadata::range_to_interval(range), repair_time);
+        }
+    });
+}
+
 void shared_tombstone_gc_state::insert_pending_repair_time_update(table_id id,
         const dht::token_range& range, gc_clock::time_point repair_time, shard_id shard) {
     _pending_updates[id].push_back(range_repair_time{range, repair_time, shard});

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <span>
 #include <seastar/core/shared_ptr.hh>
 #include "gc_clock.hh"
 #include "dht/token.hh"
@@ -108,6 +109,14 @@ public:
     }
 
     void update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time);
+
+    // A single (range, repair_time) pair used by batch_update_repair_time.
+    using repair_time_update = std::pair<dht::token_range, gc_clock::time_point>;
+
+    // Apply multiple repair-time updates for one table in a single copy-on-write
+    // operation, avoiding the O(N²) cost of calling update_repair_time() in a loop.
+    void batch_update_repair_time(table_id id, std::span<const repair_time_update> updates);
+
     void update_group0_refresh_time(gc_clock::time_point refresh_time);
 
     void drop_repair_history_for_table(const table_id& id);


### PR DESCRIPTION
shared_tombstone_gc_state::update_repair_time() uses copy-on-write semantics: each call copies the entire per_table_history_maps and the per-table repair_history_map.  repair_service::load_history() called this once per history entry, making the load O(N²) in both time and memory.

Introduce batch_update_repair_time() which performs a single copy-on-write for any number of entries belonging to the same table. Restructure load_history() to collect entries into batches of up to
1000 and flush each batch in one call, keeping peak memory bounded. The batch size limit is intentional: the repair history table currently has no bound on the number of entries and can grow large.   Note that this does not cause a problem in the in-memory history map itself: entries are coalesced internally and only the latest repair time is kept per range.  The unbounded entry count only makes the batched update during load expensive.

Fixes: SCYLLADB-104

Backport: performance improvement, no backport