### PR TITLE
cql: Include parallelized queries in the scylla_cql_select_partition_range_scan_no_bypass_cache metric

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -231,6 +231,20 @@ select_statement::select_statement(schema_ptr schema,
     _opts.set_if<query::partition_slice::option::bypass_cache>(_parameters->bypass_cache());
     _opts.set_if<query::partition_slice::option::distinct>(_parameters->is_distinct());
     _opts.set_if<query::partition_slice::option::reversed>(_is_reversed);
+    detect_range_scan();
+}
+
+void select_statement::detect_range_scan() {
+    if (_ks_sel == ks_selector::NONSYSTEM) {
+        if (_restrictions->need_filtering() ||
+                _restrictions->partition_key_restrictions_is_empty() ||
+                (_restrictions->has_token_restrictions() &&
+                 !find(_restrictions->get_partition_key_restrictions(), expr::oper_t::EQ))) {
+            _range_scan = true;
+            if (!_parameters->bypass_cache())
+                _range_scan_no_bypass_cache = true;
+        }
+    }
 }
 
 db::timeout_clock::duration select_statement::get_timeout(const service::client_state& state, const query_options& options) const {
@@ -997,16 +1011,6 @@ primary_key_select_statement::primary_key_select_statement(schema_ptr schema, ui
                                                            std::unique_ptr<attributes> attrs)
     : select_statement{schema, bound_terms, parameters, selection, restrictions, group_by_cell_indices, is_reversed, ordering_comparator, std::move(limit), std::move(per_partition_limit), stats, std::move(attrs)}
 {
-    if (_ks_sel == ks_selector::NONSYSTEM) {
-        if (_restrictions->need_filtering() ||
-                _restrictions->partition_key_restrictions_is_empty() ||
-                (_restrictions->has_token_restrictions() &&
-                 !find(_restrictions->get_partition_key_restrictions(), expr::oper_t::EQ))) {
-            _range_scan = true;
-            if (!_parameters->bypass_cache())
-                _range_scan_no_bypass_cache = true;
-        }
-    }
 }
 
 bool check_needs_allow_filtering_anyway(const restrictions::statement_restrictions& restrictions) {

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -101,6 +101,7 @@ protected:
 private:
     future<shared_ptr<cql_transport::messages::result_message>> process_results_complex(foreign_ptr<lw_shared_ptr<query::result>> results,
         lw_shared_ptr<query::read_command> cmd, const query_options& options, gc_clock::time_point now) const;
+    void detect_range_scan();
 protected :
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(query_processor& qp,
         service::query_state& state, const query_options& options) const;

--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -236,6 +236,65 @@ class TestBypassCache(Tester):
             },
         )
 
+    def test_parallelized_aggregation_range_scan_no_bypass_cache(self):
+        """Verify that select_partition_range_scan_no_bypass_cache is incremented
+        for parallelized aggregation queries (e.g. SELECT count(*) FROM ...) that
+        don't use BYPASS CACHE, and that BYPASS CACHE actually bypasses the
+        cache when the query is parallelized.
+
+        Bug: parallelized_select_statement inherits from select_statement
+        directly (not primary_key_select_statement), so _range_scan and
+        _range_scan_no_bypass_cache are never set to true.  As a result,
+        neither select_partition_range_scan nor
+        select_partition_range_scan_no_bypass_cache is bumped for parallelized
+        queries.
+        """
+        session = self.prepare()
+        node = self.cluster.nodelist()[0]
+
+        # Sanity: a non-parallelized full scan without BYPASS CACHE bumps both
+        # select_partition_range_scan and select_partition_range_scan_no_bypass_cache.
+        errors = self.run_query_and_check_metrics(
+            node,
+            session,
+            query="SELECT * FROM cf",
+            num_runs=1,
+            metrics_validators={
+                "select_partition_range_scan": "increased_by_1",
+                "select_partition_range_scan_no_bypass_cache": "increased_by_1",
+                "select_parallelized": "not_changed",
+            },
+        )
+        assert not errors, "Non-parallelized full scan metric errors:\n" + "\n".join(errors)
+
+        # A parallelized aggregation (count(*)) without BYPASS CACHE must bump
+        # select_partition_range_scan_no_bypass_cache and read from cache.
+        errors = self.run_query_and_check_metrics(
+            node,
+            session,
+            query="SELECT count(*) FROM cf",
+            metrics_validators={
+                "select_partition_range_scan_no_bypass_cache": "increased_by_at_least_1",
+                "select_parallelized": "increased_by_at_least_1",
+                "scylla_cache_reads": self.gen_more_than(self.cache_thresh()),
+            },
+        )
+        assert not errors, "Parallelized aggregation scan metric errors:\n" + "\n".join(errors)
+
+        # A parallelized aggregation with BYPASS CACHE must NOT bump
+        # select_partition_range_scan_no_bypass_cache, and must not read from cache.
+        errors = self.run_query_and_check_metrics(
+            node,
+            session,
+            query="SELECT count(*) FROM cf BYPASS CACHE",
+            metrics_validators={
+                "select_partition_range_scan_no_bypass_cache": "not_changed",
+                "select_parallelized": "increased_by_at_least_1",
+                "scylla_cache_reads": self.gen_less_than(self.cache_thresh()),
+            },
+        )
+        assert not errors, "Parallelized aggregation with BYPASS CACHE metric errors:\n" + "\n".join(errors)
+
     @pytest.mark.parametrize("cache_index_pages", [True, False], ids=["cache_index_pages", "no_cache_index_pages"])
     def test_create_table_caching_disabled(self, cache_index_pages: bool):
         session = self.prepare(insert_data=False, cache_index_pages=cache_index_pages)

--- a/test/cluster/dtest/tools/metrics.py
+++ b/test/cluster/dtest/tools/metrics.py
@@ -21,7 +21,7 @@ def get_node_metrics(node_ip: str, metrics: list[str], port="9180"):
     filter_metrics = [metric for metric in prometheus_get(node_ip, port).splitlines() if not metric.startswith("#")]
     for metric in filter_metrics:
         for metric_name in metrics:
-            if re.search(metric_name, metric):
+            if re.search(metric_name + r"[\s{]", metric):
                 val = metric.split()[-1]
                 try:
                     val = int(val)


### PR DESCRIPTION
This metric is used to catch execution of scans which go via row
cache, which can have bad effect on performance.

Since f344bd0aaa596fe3df9089394dc6c6fe63f5ebe1, aggregate queries go
via new statement class: parallelized_select_statement. This class
inherits from select_statement directly rather than from
primary_key_select_statement. The range scan detection logic
(_range_scan, _range_scan_no_bypass_cache) was only in
primary_key_select_statement's constructor, so parallelized queries
were not counted in select_partition_range_scan and
select_partition_range_scan_no_bypass_cache metrics.

Fix by moving the range scan detection into select_statement's
constructor, so that all subclasses get it.

No backport: enhancement