### PR TITLE
reader_concurrency_semaphore: drop unused stop_ext_{pre,post}()

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1294,7 +1294,6 @@ std::runtime_error reader_concurrency_semaphore::stopped_exception() {
 future<> reader_concurrency_semaphore::stop() noexcept {
     SCYLLA_ASSERT(!_stopped);
     _stopped = true;
-    co_await stop_ext_pre();
     clear_inactive_reads();
     co_await _permit_gate.close();
     // Gate for closing readers is only closed after waiting for all reads, as the evictable
@@ -1305,7 +1304,6 @@ future<> reader_concurrency_semaphore::stop() noexcept {
         co_await std::move(*_execution_loop_future);
     }
     broken(std::make_exception_ptr(stopped_exception()));
-    co_await stop_ext_post();
     co_return;
 }
 

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -334,7 +334,7 @@ public:
                 std::move(kill_limit_multipler), std::move(cpu_concurrency), std::move(preemptive_abort_factor), metrics)
     {}
 
-    virtual ~reader_concurrency_semaphore();
+    ~reader_concurrency_semaphore();
 
     reader_concurrency_semaphore(const reader_concurrency_semaphore&) = delete;
     reader_concurrency_semaphore& operator=(const reader_concurrency_semaphore&) = delete;
@@ -397,16 +397,6 @@ public:
     /// If the range for an inactive read was not provided, all reads for the
     /// table are evicted.
     future<> evict_inactive_reads_for_table(table_id id, const dht::partition_range* range = nullptr) noexcept;
-private:
-    // The following two functions are extension points for
-    // future inheriting classes that needs to run some stop
-    // logic just before or just after the current stop logic.
-    virtual future<> stop_ext_pre() {
-        return make_ready_future<>();
-    }
-    virtual future<> stop_ext_post() {
-        return make_ready_future<>();
-    }
 public:
     /// Stop the reader_concurrency_semaphore and clear all inactive reads.
     ///


### PR DESCRIPTION
Left over from primordial times, when reader_concurrency_semaphore was baseclass for extensions in the separate enterprise repository. Also remove the now unneded virtual marker from the destructor.

Backport: code cleanup, no backport.