### PR TITLE
replicate system.sstables over raft

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -125,6 +125,7 @@ namespace {
                 system_keyspace::VIEW_BUILDING_TASKS,
                 system_keyspace::CLIENT_ROUTES,
                 system_keyspace::REPAIR_TASKS,
+                system_keyspace::SSTABLES_REGISTRY,
             };
             if (builder.ks_name() == system_keyspace::NAME && tables.contains(builder.cf_name())) {
                 builder.set_is_group0_table();
@@ -3407,27 +3408,50 @@ system_keyspace::read_cdc_generation_opt(utils::UUID id) {
 future<> system_keyspace::sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc, service::group0_batch& mc) {
     static const auto req = format("INSERT INTO system.{} (owner, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
     slogger.trace("Inserting {}.{} into {}", owner, desc.generation, SSTABLES_REGISTRY);
-    co_await execute_cql(req, owner.id, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
+    if (mc.has_guard()) {
+        auto muts = co_await _qp.get_mutations_internal(req, internal_system_query_state(), mc.write_timestamp(),
+                {data_value(owner.id), data_value(desc.generation), data_value(status), data_value(sstables::state_to_dir(state)), data_value(fmt::to_string(desc.version)), data_value(fmt::to_string(desc.format))});
+        mc.add_mutations(std::move(muts), fmt::format("sstables_registry create_entry {}.{}", owner, desc.generation));
+    } else {
+        co_await execute_cql(req, owner.id, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
+    }
 }
 
 future<> system_keyspace::sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status, service::group0_batch& mc) {
     static const auto req = format("UPDATE system.{} SET status = ? WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Updating {}.{} -> status={} in {}", owner, gen, status, SSTABLES_REGISTRY);
-    co_await execute_cql(req, status, owner.id, gen).discard_result();
+    if (mc.has_guard()) {
+        auto muts = co_await _qp.get_mutations_internal(req, internal_system_query_state(), mc.write_timestamp(),
+                {data_value(status), data_value(owner.id), data_value(gen)});
+        mc.add_mutations(std::move(muts), fmt::format("sstables_registry update_entry_status {}.{}", owner, gen));
+    } else {
+        co_await execute_cql(req, status, owner.id, gen).discard_result();
+    }
 }
 
 future<> system_keyspace::sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state, service::group0_batch& mc) {
     static const auto req = format("UPDATE system.{} SET state = ? WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
     auto new_state = sstables::state_to_dir(state);
     slogger.trace("Updating {}.{} -> state={} in {}", owner, gen, new_state, SSTABLES_REGISTRY);
-    co_await execute_cql(req, new_state, owner.id, gen).discard_result();
+    if (mc.has_guard()) {
+        auto muts = co_await _qp.get_mutations_internal(req, internal_system_query_state(), mc.write_timestamp(),
+                {data_value(new_state), data_value(owner.id), data_value(gen)});
+        mc.add_mutations(std::move(muts), fmt::format("sstables_registry update_entry_state {}.{}", owner, gen));
+    } else {
+        co_await execute_cql(req, new_state, owner.id, gen).discard_result();
+    }
 }
 
 future<> system_keyspace::sstables_registry_delete_entry(table_id owner, sstables::generation_type gen, service::group0_batch& mc) {
     static const auto req = format("DELETE FROM system.{} WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Removing {}.{} from {}", owner, gen, SSTABLES_REGISTRY);
-    co_await execute_cql(req, owner.id, gen).discard_result();
-
+    if (mc.has_guard()) {
+        auto muts = co_await _qp.get_mutations_internal(req, internal_system_query_state(), mc.write_timestamp(),
+                {data_value(owner.id), data_value(gen)});
+        mc.add_mutations(std::move(muts), fmt::format("sstables_registry delete_entry {}.{}", owner, gen));
+    } else {
+        co_await execute_cql(req, owner.id, gen).discard_result();
+    }
 }
 
 future<> system_keyspace::sstables_registry_list(table_id owner, sstable_registry_entry_consumer consumer) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3470,6 +3470,15 @@ future<> system_keyspace::sstables_registry_list(table_id owner, sstable_registr
     });
 }
 
+mutation system_keyspace::make_drop_sstables_registry_mutation(table_id id, api::timestamp_type ts) {
+    auto s = db::system_keyspace::sstables_registry();
+    mutation m(s, partition_key::from_single_value(*s,
+        data_value(id.uuid()).serialize_nonnull()
+    ));
+    m.partition().apply(tombstone(ts, gc_clock::now()));
+    return m;
+}
+
 future<service::topology_request_state> system_keyspace::get_topology_request_state(utils::UUID id, bool require_entry) {
     auto rs = co_await execute_cql(
         format("SELECT done, error FROM system.{} WHERE id = {}", TOPOLOGY_REQUESTS, id));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3404,26 +3404,26 @@ system_keyspace::read_cdc_generation_opt(utils::UUID id) {
     co_return cdc::topology_description{std::move(entries)};
 }
 
-future<> system_keyspace::sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
+future<> system_keyspace::sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc, service::group0_batch& mc) {
     static const auto req = format("INSERT INTO system.{} (owner, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
     slogger.trace("Inserting {}.{} into {}", owner, desc.generation, SSTABLES_REGISTRY);
     co_await execute_cql(req, owner.id, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status) {
+future<> system_keyspace::sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status, service::group0_batch& mc) {
     static const auto req = format("UPDATE system.{} SET status = ? WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Updating {}.{} -> status={} in {}", owner, gen, status, SSTABLES_REGISTRY);
     co_await execute_cql(req, status, owner.id, gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) {
+future<> system_keyspace::sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state, service::group0_batch& mc) {
     static const auto req = format("UPDATE system.{} SET state = ? WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
     auto new_state = sstables::state_to_dir(state);
     slogger.trace("Updating {}.{} -> state={} in {}", owner, gen, new_state, SSTABLES_REGISTRY);
     co_await execute_cql(req, new_state, owner.id, gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_delete_entry(table_id owner, sstables::generation_type gen) {
+future<> system_keyspace::sstables_registry_delete_entry(table_id owner, sstables::generation_type gen, service::group0_batch& mc) {
     static const auto req = format("DELETE FROM system.{} WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Removing {}.{} from {}", owner, gen, SSTABLES_REGISTRY);
     co_await execute_cql(req, owner.id, gen).discard_result();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -665,6 +665,7 @@ public:
     future<> sstables_registry_delete_entry(table_id owner, sstables::generation_type gen, service::group0_batch& mc);
     using sstable_registry_entry_consumer = sstables::sstables_registry::entry_consumer;
     future<> sstables_registry_list(table_id owner, sstable_registry_entry_consumer consumer);
+    static mutation make_drop_sstables_registry_mutation(table_id id, api::timestamp_type ts);
 
     future<std::optional<sstring>> load_group0_upgrade_state();
     future<> save_group0_upgrade_state(sstring);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -59,6 +59,7 @@ struct topology_request_state;
 class group0_guard;
 
 class raft_group0_client;
+class group0_batch;
 }
 
 namespace netw {
@@ -658,10 +659,10 @@ public:
     future<mutation> make_view_builder_version_mutation(api::timestamp_type ts, view_builder_version_t version);
     future<view_builder_version_t> get_view_builder_version();
 
-    future<> sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
-    future<> sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status);
-    future<> sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state);
-    future<> sstables_registry_delete_entry(table_id owner, sstables::generation_type gen);
+    future<> sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc, service::group0_batch& mc);
+    future<> sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status, service::group0_batch& mc);
+    future<> sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state, service::group0_batch& mc);
+    future<> sstables_registry_delete_entry(table_id owner, sstables::generation_type gen, service::group0_batch& mc);
     using sstable_registry_entry_consumer = sstables::sstables_registry::entry_consumer;
     future<> sstables_registry_list(table_id owner, sstable_registry_entry_consumer consumer);
 

--- a/db/system_keyspace_sstables_registry.hh
+++ b/db/system_keyspace_sstables_registry.hh
@@ -15,20 +15,20 @@ class system_keyspace_sstables_registry : public sstables::sstables_registry {
 public:
     system_keyspace_sstables_registry(system_keyspace& keyspace) : _keyspace(keyspace.shared_from_this()) {}
 
-    virtual seastar::future<> create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
-        return _keyspace->sstables_registry_create_entry(owner, status, state, desc);
+    virtual seastar::future<> create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc, service::group0_batch& mc) override {
+        return _keyspace->sstables_registry_create_entry(owner, status, state, desc, mc);
     }
 
-    virtual seastar::future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) override {
-        return _keyspace->sstables_registry_update_entry_status(owner, gen, status);
+    virtual seastar::future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status, service::group0_batch& mc) override {
+        return _keyspace->sstables_registry_update_entry_status(owner, gen, status, mc);
     }
 
-    virtual seastar::future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) override {
-        return _keyspace->sstables_registry_update_entry_state(owner, gen, state);
+    virtual seastar::future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state, service::group0_batch& mc) override {
+        return _keyspace->sstables_registry_update_entry_state(owner, gen, state, mc);
     }
 
-    virtual seastar::future<> delete_entry(table_id owner, sstables::generation_type gen) override {
-        return _keyspace->sstables_registry_delete_entry(owner, gen);
+    virtual seastar::future<> delete_entry(table_id owner, sstables::generation_type gen, service::group0_batch& mc) override {
+        return _keyspace->sstables_registry_delete_entry(owner, gen, mc);
     }
 
     virtual seastar::future<> sstables_registry_list(table_id owner, entry_consumer consumer) override {

--- a/main.cc
+++ b/main.cc
@@ -1755,6 +1755,34 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             };
             auto the_sstable_dict_deleter = sstable_dict_deleter(mm_notifier.local(), feature_service.local());
 
+            class sstables_registry_dropper : public service::migration_listener::empty_listener {
+                service::migration_notifier& _mn;
+                replica::database& _db;
+            public:
+                sstables_registry_dropper(service::migration_notifier& mn, replica::database& db) : _mn(mn), _db(db) {
+                    _mn.register_listener(this);
+                }
+                ~sstables_registry_dropper() {
+                    _mn.unregister_listener(this).get();
+                }
+                void on_before_drop_column_family(const schema& s, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
+                    if (!_db.find_keyspace(s.ks_name()).metadata()->get_storage_options().is_object_storage_type()) {
+                        return;
+                    }
+                    muts.emplace_back(db::system_keyspace::make_drop_sstables_registry_mutation(s.id(), ts));
+                }
+                void on_before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
+                    auto& ks = _db.find_keyspace(keyspace_name);
+                    if (!ks.metadata()->get_storage_options().is_object_storage_type()) {
+                        return;
+                    }
+                    for (auto&& [name, s] : ks.metadata()->cf_meta_data()) {
+                        muts.emplace_back(db::system_keyspace::make_drop_sstables_registry_mutation(s->id(), ts));
+                    }
+                }
+            };
+            auto the_sstables_registry_dropper = sstables_registry_dropper(mm_notifier.local(), db.local());
+
             checkpoint(stop_signal, "starting migration manager");
             debug::the_migration_manager = &mm;
             mm.start(std::ref(mm_notifier), std::ref(feature_service), std::ref(messaging), std::ref(proxy), std::ref(gossiper), std::ref(group0_client), std::ref(sys_ks)).get();

--- a/main.cc
+++ b/main.cc
@@ -1769,6 +1769,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     if (!_db.find_keyspace(s.ks_name()).metadata()->get_storage_options().is_object_storage_type()) {
                         return;
                     }
+                    if (utils::get_local_injector().enter("skip_sstables_registry_drop_tombstone")) {
+                        return;
+                    }
                     muts.emplace_back(db::system_keyspace::make_drop_sstables_registry_mutation(s.id(), ts));
                 }
                 void on_before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {

--- a/main.cc
+++ b/main.cc
@@ -1708,6 +1708,14 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // The client has to be created before `stop_raft` since during
             // destruction it has to exist until raft_gr.stop() completes.
             service::raft_group0_client group0_client{raft_gr.local(), gossiper.local(), sys_ks.local(), token_metadata.local(), maintenance_mode_enabled{cfg->maintenance_mode()}};
+            db.invoke_on_all([&group0_client, &db, &stop_signal](replica::database& local_db) {
+                local_db.get_user_sstables_manager().plug_group0_client(group0_client, db, stop_signal.as_sharded_abort_source());
+            }).get();
+            auto unplug_group0_client = defer_verbose_shutdown("sstables_manager group0_client", [&db] {
+                db.invoke_on_all([](replica::database& local_db) {
+                    local_db.get_user_sstables_manager().unplug_group0_client();
+                }).get();
+            });
 
             service::raft_group0 group0_service{
                     stop_signal.as_local_abort_source(), raft_gr.local(), messaging,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1363,7 +1363,13 @@ future<> database::cleanup_drop_table_on_all_shards(sharded<database>& sharded_d
     if (with_snapshot) {
         snapshot_name_opt = format("pre-drop-{}", db_clock::now().time_since_epoch().count());
     }
+    co_await sharded_db.invoke_on_all([&] (database& db) {
+        db.get_user_sstables_manager().set_in_group0_drop_schema_trx(true);
+    });
     auto f = co_await coroutine::as_future(truncate_table_on_all_shards(sharded_db, sys_ks, table_shards, truncated_at, with_snapshot, std::move(snapshot_name_opt)));
+    co_await sharded_db.invoke_on_all([&] (database& db) {
+        db.get_user_sstables_manager().set_in_group0_drop_schema_trx(false);
+    });
     co_await smp::invoke_on_all([&] {
         return table_shards->stop();
     });

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -222,6 +222,10 @@ public:
         return _guard.value();
     }
 
+    bool has_guard() const noexcept {
+        return _guard.has_value();
+    }
+
     // Gets timestamp which should be used when building mutations.
     api::timestamp_type write_timestamp() const;
     utils::UUID new_group0_state_id() const;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6247,6 +6247,7 @@ void storage_service::init_messaging_service() {
                 if (ss._feature_service.client_routes) {
                     additional_tables.push_back(db::system_keyspace::client_routes()->id());
                 }
+                additional_tables.push_back(db::system_keyspace::sstables_registry()->id());
             }
 
             for (const auto& table : boost::join(params.tables, additional_tables)) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -27,6 +27,7 @@
 #include "utils/directories.hh"
 #include "utils/s3/client.hh"
 #include "replica/database.hh"
+#include "service/raft/raft_group0_client.hh"
 #include "dht/auto_refreshing_sharder.hh"
 
 static logging::logger dirlog("sstable_directory");
@@ -493,7 +494,8 @@ future<> sstable_directory::sstables_registry_components_lister::garbage_collect
         co_await st.remove_by_registry_entry(std::move(desc));
     }));
     co_await coroutine::parallel_for_each(gens_to_remove, [this] (auto gen) -> future<> {
-        co_await _sstables_registry.delete_entry(_owner, gen);
+        auto mc = service::group0_batch::unused();
+        co_await _sstables_registry.delete_entry(_owner, gen, mc);
     });
 }
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -440,6 +440,18 @@ void sstables_manager::unplug_sstables_registry() noexcept {
     _sstables_registry.reset();
 }
 
+void sstables_manager::plug_group0_client(service::raft_group0_client& client, sharded<replica::database>& db, sharded<abort_source>& as) noexcept {
+    _group0_client = &client;
+    _db = &db;
+    _group0_as = &as;
+}
+
+void sstables_manager::unplug_group0_client() noexcept {
+    _group0_client = nullptr;
+    _db = nullptr;
+    _group0_as = nullptr;
+}
+
 future<lw_shared_ptr<const data_dictionary::storage_options>> sstables_manager::init_table_storage(const schema& s, const data_dictionary::storage_options& so) {
     return sstables::init_table_storage(*this, s, so);
 }

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -175,6 +175,7 @@ private:
     service::raft_group0_client* _group0_client = nullptr;
     sharded<replica::database>* _db = nullptr;
     sharded<abort_source>* _group0_as = nullptr;
+    bool _in_group0_drop_schema_trx = false;
 
     named_gate _signal_gate;
     signal_type _signal_source;
@@ -272,6 +273,8 @@ public:
     service::raft_group0_client* group0_client() const noexcept { return _group0_client; }
     sharded<replica::database>* database_container() const noexcept { return _db; }
     sharded<abort_source>* group0_abort_source() const noexcept { return _group0_as; }
+    void set_in_group0_drop_schema_trx(bool v) noexcept { _in_group0_drop_schema_trx = v; }
+    bool in_group0_drop_schema_trx() const noexcept { return _in_group0_drop_schema_trx; }
 
     future<> delete_atomically(std::vector<shared_sstable> ssts);
     future<utils::chunked_vector<sstable_snapshot_metadata>> take_snapshot(std::vector<shared_sstable> ssts, sstring jsondir);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -40,6 +40,13 @@ class config;
 
 namespace s3 { class client; }
 
+namespace replica { class database; }
+
+namespace service {
+class raft_group0_client;
+class group0_batch;
+}
+
 namespace gms { class feature_service; }
 
 namespace sstables {
@@ -165,6 +172,9 @@ private:
     sstable_compressor_factory& _compressor_factory;
 
     const abort_source& _abort;
+    service::raft_group0_client* _group0_client = nullptr;
+    sharded<replica::database>* _db = nullptr;
+    sharded<abort_source>* _group0_as = nullptr;
 
     named_gate _signal_gate;
     signal_type _signal_source;
@@ -250,12 +260,18 @@ public:
 
     void plug_sstables_registry(std::unique_ptr<sstables_registry>) noexcept;
     void unplug_sstables_registry() noexcept;
+    void plug_group0_client(service::raft_group0_client& client, sharded<replica::database>& db, sharded<abort_source>& as) noexcept;
+    void unplug_group0_client() noexcept;
 
     // Only for sstable::storage usage
     sstables::sstables_registry& sstables_registry() const noexcept {
         SCYLLA_ASSERT(_sstables_registry && "sstables_registry is not plugged");
         return *_sstables_registry;
     }
+
+    service::raft_group0_client* group0_client() const noexcept { return _group0_client; }
+    sharded<replica::database>* database_container() const noexcept { return _db; }
+    sharded<abort_source>* group0_abort_source() const noexcept { return _group0_as; }
 
     future<> delete_atomically(std::vector<shared_sstable> ssts);
     future<utils::chunked_vector<sstable_snapshot_metadata>> take_snapshot(std::vector<shared_sstable> ssts, sstring jsondir);

--- a/sstables/sstables_registry.hh
+++ b/sstables/sstables_registry.hh
@@ -10,6 +10,10 @@
 #include "schema/schema_fwd.hh"
 #include "seastarx.hh"
 
+namespace service {
+class group0_batch;
+}
+
 namespace sstables {
 
 // sstables_manager needs to store the names of its sstables somewhere, when
@@ -19,10 +23,10 @@ namespace sstables {
 class sstables_registry {
 public:
     virtual ~sstables_registry();
-    virtual future<> create_entry(table_id owner, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
-    virtual future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) = 0;
-    virtual future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) = 0;
-    virtual future<> delete_entry(table_id owner, sstables::generation_type gen) = 0;
+    virtual future<> create_entry(table_id owner, sstring status, sstable_state state, sstables::entry_descriptor desc, service::group0_batch& mc) = 0;
+    virtual future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status, service::group0_batch& mc) = 0;
+    virtual future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state, service::group0_batch& mc) = 0;
+    virtual future<> delete_entry(table_id owner, sstables::generation_type gen, service::group0_batch& mc) = 0;
     using entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
     virtual future<> sstables_registry_list(table_id owner, entry_consumer consumer) = 0;
 };

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -31,6 +31,7 @@
 #include "sstables/integrity_checked_file_impl.hh"
 #include "sstables/writer.hh"
 #include "utils/assert.hh"
+#include "service/raft/raft_group0_client.hh"
 #include "utils/lister.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/memory_data_sink.hh"
@@ -719,7 +720,8 @@ object_name object_storage_base::make_object_name(const sstable& sst, component_
 
 void object_storage_base::open(sstable& sst) {
     entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
-    sst.manager().sstables_registry().create_entry(owner(), status_creating, sst._state, std::move(desc)).get();
+    auto mc = service::group0_batch::unused();
+    sst.manager().sstables_registry().create_entry(owner(), status_creating, sst._state, std::move(desc), mc).get();
 
     memory_data_sink_buffers bufs;
     auto out = data_sink(std::make_unique<memory_data_sink>(bufs));
@@ -807,7 +809,8 @@ future<data_sink> object_storage_base::make_component_sink(sstable& sst, compone
 }
 
 future<> object_storage_base::seal(const sstable& sst) {
-    co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.generation(), status_sealed);
+    auto mc = service::group0_batch::unused();
+    co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.generation(), status_sealed, mc);
 }
 
 future<> object_storage_base::change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) {
@@ -817,19 +820,22 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
         // is moved from upload directory and this is another issue for S3 (#13018)
         co_await coroutine::return_exception(std::runtime_error("Cannot change state and generation of an S3 object"));
     }
-    co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.generation(), state);
+    auto mc = service::group0_batch::unused();
+    co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.generation(), state, mc);
 }
 
 future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
     auto& sstables_registry = sst.manager().sstables_registry();
 
-    co_await sstables_registry.update_entry_status(owner(), sst.generation(), status_removing);
+    auto mc1 = service::group0_batch::unused();
+    co_await sstables_registry.update_entry_status(owner(), sst.generation(), status_removing, mc1);
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
         co_await delete_object(make_object_name(sst, type));
     });
 
-    co_await sstables_registry.delete_entry(owner(), sst.generation());
+    auto mc2 = service::group0_batch::unused();
+    co_await sstables_registry.delete_entry(owner(), sst.generation(), mc2);
 }
 
 future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>&) const {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -848,12 +848,19 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
 }
 
 future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
+    // When called during DROP TABLE schema merge, the on_before_drop_column_family
+    // listener already piggybacked a partition tombstone for this table's registry
+    // entries into the group0 command. Skip registry updates to avoid deadlock.
+    bool skip_registry = sst.manager().in_group0_drop_schema_trx();
+
     try {
-    co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
-        return registry.update_entry_status(owner, gen, status_removing, mc);
-    });
+        if (!skip_registry) {
+            co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
+                return registry.update_entry_status(owner, gen, status_removing, mc);
+            });
+        }
     } catch (...) {
-        sstlog.warn("Failed to mark sstable {}.{} as removing in registry: {}. Orphaned entry will be cleaned up by GC.", owner(), sst.generation(), std::current_exception());
+        sstlog.warn("Failed to mark sstable {}.{} as removing in registry: {}. Orphaned entry will be cleaned up by GC during next boot.", owner(), sst.generation(), std::current_exception());
     }
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
@@ -861,11 +868,13 @@ future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
     });
 
     try {
-    co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
-        return registry.delete_entry(owner, gen, mc);
-    });
+        if (!skip_registry) {
+            co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
+                return registry.delete_entry(owner, gen, mc);
+            });
+        }
     } catch (...) {
-        sstlog.warn("Failed to delete sstable {}.{} from registry: {}. Orphaned entry will be cleaned up by GC.", owner(), sst.generation(), std::current_exception());
+        sstlog.warn("Failed to delete sstable {}.{} from registry: {}. Orphaned entry will be cleaned up by GC during next boot.", owner(), sst.generation(), std::current_exception());
     }
 }
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -31,6 +31,7 @@
 #include "sstables/integrity_checked_file_impl.hh"
 #include "sstables/writer.hh"
 #include "utils/assert.hh"
+#include "replica/database.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "utils/lister.hh"
 #include "utils/overloaded_functor.hh"
@@ -718,10 +719,30 @@ object_name object_storage_base::make_object_name(const sstable& sst, component_
     }, _location);
 }
 
+// Executes a registry operation via group0 Raft replication if available,
+// falling back to local execution otherwise.
+static future<> sstables_registry_apply_operation(const sstables_manager& mgr,
+        noncopyable_function<future<>(sstables_registry&, service::group0_batch&)> func) {
+    if (mgr.group0_client()) {
+        co_await mgr.database_container()->invoke_on(0, [func = std::move(func)](replica::database& db) mutable -> future<> {
+            auto& mgr = db.get_user_sstables_manager();
+            auto& as = mgr.group0_abort_source()->local();
+            auto guard = co_await mgr.group0_client()->start_operation(as, service::raft_timeout{});
+            service::group0_batch mc(std::move(guard));
+            co_await func(mgr.sstables_registry(), mc);
+            co_await std::move(mc).commit(*mgr.group0_client(), as, service::raft_timeout{});
+        });
+    } else {
+        auto mc = service::group0_batch::unused();
+        co_await func(mgr.sstables_registry(), mc);
+    }
+}
+
 void object_storage_base::open(sstable& sst) {
     entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
-    auto mc = service::group0_batch::unused();
-    sst.manager().sstables_registry().create_entry(owner(), status_creating, sst._state, std::move(desc), mc).get();
+    sstables_registry_apply_operation(sst.manager(), [owner = owner(), state = sst._state, desc = std::move(desc)](sstables_registry& registry, service::group0_batch& mc) mutable {
+        return registry.create_entry(owner, status_creating, state, std::move(desc), mc);
+    }).get();
 
     memory_data_sink_buffers bufs;
     auto out = data_sink(std::make_unique<memory_data_sink>(bufs));
@@ -809,8 +830,9 @@ future<data_sink> object_storage_base::make_component_sink(sstable& sst, compone
 }
 
 future<> object_storage_base::seal(const sstable& sst) {
-    auto mc = service::group0_batch::unused();
-    co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.generation(), status_sealed, mc);
+    co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
+        return registry.update_entry_status(owner, gen, status_sealed, mc);
+    });
 }
 
 future<> object_storage_base::change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) {
@@ -820,22 +842,23 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
         // is moved from upload directory and this is another issue for S3 (#13018)
         co_await coroutine::return_exception(std::runtime_error("Cannot change state and generation of an S3 object"));
     }
-    auto mc = service::group0_batch::unused();
-    co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.generation(), state, mc);
+    co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation(), state](sstables_registry& registry, service::group0_batch& mc) {
+        return registry.update_entry_state(owner, gen, state, mc);
+    });
 }
 
 future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
-    auto& sstables_registry = sst.manager().sstables_registry();
-
-    auto mc1 = service::group0_batch::unused();
-    co_await sstables_registry.update_entry_status(owner(), sst.generation(), status_removing, mc1);
+    co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
+        return registry.update_entry_status(owner, gen, status_removing, mc);
+    });
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
         co_await delete_object(make_object_name(sst, type));
     });
 
-    auto mc2 = service::group0_batch::unused();
-    co_await sstables_registry.delete_entry(owner(), sst.generation(), mc2);
+    co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
+        return registry.delete_entry(owner, gen, mc);
+    });
 }
 
 future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>&) const {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -848,17 +848,25 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
 }
 
 future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
+    try {
     co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
         return registry.update_entry_status(owner, gen, status_removing, mc);
     });
+    } catch (...) {
+        sstlog.warn("Failed to mark sstable {}.{} as removing in registry: {}. Orphaned entry will be cleaned up by GC.", owner(), sst.generation(), std::current_exception());
+    }
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
         co_await delete_object(make_object_name(sst, type));
     });
 
+    try {
     co_await sstables_registry_apply_operation(sst.manager(), [owner = owner(), gen = sst.generation()](sstables_registry& registry, service::group0_batch& mc) {
         return registry.delete_entry(owner, gen, mc);
     });
+    } catch (...) {
+        sstlog.warn("Failed to delete sstable {}.{} from registry: {}. Orphaned entry will be cleaned up by GC.", owner(), sst.generation(), std::current_exception());
+    }
 }
 
 future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>&) const {

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -316,3 +316,81 @@ async def test_create_keyspace_after_config_update(manager: ManagerClient, objec
     cql.execute((f'CREATE KEYSPACE random_ks WITH'
                     f' REPLICATION = {replication_opts} AND STORAGE = {storage_opts};'))
 
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_drop_table_object_storage_no_deadlock(manager: ManagerClient, object_storage):
+    """
+    Verify DROP TABLE on an object-storage-backed keyspace does not deadlock
+    and that the on_before_drop_column_family listener atomically removes
+    sstables registry entries via a partition tombstone in the group0 command.
+
+    Without the listener, wipe() during schema merge would either deadlock
+    (trying to acquire the group0 operation mutex already held by the DROP
+    TABLE caller) or, with the in_group0_drop_schema_trx safety flag, silently
+    skip per-SSTable registry cleanup — leaking registry entries.
+
+    Part 1 enables an error injection that skips the tombstone, proving
+    that registry entries leak when the listener is bypassed.
+
+    Part 2 runs without the injection, proving that the listener correctly
+    cleans up registry entries and that DROP TABLE completes without deadlock.
+
+    Reproduces SCYLLADB-1004.
+    """
+    cfg = {
+        'object_storage_endpoints': object_storage.create_endpoint_conf(),
+        'experimental_features': ['keyspace-storage-options'],
+    }
+    server = await manager.server_add(config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
+        # injection skips the tombstone — registry entries leak
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int)")
+        for i in range(10):
+            await cql.run_async(f"INSERT INTO {ks}.t1 (pk, v) VALUES ({i}, {i})")
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        tid = await cql.run_async(
+            f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 't1'")
+        table_id = tid[0].id
+
+        # Verify registry entries exist before DROP
+        rows = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id])
+        assert len(rows) > 0, "Expected registry entries before DROP TABLE"
+
+        await manager.api.enable_injection(
+            server.ip_addr, "skip_sstables_registry_drop_tombstone", one_shot=False)
+
+        await asyncio.wait_for(
+            cql.run_async(f"DROP TABLE {ks}.t1"),
+            timeout=10)
+
+        # Without the tombstone, registry entries should still exist (leaked)
+        rows = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id])
+        assert len(rows) > 0, "Registry entries should leak when tombstone is skipped"
+
+        await manager.api.disable_injection(
+            server.ip_addr, "skip_sstables_registry_drop_tombstone")
+
+        # no injection — tombstone cleans up registry entries
+        await cql.run_async(f"CREATE TABLE {ks}.t2 (pk int PRIMARY KEY, v int)")
+        for i in range(10):
+            await cql.run_async(f"INSERT INTO {ks}.t2 (pk, v) VALUES ({i}, {i})")
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        tid = await cql.run_async(
+            f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 't2'")
+        table_id = tid[0].id
+
+        rows = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id])
+        assert len(rows) > 0, "Expected registry entries before DROP TABLE"
+
+        await asyncio.wait_for(
+            cql.run_async(f"DROP TABLE {ks}.t2"),
+            timeout=10)
+
+        # With the tombstone, registry entries should be cleaned up
+        rows = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id])
+        assert len(rows) == 0, f"Registry entries should be cleaned up after DROP TABLE, found {len(rows)}"

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -17,6 +17,7 @@ from test.cqlpy.rest_api import scylla_inject_error
 from test.cluster.test_config import wait_for_config
 from test.cluster.util import new_test_keyspace
 from test.pylib.tablets import get_all_tablet_replicas
+from test.pylib.util import unique_name
 
 logger = logging.getLogger(__name__)
 
@@ -394,3 +395,106 @@ async def test_drop_table_object_storage_no_deadlock(manager: ManagerClient, obj
         # With the tombstone, registry entries should be cleaned up
         rows = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id])
         assert len(rows) == 0, f"Registry entries should be cleaned up after DROP TABLE, found {len(rows)}"
+
+
+@pytest.mark.asyncio
+async def test_drop_keyspace_object_storage_cleans_registry(manager: ManagerClient, object_storage):
+    """
+    Verify DROP KEYSPACE on an object-storage-backed keyspace cleans up
+    sstables registry entries for ALL tables in the keyspace.
+
+    The on_before_drop_keyspace listener iterates all tables in the
+    keyspace and adds partition tombstones for each table's registry
+    entries into the group0 command.  This test creates two tables,
+    verifies their registry entries exist, drops the keyspace, and
+    confirms that registry entries for both tables are gone.
+
+    Uses asyncio.wait_for with a timeout to detect a potential deadlock.
+    """
+    cfg = {
+        'object_storage_endpoints': object_storage.create_endpoint_conf(),
+        'experimental_features': ['keyspace-storage-options'],
+    }
+    server = await manager.server_add(config=cfg)
+    cql = manager.get_cql()
+
+    ks = unique_name()
+    ks_opts = keyspace_options(object_storage)
+    await cql.run_async(f"CREATE KEYSPACE IF NOT EXISTS {ks} {ks_opts}")
+
+    await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int)")
+    await cql.run_async(f"CREATE TABLE {ks}.t2 (pk int PRIMARY KEY, v int)")
+
+    for i in range(10):
+        await cql.run_async(f"INSERT INTO {ks}.t1 (pk, v) VALUES ({i}, {i})")
+        await cql.run_async(f"INSERT INTO {ks}.t2 (pk, v) VALUES ({i}, {i})")
+    await manager.api.flush_keyspace(server.ip_addr, ks)
+
+    tid1 = await cql.run_async(
+        f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 't1'")
+    table_id1 = tid1[0].id
+    tid2 = await cql.run_async(
+        f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 't2'")
+    table_id2 = tid2[0].id
+
+    rows1 = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id1])
+    assert len(rows1) > 0, "Expected registry entries for t1 before DROP KEYSPACE"
+    rows2 = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id2])
+    assert len(rows2) > 0, "Expected registry entries for t2 before DROP KEYSPACE"
+
+    await asyncio.wait_for(
+        cql.run_async(f"DROP KEYSPACE {ks}"),
+        timeout=10)
+
+    # After DROP KEYSPACE, registry entries for both tables should be gone
+    rows1 = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id1])
+    assert len(rows1) == 0, f"Registry entries for t1 should be cleaned up after DROP KEYSPACE, found {len(rows1)}"
+    rows2 = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id2])
+    assert len(rows2) == 0, f"Registry entries for t2 should be cleaned up after DROP KEYSPACE, found {len(rows2)}"
+  
+@pytest.mark.asyncio
+async def test_truncate_object_storage_cleans_registry(manager: ManagerClient, object_storage):
+    """
+    Verify TRUNCATE on an object-storage-backed table cleans up sstables
+    registry entries while keeping the table itself intact.
+    """
+    cfg = {
+        'object_storage_endpoints': object_storage.create_endpoint_conf(),
+        'experimental_features': ['keyspace-storage-options'],
+    }
+    server = await manager.server_add(config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int)")
+        for i in range(10):
+            await cql.run_async(f"INSERT INTO {ks}.t1 (pk, v) VALUES ({i}, {i})")
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        tid = await cql.run_async(
+            f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 't1'")
+        table_id = tid[0].id
+
+        rows = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id])
+        assert len(rows) > 0, "Expected registry entries before TRUNCATE"
+
+        await cql.run_async(f"TRUNCATE {ks}.t1")
+
+        # After truncate, registry entries should be cleaned up
+        rows = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id])
+        assert len(rows) == 0, f"Registry entries should be cleaned up after TRUNCATE, found {len(rows)}"
+
+        # Table should still exist but be empty
+        res = await cql.run_async(f"SELECT * FROM {ks}.t1")
+        assert len(res) == 0, f"Table should be empty after TRUNCATE, found {len(res)} rows"
+
+        # Verify the table is still functional: insert new data, flush, check new registry entries
+        for i in range(5):
+            await cql.run_async(f"INSERT INTO {ks}.t1 (pk, v) VALUES ({i}, {i})")
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        rows = await cql.run_async("SELECT * FROM system.sstables WHERE owner = %s", parameters=[table_id])
+        assert len(rows) > 0, "Expected new registry entries after inserting into truncated table"
+
+        res = await cql.run_async(f"SELECT * FROM {ks}.t1")
+        assert len(res) == 5, f"Expected 5 rows after re-inserting into truncated table, found {len(res)}"

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -17,7 +17,9 @@ from test.cqlpy.rest_api import scylla_inject_error
 from test.cluster.test_config import wait_for_config
 from test.cluster.util import new_test_keyspace
 from test.pylib.tablets import get_all_tablet_replicas
-from test.pylib.util import unique_name
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
+from test.pylib.rest_client import read_barrier
+from time import time
 
 logger = logging.getLogger(__name__)
 
@@ -498,3 +500,63 @@ async def test_truncate_object_storage_cleans_registry(manager: ManagerClient, o
 
         res = await cql.run_async(f"SELECT * FROM {ks}.t1")
         assert len(res) == 5, f"Expected 5 rows after re-inserting into truncated table, found {len(res)}"
+
+
+@pytest.mark.asyncio
+async def test_sstables_registry_replicated_across_nodes(manager: ManagerClient, object_storage):
+    """
+    Verify that sstables registry entries written through group0 Raft
+    replication are visible on ALL nodes in the cluster, not just the
+    node that performed the flush.
+
+    Starts a 2-node cluster with RF=1 object-storage-backed keyspace,
+    inserts data, flushes on both nodes (only the replica owner will
+    actually create SSTables), then verifies that both nodes see the
+    same set of registry entries in system.sstables.
+
+    This proves that system.sstables is replicated via Raft group0
+    rather than being local-only.
+
+    Related to SCYLLADB-1004.
+    """
+    cfg = {
+        'object_storage_endpoints': object_storage.create_endpoint_conf(),
+        'experimental_features': ['keyspace-storage-options'],
+    }
+    servers = await manager.servers_add(2, config=cfg)
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time() + 60)
+
+    ks = unique_name()
+    await cql.run_async(f"CREATE KEYSPACE {ks} {keyspace_options(object_storage, rf=1)}")
+    await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int)")
+    for i in range(10):
+        await cql.run_async(f"INSERT INTO {ks}.t1 (pk, v) VALUES ({i}, {i})")
+
+    # Flush on both nodes — only the RF=1 replica owner creates SSTables,
+    # but flushing both ensures we don't need to figure out which node owns data.
+    for srv in servers:
+        await manager.api.flush_keyspace(srv.ip_addr, ks)
+
+    tid = await cql.run_async(
+        f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 't1'")
+    table_id = tid[0].id
+
+    # Ensure Raft log is fully applied on both nodes before querying
+    for srv in servers:
+        await read_barrier(manager.api, srv.ip_addr)
+
+    rows_node0 = await cql.run_async(
+        "SELECT generation FROM system.sstables WHERE owner = %s",
+        parameters=[table_id], host=hosts[0])
+    rows_node1 = await cql.run_async(
+        "SELECT generation FROM system.sstables WHERE owner = %s",
+        parameters=[table_id], host=hosts[1])
+
+    gens_node0 = sorted(str(r.generation) for r in rows_node0)
+    gens_node1 = sorted(str(r.generation) for r in rows_node1)
+
+    assert len(gens_node0) > 0 or len(gens_node1) > 0, \
+        "Expected at least one node to have registry entries after flush"
+    assert gens_node0 == gens_node1, \
+        f"Registry entries differ between nodes: node0={gens_node0}, node1={gens_node1}"

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -28,6 +28,7 @@
 #include <fmt/ranges.h>
 #include <seastar/util/defer.hh>
 #include "sstables/generation_type.hh"
+#include "service/raft/raft_group0_client.hh"
 
 static const sstring some_keyspace("ks");
 static const sstring some_column_family("cf");
@@ -314,11 +315,11 @@ class mock_sstables_registry : public sstables::sstables_registry {
     };
     std::map<std::pair<table_id, generation_type>, entry> _entries;
 public:
-    virtual future<> create_entry(table_id owner, sstring status, sstable_state state, sstables::entry_descriptor desc) override {
+    virtual future<> create_entry(table_id owner, sstring status, sstable_state state, sstables::entry_descriptor desc, service::group0_batch&) override {
         _entries.emplace(std::make_pair(owner, desc.generation), entry { status, state, desc });
         co_return;
     };
-    virtual future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) override {
+    virtual future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status, service::group0_batch&) override {
         auto it = _entries.find(std::make_pair(owner, gen));
         if (it != _entries.end()) {
             it->second.status = status;
@@ -327,7 +328,7 @@ public:
         }
         co_return;
     }
-    virtual future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) override {
+    virtual future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state, service::group0_batch&) override {
         auto it = _entries.find(std::make_pair(owner, gen));
         if (it != _entries.end()) {
             it->second.state = state;
@@ -336,7 +337,7 @@ public:
         }
         co_return;
     }
-    virtual future<> delete_entry(table_id owner, sstables::generation_type gen) override {
+    virtual future<> delete_entry(table_id owner, sstables::generation_type gen, service::group0_batch&) override {
         auto it = _entries.find(std::make_pair(owner, gen));
         if (it != _entries.end()) {
             _entries.erase(it);


### PR DESCRIPTION
This PR replicates `system.sstables` through Raft group0 so all nodes in the cluster share a consistent view of SSTable ownership.
Previously, the table was written locally on each node, thus blocking us from delivering critical features required for production-ready keyspace over object storage,  e.g. atomic deletion of sstables, improved tablet migration via sstables refcounting, etc.

This PR does a few set of changes:
- plumbing code to let sstables_registry operations support new mutations-based code and the original cql-based code (useful for e.g. tests that dont have a group0_client available)
- deadlock prevention in DROP TABLE/KEYSPACE paths due to the fact that by design this table holds entries for each sstable on object storage and dropping risks creating a nested raft transaction when removing the corresponding entries.
- small patch to add the table into the `raft_pull_snapshot` paths so that nodes joining the cluster get the registry state upfront.
- a few tests proving the new paths work.

The PR doesnt need backport as it's aimed to help keyspace over object storage get production ready.  

Fixes [SCYLLADB-1004](https://scylladb.atlassian.net/browse/SCYLLADB-1004)

[SCYLLADB-1004]: https://scylladb.atlassian.net/browse/SCYLLADB-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ