### PR TITLE
commitlog: fix segment replay order by using ordered map per shard

### DIFF
--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <unordered_map>
 #include <ranges>
+#include "utils/chunked_vector.hh"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
@@ -331,7 +332,7 @@ future<db::commitlog_replayer> db::commitlog_replayer::create_replayer(seastar::
 }
 
 future<> db::commitlog_replayer::recover(std::vector<sstring> files, sstring fname_prefix) {
-    using shard_file_map = std::unordered_multimap<unsigned, commitlog::descriptor>;
+    using shard_file_map = std::unordered_map<unsigned, utils::chunked_vector<commitlog::descriptor>>;
 
     rlogger.info("Replaying {}", fmt::join(files, ", "));
 
@@ -349,7 +350,7 @@ future<> db::commitlog_replayer::recover(std::vector<sstring> files, sstring fna
  
         for (auto& d : descs) {
             replay_position p = d;
-            map.emplace(p.shard_id() % smp::count, std::move(d));
+            map[p.shard_id() % smp::count].push_back(std::move(d));
         }
     }
 
@@ -363,8 +364,11 @@ future<> db::commitlog_replayer::recover(std::vector<sstring> files, sstring fna
                 // TODO: or something. For now, we do this serialized per shard,
                 // to reduce mutation congestion. We could probably (says avi)
                 // do 2 segments in parallel or something, but lets use this first.
-                auto range = map.equal_range(id);
-                for (auto& [id, d] : std::ranges::subrange(range.first, range.second)) {
+                auto it = map.find(id);
+                if (it == map.end()) {
+                    co_return total;
+                }
+                for (auto& d : it->second) {
                     auto f = d.filename();
                     rlogger.debug("Replaying {}", f);
                     auto stats = co_await _impl->recover(d, states[replay_position(d).shard_id()]);

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -10,6 +10,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <stdlib.h>
+#include <sstream>
+#include <regex>
 #include <iostream>
 #include <unordered_map>
 #include <unordered_set>
@@ -2332,6 +2334,76 @@ SEASTAR_TEST_CASE(test_segment_end_on_entry_end) {
         co_await log.sync_all_segments();
         // Without the fix, this will throw.
         co_await replay_segment(segment_path);
+    });
+}
+
+
+// Verify that commitlog segments are replayed in ascending segment ID
+// order within each shard. The replayer distributes segments by shard and
+// iterates them per-shard; this test captures the "Replaying" debug log
+// messages and checks that segment IDs appear in strictly ascending order.
+//
+SEASTAR_TEST_CASE(test_commitlog_replay_segment_order) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        env.execute_cql("create table t (pk text primary key, v text)").get();
+
+        auto& db = env.local_db();
+        auto& table = db.find_column_family("ks", "t");
+        auto& cl = *table.commitlog();
+        auto s = table.schema();
+
+        // Write a mutation and force a new segment, repeat several
+        // times to produce multiple segments on the current shard.
+        // Keep rp_handles alive so segments are not recycled.
+        constexpr int num_segments = 4;
+        auto uuid = s->id();
+        sstring tmp = "test mutation data";
+        std::vector<rp_handle> handles;
+        for (int i = 0; i < num_segments; ++i) {
+            auto h = cl.add_mutation(uuid, tmp.size(), db::commitlog::force_sync::yes, [&tmp](db::commitlog::output& dst) {
+                           dst.write(tmp.data(), tmp.size());
+                       }).get();
+            handles.push_back(std::move(h));
+            cl.force_new_active_segment().get();
+        }
+
+        cl.sync_all_segments().get();
+        auto paths = cl.get_active_segment_names();
+        BOOST_REQUIRE_GE(paths.size(), num_segments);
+
+        // Enable debug logging for the replayer and capture output.
+        auto prev_level = logging::logger_registry().get_logger_level("commitlog_replayer");
+        logging::logger_registry().set_logger_level("commitlog_replayer", logging::log_level::debug);
+
+        std::ostringstream captured;
+        seastar::logger::set_ostream(captured);
+
+        auto rp = db::commitlog_replayer::create_replayer(env.db(), env.get_system_keyspace()).get();
+        rp.recover(paths, db::commitlog::descriptor::FILENAME_PREFIX).get();
+
+        // Restore logger state.
+        seastar::logger::set_ostream(std::cerr);
+        logging::logger_registry().set_logger_level("commitlog_replayer", prev_level);
+
+        // Parse captured log lines for per-segment "Replaying <path>"
+        // debug messages and extract segment IDs.
+        auto log_output = captured.str();
+        std::vector<segment_id_type> replayed_ids;
+        std::regex re(R"(DEBUG.*Replaying (\S+))");
+        std::sregex_iterator it(log_output.begin(), log_output.end(), re);
+        std::sregex_iterator end;
+        for (; it != end; ++it) {
+            auto fname = (*it)[1].str();
+            commitlog::descriptor desc(fname, db::commitlog::descriptor::FILENAME_PREFIX);
+            replayed_ids.push_back(desc.id);
+        }
+
+        BOOST_REQUIRE_GE(replayed_ids.size(), num_segments);
+
+        // Check strictly ascending order.
+        for (size_t i = 1; i < replayed_ids.size(); ++i) {
+            BOOST_CHECK_GT(replayed_ids[i], replayed_ids[i - 1]);
+        }
     });
 }
 


### PR DESCRIPTION
The commitlog replayer groups segments by shard using a
std::unordered_multimap, then iterates per-shard segments via
equal_range(). However, equal_range() does not guarantee iteration
order for elements with the same key, so segments could be replayed
out of order within a shard.

Correct segment ordering is required for:
- Fragmented entry reconstruction, which accumulates fragments across
  segments and depends on ascending order for efficient processing.
- Commitlog-based storage used by the strongly consistent tables
  feature, which relies on replayed raft items being stored in order.

Fix by changing the data structure from
  std::unordered_multimap<unsigned, commitlog::descriptor>
to
  std::unordered_map<unsigned, utils::chunked_vector<commitlog::descriptor>>

Since the descriptors are inserted from a std::set ordered by ID, the
vector preserves insertion (and thus ID) order. The per-shard iteration
now simply iterates the vector, guaranteeing correct replay order.

Fixes: SCYLLADB-1411

Backport: It looks like this issue doesn't cause any trouble, and is required only by the strong consistent tables, so no backporting required.