### PR TITLE
transport: refactor result_message bounce interface

### DIFF
--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4777,7 +4777,7 @@ static void prepared_on_shard(cql_test_env& e, const sstring& query,
 
             auto qo = q_serial_opts(std::move(raw_values), cl);
             auto msg = e.execute_prepared_with_qo(id, std::move(qo)).get();
-            if (!msg->move_to_shard()) {
+            if (!msg->as_bounce()) {
                 assert_that(msg).is_rows().with_rows_ignore_order(expected_rows);
             }
             return make_foreign(msg);
@@ -4785,8 +4785,8 @@ static void prepared_on_shard(cql_test_env& e, const sstring& query,
     };
 
     auto msg = execute().get();
-    if (msg->move_to_shard()) {
-        unsigned shard = *msg->move_to_shard();
+    if (auto bounce = msg->as_bounce()) {
+        unsigned shard = bounce->target_shard();
         smp::submit_to(shard, std::move(execute)).get();
     }
 }

--- a/transport/messages/result_message.cc
+++ b/transport/messages/result_message.cc
@@ -20,7 +20,7 @@ std::ostream& operator<<(std::ostream& os, const result_message::void_message& m
 }
 
 std::ostream& operator<<(std::ostream& os, const result_message::bounce& msg) {
-    fmt::print(os, "{{result_message::bounce to host {}, shard {} }}", msg.move_to_host(), msg.move_to_shard());
+    fmt::print(os, "{{result_message::bounce to host {}, shard {} }}", msg.target_host(), msg.target_shard());
     return os;
 }
 

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -113,11 +113,15 @@ public:
     virtual void accept(result_message::visitor& v) const override {
         v.visit(*this);
     }
-    virtual std::optional<unsigned> move_to_shard() const override {
+    virtual const result_message::bounce* as_bounce() const override {
+        return this;
+    }
+
+    unsigned target_shard() const {
         return _shard;
     }
 
-    locator::host_id move_to_host() const {
+    locator::host_id target_host() const {
         return _host;
     }
 

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -26,6 +26,16 @@ class result_message {
 public:
     class visitor;
     class visitor_base;
+    //
+    // Message types:
+    //
+    class void_message;
+    class set_keyspace;
+    class prepared;
+    class schema_change;
+    class rows;
+    class bounce;
+    class exception;
 
     virtual ~result_message() {}
 
@@ -61,8 +71,8 @@ public:
         return _custom_payload;
     }
 
-    virtual std::optional<unsigned> move_to_shard() const {
-        return std::nullopt;
+    virtual const result_message::bounce* as_bounce() const {
+        return nullptr;
     }
 
     virtual bool is_exception() const {
@@ -70,16 +80,6 @@ public:
     }
 
     virtual void throw_if_exception() const {}
-    //
-    // Message types:
-    //
-    class void_message;
-    class set_keyspace;
-    class prepared;
-    class schema_change;
-    class rows;
-    class bounce;
-    class exception;
 };
 
 std::ostream& operator<<(std::ostream& os, const result_message& msg);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -490,8 +490,8 @@ future<forward_cql_execute_response> cql_server::handle_forward_execute(
         handling_node_bounce::yes));
 
     if (auto* bounce_msg = std::get_if<cql_server::result_with_bounce>(&result)) {
-        auto host = (*bounce_msg)->move_to_host();
-        auto shard = (*bounce_msg)->move_to_shard().value();
+        auto host = (*bounce_msg)->target_host();
+        auto shard = (*bounce_msg)->target_shard();
         co_return forward_cql_execute_response{
             .status = forward_cql_status::redirect,
             .target_host = host,
@@ -1517,8 +1517,8 @@ process_query_internal(service::client_state& client_state, sharded<cql3::query_
     }
 
     return qp.local().execute_direct_without_checking_exception_message(query.assume_value(), query_state, dialect, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
-        if (msg->move_to_shard()) {
-            return cql_server::process_fn_return_type(make_foreign(dynamic_pointer_cast<messages::result_message::bounce>(msg)));
+        if (msg->as_bounce()) {
+            return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
             return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
         } else {
@@ -1635,8 +1635,8 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
     tracing::trace(trace_state, "Processing a statement");
     return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization)
             .then([trace_state = query_state.get_trace_state(), skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
-        if (msg->move_to_shard()) {
-            return cql_server::process_fn_return_type(make_foreign(dynamic_pointer_cast<messages::result_message::bounce>(msg)));
+        if (msg->as_bounce()) {
+            return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
             return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
         } else {
@@ -1774,8 +1774,8 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
     auto batch = ::make_shared<cql3::statements::batch_statement>(cql3::statements::batch_statement::type(type.assume_value()), std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
     return qp.local().execute_batch_without_checking_exception_message(batch, query_state, options, std::move(pending_authorization_entries))
             .then([stream, batch, q_state = std::move(q_state), trace_state = query_state.get_trace_state(), version] (auto msg) {
-        if (msg->move_to_shard()) {
-            return cql_server::process_fn_return_type(make_foreign(dynamic_pointer_cast<messages::result_message::bounce>(msg)));
+        if (msg->as_bounce()) {
+            return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
             return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
         } else {
@@ -1823,9 +1823,9 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
     auto msg = co_await coroutine::try_future(process_fn(client_state, _query_processor, in, stream,
         version, permit, trace_state, init_trace, {}, dialect));
     while (auto* bounce_msg = std::get_if<cql_server::result_with_bounce>(&msg)) {
-        auto shard = (*bounce_msg)->move_to_shard().value();
+        auto shard = (*bounce_msg)->target_shard();
         auto&& cached_vals = (*bounce_msg)->take_cached_pk_function_calls();
-        auto target_host = (*bounce_msg)->move_to_host();
+        auto target_host = (*bounce_msg)->target_host();
         auto my_host_id = _query_processor.local().proxy().get_token_metadata_ptr()->get_topology().my_host_id();
         if (target_host == my_host_id) {
             // Shard bounce


### PR DESCRIPTION
Replace move_to_shard()/move_to_host() with as_bounce()/target_shard()/ target_host() to clarify the interface after bounce was extended to support cross-node bouncing.

- Add virtual as_bounce() returning const bounce* to the base class (nullptr by default, overridden in bounce to return this), replacing the virtual move_to_shard() which conflated bounce detection with shard access
- Rename move_to_shard() -> target_shard() (now non-virtual, returns unsigned directly) and move_to_host() -> target_host() on bounce
- Replace dynamic_pointer_cast with static_pointer_cast at call sites that already checked as_bounce()
- Move forward declarations of message types before the virtual methods so as_bounce() can reference bounce

Fixes: SCYLLADB-1066
