### PR TITLE
Untie (partially) cql3/statements from db::config

### DIFF
--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -22,17 +22,20 @@ struct cql_config {
     restrictions::restrictions_config restrictions;
     utils::updateable_value<uint32_t> select_internal_page_size;
     utils::updateable_value<db::tri_mode_restriction> strict_allow_filtering;
+    utils::updateable_value<bool> enable_parallelized_aggregation;
 
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
         , select_internal_page_size(cfg.select_internal_page_size)
         , strict_allow_filtering(cfg.strict_allow_filtering)
+        , enable_parallelized_aggregation(cfg.enable_parallelized_aggregation)
     {}
     struct default_tag{};
     cql_config(default_tag)
         : restrictions(restrictions::restrictions_config::default_tag{})
         , select_internal_page_size(10000)
         , strict_allow_filtering(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
+        , enable_parallelized_aggregation(true)
     {}
 };
 

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -23,12 +23,14 @@ struct cql_config {
     utils::updateable_value<uint32_t> select_internal_page_size;
     utils::updateable_value<db::tri_mode_restriction> strict_allow_filtering;
     utils::updateable_value<bool> enable_parallelized_aggregation;
+    utils::updateable_value<uint32_t> batch_size_warn_threshold_in_kb;
 
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
         , select_internal_page_size(cfg.select_internal_page_size)
         , strict_allow_filtering(cfg.strict_allow_filtering)
         , enable_parallelized_aggregation(cfg.enable_parallelized_aggregation)
+        , batch_size_warn_threshold_in_kb(cfg.batch_size_warn_threshold_in_kb)
     {}
     struct default_tag{};
     cql_config(default_tag)
@@ -36,6 +38,7 @@ struct cql_config {
         , select_internal_page_size(10000)
         , strict_allow_filtering(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
         , enable_parallelized_aggregation(true)
+        , batch_size_warn_threshold_in_kb(128)
     {}
 };
 

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -32,6 +32,7 @@ struct cql_config {
     utils::updateable_value<uint32_t> batch_size_warn_threshold_in_kb;
     utils::updateable_value<uint32_t> batch_size_fail_threshold_in_kb;
     utils::updateable_value<bool> restrict_future_timestamp;
+    utils::updateable_value<bool> enable_create_table_with_compact_storage;
 
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
@@ -44,6 +45,7 @@ struct cql_config {
         , batch_size_warn_threshold_in_kb(cfg.batch_size_warn_threshold_in_kb)
         , batch_size_fail_threshold_in_kb(cfg.batch_size_fail_threshold_in_kb)
         , restrict_future_timestamp(cfg.restrict_future_timestamp)
+        , enable_create_table_with_compact_storage(cfg.enable_create_table_with_compact_storage)
     {}
     struct default_tag{};
     cql_config(default_tag)
@@ -57,6 +59,7 @@ struct cql_config {
         , batch_size_warn_threshold_in_kb(128)
         , batch_size_fail_threshold_in_kb(1024)
         , restrict_future_timestamp(true)
+        , enable_create_table_with_compact_storage(false)
     {}
 };
 

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -24,6 +24,7 @@ struct cql_config {
     utils::updateable_value<db::tri_mode_restriction> strict_allow_filtering;
     utils::updateable_value<bool> enable_parallelized_aggregation;
     utils::updateable_value<uint32_t> batch_size_warn_threshold_in_kb;
+    utils::updateable_value<uint32_t> batch_size_fail_threshold_in_kb;
 
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
@@ -31,6 +32,7 @@ struct cql_config {
         , strict_allow_filtering(cfg.strict_allow_filtering)
         , enable_parallelized_aggregation(cfg.enable_parallelized_aggregation)
         , batch_size_warn_threshold_in_kb(cfg.batch_size_warn_threshold_in_kb)
+        , batch_size_fail_threshold_in_kb(cfg.batch_size_fail_threshold_in_kb)
     {}
     struct default_tag{};
     cql_config(default_tag)
@@ -39,6 +41,7 @@ struct cql_config {
         , strict_allow_filtering(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
         , enable_parallelized_aggregation(true)
         , batch_size_warn_threshold_in_kb(128)
+        , batch_size_fail_threshold_in_kb(1024)
     {}
 };
 

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "restrictions/restrictions_config.hh"
+#include "cql3/restrictions/replication_restrictions.hh"
 #include "db/tri_mode_restriction.hh"
 #include "utils/updateable_value.hh"
 
@@ -20,6 +21,7 @@ namespace cql3 {
 
 struct cql_config {
     restrictions::restrictions_config restrictions;
+    replication_restrictions replication_restrictions;
     utils::updateable_value<uint32_t> select_internal_page_size;
     utils::updateable_value<db::tri_mode_restriction> strict_allow_filtering;
     utils::updateable_value<bool> enable_parallelized_aggregation;
@@ -28,6 +30,7 @@ struct cql_config {
 
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
+        , replication_restrictions(cfg)
         , select_internal_page_size(cfg.select_internal_page_size)
         , strict_allow_filtering(cfg.strict_allow_filtering)
         , enable_parallelized_aggregation(cfg.enable_parallelized_aggregation)
@@ -37,6 +40,7 @@ struct cql_config {
     struct default_tag{};
     cql_config(default_tag)
         : restrictions(restrictions::restrictions_config::default_tag{})
+        , replication_restrictions(replication_restrictions::default_tag{})
         , select_internal_page_size(10000)
         , strict_allow_filtering(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
         , enable_parallelized_aggregation(true)

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "restrictions/restrictions_config.hh"
+#include "utils/updateable_value.hh"
 
 namespace db { class config; }
 
@@ -18,9 +19,17 @@ namespace cql3 {
 
 struct cql_config {
     restrictions::restrictions_config restrictions;
-    explicit cql_config(const db::config& cfg) : restrictions(cfg) {}
+    utils::updateable_value<uint32_t> select_internal_page_size;
+
+    explicit cql_config(const db::config& cfg)
+        : restrictions(cfg)
+        , select_internal_page_size(cfg.select_internal_page_size)
+    {}
     struct default_tag{};
-    cql_config(default_tag) : restrictions(restrictions::restrictions_config::default_tag{}) {}
+    cql_config(default_tag)
+        : restrictions(restrictions::restrictions_config::default_tag{})
+        , select_internal_page_size(10000)
+    {}
 };
 
 extern const cql_config default_cql_config;

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -29,6 +29,7 @@ struct cql_config {
     utils::updateable_value<bool> enable_parallelized_aggregation;
     utils::updateable_value<uint32_t> batch_size_warn_threshold_in_kb;
     utils::updateable_value<uint32_t> batch_size_fail_threshold_in_kb;
+    utils::updateable_value<bool> restrict_future_timestamp;
 
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
@@ -39,6 +40,7 @@ struct cql_config {
         , enable_parallelized_aggregation(cfg.enable_parallelized_aggregation)
         , batch_size_warn_threshold_in_kb(cfg.batch_size_warn_threshold_in_kb)
         , batch_size_fail_threshold_in_kb(cfg.batch_size_fail_threshold_in_kb)
+        , restrict_future_timestamp(cfg.restrict_future_timestamp)
     {}
     struct default_tag{};
     cql_config(default_tag)
@@ -50,6 +52,7 @@ struct cql_config {
         , enable_parallelized_aggregation(true)
         , batch_size_warn_threshold_in_kb(128)
         , batch_size_fail_threshold_in_kb(1024)
+        , restrict_future_timestamp(true)
     {}
 };
 

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -12,6 +12,7 @@
 
 #include "restrictions/restrictions_config.hh"
 #include "cql3/restrictions/replication_restrictions.hh"
+#include "cql3/restrictions/twcs_restrictions.hh"
 #include "db/tri_mode_restriction.hh"
 #include "utils/updateable_value.hh"
 
@@ -22,6 +23,7 @@ namespace cql3 {
 struct cql_config {
     restrictions::restrictions_config restrictions;
     replication_restrictions replication_restrictions;
+    twcs_restrictions twcs_restrictions;
     utils::updateable_value<uint32_t> select_internal_page_size;
     utils::updateable_value<db::tri_mode_restriction> strict_allow_filtering;
     utils::updateable_value<bool> enable_parallelized_aggregation;
@@ -31,6 +33,7 @@ struct cql_config {
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
         , replication_restrictions(cfg)
+        , twcs_restrictions(cfg)
         , select_internal_page_size(cfg.select_internal_page_size)
         , strict_allow_filtering(cfg.strict_allow_filtering)
         , enable_parallelized_aggregation(cfg.enable_parallelized_aggregation)
@@ -41,6 +44,7 @@ struct cql_config {
     cql_config(default_tag)
         : restrictions(restrictions::restrictions_config::default_tag{})
         , replication_restrictions(replication_restrictions::default_tag{})
+        , twcs_restrictions(twcs_restrictions::default_tag{})
         , select_internal_page_size(10000)
         , strict_allow_filtering(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
         , enable_parallelized_aggregation(true)

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -13,6 +13,7 @@
 #include "restrictions/restrictions_config.hh"
 #include "cql3/restrictions/replication_restrictions.hh"
 #include "cql3/restrictions/twcs_restrictions.hh"
+#include "cql3/restrictions/view_restrictions.hh"
 #include "db/tri_mode_restriction.hh"
 #include "utils/updateable_value.hh"
 
@@ -24,6 +25,7 @@ struct cql_config {
     restrictions::restrictions_config restrictions;
     replication_restrictions replication_restrictions;
     twcs_restrictions twcs_restrictions;
+    view_restrictions view_restrictions;
     utils::updateable_value<uint32_t> select_internal_page_size;
     utils::updateable_value<db::tri_mode_restriction> strict_allow_filtering;
     utils::updateable_value<bool> enable_parallelized_aggregation;
@@ -35,6 +37,7 @@ struct cql_config {
         : restrictions(cfg)
         , replication_restrictions(cfg)
         , twcs_restrictions(cfg)
+        , view_restrictions(cfg)
         , select_internal_page_size(cfg.select_internal_page_size)
         , strict_allow_filtering(cfg.strict_allow_filtering)
         , enable_parallelized_aggregation(cfg.enable_parallelized_aggregation)
@@ -47,6 +50,7 @@ struct cql_config {
         : restrictions(restrictions::restrictions_config::default_tag{})
         , replication_restrictions(replication_restrictions::default_tag{})
         , twcs_restrictions(twcs_restrictions::default_tag{})
+        , view_restrictions(view_restrictions::default_tag{})
         , select_internal_page_size(10000)
         , strict_allow_filtering(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
         , enable_parallelized_aggregation(true)

--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "restrictions/restrictions_config.hh"
+#include "db/tri_mode_restriction.hh"
 #include "utils/updateable_value.hh"
 
 namespace db { class config; }
@@ -20,15 +21,18 @@ namespace cql3 {
 struct cql_config {
     restrictions::restrictions_config restrictions;
     utils::updateable_value<uint32_t> select_internal_page_size;
+    utils::updateable_value<db::tri_mode_restriction> strict_allow_filtering;
 
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
         , select_internal_page_size(cfg.select_internal_page_size)
+        , strict_allow_filtering(cfg.strict_allow_filtering)
     {}
     struct default_tag{};
     cql_config(default_tag)
         : restrictions(restrictions::restrictions_config::default_tag{})
         , select_internal_page_size(10000)
+        , strict_allow_filtering(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
     {}
 };
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -791,7 +791,7 @@ query_processor::get_statement(const std::string_view& query, const service::cli
         cf_stmt->prepare_keyspace(client_state);
     }
     ++_stats.prepare_invocations;
-    auto p = statement->prepare(_db, _cql_stats);
+    auto p = statement->prepare(_db, _cql_stats, _cql_config);
     p->statement->raw_cql_statement = sstring(query);
     auto audit_info = p->statement->get_audit_info();
     if (audit_info) {
@@ -906,7 +906,7 @@ query_options query_processor::make_internal_options(
 statements::prepared_statement::checked_weak_ptr query_processor::prepare_internal(const sstring& query_string) {
     auto& p = _internal_statements[query_string];
     if (p == nullptr) {
-        auto np = parse_statement(query_string, internal_dialect())->prepare(_db, _cql_stats);
+        auto np = parse_statement(query_string, internal_dialect())->prepare(_db, _cql_stats, _cql_config);
         np->statement->raw_cql_statement = query_string;
         p = std::move(np); // inserts it into map
     }
@@ -1017,7 +1017,7 @@ query_processor::execute_internal(
         return execute_with_params(std::move(p), cl, query_state, values);
     } else {
         // For internal queries, we want the default dialect, not the user provided one
-        auto p = parse_statement(query_string, dialect{})->prepare(_db, _cql_stats);
+        auto p = parse_statement(query_string, dialect{})->prepare(_db, _cql_stats, _cql_config);
         p->statement->raw_cql_statement = query_string;
         auto checked_weak_ptr = p->checked_weak_from_this();
         return execute_with_params(std::move(checked_weak_ptr), cl, query_state, values).finally([p = std::move(p)] {});

--- a/cql3/restrictions/replication_restrictions.hh
+++ b/cql3/restrictions/replication_restrictions.hh
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include "db/config.hh"
+#include "utils/updateable_value.hh"
+
+namespace cql3 {
+
+struct replication_restrictions {
+    utils::updateable_value<db::tri_mode_restriction> restrict_replication_simplestrategy;
+    utils::updateable_value<std::vector<enum_option<db::replication_strategy_restriction_t>>> replication_strategy_warn_list;
+    utils::updateable_value<std::vector<enum_option<db::replication_strategy_restriction_t>>> replication_strategy_fail_list;
+    utils::updateable_value<int> minimum_replication_factor_fail_threshold;
+    utils::updateable_value<int> minimum_replication_factor_warn_threshold;
+    utils::updateable_value<int> maximum_replication_factor_fail_threshold;
+    utils::updateable_value<int> maximum_replication_factor_warn_threshold;
+
+    explicit replication_restrictions(const db::config& cfg)
+        : restrict_replication_simplestrategy(cfg.restrict_replication_simplestrategy)
+        , replication_strategy_warn_list(cfg.replication_strategy_warn_list)
+        , replication_strategy_fail_list(cfg.replication_strategy_fail_list)
+        , minimum_replication_factor_fail_threshold(cfg.minimum_replication_factor_fail_threshold)
+        , minimum_replication_factor_warn_threshold(cfg.minimum_replication_factor_warn_threshold)
+        , maximum_replication_factor_fail_threshold(cfg.maximum_replication_factor_fail_threshold)
+        , maximum_replication_factor_warn_threshold(cfg.maximum_replication_factor_warn_threshold)
+    {}
+
+    struct default_tag{};
+    replication_restrictions(default_tag)
+        : restrict_replication_simplestrategy(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::FALSE))
+        , replication_strategy_warn_list(std::vector<enum_option<db::replication_strategy_restriction_t>>{})
+        , replication_strategy_fail_list(std::vector<enum_option<db::replication_strategy_restriction_t>>{})
+        , minimum_replication_factor_fail_threshold(-1)
+        , minimum_replication_factor_warn_threshold(3)
+        , maximum_replication_factor_fail_threshold(-1)
+        , maximum_replication_factor_warn_threshold(-1)
+    {}
+};
+
+} // namespace cql3

--- a/cql3/restrictions/twcs_restrictions.hh
+++ b/cql3/restrictions/twcs_restrictions.hh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include "db/config.hh"
+#include "utils/updateable_value.hh"
+
+namespace cql3 {
+
+struct twcs_restrictions {
+    utils::updateable_value<uint32_t> twcs_max_window_count;
+    utils::updateable_value<db::tri_mode_restriction> restrict_twcs_without_default_ttl;
+
+    explicit twcs_restrictions(const db::config& cfg)
+        : twcs_max_window_count(cfg.twcs_max_window_count)
+        , restrict_twcs_without_default_ttl(cfg.restrict_twcs_without_default_ttl)
+    {}
+
+    struct default_tag{};
+    twcs_restrictions(default_tag)
+        : twcs_max_window_count(10000)
+        , restrict_twcs_without_default_ttl(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
+    {}
+};
+
+} // namespace cql3

--- a/cql3/restrictions/view_restrictions.hh
+++ b/cql3/restrictions/view_restrictions.hh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include "db/config.hh"
+#include "db/tri_mode_restriction.hh"
+#include "utils/updateable_value.hh"
+
+namespace db { class config; }
+
+namespace cql3 {
+
+struct view_restrictions {
+    utils::updateable_value<db::tri_mode_restriction> strict_is_not_null_in_views;
+
+    explicit view_restrictions(const db::config& cfg)
+        : strict_is_not_null_in_views(cfg.strict_is_not_null_in_views)
+    {}
+
+    struct default_tag{};
+    view_restrictions(default_tag)
+        : strict_is_not_null_in_views(db::tri_mode_restriction(db::tri_mode_restriction_t::mode::WARN))
+    {}
+};
+
+}

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -27,6 +27,7 @@
 #include "data_dictionary/data_dictionary.hh"
 #include "data_dictionary/keyspace_metadata.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/cql_config.hh"
 #include "cql3/statements/ks_prop_defs.hh"
 #include "create_keyspace_statement.hh"
 #include "gms/feature_service.hh"
@@ -267,7 +268,7 @@ cql3::statements::alter_keyspace_statement::prepare(data_dictionary::database db
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 cql3::statements::alter_keyspace_statement::execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const {
-    std::vector<sstring> warnings = check_against_restricted_replication_strategies(qp, keyspace(), *_attrs, qp.get_cql_stats());
+    std::vector<sstring> warnings = check_against_restricted_replication_strategies(qp, keyspace(), *_attrs, qp.get_cql_stats(), qp.get_cql_config().replication_restrictions);
     return schema_altering_statement::execute(qp, state, options, std::move(guard)).then([warnings = std::move(warnings)] (::shared_ptr<messages::result_message> msg) {
         for (const auto& warning : warnings) {
             msg->add_warning(warning);

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -260,7 +260,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::alter_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+cql3::statements::alter_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<alter_keyspace_statement>(*this));
 }
 

--- a/cql3/statements/alter_keyspace_statement.hh
+++ b/cql3/statements/alter_keyspace_statement.hh
@@ -37,7 +37,7 @@ public:
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
     void validate(query_processor& qp, const service::client_state& state) const override;
     virtual future<std::tuple<::shared_ptr<event_t>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
     bool changes_tablets(query_processor& qp) const;
 };

--- a/cql3/statements/alter_role_statement.hh
+++ b/cql3/statements/alter_role_statement.hh
@@ -33,7 +33,7 @@ public:
                 , _options(std::move(options)) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
 

--- a/cql3/statements/alter_service_level_statement.cc
+++ b/cql3/statements/alter_service_level_statement.cc
@@ -25,7 +25,7 @@ alter_service_level_statement::alter_service_level_statement(sstring service_lev
 
 std::unique_ptr<cql3::statements::prepared_statement>
 cql3::statements::alter_service_level_statement::prepare(
-        data_dictionary::database db, cql_stats &stats) {
+        data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<alter_service_level_statement>(*this));
 }
 

--- a/cql3/statements/alter_service_level_statement.hh
+++ b/cql3/statements/alter_service_level_statement.hh
@@ -23,7 +23,7 @@ class alter_service_level_statement final : public service_level_statement {
 
 public:
     alter_service_level_statement(sstring service_level, shared_ptr<sl_prop_defs> attrs);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats) override;
+    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&, std::optional<service::group0_guard> guard) const override;

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -14,6 +14,7 @@
 #include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include "cql3/query_options.hh"
+#include "cql3/cql_config.hh"
 #include "cql3/statements/alter_table_statement.hh"
 #include "cql3/statements/alter_type_statement.hh"
 #include "exceptions/exceptions.hh"
@@ -592,7 +593,7 @@ std::unique_ptr<cql3::statements::prepared_statement>
 alter_table_statement::raw_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     auto t = db.try_find_table(keyspace(), column_family());
     std::optional<schema_ptr> s = t ? std::make_optional(t->schema()) : std::nullopt;
-    std::optional<sstring> warning = check_restricted_table_properties(db, s, keyspace(), column_family(), *_properties);
+    std::optional<sstring> warning = check_restricted_table_properties(s, keyspace(), column_family(), *_properties, cfg.twcs_restrictions);
     if (warning) {
         // FIXME: should this warning be returned to the caller?
         // See https://github.com/scylladb/scylladb/issues/20945

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -560,7 +560,7 @@ alter_table_statement::prepare_schema_mutations(query_processor& qp, const query
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::alter_table_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+cql3::statements::alter_table_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     // Cannot happen; alter_table_statement is never instantiated as a raw statement
     // (instead we instantiate alter_table_statement::raw_statement)
     utils::on_internal_error("alter_table_statement cannot be prepared. Use alter_table_statement::raw_statement instead");
@@ -589,7 +589,7 @@ alter_table_statement::raw_statement::raw_statement(cf_name name,
     {}
 
 std::unique_ptr<cql3::statements::prepared_statement>
-alter_table_statement::raw_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+alter_table_statement::raw_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     auto t = db.try_find_table(keyspace(), column_family());
     std::optional<schema_ptr> s = t ? std::make_optional(t->schema()) : std::nullopt;
     std::optional<sstring> warning = check_restricted_table_properties(db, s, keyspace(), column_family(), *_properties);

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -64,7 +64,7 @@ public:
 
     virtual uint32_t get_bound_terms() const override;
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
@@ -92,7 +92,7 @@ public:
                   std::unique_ptr<attributes::raw> attrs,
                   shared_ptr<column_identifier::raw> ttl_change);
     
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual audit::statement_category category() const override { return audit::statement_category::DDL; }
 };

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -209,12 +209,12 @@ user_type alter_type_statement::renames::make_updated_type(data_dictionary::data
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-alter_type_statement::add_or_alter::prepare(data_dictionary::database db, cql_stats& stats) {
+alter_type_statement::add_or_alter::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<alter_type_statement::add_or_alter>(*this));
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-alter_type_statement::renames::prepare(data_dictionary::database db, cql_stats& stats) {
+alter_type_statement::renames::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<alter_type_statement::renames>(*this));
 }
 

--- a/cql3/statements/alter_type_statement.hh
+++ b/cql3/statements/alter_type_statement.hh
@@ -54,7 +54,7 @@ public:
                  const shared_ptr<column_identifier> field_name,
                  const shared_ptr<cql3_type::raw> field_type);
     virtual user_type make_updated_type(data_dictionary::database db, user_type to_update) const override;
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 private:
     user_type do_add(data_dictionary::database db, user_type to_update) const;
     user_type do_alter(data_dictionary::database db, user_type to_update) const;
@@ -71,7 +71,7 @@ public:
     void add_rename(shared_ptr<column_identifier> previous_name, shared_ptr<column_identifier> new_name);
 
     virtual user_type make_updated_type(data_dictionary::database db, user_type to_update) const override;
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -98,7 +98,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-alter_view_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+alter_view_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<alter_view_statement>(*this));
 }
 

--- a/cql3/statements/alter_view_statement.hh
+++ b/cql3/statements/alter_view_statement.hh
@@ -35,7 +35,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/attach_service_level_statement.cc
+++ b/cql3/statements/attach_service_level_statement.cc
@@ -30,7 +30,7 @@ bool attach_service_level_statement::needs_guard(query_processor& qp, service::q
 
 std::unique_ptr<cql3::statements::prepared_statement>
 cql3::statements::attach_service_level_statement::prepare(
-        data_dictionary::database db, cql_stats &stats) {
+        data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<attach_service_level_statement>(*this));
 }
 

--- a/cql3/statements/attach_service_level_statement.hh
+++ b/cql3/statements/attach_service_level_statement.hh
@@ -22,7 +22,7 @@ class attach_service_level_statement final : public service_level_statement {
 public:
     attach_service_level_statement(sstring service_level, sstring role_name);
     virtual bool needs_guard(query_processor& qp, service::query_state&) const override;
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats) override;
+    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&, std::optional<service::group0_guard> guard) const override;

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -11,6 +11,7 @@
 #include "cql3/util.hh"
 #include "raw/batch_statement.hh"
 #include "db/config.hh"
+#include "cql3/cql_config.hh"
 #include "db/consistency_level_validations.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include <seastar/core/execution_stage.hh>
@@ -195,7 +196,7 @@ void batch_statement::verify_batch_size(query_processor& qp, const utils::chunke
         return;     // We only warn for batch spanning multiple mutations
     }
 
-    size_t warn_threshold = qp.db().get_config().batch_size_warn_threshold_in_kb() * 1024;
+    size_t warn_threshold = qp.get_cql_config().batch_size_warn_threshold_in_kb() * 1024;
     size_t fail_threshold = qp.db().get_config().batch_size_fail_threshold_in_kb() * 1024;
 
     size_t size = 0;

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -441,7 +441,7 @@ void batch_statement::build_cas_result_set_metadata() {
 namespace raw {
 
 std::unique_ptr<prepared_statement>
-batch_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     auto&& meta = get_prepare_context();
 
     std::optional<sstring> first_ks;

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -10,7 +10,6 @@
 #include "batch_statement.hh"
 #include "cql3/util.hh"
 #include "raw/batch_statement.hh"
-#include "db/config.hh"
 #include "cql3/cql_config.hh"
 #include "db/consistency_level_validations.hh"
 #include "data_dictionary/data_dictionary.hh"
@@ -243,7 +242,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
 
 future<shared_ptr<cql_transport::messages::result_message>> batch_statement::execute_without_checking_exception_message(
         query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const {
-    cql3::util::validate_timestamp(qp.db().get_config(), options, _attrs);
+    cql3::util::validate_timestamp(qp.get_cql_config(), options, _attrs);
     return batch_stage(this, seastar::ref(qp), seastar::ref(state),
                        seastar::cref(options), false, options.get_timestamp(state));
 }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -197,7 +197,7 @@ void batch_statement::verify_batch_size(query_processor& qp, const utils::chunke
     }
 
     size_t warn_threshold = qp.get_cql_config().batch_size_warn_threshold_in_kb() * 1024;
-    size_t fail_threshold = qp.db().get_config().batch_size_fail_threshold_in_kb() * 1024;
+    size_t fail_threshold = qp.get_cql_config().batch_size_fail_threshold_in_kb() * 1024;
 
     size_t size = 0;
     for (auto&m : mutations) {

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -78,7 +78,7 @@ seastar::future<shared_ptr<db::functions::function>> create_aggregate_statement:
     co_return ::make_shared<functions::user_aggregate>(_name, initcond, std::move(state_func), std::move(reduce_func), std::move(final_func));
 }
 
-std::unique_ptr<prepared_statement> create_aggregate_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+std::unique_ptr<prepared_statement> create_aggregate_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_aggregate_statement>(*this));
 }
 

--- a/cql3/statements/create_aggregate_statement.hh
+++ b/cql3/statements/create_aggregate_statement.hh
@@ -24,7 +24,7 @@ namespace functions {
 namespace statements {
 
 class create_aggregate_statement final : public create_function_statement_base {
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -54,7 +54,7 @@ create_function_statement::audit_info() const {
     return audit::audit::create_audit_info(category(), sstring(), sstring());
 }
 
-std::unique_ptr<prepared_statement> create_function_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+std::unique_ptr<prepared_statement> create_function_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_function_statement>(*this));
 }
 

--- a/cql3/statements/create_function_statement.hh
+++ b/cql3/statements/create_function_statement.hh
@@ -23,7 +23,7 @@ namespace functions {
 namespace statements {
 
 class create_function_statement final : public create_function_statement_base {
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const override;

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -749,7 +749,7 @@ create_index_statement::prepare_schema_mutations(query_processor& qp, const quer
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-create_index_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+create_index_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     _cql_stats = &stats;
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_index_statement>(*this));
 }

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -54,7 +54,7 @@ public:
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     struct base_schema_with_new_index {
         schema_ptr schema;

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -158,7 +158,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::create_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+cql3::statements::create_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     _attrs->set_default_replication_strategy_class_option();
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_keyspace_statement>(*this));
 }

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -20,6 +20,7 @@
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/cql_config.hh"
 #include "db/config.hh"
 #include "gms/feature_service.hh"
 #include "replica/database.hh"
@@ -188,7 +189,8 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     query_processor& qp,
     const sstring& keyspace,
     const ks_prop_defs& attrs,
-    cql_stats& stats)
+    cql_stats& stats,
+    const cql3::replication_restrictions& rr)
 {
     if (!attrs.get_replication_strategy_class()) {
         return {};
@@ -201,11 +203,11 @@ std::vector<sstring> check_against_restricted_replication_strategies(
             locator::abstract_replication_strategy::to_qualified_class_name(
                     *attrs.get_replication_strategy_class()), params,
                     qp.db().real_database().get_token_metadata().get_topology())->get_type();
-    auto rs_warn_list = qp.db().get_config().replication_strategy_warn_list();
-    auto rs_fail_list = qp.db().get_config().replication_strategy_fail_list();
+    auto rs_warn_list = rr.replication_strategy_warn_list();
+    auto rs_fail_list = rr.replication_strategy_fail_list();
 
     if (replication_strategy == locator::replication_strategy_type::simple) {
-        if (auto simple_strategy_restriction = qp.db().get_config().restrict_replication_simplestrategy();
+        if (auto simple_strategy_restriction = rr.restrict_replication_simplestrategy();
                 simple_strategy_restriction == db::tri_mode_restriction_t::mode::TRUE) {
             rs_fail_list.emplace_back(locator::replication_strategy_type::simple);
         } else if (simple_strategy_restriction == db::tri_mode_restriction_t::mode::WARN) {
@@ -251,7 +253,7 @@ std::vector<sstring> check_against_restricted_replication_strategies(
             }
 
             if (rf > 0) {
-                if (auto min_fail = qp.proxy().data_dictionary().get_config().minimum_replication_factor_fail_threshold();
+                if (auto min_fail = rr.minimum_replication_factor_fail_threshold();
                     min_fail >= 0 && rf < min_fail) {
                     ++stats.minimum_replication_factor_fail_violations;
                     throw exceptions::configuration_exception(format(
@@ -259,9 +261,9 @@ std::vector<sstring> check_against_restricted_replication_strategies(
                             "configuration setting of minimum_replication_factor_fail_threshold={}. Please "
                             "increase replication factor, or lower minimum_replication_factor_fail_threshold "
                             "set in the configuration.", opt.first, rf,
-                            qp.proxy().data_dictionary().get_config().minimum_replication_factor_fail_threshold()));
+                            rr.minimum_replication_factor_fail_threshold()));
                 }
-                else if (auto max_fail = qp.proxy().data_dictionary().get_config().maximum_replication_factor_fail_threshold();
+                else if (auto max_fail = rr.maximum_replication_factor_fail_threshold();
                          max_fail >= 0 && rf > max_fail) {
                     ++stats.maximum_replication_factor_fail_violations;
                     throw exceptions::configuration_exception(format(
@@ -269,23 +271,23 @@ std::vector<sstring> check_against_restricted_replication_strategies(
                             "configuration setting of maximum_replication_factor_fail_threshold={}. Please "
                             "decrease replication factor, or increase maximum_replication_factor_fail_threshold "
                             "set in the configuration.", opt.first, rf,
-                            qp.proxy().data_dictionary().get_config().maximum_replication_factor_fail_threshold()));
+                            rr.maximum_replication_factor_fail_threshold()));
                 }
-                else if (auto min_warn = qp.proxy().data_dictionary().get_config().minimum_replication_factor_warn_threshold();
+                else if (auto min_warn = rr.minimum_replication_factor_warn_threshold();
                          min_warn >= 0 && rf < min_warn)
                 {
                     ++stats.minimum_replication_factor_warn_violations;
                     warnings.push_back(format("Using Replication Factor {}={} lower than the "
                                               "minimum_replication_factor_warn_threshold={} is not recommended.", opt.first, rf,
-                                              qp.proxy().data_dictionary().get_config().minimum_replication_factor_warn_threshold()));
+                                              rr.minimum_replication_factor_warn_threshold()));
                 }
-                else if (auto max_warn = qp.proxy().data_dictionary().get_config().maximum_replication_factor_warn_threshold();
+                else if (auto max_warn = rr.maximum_replication_factor_warn_threshold();
                         max_warn >= 0 && rf > max_warn)
                 {
                     ++stats.maximum_replication_factor_warn_violations;
                     warnings.push_back(format("Using Replication Factor {}={} greater than the "
                                               "maximum_replication_factor_warn_threshold={} is not recommended.", opt.first, rf,
-                                              qp.proxy().data_dictionary().get_config().maximum_replication_factor_warn_threshold()));
+                                              rr.maximum_replication_factor_warn_threshold()));
                 }
             }
         } catch (std::invalid_argument&) {
@@ -297,7 +299,7 @@ std::vector<sstring> check_against_restricted_replication_strategies(
 
 future<::shared_ptr<messages::result_message>>
 create_keyspace_statement::execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const {
-    std::vector<sstring> warnings = check_against_restricted_replication_strategies(qp, keyspace(), *_attrs, qp.get_cql_stats());
+    std::vector<sstring> warnings = check_against_restricted_replication_strategies(qp, keyspace(), *_attrs, qp.get_cql_stats(), qp.get_cql_config().replication_restrictions);
         return schema_altering_statement::execute(qp, state, options, std::move(guard)).then([warnings = std::move(warnings)] (::shared_ptr<messages::result_message> msg) {
         for (const auto& warning : warnings) {
             msg->add_warning(warning);

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -71,7 +71,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> grant_permissions_to_creator(const service::client_state&, service::group0_batch&) const override;
 

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -30,6 +30,7 @@ class keyspace_metadata;
 namespace cql3 {
 
 class query_processor;
+struct replication_restrictions;
 
 namespace statements {
 
@@ -88,7 +89,8 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     query_processor& qp,
     const sstring& keyspace,
     const ks_prop_defs& attrs,
-    cql_stats& stats);
+    cql_stats& stats,
+    const cql3::replication_restrictions& rr);
 
 }
 

--- a/cql3/statements/create_role_statement.hh
+++ b/cql3/statements/create_role_statement.hh
@@ -37,7 +37,7 @@ public:
                 , _if_not_exists(if_not_exists) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
 

--- a/cql3/statements/create_service_level_statement.cc
+++ b/cql3/statements/create_service_level_statement.cc
@@ -28,7 +28,7 @@ create_service_level_statement::create_service_level_statement(sstring service_l
 
 std::unique_ptr<cql3::statements::prepared_statement>
 cql3::statements::create_service_level_statement::prepare(
-        data_dictionary::database db, cql_stats &stats) {
+        data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<create_service_level_statement>(*this));
 }
 

--- a/cql3/statements/create_service_level_statement.hh
+++ b/cql3/statements/create_service_level_statement.hh
@@ -24,7 +24,7 @@ class create_service_level_statement final : public service_level_statement {
 
 public:
     create_service_level_statement(sstring service_level, shared_ptr<sl_prop_defs> attrs, bool if_not_exists);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats) override;
+    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&, std::optional<service::group0_guard> guard) const override;

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -149,7 +149,7 @@ void create_table_statement::add_column_metadata_from_aliases(schema_builder& bu
 }
 
 std::unique_ptr<prepared_statement>
-create_table_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+create_table_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     // Cannot happen; create_table_statement is never instantiated as a raw statement
     // (instead we instantiate create_table_statement::raw_statement)
     throwing_assert(0 && "create_table_statement::prepare");
@@ -173,7 +173,7 @@ create_table_statement::raw_statement::raw_statement(cf_name name, bool if_not_e
     , _if_not_exists{if_not_exists}
 { }
 
-std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     // Column family name
     const sstring& cf_name = _cf_name->get_column_family();
     boost::regex name_regex("\\w+");

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -19,6 +19,7 @@
 #include "cql3/statements/create_table_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/cql_config.hh"
 
 #include "auth/resource.hh"
 #include "auth/service.hh"
@@ -203,7 +204,7 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
         }
         stmt_warnings.emplace_back(std::move(msg));
     };
-    std::optional<sstring> warning = check_restricted_table_properties(db, std::nullopt, keyspace(), column_family(), *_properties.properties());
+    std::optional<sstring> warning = check_restricted_table_properties(std::nullopt, keyspace(), column_family(), *_properties.properties(), cfg.twcs_restrictions);
     if (warning) {
         // FIXME: should this warning be returned to the caller?
         // See https://github.com/scylladb/scylladb/issues/20945
@@ -502,10 +503,10 @@ void create_table_statement::raw_statement::add_column_alias(::shared_ptr<column
 // legal but restricted by the configuration. Checks for other of errors
 // in the table's options are done elsewhere.
 std::optional<sstring> check_restricted_table_properties(
-    data_dictionary::database db,
     std::optional<schema_ptr> schema,
     const sstring& keyspace, const sstring& table,
-    const cf_prop_defs& cfprops)
+    const cf_prop_defs& cfprops,
+    const cql3::twcs_restrictions& tr)
 {
     // Note: In the current implementation, CREATE TABLE calls this function
     // after cfprops.validate() was called, but ALTER TABLE calls this
@@ -536,7 +537,7 @@ std::optional<sstring> check_restricted_table_properties(
         std::map<sstring, sstring> options = (strategy) ? cfprops.get_compaction_type_options() : (*schema)->compaction_strategy_options();
         compaction::time_window_compaction_strategy_options twcs_options(options);
         long ttl = (cfprops.has_property(cf_prop_defs::KW_DEFAULT_TIME_TO_LIVE)) ? cfprops.get_default_time_to_live() : current_ttl.count();
-        auto max_windows = db.get_config().twcs_max_window_count();
+        auto max_windows = tr.twcs_max_window_count();
 
         // It may happen that an user tries to update an unrelated table property. Allow the request through.
         if (!cfprops.has_property(cf_prop_defs::KW_DEFAULT_TIME_TO_LIVE) && !strategy) {
@@ -556,7 +557,7 @@ std::optional<sstring> check_restricted_table_properties(
                                                    "highly discouraged.", ttl, twcs_options.get_sstable_window_size().count(), window_count, max_windows));
             }
         } else {
-              switch (db.get_config().restrict_twcs_without_default_ttl()) {
+              switch (tr.restrict_twcs_without_default_ttl()) {
               case db::tri_mode_restriction_t::mode::TRUE:
                   throw exceptions::configuration_exception(
                       "TimeWindowCompactionStrategy tables without a strict default_time_to_live setting "

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -30,7 +30,6 @@
 #include "gms/feature_service.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
-#include "db/config.hh"
 #include "compaction/time_window_compaction_strategy.hh"
 #include "db/tags/extension.hh"
 #include "db/tags/utils.hh"
@@ -262,7 +261,7 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
 
     stmt->_use_compact_storage = _properties.use_compact_storage();
     if (stmt->_use_compact_storage) {
-        if (!db.get_config().enable_create_table_with_compact_storage()) {
+        if (!cfg.enable_create_table_with_compact_storage()) {
             throw exceptions::invalid_request_exception("Support for the deprecated feature of 'CREATE TABLE WITH COMPACT STORAGE' is disabled and will eventually be removed in a future version.  To enable, set the 'enable_create_table_with_compact_storage' config option to 'true'.");
         }
         stmt_warning("CREATE TABLE WITH COMPACT STORAGE is deprecated and will eventually be removed in a future version.");

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -73,7 +73,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> grant_permissions_to_creator(const service::client_state&, service::group0_batch&) const override;
 
@@ -111,7 +111,7 @@ private:
 public:
     raw_statement(cf_name name, bool if_not_exists);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     cf_properties& properties() {
         return _properties;

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -28,6 +28,7 @@
 namespace cql3 {
 
 class query_processor;
+struct twcs_restrictions;
 class cf_prop_defs;
 
 namespace statements {
@@ -129,10 +130,10 @@ protected:
 };
 
 std::optional<sstring> check_restricted_table_properties(
-    data_dictionary::database db,
     std::optional<schema_ptr> schema,
     const sstring& keyspace, const sstring& table,
-    const cf_prop_defs& cfprops);
+    const cf_prop_defs& cfprops,
+    const twcs_restrictions& tr);
 
 }
 

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -145,7 +145,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-create_type_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+create_type_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_type_statement>(*this));
 }
 

--- a/cql3/statements/create_type_statement.hh
+++ b/cql3/statements/create_type_statement.hh
@@ -43,7 +43,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     static void check_for_duplicate_names(user_type type);
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -34,6 +34,7 @@
 #include "service/migration_manager.hh"
 #include "replica/database.hh"
 #include "db/config.hh"
+#include "cql3/cql_config.hh"
 
 namespace cql3 {
 
@@ -208,7 +209,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     raw_select.set_bound_variables({});
 
     cql_stats ignored;
-    auto prepared = raw_select.prepare(db, ignored, true);
+    auto prepared = raw_select.prepare(db, ignored, default_cql_config, true);
     auto restrictions = static_pointer_cast<statements::select_statement>(prepared->statement)->get_restrictions();
 
     auto base_primary_key_cols =
@@ -422,7 +423,7 @@ create_view_statement::prepare_schema_mutations(query_processor& qp, const query
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-create_view_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+create_view_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     if (!_prepare_ctx.get_variable_specifications().empty()) {
         throw exceptions::invalid_request_exception(format("Cannot use query parameters in CREATE MATERIALIZED VIEW statements"));
     }

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -33,7 +33,6 @@
 #include "db/view/view.hh"
 #include "service/migration_manager.hh"
 #include "replica/database.hh"
-#include "db/config.hh"
 #include "cql3/cql_config.hh"
 
 namespace cql3 {
@@ -107,7 +106,7 @@ static bool validate_primary_key(
     return new_non_pk_column;
 }
 
-std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(data_dictionary::database db, locator::token_metadata_ptr tmptr) const {
+std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(data_dictionary::database db, locator::token_metadata_ptr tmptr, const view_restrictions& vr) const {
     // We need to make sure that:
     //  - materialized view name is valid
     //  - primary key includes all columns in base table's primary key
@@ -325,7 +324,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     }
 
     if (!invalid_not_null_column_names.empty() &&
-        db.get_config().strict_is_not_null_in_views() == db::tri_mode_restriction_t::mode::TRUE) {
+        vr.strict_is_not_null_in_views() == db::tri_mode_restriction_t::mode::TRUE) {
         throw exceptions::invalid_request_exception(
             fmt::format("The IS NOT NULL restriction is allowed only columns which are part of the view's primary key,"
                         " found columns: {}. The flag strict_is_not_null_in_views can be used to turn this error "
@@ -334,7 +333,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     }
 
     if (!invalid_not_null_column_names.empty() &&
-        db.get_config().strict_is_not_null_in_views() == db::tri_mode_restriction_t::mode::WARN) {
+        vr.strict_is_not_null_in_views() == db::tri_mode_restriction_t::mode::WARN) {
         sstring warning_text = fmt::format(
             "The IS NOT NULL restriction is allowed only columns which are part of the view's primary key,"
             " found columns: {}. Restrictions on these columns will be silently ignored. "
@@ -402,7 +401,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>>
 create_view_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     utils::chunked_vector<mutation> m;
-    auto [definition, warnings] = prepare_view(qp.db(), qp.proxy().get_token_metadata_ptr());
+    auto [definition, warnings] = prepare_view(qp.db(), qp.proxy().get_token_metadata_ptr(), qp.get_cql_config().view_restrictions);
     try {
         m = co_await service::prepare_new_view_announcement(qp.proxy(), std::move(definition), ts);
     } catch (const exceptions::already_exists_exception& e) {

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -19,6 +19,7 @@
 namespace cql3 {
 
 class query_processor;
+struct view_restrictions;
 class relation;
 
 namespace selection {
@@ -48,7 +49,7 @@ public:
             std::vector<::shared_ptr<cql3::column_identifier::raw>> clustering_keys,
             bool if_not_exists);
 
-    std::pair<view_ptr, cql3::cql_warnings_vec> prepare_view(data_dictionary::database db, locator::token_metadata_ptr tmptr) const;
+    std::pair<view_ptr, cql3::cql_warnings_vec> prepare_view(data_dictionary::database db, locator::token_metadata_ptr tmptr, const view_restrictions& vr) const;
 
     auto& properties() {
         return _properties;

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -58,7 +58,7 @@ public:
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     // FIXME: continue here. See create_table_statement.hh and CreateViewStatement.java
 private:

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -880,7 +880,7 @@ describe_statement::audit_info() const {
     return audit::audit::create_audit_info(category(), "system", "");
 }
 
-std::unique_ptr<prepared_statement> describe_statement::prepare(data_dictionary::database db, cql_stats &stats) {
+std::unique_ptr<prepared_statement> describe_statement::prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     bool internals = bool(_with_internals);
     auto desc_stmt = std::visit(overloaded_functor{
         [] (const describe_cluster&) -> ::shared_ptr<statements::describe_statement> {

--- a/cql3/statements/detach_service_level_statement.cc
+++ b/cql3/statements/detach_service_level_statement.cc
@@ -28,7 +28,7 @@ bool detach_service_level_statement::needs_guard(query_processor& qp, service::q
 
 std::unique_ptr<cql3::statements::prepared_statement>
 cql3::statements::detach_service_level_statement::prepare(
-        data_dictionary::database db, cql_stats &stats) {
+        data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<detach_service_level_statement>(*this));
 }
 

--- a/cql3/statements/detach_service_level_statement.hh
+++ b/cql3/statements/detach_service_level_statement.hh
@@ -19,7 +19,7 @@ class detach_service_level_statement final : public service_level_statement {
     sstring _role_name;
 public:
     detach_service_level_statement(sstring role_name);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats) override;
+    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>

--- a/cql3/statements/drop_aggregate_statement.cc
+++ b/cql3/statements/drop_aggregate_statement.cc
@@ -19,7 +19,7 @@ namespace cql3 {
 
 namespace statements {
 
-std::unique_ptr<prepared_statement> drop_aggregate_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+std::unique_ptr<prepared_statement> drop_aggregate_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_aggregate_statement>(*this));
 }
 

--- a/cql3/statements/drop_aggregate_statement.hh
+++ b/cql3/statements/drop_aggregate_statement.hh
@@ -14,7 +14,7 @@ namespace cql3 {
 class query_processor;
 namespace statements {
 class drop_aggregate_statement final : public drop_function_statement_base {
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
 
 protected:

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -30,7 +30,7 @@ drop_function_statement::audit_info() const {
     return audit::audit::create_audit_info(category(), sstring(), sstring());
 }
 
-std::unique_ptr<prepared_statement> drop_function_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+std::unique_ptr<prepared_statement> drop_function_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_function_statement>(*this));
 }
 

--- a/cql3/statements/drop_function_statement.hh
+++ b/cql3/statements/drop_function_statement.hh
@@ -15,7 +15,7 @@ namespace cql3 {
 class query_processor;
 namespace statements {
 class drop_function_statement final : public drop_function_statement_base {
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
 protected:
     virtual audit::statement_category category() const override;

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -91,7 +91,7 @@ drop_index_statement::prepare_schema_mutations(query_processor& qp, const query_
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_index_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+drop_index_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     _cql_stats = &stats;
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_index_statement>(*this));
 }

--- a/cql3/statements/drop_index_statement.hh
+++ b/cql3/statements/drop_index_statement.hh
@@ -46,7 +46,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 private:
     schema_ptr lookup_indexed_table(query_processor& qp) const;
     schema_ptr make_drop_idex_schema(query_processor& qp) const;

--- a/cql3/statements/drop_keyspace_statement.cc
+++ b/cql3/statements/drop_keyspace_statement.cc
@@ -73,7 +73,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_w
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+drop_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_keyspace_statement>(*this));
 }
 

--- a/cql3/statements/drop_keyspace_statement.hh
+++ b/cql3/statements/drop_keyspace_statement.hh
@@ -32,7 +32,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/drop_role_statement.hh
+++ b/cql3/statements/drop_role_statement.hh
@@ -31,7 +31,7 @@ public:
     drop_role_statement(const cql3::role_name& name, bool if_exists) : _role(name.to_string()), _if_exists(if_exists) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual void validate(query_processor&, const service::client_state&) const override;
 

--- a/cql3/statements/drop_service_level_statement.cc
+++ b/cql3/statements/drop_service_level_statement.cc
@@ -21,7 +21,7 @@ drop_service_level_statement::drop_service_level_statement(sstring service_level
 
 std::unique_ptr<cql3::statements::prepared_statement>
 cql3::statements::drop_service_level_statement::prepare(
-        data_dictionary::database db, cql_stats &stats) {
+        data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<drop_service_level_statement>(*this));
 }
 

--- a/cql3/statements/drop_service_level_statement.hh
+++ b/cql3/statements/drop_service_level_statement.hh
@@ -21,7 +21,7 @@ class drop_service_level_statement final : public service_level_statement {
     bool _if_exists;
 public:
     drop_service_level_statement(sstring service_level, bool if_exists);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats) override;
+    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&, std::optional<service::group0_guard> guard) const override;

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -67,7 +67,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_w
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_table_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+drop_table_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_table_statement>(*this));
 }
 

--- a/cql3/statements/drop_table_statement.hh
+++ b/cql3/statements/drop_table_statement.hh
@@ -28,7 +28,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -151,7 +151,7 @@ drop_type_statement::prepare_schema_mutations(query_processor& qp, const query_o
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_type_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+drop_type_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_type_statement>(*this));
 }
 

--- a/cql3/statements/drop_type_statement.hh
+++ b/cql3/statements/drop_type_statement.hh
@@ -32,7 +32,7 @@ public:
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 private:
     bool validate_while_executing(query_processor&) const;
 };

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -65,7 +65,7 @@ drop_view_statement::prepare_schema_mutations(query_processor& qp, const query_o
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_view_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+drop_view_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_view_statement>(*this));
 }
 

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -34,7 +34,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/grant_role_statement.hh
+++ b/cql3/statements/grant_role_statement.hh
@@ -32,7 +32,7 @@ public:
         : _role(name.to_string()), _grantee(grantee.to_string()) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
 

--- a/cql3/statements/grant_statement.cc
+++ b/cql3/statements/grant_statement.cc
@@ -15,7 +15,7 @@
 #include "service/raft/raft_group0_client.hh"
 
 std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::grant_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<grant_statement>(*this));
 }
 

--- a/cql3/statements/grant_statement.hh
+++ b/cql3/statements/grant_statement.hh
@@ -22,7 +22,7 @@ class grant_statement : public permission_altering_statement {
 public:
     using permission_altering_statement::permission_altering_statement;
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor&
                     , service::query_state&

--- a/cql3/statements/list_effective_service_level_statement.cc
+++ b/cql3/statements/list_effective_service_level_statement.cc
@@ -26,7 +26,7 @@ list_effective_service_level_statement::list_effective_service_level_statement(s
 : _role_name(std::move(role_name)) {}
 
 std::unique_ptr<prepared_statement> 
-list_effective_service_level_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+list_effective_service_level_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_effective_service_level_statement>(*this));
 }
 

--- a/cql3/statements/list_effective_service_level_statement.hh
+++ b/cql3/statements/list_effective_service_level_statement.hh
@@ -19,7 +19,7 @@ class list_effective_service_level_statement final : public service_level_statem
 public:
     list_effective_service_level_statement(sstring role_name);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/list_permissions_statement.cc
+++ b/cql3/statements/list_permissions_statement.cc
@@ -38,7 +38,7 @@ cql3::statements::list_permissions_statement::list_permissions_statement(
 }
 
 std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::list_permissions_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_permissions_statement>(*this));
 }
 

--- a/cql3/statements/list_permissions_statement.hh
+++ b/cql3/statements/list_permissions_statement.hh
@@ -32,7 +32,7 @@ private:
 public:
     list_permissions_statement(auth::permission_set, std::optional<auth::resource>, std::optional<sstring>, bool);
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/list_roles_statement.hh
+++ b/cql3/statements/list_roles_statement.hh
@@ -33,7 +33,7 @@ public:
     list_roles_statement(const std::optional<role_name>& grantee, bool recursive)
         : _grantee(grantee ? sstring(grantee->to_string()) : std::optional<sstring>()), _recursive(recursive) {}
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/list_service_level_attachments_statement.cc
+++ b/cql3/statements/list_service_level_attachments_statement.cc
@@ -35,7 +35,7 @@ list_service_level_attachments_statement::list_service_level_attachments_stateme
 
 std::unique_ptr<cql3::statements::prepared_statement>
 cql3::statements::list_service_level_attachments_statement::prepare(
-        data_dictionary::database db, cql_stats &stats) {
+        data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_service_level_attachments_statement>(*this));
 }
 

--- a/cql3/statements/list_service_level_attachments_statement.hh
+++ b/cql3/statements/list_service_level_attachments_statement.hh
@@ -21,7 +21,7 @@ class list_service_level_attachments_statement final : public service_level_stat
 public:
     list_service_level_attachments_statement(sstring role_name);
     list_service_level_attachments_statement();
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats) override;
+    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>

--- a/cql3/statements/list_service_level_statement.cc
+++ b/cql3/statements/list_service_level_statement.cc
@@ -38,7 +38,7 @@ list_service_level_statement::list_service_level_statement(sstring service_level
 
 std::unique_ptr<cql3::statements::prepared_statement>
 cql3::statements::list_service_level_statement::prepare(
-        data_dictionary::database db, cql_stats &stats) {
+        data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_service_level_statement>(*this));
 }
 

--- a/cql3/statements/list_service_level_statement.hh
+++ b/cql3/statements/list_service_level_statement.hh
@@ -20,7 +20,7 @@ class list_service_level_statement final : public service_level_statement {
     bool _describe_all;
 public:
     list_service_level_statement(sstring service_level, bool describe_all);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats) override;
+    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>

--- a/cql3/statements/list_users_statement.cc
+++ b/cql3/statements/list_users_statement.cc
@@ -24,7 +24,7 @@ shared_ptr<const cql3::metadata> cql3::statements::list_users_statement::get_res
 }
 
 std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::list_users_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_users_statement>(*this));
 }
 

--- a/cql3/statements/list_users_statement.hh
+++ b/cql3/statements/list_users_statement.hh
@@ -21,7 +21,7 @@ namespace statements {
 class list_users_statement : public authentication_statement {
 public:
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -576,7 +576,7 @@ modification_statement::prepare_for_broadcast_tables() const {
 namespace raw {
 
 std::unique_ptr<prepared_statement>
-modification_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+modification_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     auto meta = get_prepare_context();
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -256,7 +256,7 @@ modification_statement::execute(query_processor& qp, service::query_state& qs, c
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options, std::optional<service::group0_guard> guard) const {
-    cql3::util::validate_timestamp(qp.db().get_config(), options, attrs);
+    cql3::util::validate_timestamp(qp.get_cql_config(), options, attrs);
     return modify_stage(this, seastar::ref(qp), seastar::ref(qs), seastar::cref(options));
 }
 

--- a/cql3/statements/raw/batch_statement.hh
+++ b/cql3/statements/raw/batch_statement.hh
@@ -46,7 +46,7 @@ public:
         }
     }
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 protected:
     virtual audit::statement_category category() const override;
     virtual audit::audit_info_ptr audit_info() const override {

--- a/cql3/statements/raw/describe_statement.hh
+++ b/cql3/statements/raw/describe_statement.hh
@@ -81,7 +81,7 @@ public:
     explicit describe_statement(describe_config config);
     void with_internals_details(bool with_hashed_passwords);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     static std::unique_ptr<describe_statement> cluster();
     static std::unique_ptr<describe_statement> schema(bool full);

--- a/cql3/statements/raw/modification_statement.hh
+++ b/cql3/statements/raw/modification_statement.hh
@@ -39,7 +39,7 @@ protected:
     modification_statement(cf_name name, std::unique_ptr<attributes::raw> attrs, std::optional<expr::expression> conditions = {}, bool if_not_exists = false, bool if_exists = false);
 
 public:
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     ::shared_ptr<cql3::statements::modification_statement> prepare(data_dictionary::database db, prepare_context& ctx, cql_stats& stats) const;
     void add_raw(sstring&& raw) { _raw_cql = std::move(raw); }
     const sstring& get_raw_cql() const { return _raw_cql; }

--- a/cql3/statements/raw/parsed_statement.hh
+++ b/cql3/statements/raw/parsed_statement.hh
@@ -23,6 +23,7 @@ namespace cql3 {
 
 class column_identifier;
 class cql_stats;
+class cql_config;
 
 namespace statements {
 
@@ -42,7 +43,7 @@ public:
 
     void set_bound_variables(const std::vector<::shared_ptr<column_identifier>>& bound_names);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) = 0;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) = 0;
 
 protected:
     virtual audit::statement_category category() const = 0;

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -103,10 +103,10 @@ public:
             std::vector<::shared_ptr<cql3::column_identifier::raw>> group_by_columns,
             std::unique_ptr<cql3::attributes::raw> attrs);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override {
-        return prepare(db, stats, false);
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override {
+        return prepare(db, stats, cfg, false);
     }
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, bool for_view);
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg, bool for_view);
 private:
     std::vector<selection::prepared_selector> maybe_jsonize_select_clause(std::vector<selection::prepared_selector> select, data_dictionary::database db, schema_ptr schema);
     ::shared_ptr<restrictions::statement_restrictions> prepare_restrictions(

--- a/cql3/statements/raw/truncate_statement.hh
+++ b/cql3/statements/raw/truncate_statement.hh
@@ -31,7 +31,7 @@ public:
      */
     truncate_statement(cf_name name, std::unique_ptr<attributes::raw> attrs);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual audit::statement_category category() const override;
 };

--- a/cql3/statements/raw/use_statement.hh
+++ b/cql3/statements/raw/use_statement.hh
@@ -29,7 +29,7 @@ private:
 public:
     use_statement(sstring keyspace);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 protected:
     virtual audit::statement_category category() const override;
     virtual audit::audit_info_ptr audit_info() const override {

--- a/cql3/statements/revoke_role_statement.hh
+++ b/cql3/statements/revoke_role_statement.hh
@@ -32,7 +32,7 @@ public:
             : _role(name.to_string()), _revokee(revokee.to_string()) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
 

--- a/cql3/statements/revoke_statement.cc
+++ b/cql3/statements/revoke_statement.cc
@@ -14,7 +14,7 @@
 #include "service/query_state.hh"
 
 std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::revoke_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<revoke_statement>(*this));
 }
 

--- a/cql3/statements/revoke_statement.hh
+++ b/cql3/statements/revoke_statement.hh
@@ -22,7 +22,7 @@ class revoke_statement : public permission_altering_statement {
 public:
     using permission_altering_statement::permission_altering_statement;
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor&
                     , service::query_state&

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -68,7 +68,7 @@ static auth::authentication_options extract_authentication_options(const cql3::r
 //
 
 std::unique_ptr<prepared_statement> create_role_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<create_role_statement>(*this));
 }
 
@@ -203,7 +203,7 @@ void create_role_statement::sanitize_audit_info() {
 //
 
 std::unique_ptr<prepared_statement> alter_role_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<alter_role_statement>(*this));
 }
 
@@ -289,7 +289,7 @@ void alter_role_statement::sanitize_audit_info() {
 //
 
 std::unique_ptr<prepared_statement> drop_role_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<drop_role_statement>(*this));
 }
 
@@ -344,7 +344,7 @@ drop_role_statement::execute(query_processor&, service::query_state& state, cons
 //
 
 std::unique_ptr<prepared_statement> list_roles_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_roles_statement>(*this));
 }
 
@@ -474,7 +474,7 @@ list_roles_statement::execute(query_processor& qp, service::query_state& state, 
 //
 
 std::unique_ptr<prepared_statement> grant_role_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<grant_role_statement>(*this));
 }
 
@@ -504,7 +504,7 @@ grant_role_statement::execute(query_processor&, service::query_state& state, con
 //
 
 std::unique_ptr<prepared_statement> revoke_role_statement::prepare(
-                data_dictionary::database db, cql_stats& stats) {
+                data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<revoke_role_statement>(*this));
 }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -60,7 +60,6 @@
 #include "utils/result_loop.hh"
 #include "replica/database.hh"
 #include "replica/mutation_dump.hh"
-#include "db/config.hh"
 #include "cql3/cql_config.hh"
 
 
@@ -2470,7 +2469,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
             )
             && !restrictions->need_filtering()  // No filtering
             && group_by_cell_indices->empty()   // No GROUP BY
-            && db.get_config().enable_parallelized_aggregation()
+            && cfg.enable_parallelized_aggregation()
             && !is_local_table()
             && !( // Do not parallelize the request if it's single partition read
                 restrictions->partition_key_restrictions_is_all_eq() 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -61,6 +61,7 @@
 #include "replica/database.hh"
 #include "replica/mutation_dump.hh"
 #include "db/config.hh"
+#include "cql3/cql_config.hh"
 
 
 template<typename T = void>
@@ -477,7 +478,7 @@ select_statement::do_execute(query_processor& qp,
     const bool aggregate = _selection->is_aggregate() || has_group_by();
     const bool nonpaged_filtering = _restrictions_need_filtering && page_size <= 0;
     if (aggregate || nonpaged_filtering) {
-        page_size = page_size <= 0 ? qp.db().get_config().select_internal_page_size() : page_size;
+        page_size = page_size <= 0 ? qp.get_cql_config().select_internal_page_size : page_size;
     }
 
     auto key_ranges = _restrictions->get_partition_key_ranges(options);
@@ -789,7 +790,7 @@ view_indexed_table_select_statement::execute_base_query(
         gc_clock::time_point now,
         lw_shared_ptr<const service::pager::paging_state> paging_state) const {
     return do_execute_base_query(qp, std::move(partition_ranges), state, options, now, paging_state).then(wrap_result_to_error_message(
-            [this, &state, &options, now, paging_state = std::move(paging_state), internal_page_size = qp.db().get_config().select_internal_page_size()] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd) {
+            [this, &state, &options, now, paging_state = std::move(paging_state), internal_page_size = qp.get_cql_config().select_internal_page_size.get()] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd) {
         auto&& [result, cmd] = result_and_cmd;
         return process_base_query_results(std::move(result), std::move(cmd), state, options, now, std::move(paging_state), internal_page_size);
     }));
@@ -869,7 +870,7 @@ view_indexed_table_select_statement::execute_base_query(
         gc_clock::time_point now,
         lw_shared_ptr<const service::pager::paging_state> paging_state) const {
     return do_execute_base_query(qp, std::move(primary_keys), state, options, now, paging_state).then(wrap_result_to_error_message(
-            [this, &state, &options, now, paging_state = std::move(paging_state), internal_page_size = qp.db().get_config().select_internal_page_size()] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd){
+            [this, &state, &options, now, paging_state = std::move(paging_state), internal_page_size = qp.get_cql_config().select_internal_page_size.get()] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd){
         auto&& [result, cmd] = result_and_cmd;
         return process_base_query_results(std::move(result), std::move(cmd), state, options, now, std::move(paging_state), internal_page_size);
     }));
@@ -1261,7 +1262,7 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
         std::unique_ptr<cql3::query_options> internal_options = std::make_unique<cql3::query_options>(cql3::query_options(options));
         stop_iteration stop;
         // page size is set to the internal count page size, regardless of the user-provided value
-        auto internal_page_size = qp.db().get_config().select_internal_page_size();
+        auto internal_page_size = qp.get_cql_config().select_internal_page_size.get();
         internal_options.reset(new cql3::query_options(std::move(internal_options), options.get_paging_state(), internal_page_size));
         do {
             auto consume_results = [this, &builder, &options, &internal_options, &state, internal_page_size] (foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd, lw_shared_ptr<const service::pager::paging_state> paging_state) -> stop_iteration {
@@ -1871,7 +1872,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
     const bool aggregate = _selection->is_aggregate() || has_group_by();
     const bool nonpaged_filtering = _restrictions_need_filtering && page_size <= 0;
     if (aggregate || nonpaged_filtering) {
-        page_size = qp.db().get_config().select_internal_page_size();
+        page_size = qp.get_cql_config().select_internal_page_size;
     }
 
     auto key_ranges = _restrictions->get_partition_key_ranges(options);

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2322,7 +2322,7 @@ group_by_references_clustering_keys(const selection::selection& sel, const std::
     });
 }
 
-std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::database db, cql_stats& stats, bool for_view) {
+std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg, bool for_view) {
     schema_ptr underlying_schema = validation::validate_column_family(db, keyspace(), column_family());
     schema_ptr schema = _parameters->is_mutation_fragments() ? mutation_fragments_select_statement::generate_output_schema(underlying_schema) : underlying_schema;
     prepare_context& ctx = get_prepare_context();

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2424,7 +2424,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
 
     std::vector<sstring> warnings;
     if (!is_ann_query) {
-        check_needs_filtering(*restrictions, db.get_config().strict_allow_filtering(), warnings);
+        check_needs_filtering(*restrictions, cfg.strict_allow_filtering(), warnings);
         ensure_filtering_columns_retrieval(db, *selection, *restrictions);
     }
     auto group_by_cell_indices = ::make_shared<std::vector<size_t>>(prepare_group_by(*schema, *selection));

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -35,7 +35,7 @@ truncate_statement::truncate_statement(cf_name name, std::unique_ptr<attributes:
     throwing_assert(!_attrs->time_to_live.has_value());
 }
 
-std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary::database db, cql_stats& stats) {
+std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     auto prepared_attributes = _attrs->prepare(db, keyspace(), column_family());
     auto ctx = get_prepare_context();

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -36,7 +36,7 @@ use_statement::use_statement(sstring keyspace)
 {
 }
 
-std::unique_ptr<prepared_statement> use_statement::prepare(data_dictionary::database db, cql_stats& stats)
+std::unique_ptr<prepared_statement> use_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg)
 {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<cql3::statements::use_statement>(_keyspace));
 }

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -6,8 +6,9 @@
 
 #include "utils/assert.hh"
 #include "util.hh"
+#include "cql_config.hh"
 #include "cql3/expr/expr-utils.hh"
-#include "db/config.hh"
+#include "db_clock.hh"
 
 #ifdef DEBUG
 
@@ -117,8 +118,8 @@ void do_with_parser_impl(const std::string_view& cql, dialect d, noncopyable_fun
 
 #endif
 
-void validate_timestamp(const db::config& config, const query_options& options, const std::unique_ptr<attributes>& attrs) {
-    if (attrs->is_timestamp_set() && config.restrict_future_timestamp()) {
+void validate_timestamp(const cql_config& cql_cfg, const query_options& options, const std::unique_ptr<attributes>& attrs) {
+    if (attrs->is_timestamp_set() && cql_cfg.restrict_future_timestamp()) {
         static constexpr int64_t MAX_DIFFERENCE = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::days(3)).count();
         auto now = std::chrono::duration_cast<std::chrono::microseconds>(db_clock::now().time_since_epoch()).count();
 

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -88,7 +88,7 @@ sstring single_quote(const std::string_view s);
 
 // Check whether timestamp is not too far in the future as this probably
 // indicates its incorrectness (for example using other units than microseconds).
-void validate_timestamp(const db::config& config, const query_options& options, const std::unique_ptr<attributes>& attrs);
+void validate_timestamp(const cql_config& cql_cfg, const query_options& options, const std::unique_ptr<attributes>& attrs);
 
 template<typename T>
 std::vector<T> to_vector(const std::vector<data_value>& values) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -35,6 +35,7 @@
 #include "replica/database.hh"
 #include "keys/clustering_bounds_comparator.hh"
 #include "cql3/statements/select_statement.hh"
+#include "cql3/cql_config.hh"
 #include "cql3/util.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/expr/expr-utils.hh"
@@ -129,7 +130,7 @@ cql3::statements::select_statement& view_info::select_statement(data_dictionary:
         raw->prepare_keyspace(_schema.ks_name());
         raw->set_bound_variables({});
         cql3::cql_stats ignored;
-        auto prepared = raw->prepare(db, ignored, true);
+        auto prepared = raw->prepare(db, ignored, cql3::default_cql_config, true);
         _select_statement = static_pointer_cast<cql3::statements::select_statement>(prepared->statement);
     }
     return *_select_statement;

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -30,7 +30,7 @@ static schema_ptr parse_new_cf_statement(cql3::query_processor& qp, const sstrin
     (void)parsed_cf_stmt->keyspace(); // This will SCYLLA_ASSERT if cql statement did not contain keyspace
     ::shared_ptr<cql3::statements::create_table_statement> statement =
                     static_pointer_cast<cql3::statements::create_table_statement>(
-                                    parsed_cf_stmt->prepare(db, qp.get_cql_stats())->statement);
+                                    parsed_cf_stmt->prepare(db, qp.get_cql_stats(), qp.get_cql_config())->statement);
     auto schema = statement->get_cf_meta_data(db);
 
     // Generate the CF UUID based on its KF names. This is needed to ensure that

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -740,7 +740,7 @@ private:
             _proxy.start(std::ref(_db), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get(), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_erm_factory)).get();
             auto stop_proxy = defer_verbose_shutdown("storage proxy", [this] { _proxy.stop().get(); });
 
-            _cql_config.start(cql3::cql_config::default_tag{}).get();
+            _cql_config.start(seastar::sharded_parameter([&] { return cql3::cql_config(*cfg); })).get();
             auto stop_cql_config = defer_verbose_shutdown("cql config", [this] { _cql_config.stop().get(); });
 
             cql3::query_processor::memory_config qp_mcfg;

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -18,6 +18,7 @@
 #include "cdc/log.hh"
 #include "cdc/cdc_options.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/cql_config.hh"
 #include "cql3/statements/create_keyspace_statement.hh"
 #include "cql3/statements/create_table_statement.hh"
 #include "cql3/statements/create_type_statement.hh"
@@ -278,7 +279,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
         auto raw_statement = cql3::query_processor::parse_statement(
                 fmt::format("CREATE KEYSPACE {} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '1'}}", name),
                 cql3::dialect{});
-        auto prepared_statement = raw_statement->prepare(db, cql_stats);
+        auto prepared_statement = raw_statement->prepare(db, cql_stats, cql3::default_cql_config);
         auto* statement = prepared_statement->statement.get();
         auto p = dynamic_cast<cql3::statements::create_keyspace_statement*>(statement);
         SCYLLA_ASSERT(p);
@@ -302,7 +303,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
             throw std::runtime_error("tools::do_load_schemas(): CQL statement does not have keyspace specified");
         }
         auto ks = find_or_create_keyspace(cf_statement->keyspace());
-        auto prepared_statement = cf_statement->prepare(db, cql_stats);
+        auto prepared_statement = cf_statement->prepare(db, cql_stats, cql3::default_cql_config);
         auto* statement = prepared_statement->statement.get();
 
         if (auto p = dynamic_cast<cql3::statements::create_keyspace_statement*>(statement)) {

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -321,7 +321,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
             }
             real_db.tables.emplace_back(dd_impl, dd_impl.unwrap(ks), std::move(schema), true);
         } else if (auto p = dynamic_cast<cql3::statements::create_view_statement*>(statement)) {
-            auto&& [view, warnings] = p->prepare_view(db, token_metadata.local().get());
+            auto&& [view, warnings] = p->prepare_view(db, token_metadata.local().get(), cql3::default_cql_config.view_restrictions);
             auto it = std::find_if(real_db.tables.begin(), real_db.tables.end(), [&] (const table& t) { return t.schema->ks_name() == view->ks_name() && t.schema->cf_name() == view->cf_name(); });
             if (it != real_db.tables.end()) {
                 continue; // view already exists

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -21,6 +21,7 @@
 #include "compaction/compaction_strategy.hh"
 #include "compaction/compaction_strategy_state.hh"
 #include "cql3/statements/raw/parsed_statement.hh"
+#include "cql3/cql_config.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/select_statement.hh"
 #include "cql3/query_result_printer.hh"
@@ -1730,7 +1731,7 @@ validate_and_prepare_query(std::string_view query, std::string_view table_name, 
     cql3::cql_stats cql_stats;
 
     try {
-        auto prepared_statement = raw_statement->prepare(db, cql_stats);
+        auto prepared_statement = raw_statement->prepare(db, cql_stats, cql3::default_cql_config);
         return std::move(prepared_statement->statement);
     } catch (...) {
         throw std::invalid_argument(seastar::format("failed to prepare query: {}", std::current_exception()));


### PR DESCRIPTION
There's a bunch of db::config options that are used by cql3/statements/ code. For that they use data_dictionary/database as a proxy to get db::config reference. This PR moves most of these accessed options onto cql_config

Options migrated to cql_config:

   1. select_internal_page_size
   2. strict_allow_filtering
   3. enable_parallelized_aggregation
   4. batch_size_warn_threshold_in_kb
   5. batch_size_fail_threshold_in_kb
   6. 7 keyspace replication restriction options
   7. 2 TWCS restriction options
   8. restrict_future_timestamp
   9. strict_is_not_null_in_views (with view_restrictions struct)
   10. enable_create_table_with_compact_storage

Some options need special treatment and are still abused via database, namely:

  1. enable_logstor
  2. cluster_name
  3. partitioner
  4. endpoint_snitch

Fixing components inter-dependencies, not backporting