### PR TITLE
test: fix flaky test_create_ks_auth by removing bad retry timeout

### DIFF
--- a/test/cluster/dtest/auth_test.py
+++ b/test/cluster/dtest/auth_test.py
@@ -1182,9 +1182,9 @@ class TestAuth(Tester):
     def get_session(self, node_idx=0, user=None, password=None, exclusive=True):
         node = self.cluster.nodelist()[node_idx]
         if exclusive:
-            conn = self.patient_exclusive_cql_connection(node, user=user, password=password, timeout=0.1)
+            conn = self.patient_exclusive_cql_connection(node, user=user, password=password)
         else:
-            conn = self.patient_cql_connection(node, user=user, password=password, timeout=0.1)
+            conn = self.patient_cql_connection(node, user=user, password=password)
         return conn
 
     def assert_permissions_listed(self, expected, session, query, include_superuser=False):


### PR DESCRIPTION
get_session() was passing timeout=0.1 to patient_exclusive_cql_connection and patient_cql_connection, leaving only 0.1 seconds for the retry loop in retry_till_success(). Since each connection attempt can take up to 5 seconds (connect_timeout=5), the retry loop effectively got only one attempt with no chance to retry on transient NoHostAvailable errors.

Use the default timeout=30 seconds, consistent with all other callers.

Fixes: SCYLLADB-1373

Not backporting as this issue wasn't reproduced many times.