### PR TITLE
auth: retry on raft timeout during default superuser creation

### DIFF
--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -22,6 +22,7 @@
 #include "auth/authentication_options.hh"
 #include "auth/common.hh"
 #include "auth/passwords.hh"
+#include "utils/error_injection.hh"
 #include "auth/roles-metadata.hh"
 #include "cql3/untyped_result_set.hh"
 #include "utils/log.hh"
@@ -92,6 +93,11 @@ future<> password_authenticator::maybe_create_default_password() {
     }
     // We don't want to start operation earlier to avoid quorum requirement in
     // a common case.
+    co_await utils::get_local_injector().inject("maybe_create_default_password_timeout", [] {
+        return std::make_exception_ptr(
+            ::service::raft_operation_timeout_error(
+                "injected raft timeout in maybe_create_default_password"));
+    });
     ::service::group0_batch batch(
             co_await _group0_client.start_operation(_as, get_raft_timeout()));
     // Check again as the state may have changed before we took the guard (batch).
@@ -123,8 +129,8 @@ future<> password_authenticator::maybe_create_default_password_with_retries() {
             plogger.error("Failed to create default superuser password due to guard conflict.");
             co_return;
         } catch (const ::service::raft_operation_timeout_error& ex) {
-            plogger.error("Failed to create default superuser password due to exception: {}", ex.what());
-            co_return;
+            plogger.warn("Failed to create default superuser password due to raft timeout, will retry: {}", ex.what());
+            throw;
         }
     }
 }

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -141,8 +141,8 @@ future<> standard_role_manager::maybe_create_default_role_with_retries() {
             log.error("Failed to create default superuser role due to guard conflict.");
             co_return;
         } catch (const ::service::raft_operation_timeout_error& ex) {
-            log.error("Failed to create default superuser role due to exception: {}", ex.what());
-            co_return;
+            log.warn("Failed to create default superuser role due to raft timeout, will retry: {}", ex.what());
+            throw;
         }
     }
 }

--- a/test/cluster/auth_cluster/test_auth_password_timeout_retry.py
+++ b/test/cluster/auth_cluster/test_auth_password_timeout_retry.py
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import pytest
+import logging
+
+from test.pylib.manager_client import ManagerClient
+from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
+async def test_auth_password_timeout_retry(manager: ManagerClient) -> None:
+    """Regression test for SCYLLADB-1371: raft timeout during default password
+    creation should be retried by do_after_system_ready, not silently swallowed.
+
+    Uses a one-shot fault injection to throw raft_operation_timeout_error in
+    maybe_create_default_password() before the raft start_operation() call.
+
+    With the bug: the timeout is caught in maybe_create_default_password_with_retries()
+    and silently co_return'd, so do_after_system_ready considers the operation successful
+    and never retries. The default password is never created.
+
+    With the fix: the timeout is re-thrown, do_after_system_ready catches the failure
+    and retries with exponential backoff. On the second attempt (injection is one-shot,
+    already consumed), the password is created successfully.
+    """
+    config = {
+        **auth_config,
+        'authenticator': 'com.scylladb.auth.TransitionalAuthenticator',
+        'error_injections_at_startup': [
+            {'name': 'maybe_create_default_password_timeout', 'one_shot': True},
+        ],
+    }
+    server = await manager.server_add(config=config)
+
+    server_log = await manager.server_open_log(server.server_id)
+
+    # Verify the injection fired — the raft timeout error was hit.
+    matches = await server_log.grep("Failed to create default superuser password due to raft timeout, will retry")
+    assert len(matches) > 0, (
+        "Injection did not fire — expected raft timeout warning in log"
+    )
+    logger.info("Confirmed injection fired: %s", matches[0][0].strip())
+
+    # The password should have been created on retry (do_after_system_ready retries on failure).
+    # BUG (SCYLLADB-1371): the raft_operation_timeout_error is caught and co_return'd in
+    # maybe_create_default_password_with_retries(), so do_after_system_ready never retries,
+    # and this message never appears.
+    matches = await server_log.grep("Created default superuser authentication record")
+    assert len(matches) > 0, (
+        "BUG SCYLLADB-1371: 'Created default superuser authentication record' was never logged. "
+        "The raft_operation_timeout_error was silently swallowed in "
+        "maybe_create_default_password_with_retries(), preventing do_after_system_ready "
+        "from retrying."
+    )
+


### PR DESCRIPTION
When raft_operation_timeout_error occurs during default superuser role or password creation, the _with_retries() functions were catching the exception and returning normally (co_return). This prevented do_after_system_ready() from retrying the operation, since it only retries when the wrapped function throws (fails).

In CI, this manifested as test_transitional_auth_betweenness_from_default timing out waiting for the 'Created default superuser authentication record' log message. The root cause was a transient ~9 second leaderless raft period after a node restart in a 2-node cluster. The 5-second auth raft timeout (dev mode) expired before leadership was established, and the resulting raft_operation_timeout_error was silently swallowed. Leadership was gained just 800ms after the timeout -- a single retry would have succeeded.

Fix by re-throwing raft_operation_timeout_error from both maybe_create_default_password_with_retries() and
maybe_create_default_role_with_retries(), allowing do_after_system_ready() to retry with exponential backoff (1s to 1min). Both callers are safe: the _superuser_created_promise is set only after the _with_retries function returns successfully, so CQL will not start serving until the superuser is actually created. The re-thrown exception is caught by do_after_system_ready which logs 'Auth task failed with error, rescheduling' and retries.

Also add a fault injection point (maybe_create_default_password_timeout) in maybe_create_default_password() to allow testing this scenario, and a regression test that uses it with one-shot injection to verify that do_after_system_ready retries and the password is created on the second attempt.

Downgrade the log level from error to warn since raft timeouts are now retriable transient conditions rather than terminal failures.

Fixes: SCYLLADB-1371

Not marking for backport now. Transitional auth is very rare, as is the CI stability issue.