### PR TITLE
test: manager_client: use safe_driver_shutdown for exclusive_clusters

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -115,7 +115,7 @@ class ManagerClient:
     def driver_close(self) -> None:
         """Disconnect from cluster"""
         for cluster in self.exclusive_clusters:
-            cluster.shutdown()
+            safe_driver_shutdown(cluster)
         self.exclusive_clusters.clear()
         if self.ccluster is not None:
             logger.debug("shutting down driver")


### PR DESCRIPTION
Using `cluster.shutdown()` is an incorrect way to shut down a Cassandra `Cluster`. The correct way is using `safe_driver_shutdown`.

Fixes: SCYLLADB-1434

This is from a recent code change. No releases in-between. This is a fix for the test environment. No backport needed.
