### PR TITLE
cmake: add missing rolling_max_tracker_test and symmetric_key_test

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -200,6 +200,8 @@ add_scylla_test(reusable_buffer_test
   KIND SEASTAR)
 add_scylla_test(reservoir_sampling_test
   KIND BOOST)
+add_scylla_test(rolling_max_tracker_test
+  KIND BOOST)
 add_scylla_test(rest_client_test
   KIND SEASTAR)
 add_scylla_test(rust_test
@@ -263,6 +265,9 @@ add_scylla_test(string_format_test
   KIND BOOST)
 add_scylla_test(summary_test
   KIND BOOST)
+add_scylla_test(symmetric_key_test
+  KIND SEASTAR
+  LIBRARIES encryption)
 add_scylla_test(file_stream_test
   KIND SEASTAR)
 add_scylla_test(tagged_integer_test


### PR DESCRIPTION
Added in 5b2a07b4088341 and c596ae6eb1ab881 without cmake integration.

cmake isn't used in branches, so no backport.