### PR TITLE
auth: allow VECTOR_SEARCH_INDEXING permission to access system.tablets

### DIFF
--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -232,6 +232,7 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::VERSIONS),
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::CDC_STREAMS),
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::CDC_TIMESTAMPS),
+        auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::TABLETS),
     };
 
     if ((cmd.resource.kind() == auth::resource_kind::data && cmd.permission == auth::permission::SELECT && is_vector_indexed.has_value() && is_vector_indexed.value()) ||


### PR DESCRIPTION
Add system.tablets to the set of system resources that can be accessed with the VECTOR_SEARCH_INDEXING permission. This will be required by the future tablet-aware fullscan feature.

Fixes: VECTOR-605

