### PR TITLE
test: test_out_of_storage_prevention: fix invalid escape in regex

### DIFF
--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -542,7 +542,7 @@ async def test_repair_failure_on_split_rejection(manager: ManagerClient, volumes
 
                     # Expect repair to fail when splitting new sstables
                     await log.wait_for("Repair for tablet migration of .* failed", from_mark=mark)
-                    await log.wait_for("Failed to load SSTable.*\(critical disk utilization\)", from_mark=mark)
+                    await log.wait_for(r"Failed to load SSTable.*\(critical disk utilization\)", from_mark=mark)
 
                     assert await log.grep(f"compaction.*Split {cf}", from_mark=mark) == []
 


### PR DESCRIPTION
Python warns that the sequence "\\(" is an invalid escape and might be rejected in the future. Protect against that by using a raw string.

We're not going to backport newer Python to older branches, so backport is not required.