### PR TITLE
test: user_function_test: adjust Lua error message tests

### DIFF
--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -81,7 +81,7 @@ SEASTAR_TEST_CASE(test_user_function_use_null) {
         e.execute_cql("INSERT INTO my_table (key, val) VALUES ('foo', null);").get();
         e.execute_cql("CREATE FUNCTION my_func1(val int) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return val + 1';").get();
         e.execute_cql("CREATE FUNCTION my_func2(val int) CALLED ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return val';").get();
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT my_func1(val) FROM my_table;").get(), ire, message_equals("lua execution failed: ?:-1: attempt to perform arithmetic on a nil value"));
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT my_func1(val) FROM my_table;").get(), ire, message_contains("attempt to perform arithmetic on a nil value"));
         auto res = e.execute_cql("SELECT my_func2(val) FROM my_table;").get();
         assert_that(res).is_rows().with_rows({{std::nullopt}});
         res = e.execute_cql("SELECT val FROM my_table;").get();
@@ -924,7 +924,7 @@ SEASTAR_TEST_CASE(test_user_function_lua_error) {
         e.execute_cql("CREATE TABLE my_table (key text PRIMARY KEY, val int);").get();
         e.execute_cql("INSERT INTO my_table (key, val) VALUES ('foo', 42);").get();
         e.execute_cql("CREATE FUNCTION my_func(val int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE Lua AS 'return 2 * bar';").get();
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT my_func(val) FROM my_table;").get(), ire, message_equals("lua execution failed: ?:-1: attempt to perform arithmetic on a nil value (field 'bar')"));
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT my_func(val) FROM my_table;").get(), ire, message_contains("attempt to perform arithmetic on a nil value (field 'bar')"));
 
     });
 }


### PR DESCRIPTION
Lua 5.5 changed the error message slightly ("?:-1" -> "?:?"). Relax the error message tests to avoid this unimportant fragment.

Improvements for future toolchain, so not backporting.