### PR TITLE
test: explicitly wait for schema agreement in create_new_test_keyspace

### DIFF
--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -409,6 +409,16 @@ async def create_new_test_keyspace(cql: Session, opts, host=None):
     # Use CREATE KEYSPACE IF NOT EXISTS as a workaround for
     # https://github.com/scylladb/python-driver/issues/317
     await cql.run_async(f"CREATE KEYSPACE IF NOT EXISTS {keyspace} {opts}", host=host)
+    # Explicitly wait for schema agreement
+    # Respect max_schema_agreement_wait so that callers using
+    # disable_schema_agreement_wait() are not overridden.
+    wait_time = cql.cluster.max_schema_agreement_wait
+    if wait_time and wait_time > 0:
+        try:
+            await asyncio.get_event_loop().run_in_executor(
+                None, lambda: cql.cluster.control_connection.wait_for_schema_agreement(wait_time=wait_time))
+        except ConnectionException as e:
+            logger.warning("wait_for_schema_agreement failed: %s", e)
     return keyspace
 
 @asynccontextmanager


### PR DESCRIPTION
Add an explicit wait_for_schema_agreement() call after CREATE KEYSPACE in create_new_test_keyspace to ensure all nodes have applied the schema before proceeding.

Fixes SCYLLADB-1405

