### PR TITLE
test/cmake: remove duplicate test entries in boost CMakeLists

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -203,8 +203,6 @@ add_scylla_test(rolling_max_tracker_test
   KIND BOOST)
 add_scylla_test(rest_client_test
   KIND SEASTAR)
-add_scylla_test(rolling_max_tracker_test
-  KIND BOOST)
 add_scylla_test(rust_test
   KIND BOOST
   LIBRARIES inc)
@@ -315,10 +313,6 @@ add_scylla_test(address_map_test
   KIND SEASTAR)
 add_scylla_test(object_storage_upload_test
   KIND SEASTAR)
-add_scylla_test(symmetric_key_test
-  KIND SEASTAR
-  LIBRARIES
-    encryption)
 
 add_scylla_test(combined_tests
   KIND SEASTAR


### PR DESCRIPTION
Remove duplicate add_scylla_test() calls for rolling_max_tracker_test and symmetric_key_test that appeared after a merge with master. The duplicates caused CMake target name collisions hence have to be removed.

No need for a backport since cmake is not used in our CI