### PR TITLE
test/cluster/dtest: improve diagnostics in test_update_schema_while_n…

### DIFF
--- a/test/cluster/dtest/schema_management_test.py
+++ b/test/cluster/dtest/schema_management_test.py
@@ -270,7 +270,18 @@ class TestSchemaManagement(Tester):
             rows = session.execute(SimpleStatement("SELECT * FROM ks.cf LIMIT 1;", consistency_level=ConsistencyLevel.QUORUM))
             assert len(rows_to_list(rows)[0]) == col_mun, f"Expected {col_mun} columns but got rows:{rows} instead"
             for key in range(10):
-                query_c1c2(session=session, key=key, consistency=ConsistencyLevel.QUORUM)
+                logger.debug(f"Querying key k{key}")
+                try:
+                    query_c1c2(session=session, key=key, consistency=ConsistencyLevel.QUORUM)
+                except AssertionError:
+                    all_rows = rows_to_list(session.execute(SimpleStatement("SELECT * FROM ks.cf;", consistency_level=ConsistencyLevel.QUORUM)))
+                    logger.error(f"Key k{key} not found via QUORUM. All rows in ks.cf: {all_rows}")
+                    for node, node_name in [(node1, "node1"), (node2, "node2"), (node3, "node3")]:
+                        node_session = self.patient_exclusive_cql_connection(node)
+                        node_rows = rows_to_list(node_session.execute(SimpleStatement(
+                            f"SELECT * FROM ks.cf WHERE key='k{key}';", consistency_level=ConsistencyLevel.ONE)))
+                        logger.error(f"  {node_name} ({node.address()}) has key k{key}: {node_rows}")
+                    raise
 
         expected_case_result_map = {
             "create_table": functools.partial(create_or_alter_table_expected_result, 3),


### PR DESCRIPTION
…ode_is_killed

The alter_table case has a known failure where point lookups at QUORUM return 0 rows after node2 restarts, even though:
- the schema was correctly synced (ALTER TABLE received from cluster)
- the data commitlog was replayed (21 mutations, 0 skipped)
- all 3 nodes were alive, so QUORUM (2/3) should be satisfiable by node1+node3 regardless of node2's state

The LIMIT 1 table scan succeeds (data is present somewhere), but specific key lookups return empty. This points to a bug in how node2, acting as coordinator after restart, routes single-partition reads — most likely stale tablet routing metadata.

Add diagnostics to help distinguish data loss from a coordinator/routing bug on the next failure:
- log which key is missing
- dump all rows visible at QUORUM
- query each node individually at ONE consistency for the missing key

refs: SCYLLADB-857

Test verbodity, not backporting