### PR TITLE
cmake: remove duplicate rolling_max_tracker_test entry

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -203,8 +203,6 @@ add_scylla_test(rolling_max_tracker_test
   KIND BOOST)
 add_scylla_test(rest_client_test
   KIND SEASTAR)
-add_scylla_test(rolling_max_tracker_test
-  KIND BOOST)
 add_scylla_test(rust_test
   KIND BOOST
   LIBRARIES inc)


### PR DESCRIPTION
Two commits independently added rolling_max_tracker_test to test/boost/CMakeLists.txt:

  8b4a91982b cmake: add missing rolling_max_tracker_test and symmetric_key_test
  f3a91df0b4 test/cmake: add missing tests to boost test suite

The second was merged two days after the first, resulting in a duplicate add_scylla_test() entry that breaks the CMake build:

  CMake Error: add_executable cannot create target
  "test_boost_rolling_max_tracker_test" because another target
  with the same name already exists.

Remove the duplicate.

No backport needed. Both commits were merged very recently.