### PR TITLE
(NO MERGE) Use commitlog for SC raft group persistence (AI generated)

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -871,6 +871,9 @@ public:
     bool is_schema_version_known(schema_ptr s) {
         return _known_schema_versions.contains(s->version());
     }
+    uint32_t version() const {
+        return _desc.ver;
+    }
     void add_schema_version(schema_ptr s) {
         _known_schema_versions.emplace(s->version());
     }
@@ -3084,7 +3087,7 @@ future<db::rp_handle> db::commitlog::add_entry(const cf_id_type& id, const commi
         }
         size_t size(segment& seg) override {
             _writer.set_with_schema(!seg.is_schema_version_known(_writer.schema()));
-            return _writer.size();
+            return _writer.size(seg.version());
         }
         size_t size(segment& seg, size_t) override {
             return size(seg);
@@ -3096,7 +3099,7 @@ future<db::rp_handle> db::commitlog::add_entry(const cf_id_type& id, const commi
             if (_writer.with_schema()) {
                 seg.add_schema_version(_writer.schema());
             }
-            _writer.write(out);
+            _writer.write(out, seg.version());
         }
         void result(size_t, rp_handle h) override {
             res = std::move(h);
@@ -3139,7 +3142,7 @@ db::commitlog::add_entries(utils::chunked_vector<commitlog_entry_writer> entry_w
                     _known.emplace(i->schema()->version());
                 }
                 i->set_with_schema(!known);
-                res += i->size();
+                res += i->size(seg.version());
             }
             _sizes_computed = &seg;
             return res;
@@ -3149,7 +3152,7 @@ db::commitlog::add_entries(utils::chunked_vector<commitlog_entry_writer> entry_w
             if (_sizes_computed != &seg) {
                 w.set_with_schema(seg.is_schema_version_known(w.schema())); 
             }
-            return w.size();
+            return w.size(seg.version());
         }
         size_t size() const override {
             return std::accumulate(_writers.begin(), _writers.end(), size_t(0), [](size_t acc, const commitlog_entry_writer& w) {
@@ -3161,7 +3164,7 @@ db::commitlog::add_entries(utils::chunked_vector<commitlog_entry_writer> entry_w
             if (w.with_schema()) {
                 seg.add_schema_version(w.schema());
             }
-            w.write(out);
+            w.write(out, seg.version());
         }
         void result(size_t i, rp_handle h) override {
             SCYLLA_ASSERT(i == res.size());
@@ -3351,6 +3354,7 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
         bool eof = false;
         bool header = true;
         bool failed = false;
+        uint32_t segment_version = 0;
         fragmented_temporary_buffer::reader frag_reader;
         fragmented_temporary_buffer buffer, initial;
 
@@ -3443,8 +3447,8 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
             if (magic != segment::segment_magic) {
                 throw invalid_segment_format();
             }
-            if (ver != descriptor::current_version) {
-                throw std::invalid_argument("Cannot replay old commitlog segments");
+            if (ver < descriptor::segment_version_4 || ver > descriptor::current_version) {
+                throw std::invalid_argument("Unsupported commitlog segment version");
             }
 
             crc32_nbo crc;
@@ -3461,6 +3465,7 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
             this->id = id;
             this->next = 0;
             this->alignment = alignment;
+            this->segment_version = ver;
             this->initial = std::move(buf);
             this->pos = this->initial.size_bytes();
         }
@@ -3748,7 +3753,7 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
                 frag.offset = off;
                 frag.rem = rem;
                 frag.end = off + buf.size_bytes();
-                frag.rpbuf = buffer_and_replay_position{std::move(buf), rp};
+                frag.rpbuf = buffer_and_replay_position{std::move(buf), rp, segment_version};
 
                 clogger.debug("fragment id={} off={}, end={}, rem={} ", id, off, frag.end, rem);
 
@@ -3801,7 +3806,7 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
 
             buf = co_await read_data(size - entry_header_size);
 
-            co_await func({std::move(buf), rp});
+            co_await func({std::move(buf), rp, segment_version});
         }
 
         future<> read_file() {

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -75,6 +75,7 @@ public:
     struct buffer_and_replay_position {
         fragmented_temporary_buffer buffer;
         replay_position position;
+        uint32_t segment_version;
     };
 private:
     ::shared_ptr<segment_manager> _segment_manager;
@@ -136,7 +137,8 @@ public:
         static inline constexpr uint32_t segment_version_2 = 2u;
         static inline constexpr uint32_t segment_version_3 = 3u;
         static inline constexpr uint32_t segment_version_4 = 4u;
-        static inline constexpr uint32_t current_version = segment_version_4;
+        static inline constexpr uint32_t segment_version_5 = 5u;
+        static inline constexpr uint32_t current_version = segment_version_5;
 
         descriptor(descriptor&&) noexcept = default;
         descriptor(const descriptor&) = default;

--- a/db/commitlog/commitlog_entry.cc
+++ b/db/commitlog/commitlog_entry.cc
@@ -10,6 +10,7 @@
 #include "commitlog_entry.hh"
 #include "idl/commitlog.dist.hh"
 #include "idl/commitlog.dist.impl.hh"
+#include "db/commitlog/commitlog.hh"
 
 #include <seastar/core/simple-stream.hh>
 
@@ -30,14 +31,61 @@ void commitlog_entry_writer::compute_size() {
     _size = ms.size();
 }
 
+size_t commitlog_entry_writer::size(uint32_t segment_version) const {
+    return _size + (segment_version >= db::commitlog::descriptor::segment_version_5 ? sizeof(uint8_t) : 0);
+}
+
 void commitlog_entry_writer::write(ostream& out) const {
     serialize(out);
 }
 
+void commitlog_entry_writer::write(ostream& out, uint32_t segment_version) const {
+    if (segment_version >= db::commitlog::descriptor::segment_version_5) {
+        ser::serialize(out, uint8_t(0));
+    }
+    serialize(out);
+}
+
 commitlog_entry_reader::commitlog_entry_reader(const fragmented_temporary_buffer& buffer)
-    : _ce([&] {
-    auto in = seastar::fragmented_memory_input_stream(fragmented_temporary_buffer::view(buffer).begin(), buffer.size_bytes());
-    return ser::deserialize(in, std::type_identity<commitlog_entry>());
-}())
+    : commitlog_entry_reader(buffer, db::commitlog::descriptor::segment_version_4)
 {
+}
+
+commitlog_entry_reader::commitlog_entry_reader(const fragmented_temporary_buffer& buffer, uint32_t segment_version) {
+    auto in = seastar::fragmented_memory_input_stream(fragmented_temporary_buffer::view(buffer).begin(), buffer.size_bytes());
+    if (segment_version >= db::commitlog::descriptor::segment_version_5 && buffer.size_bytes() >= sizeof(uint8_t)) {
+        uint8_t entry_type = 0;
+        in.read(reinterpret_cast<char*>(&entry_type), sizeof(entry_type));
+        if (entry_type == 0) {
+            _ce.emplace(ser::deserialize(in, std::type_identity<commitlog_entry>()));
+        } else if (entry_type == 1) {
+            _raft_ce.emplace(ser::deserialize(in, std::type_identity<raft_commit_log_entry>()));
+        } else {
+            throw std::runtime_error(format("Unknown v5 commitlog entry type {}", entry_type));
+        }
+    } else {
+        _ce.emplace(ser::deserialize(in, std::type_identity<commitlog_entry>()));
+    }
+}
+
+const std::optional<column_mapping>& commitlog_entry_reader::get_column_mapping() const {
+    static const std::optional<column_mapping> none{};
+    if (!_ce) {
+        return none;
+    }
+    return _ce->mapping();
+}
+
+const frozen_mutation& commitlog_entry_reader::mutation() const & {
+    if (!_ce) {
+        throw std::logic_error("commitlog entry does not contain mutation payload");
+    }
+    return _ce->mutation();
+}
+
+frozen_mutation&& commitlog_entry_reader::mutation() && {
+    if (!_ce) {
+        throw std::logic_error("commitlog entry does not contain mutation payload");
+    }
+    return std::move(*_ce).mutation();
 }

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -13,8 +13,10 @@
 
 #include "commitlog_types.hh"
 #include "mutation/frozen_mutation.hh"
+#include "raft/raft.hh"
 #include "schema/schema_fwd.hh"
 #include "replay_position.hh"
+#include "utils/UUID.hh"
 
 namespace detail {
 
@@ -83,6 +85,36 @@ public:
     frozen_mutation&& mutation() && { return std::move(_mutation); }
 };
 
+class raft_commit_log_entry {
+    utils::UUID _group_id;
+    std::optional<raft::log_entry> _entry;
+    std::optional<raft::index_t> _truncate_idx;
+    std::optional<raft::index_t> _truncate_prefix_idx;
+public:
+    raft_commit_log_entry(utils::UUID group_id, std::optional<raft::log_entry> entry, std::optional<raft::index_t> truncate_idx, std::optional<raft::index_t> truncate_prefix_idx)
+        : _group_id(group_id)
+        , _entry(std::move(entry))
+        , _truncate_idx(std::move(truncate_idx))
+        , _truncate_prefix_idx(std::move(truncate_prefix_idx)) {
+    }
+
+    raft_commit_log_entry(utils::UUID group_id, raft::log_entry entry)
+        : _group_id(group_id)
+        , _entry(std::move(entry)) {
+    }
+
+    raft_commit_log_entry(utils::UUID group_id, std::optional<raft::index_t> truncate_idx, std::optional<raft::index_t> truncate_prefix_idx)
+        : _group_id(group_id)
+        , _truncate_idx(std::move(truncate_idx))
+        , _truncate_prefix_idx(std::move(truncate_prefix_idx)) {
+    }
+
+    const utils::UUID& group_id() const { return _group_id; }
+    const std::optional<raft::log_entry>& entry() const { return _entry; }
+    const std::optional<raft::index_t>& truncate_idx() const { return _truncate_idx; }
+    const std::optional<raft::index_t>& truncate_prefix_idx() const { return _truncate_prefix_idx; }
+};
+
 class commitlog_entry_writer {
 public:
     using force_sync = db::commitlog_force_sync;
@@ -118,6 +150,8 @@ public:
         return _size;
     }
 
+    size_t size(uint32_t segment_version) const;
+
     size_t mutation_size() const {
         return _mutation.representation().size();
     }
@@ -128,14 +162,21 @@ public:
     using ostream = typename seastar::memory_output_stream<detail::sector_split_iterator>;
 
     void write(ostream& out) const;
+    void write(ostream& out, uint32_t segment_version) const;
+    commitlog_entry make_entry() const;
 };
 
 class commitlog_entry_reader {
-    commitlog_entry _ce;
+    std::optional<commitlog_entry> _ce;
+    std::optional<raft_commit_log_entry> _raft_ce;
 public:
     commitlog_entry_reader(const fragmented_temporary_buffer& buffer);
+    commitlog_entry_reader(const fragmented_temporary_buffer& buffer, uint32_t segment_version);
 
-    const std::optional<column_mapping>& get_column_mapping() const { return _ce.mapping(); }
-    const frozen_mutation& mutation() const & { return _ce.mutation(); }
-    frozen_mutation&& mutation() && { return std::move(_ce).mutation(); }
+    const std::optional<column_mapping>& get_column_mapping() const;
+    const frozen_mutation& mutation() const &;
+    frozen_mutation&& mutation() &&;
+    const raft_commit_log_entry* get_raft_entry() const {
+        return _raft_ce ? &*_raft_ce : nullptr;
+    }
 };

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -208,7 +208,11 @@ future<> db::commitlog_replayer::impl::process(stats* s, commitlog::buffer_and_r
     auto&& rp = buf_rp.position;
     try {
 
-        commitlog_entry_reader cer(buf);
+        commitlog_entry_reader cer(buf, buf_rp.segment_version);
+        if (cer.get_raft_entry()) {
+            // Generic commitlog replay only applies mutation payloads.
+            co_return;
+        }
         auto& fm = cer.mutation();
 
         auto& local_cm = _column_mappings.local().map;
@@ -409,4 +413,3 @@ future<> db::commitlog_replayer::recover(std::vector<sstring> files, sstring fna
 future<> db::commitlog_replayer::recover(sstring f, sstring fname_prefix) {
     return recover(std::vector<sstring>{ f }, std::move(fname_prefix));
 }
-

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -93,8 +93,8 @@ bool hint_sender::can_send() noexcept {
     }
 }
 
-frozen_mutation_and_schema hint_sender::get_mutation(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer& buf) {
-    hint_entry_reader hr(buf);
+frozen_mutation_and_schema hint_sender::get_mutation(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer& buf, uint32_t segment_version) {
+    hint_entry_reader hr(buf, segment_version);
     auto& fm = hr.mutation();
     auto& cm = get_column_mapping(std::move(ctx_ptr), fm, hr);
     auto schema = _db.find_schema(fm.column_family_id());
@@ -275,15 +275,15 @@ future<> hint_sender::send_one_mutation(frozen_mutation_and_schema m) {
     });
 }
 
-future<> hint_sender::send_one_hint(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer buf, db::replay_position rp, gc_clock::duration secs_since_file_mod, const sstring& fname) {
-    return _resource_manager.get_send_units_for(buf.size_bytes()).then([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr] (auto units) mutable {
+future<> hint_sender::send_one_hint(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer buf, db::replay_position rp, uint32_t segment_version, gc_clock::duration secs_since_file_mod, const sstring& fname) {
+    return _resource_manager.get_send_units_for(buf.size_bytes()).then([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, segment_version, ctx_ptr] (auto units) mutable {
         ctx_ptr->mark_hint_as_in_progress(rp);
 
         // Future is waited on indirectly in `send_one_file()` (via `ctx_ptr->file_send_gate`).
         auto h = ctx_ptr->file_send_gate.hold();
-        (void)std::invoke([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr] () mutable {
+        (void)std::invoke([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, segment_version, ctx_ptr] () mutable {
             try {
-                auto m = this->get_mutation(ctx_ptr, buf);
+                auto m = this->get_mutation(ctx_ptr, buf, segment_version);
                 gc_clock::duration gc_grace_sec = m.s->gc_grace_seconds();
 
                 // The hint is too old - drop it.
@@ -503,7 +503,7 @@ bool hint_sender::send_one_file(const sstring& fname) {
                     co_await sleep(std::chrono::milliseconds(100));
                     continue;
                 } else {
-                    co_await send_one_hint(ctx_ptr, std::move(buf), rp, secs_since_file_mod, fname);
+                    co_await send_one_hint(ctx_ptr, std::move(buf), rp, buf_rp.segment_version, secs_since_file_mod, fname);
                     break;
                 }
             };

--- a/db/hints/internal/hint_sender.hh
+++ b/db/hints/internal/hint_sender.hh
@@ -214,7 +214,7 @@ private:
     /// \param secs_since_file_mod last modification time stamp (in seconds since Epoch) of the current hints file
     /// \param fname name of the hints file this hint was read from
     /// \return future that resolves when next hint may be sent
-    future<> send_one_hint(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer buf, db::replay_position rp, gc_clock::duration secs_since_file_mod, const sstring& fname);
+    future<> send_one_hint(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer buf, db::replay_position rp, uint32_t segment_version, gc_clock::duration secs_since_file_mod, const sstring& fname);
 
     /// \brief Send all hint from a single file and delete it after it has been successfully sent.
     /// Send all hints from the given file. If we failed to send the current segment we will pick up in the next
@@ -232,7 +232,7 @@ private:
     /// \param ctx_ptr pointer to the send context
     /// \param buf hints file entry
     /// \return The mutation object representing the original mutation stored in the hints file.
-    frozen_mutation_and_schema get_mutation(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer& buf);
+    frozen_mutation_and_schema get_mutation(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer& buf, uint32_t segment_version);
 
     /// \brief Get a reference to the column_mapping object for a given frozen mutation.
     /// \param ctx_ptr pointer to the send context

--- a/docs/dev/strong_consistency.md
+++ b/docs/dev/strong_consistency.md
@@ -30,6 +30,24 @@ related to writing metadata to all shards.
 
 ## Strongly consistent table persistence
 
+Raft persistence for strongly consistent tablet groups is split between commitlog
+and system tables:
+
+- Raft log entries are persisted in a dedicated commitlog domain
+  (`RaftGroupsLog-*`) and recovered from commitlog replay on startup.
+- Raft metadata remains in system tables:
+  - `system.raft_groups` static metadata (`vote_term`, `vote`, `commit_idx`, `snapshot_id`)
+  - `system.raft_groups_snapshots` snapshot descriptor (`idx`, `term`)
+  - `system.raft_groups_snapshot_config` snapshot configuration members
+
+On upgraded nodes, startup performs a one-way import from legacy
+`system.raft_groups` log-entry rows into commitlog-backed state when replayed
+commitlog data is behind legacy table data. After successful import,
+legacy log-entry rows are cleaned up and normal persistence remains
+commitlog-only for log entries.
+
+## Strongly consistent metadata tables
+
 We introduce a separate set of Raft system tables for strongly consistent tablets:
 
 - `system.raft_groups`

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -34,6 +34,9 @@ This section describes the layouts and usage of `system.*` tables.
 - [system.peers](#systempeers)
 - [system.protocol_servers](#systemprotocol_servers)
 - [system.raft](#systemraft)
+- [system.raft_groups](#systemraft_groups)
+- [system.raft_groups_snapshot_config](#systemraft_groups_snapshot_config)
+- [system.raft_groups_snapshots](#systemraft_groups_snapshots)
 - [system.raft_snapshot_config](#systemraft_snapshot_config)
 - [system.raft_snapshots](#systemraft_snapshots)
 - [system.raft_state](#systemraft_state)
@@ -70,7 +73,7 @@ This section describes the layouts and usage of `system.*` tables.
 |----------|---------------|
 | **Core Cluster Information** | [local](#systemlocal), [peers](#systempeers), [scylla_local](#systemscylla_local) |
 | **Topology and Cluster Management** | [topology](#systemtopology), [topology_requests](#systemtopology_requests), [tablets](#systemtablets), [tablet_sizes](#systemtablet_sizes), [cluster_status](#systemcluster_status), [token_ring](#systemtoken_ring), [load_per_node](#systemload_per_node), [commitlog_cleanups](#systemcommitlog_cleanups), [discovery](#systemdiscovery) |
-| **Raft Consensus** | [raft](#systemraft), [raft_state](#systemraft_state), [raft_snapshots](#systemraft_snapshots), [raft_snapshot_config](#systemraft_snapshot_config), [group0_history](#systemgroup0_history) |
+| **Raft Consensus** | [raft](#systemraft), [raft_groups](#systemraft_groups), [raft_state](#systemraft_state), [raft_snapshots](#systemraft_snapshots), [raft_groups_snapshots](#systemraft_groups_snapshots), [raft_snapshot_config](#systemraft_snapshot_config), [raft_groups_snapshot_config](#systemraft_groups_snapshot_config), [group0_history](#systemgroup0_history) |
 | **CDC (Change Data Capture)** | [cdc_local](#systemcdc_local), [cdc_streams](#systemcdc_streams), [cdc_streams_history](#systemcdc_streams_history), [cdc_streams_state](#systemcdc_streams_state), [cdc_generations_v3](#systemcdc_generations_v3) |
 | **Materialized Views** | [views_builds_in_progress](#systemviews_builds_in_progress), [scylla_views_builds_in_progress](#systemscylla_views_builds_in_progress), [built_views](#systembuilt_views), [view_build_status_v2](#systemview_build_status_v2), [view_building_tasks](#systemview_building_tasks) |
 | **Lightweight Transactions (Paxos)** | [paxos](#systempaxos) |
@@ -979,6 +982,10 @@ Implemented by `protocol_servers_table` in `db/system_keyspace.cc`.
 
 Core Raft consensus state table. Holds information about Raft groups including the log entries.
 
+This table is authoritative for group0 Raft persistence. For strongly consistent
+tablet Raft groups, log entries are persisted in a dedicated commitlog domain,
+not in `system.raft_groups` rows.
+
 Schema:
 ```cql
 CREATE TABLE system.raft (
@@ -1005,6 +1012,103 @@ CREATE TABLE system.raft (
 - `commit_idx`: (static) Index of the last committed entry
 
 **Related tables:** [raft_state](#systemraft_state), [raft_snapshots](#systemraft_snapshots), [raft_snapshot_config](#systemraft_snapshot_config), [group0_history](#systemgroup0_history)
+
+---
+
+## system.raft_groups
+
+Shard-local metadata table for strongly consistent tablet Raft groups.
+
+Schema:
+```cql
+CREATE TABLE system.raft_groups (
+    shard smallint,
+    group_id timeuuid,
+    index bigint,
+    term bigint,
+    data blob,
+    vote_term bigint STATIC,
+    vote uuid STATIC,
+    snapshot_id uuid STATIC,
+    commit_idx bigint STATIC,
+    PRIMARY KEY ((shard, group_id), index)
+) WITH CLUSTERING ORDER BY (index ASC);
+```
+
+**Columns:**
+- `shard`: Shard-local placement key for tablet-group metadata
+- `group_id`: Identifier for the tablet Raft group
+- `index`: Legacy Raft log entry index (kept for upgrade import/cleanup)
+- `term`: Legacy Raft log entry term
+- `data`: Legacy serialized Raft log entry payload
+- `vote_term`: (static) Term of the last vote
+- `vote`: (static) Server ID that received the vote
+- `snapshot_id`: (static) ID of the current snapshot
+- `commit_idx`: (static) Index of the last committed entry
+
+**Authority and migration notes:**
+- After commitlog cutover, `term/index/data` rows are no longer the authoritative
+  source for strongly consistent tablet-group Raft log entries.
+- Startup can import missing legacy suffix entries from these rows into the
+  dedicated Raft commitlog domain, then delete imported legacy rows.
+- Static metadata columns (`vote_term`, `vote`, `snapshot_id`, `commit_idx`)
+  remain authoritative in this table.
+
+**Related tables:** [raft_groups_snapshots](#systemraft_groups_snapshots), [raft_groups_snapshot_config](#systemraft_groups_snapshot_config)
+
+---
+
+## system.raft_groups_snapshot_config
+
+Stores snapshot configuration for strongly consistent tablet Raft groups.
+
+Schema:
+```cql
+CREATE TABLE system.raft_groups_snapshot_config (
+    shard smallint,
+    group_id timeuuid,
+    disposition text,
+    server_id uuid,
+    can_vote boolean,
+    PRIMARY KEY ((shard, group_id), disposition, server_id)
+) WITH CLUSTERING ORDER BY (disposition ASC, server_id ASC);
+```
+
+**Columns:**
+- `shard`: Shard-local placement key
+- `group_id`: Identifier for the tablet Raft group
+- `disposition`: Configuration disposition (`CURRENT` or `PREVIOUS`)
+- `server_id`: ID of the server in snapshot configuration
+- `can_vote`: Whether this server can vote in the Raft group
+
+**Related tables:** [raft_groups](#systemraft_groups), [raft_groups_snapshots](#systemraft_groups_snapshots)
+
+---
+
+## system.raft_groups_snapshots
+
+Stores snapshot descriptor data for strongly consistent tablet Raft groups.
+
+Schema:
+```cql
+CREATE TABLE system.raft_groups_snapshots (
+    shard smallint,
+    group_id timeuuid,
+    snapshot_id uuid,
+    idx bigint,
+    term bigint,
+    PRIMARY KEY ((shard, group_id))
+);
+```
+
+**Columns:**
+- `shard`: Shard-local placement key
+- `group_id`: Identifier for the tablet Raft group
+- `snapshot_id`: Snapshot identifier
+- `idx`: Log index of the snapshot
+- `term`: Raft term of the snapshot
+
+**Related tables:** [raft_groups](#systemraft_groups), [raft_groups_snapshot_config](#systemraft_groups_snapshot_config)
 
 ---
 

--- a/idl/commitlog.idl.hh
+++ b/idl/commitlog.idl.hh
@@ -8,8 +8,16 @@
 
 #include "idl/mutation.idl.hh"
 #include "idl/frozen_mutation.idl.hh"
+#include "idl/raft_storage.idl.hh"
 
 class commitlog_entry [[writable]] {
     std::optional<column_mapping> mapping();
     frozen_mutation mutation();
+};
+
+class raft_commit_log_entry [[writable]] {
+    utils::UUID group_id();
+    std::optional<raft::log_entry> entry();
+    std::optional<raft::index_t> truncate_idx();
+    std::optional<raft::index_t> truncate_prefix_idx();
 };

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -111,6 +111,8 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
         raft::group_id group_id,
         token_metadata_ptr tm)
 {
+    co_await ensure_raft_commitlog_initialized();
+
     const auto my_id = to_server_id(tm->get_my_id());
 
     auto state_machine = make_state_machine(tablet, group_id, _db, _mm, _sys_ks);
@@ -348,6 +350,28 @@ future<> groups_manager::start() {
         co_return;
     }
 
+    co_await ensure_raft_commitlog_initialized();
+
+    _started = true;
+
+    if (_pending_tm) {
+        update(std::move(_pending_tm));
+        co_await wait_for_groups_to_start();
+    }
+
+    _raft_replay_state.clear();
+}
+
+future<> groups_manager::ensure_raft_commitlog_initialized() {
+    if (!_features.strongly_consistent_tables || _raft_commitlog) {
+        co_return;
+    }
+
+    auto units = co_await get_units(_raft_commitlog_init_sem, 1);
+    if (_raft_commitlog) {
+        co_return;
+    }
+
     db::commitlog::config cl_cfg;
     cl_cfg.sched_group = _db.commitlog()->active_config().sched_group;
     cl_cfg.commit_log_location = _db.get_config().commitlog_directory();
@@ -368,15 +392,6 @@ future<> groups_manager::start() {
     auto replay_files = co_await _raft_commitlog->list_existing_segments();
     _raft_replay_had_errors = false;
     _raft_replay_state = co_await raft_groups_storage::replay_log_entries_for_groups(_qp, std::move(replay_files), &_raft_replay_had_errors);
-
-    _started = true;
-
-    if (_pending_tm) {
-        update(std::move(_pending_tm));
-        co_await wait_for_groups_to_start();
-    }
-
-    _raft_replay_state.clear();
 }
 
 future<> groups_manager::stop() {

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -16,6 +16,7 @@
 #include "service/storage_proxy.hh"
 #include "replica/database.hh"
 #include "db/config.hh"
+#include "db/commitlog/commitlog.hh"
 
 namespace service::strong_consistency {
 
@@ -117,12 +118,40 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
     auto rpc = std::make_unique<rpc_impl>(state_machine_ref, _ms, _raft_gr.failure_detector(), group_id, my_id);
     // Keep a reference to a specific RPC class.
     auto& rpc_ref = *rpc;
-    auto storage = std::make_unique<raft_groups_storage>(_qp, group_id, my_id, this_shard_id());
+    auto storage = std::make_unique<raft_groups_storage>(_qp, group_id, my_id, this_shard_id(), _raft_commitlog.get());
+
+    if (!_raft_commitlog) {
+        on_internal_error(logger, "raft commitlog is not initialized");
+    }
+
+    const auto already_started = _started_groups.contains(group_id);
+    if (auto it = _raft_replay_state.find(group_id); it != _raft_replay_state.end()) {
+        storage->set_replayed_log_state(std::move(it->second));
+        storage->set_replay_had_errors(_raft_replay_had_errors);
+        _raft_replay_state.erase(it);
+    } else {
+        auto replay_files = co_await _raft_commitlog->list_existing_segments();
+        co_await storage->replay_log_entries(std::move(replay_files));
+    }
+    co_await storage->filter_replayed_log_with_snapshot();
+
+    bool imported_legacy_entries = false;
+    if (!already_started) {
+        imported_legacy_entries = co_await storage->import_legacy_log_entries();
+    }
+    if (imported_legacy_entries || already_started || (!already_started && storage->has_commitlog_log_entries())) {
+        co_await storage->materialize_log_state_to_commitlog();
+    }
+    if (!already_started && imported_legacy_entries) {
+        co_await storage->cleanup_legacy_log_entries();
+    } else if (!already_started && storage->should_cleanup_legacy_log_entries()) {
+        co_await storage->cleanup_legacy_log_entries();
+    }
 
     // Store the initial configuration if this is the first time we create this group
     // on this node
     const auto snapshot = co_await storage->load_snapshot_descriptor();
-    if (!snapshot.id) {
+    if (!snapshot.id && !storage->has_commitlog_log_entries()) {
         const auto& tablet_map = tm->tablets().get_tablet_map(tablet.table);
         const auto& tablet_info = tablet_map.get_tablet_info(tablet.tablet);
 
@@ -157,6 +186,8 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
         .persistence = persistence_ref,
         .state_machine = state_machine_ref
     });
+
+    _started_groups.emplace(group_id);
 }
 
 void groups_manager::schedule_raft_group_deletion(raft::group_id id, raft_group_state& state) {
@@ -176,8 +207,11 @@ void groups_manager::schedule_raft_group_deletion(raft::group_id id, raft_group_
         // We need to erase the raft group state only if we are still the last operation on it.
         // If another start arrived while we were stopping the raft server, a new gate
         // would have been assigned, and we should leave the state in the map.
-        if (state.gate.get() == g.get() && _raft_groups.erase(id) != 1) {
-            on_internal_error(logger, format("raft group {} is already deleted", id));
+        if (state.gate.get() == g.get()) {
+            if (_raft_groups.erase(id) != 1) {
+                on_internal_error(logger, format("raft group {} is already deleted", id));
+            }
+            _started_groups.erase(id);
         }
     });
 }
@@ -309,16 +343,40 @@ future<raft_server> groups_manager::acquire_server(raft::group_id group_id) {
 }
 
 future<> groups_manager::start() {
-    _started = true;
-
     if (!_features.strongly_consistent_tables) {
+        _started = true;
         co_return;
     }
+
+    db::commitlog::config cl_cfg;
+    cl_cfg.sched_group = _db.commitlog()->active_config().sched_group;
+    cl_cfg.commit_log_location = _db.get_config().commitlog_directory();
+    const auto total_space_mb = _db.get_config().commitlog_total_space_in_mb();
+    cl_cfg.commitlog_total_space_in_mb = total_space_mb >= 0
+            ? uint64_t(total_space_mb)
+            : _db.commitlog()->active_config().commitlog_total_space_in_mb;
+    cl_cfg.commitlog_segment_size_in_mb = _db.get_config().commitlog_segment_size_in_mb();
+    cl_cfg.commitlog_sync_period_in_ms = _db.get_config().commitlog_sync_period_in_ms();
+    cl_cfg.mode = _db.get_config().commitlog_sync() == "batch" ? db::commitlog::sync_mode::BATCH : db::commitlog::sync_mode::PERIODIC;
+    cl_cfg.extensions = &_db.get_config().extensions();
+    cl_cfg.use_o_dsync = _db.get_config().commitlog_use_o_dsync();
+    cl_cfg.allow_going_over_size_limit = true;
+    cl_cfg.allow_fragmented_entries = true;
+    cl_cfg.fname_prefix = raft_groups_storage::COMMITLOG_FILENAME_PREFIX;
+    _raft_commitlog = std::make_unique<db::commitlog>(co_await db::commitlog::create_commitlog(cl_cfg));
+
+    auto replay_files = co_await _raft_commitlog->list_existing_segments();
+    _raft_replay_had_errors = false;
+    _raft_replay_state = co_await raft_groups_storage::replay_log_entries_for_groups(_qp, std::move(replay_files), &_raft_replay_had_errors);
+
+    _started = true;
 
     if (_pending_tm) {
         update(std::move(_pending_tm));
         co_await wait_for_groups_to_start();
     }
+
+    _raft_replay_state.clear();
 }
 
 future<> groups_manager::stop() {
@@ -332,6 +390,16 @@ future<> groups_manager::stop() {
 
     while (!_raft_groups.empty()) {
         co_await _raft_groups.begin()->second.server_control_op.get_future();
+    }
+
+    _started_groups.clear();
+    _raft_replay_state.clear();
+    _raft_replay_had_errors = false;
+
+    if (_raft_commitlog) {
+        co_await _raft_commitlog->shutdown();
+        co_await _raft_commitlog->release();
+        _raft_commitlog.reset();
     }
 
     logger.info("stop() completed");

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -15,6 +15,8 @@
 #include "db/commitlog/commitlog.hh"
 #include "service/strong_consistency/raft_groups_storage.hh"
 
+#include <seastar/core/semaphore.hh>
+
 #include <unordered_set>
 
 namespace db {
@@ -87,8 +89,11 @@ class groups_manager : public peering_sharded_service<groups_manager> {
     std::unordered_map<raft::group_id, raft_groups_storage::group_replay_state> _raft_replay_state = {};
     bool _raft_replay_had_errors = false;
     std::unordered_set<raft::group_id> _started_groups = {};
+    semaphore _raft_commitlog_init_sem{1};
     locator::token_metadata_ptr _pending_tm = nullptr;
     bool _started = false;
+
+    future<> ensure_raft_commitlog_initialized();
 
     // Should be called on the shard that hosts the Raft group
     future<> start_raft_group(locator::global_tablet_id tablet,

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -12,6 +12,10 @@
 #include "message/messaging_service.hh"
 #include "service/raft/raft_group_registry.hh"
 #include "cql3/query_processor.hh"
+#include "db/commitlog/commitlog.hh"
+#include "service/strong_consistency/raft_groups_storage.hh"
+
+#include <unordered_set>
 
 namespace db {
 class system_keyspace;
@@ -79,6 +83,10 @@ class groups_manager : public peering_sharded_service<groups_manager> {
     db::system_keyspace& _sys_ks;
     gms::feature_service& _features;
     std::unordered_map<raft::group_id, raft_group_state> _raft_groups = {};
+    std::unique_ptr<db::commitlog> _raft_commitlog;
+    std::unordered_map<raft::group_id, raft_groups_storage::group_replay_state> _raft_replay_state = {};
+    bool _raft_replay_had_errors = false;
+    std::unordered_set<raft::group_id> _started_groups = {};
     locator::token_metadata_ptr _pending_tm = nullptr;
     bool _started = false;
 

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -8,7 +8,6 @@
 #include "service/strong_consistency/raft_groups_storage.hh"
 
 #include "cql3/untyped_result_set.hh"
-#include "db/config.hh"
 #include "db/system_keyspace.hh"
 #include "raft/raft.hh"
 #include "utils/UUID.hh"
@@ -19,38 +18,78 @@
 #include "serializer_impl.hh"
 #include "idl/raft_storage.dist.impl.hh"
 
-#include "cql3/statements/batch_statement.hh"
-#include "cql3/statements/modification_statement.hh"
-#include "cql3/query_processor.hh"
+#include "idl/commitlog.dist.hh"
+#include "idl/commitlog.dist.impl.hh"
 
-#include <seastar/core/loop.hh>
+#include "cql3/query_processor.hh"
+#include "db/commitlog/commitlog_entry.hh"
+#include "service/storage_proxy.hh"
+#include "replica/database.hh"
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+
+#include <algorithm>
+#include <limits>
+#include <utility>
 
 namespace service::strong_consistency {
 
 logging::logger rgslog("raft_groups_storage");
 
-raft_groups_storage::raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard)
+namespace {
+
+using groups_replay_state_map = std::unordered_map<raft::group_id, raft_groups_storage::group_replay_state>;
+
+void apply_group_replayed_entry(raft_groups_storage::group_replay_state& state, const raft::log_entry& entry) {
+    state.log[entry.idx] = make_lw_shared<const raft::log_entry>(entry);
+    if (state.replayed_truncate_idx && entry.idx.value() >= state.replayed_truncate_idx->value()) {
+        state.replayed_truncate_idx.reset();
+    }
+    if (!state.replayed_seen_max_idx || state.replayed_seen_max_idx->value() < entry.idx.value()) {
+        state.replayed_seen_max_idx = entry.idx;
+    }
+    if (!state.replayed_max_idx || state.replayed_max_idx->value() < entry.idx.value()) {
+        state.replayed_max_idx = entry.idx;
+    }
+}
+
+void apply_group_replayed_truncate(raft_groups_storage::group_replay_state& state, raft::index_t idx) {
+    state.replayed_has_truncate = true;
+    state.replayed_truncate_idx = idx;
+    state.replayed_truncate_prefix_idx.reset();
+    if (!state.replayed_seen_max_idx || state.replayed_seen_max_idx->value() < idx.value()) {
+        state.replayed_seen_max_idx = idx;
+    }
+    auto it = state.log.lower_bound(idx);
+    state.log.erase(it, state.log.end());
+    if (state.log.empty()) {
+        state.replayed_max_idx.reset();
+    } else {
+        state.replayed_max_idx = state.log.rbegin()->first;
+    }
+}
+
+} // anonymous namespace
+
+raft_groups_storage::raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard, db::commitlog* commitlog)
     : _group_id(std::move(gid))
     , _server_id(std::move(server_id))
     , _qp(qp)
     , _dummy_query_state(service::client_state::for_internal_calls(), empty_service_permit())
     , _pending_op_fut(make_ready_future<>())
-    // max_mutation_size = 1/2 of commitlog segment size, thus _max_mutation_size is set 1/3 of commitlog segment size to leave space for metadata.
-    , _max_mutation_size(_qp.db().get_config().commitlog_segment_size_in_mb() * 1024 * 1024 / 3)
+    , _commitlog(commitlog)
+    , _table_id(_qp.db().find_schema("system", db::system_keyspace::RAFT_GROUPS)->id())
 {
-    rgslog.trace("Creating raft_groups_storage for group_id={}, server_id={}, shard={}", _group_id, _server_id, _shard);
+    rgslog.trace("Creating raft_groups_storage for group_id={}, server_id={}, shard={}", _group_id, _server_id, shard);
     if (shard > std::numeric_limits<int16_t>::max()) {
-        // The shard should fit in int16_t since that's the column type (smallint) we use in the Raft tables
         on_internal_error(rgslog, fmt::format("Shard value {} exceeds maximum allowed {}", shard, std::numeric_limits<int16_t>::max()));
     }
     _shard = static_cast<uint16_t>(shard);
-    static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, term, \"index\", data) VALUES (?, ?, ?, ?, ?)",
-        db::system_keyspace::RAFT_GROUPS);
-    auto prepared_stmt_ptr = _qp.prepare_internal(store_cql);
-    shared_ptr<cql3::cql_statement> cql_stmt = prepared_stmt_ptr->statement;
-    _store_entry_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(cql_stmt);
+}
+
+raft_groups_storage::raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard)
+    : raft_groups_storage(qp, std::move(gid), std::move(server_id), shard, qp.proxy().local_db().commitlog()) {
 }
 
 future<> raft_groups_storage::store_term_and_vote(raft::term_t term, raft::server_id vote) {
@@ -97,26 +136,10 @@ future<raft::index_t> raft_groups_storage::load_commit_idx() {
 }
 
 future<raft::log_entries> raft_groups_storage::load_log() {
-    static const auto load_cql = format("SELECT term, \"index\", data FROM system.{} WHERE shard = ? AND group_id = ?", db::system_keyspace::RAFT_GROUPS);
-    ::shared_ptr<cql3::untyped_result_set> rs = co_await _qp.execute_internal(load_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
-
     raft::log_entries log;
-    for (const cql3::untyped_result_set_row& row : *rs) {
-        if (!row.has("data")) {
-            // The partition only contains static cells, the log
-            // is empty.
-            break;
-        }
-        raft::term_t term = raft::term_t(row.get_as<int64_t>("term"));
-        raft::index_t idx = raft::index_t(row.get_as<int64_t>("index"));
-        auto raw_data = row.get_view("data");
-        auto in = ser::as_input_stream(raw_data);
-        using data_variant_type = decltype(raft::log_entry::data);
-        data_variant_type data = ser::deserialize(in, std::type_identity<data_variant_type>());
-
-        log.emplace_back(make_lw_shared<const raft::log_entry>(
-            raft::log_entry{.term = term, .idx = idx, .data = std::move(data)}));
-
+    for (const auto& [idx, entry] : _log) {
+        (void) idx;
+        log.push_back(entry);
         co_await coroutine::maybe_yield();
     }
     co_return log;
@@ -128,22 +151,24 @@ future<raft::snapshot_descriptor> raft_groups_storage::load_snapshot_descriptor(
     if (id_rs->empty() || !id_rs->one().has("snapshot_id")) {
         co_return raft::snapshot_descriptor();
     }
-    const auto& id_row = id_rs->one(); // should be only one row since snapshot_id column is static
+    const auto& id_row = id_rs->one();
     utils::UUID snapshot_id = id_row.get_as<utils::UUID>("snapshot_id");
 
-    // Fetch raft log index and term for the latest snapshot descriptor
-    static const auto load_snp_info_cql = format("SELECT idx, term FROM system.{} WHERE shard = ? AND group_id = ?",
+    static const auto load_snp_info_cql = format("SELECT snapshot_id, idx, term FROM system.{} WHERE shard = ? AND group_id = ?",
         db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
     ::shared_ptr<cql3::untyped_result_set> snp_rs = co_await _qp.execute_internal(load_snp_info_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
-    // Should be only one matching row, since each individual server can only
-    // have a single snapshot installed at a time
+    if (snp_rs->empty() || !snp_rs->one().has("snapshot_id")) {
+        co_return raft::snapshot_descriptor();
+    }
     const auto& snp_row = snp_rs->one();
-    // Fetch current and previous raft configurations for the snapshot
+    if (snp_row.get_as<utils::UUID>("snapshot_id") != snapshot_id) {
+        co_return raft::snapshot_descriptor();
+    }
+
     static const auto load_cfg_cql = format("SELECT disposition, server_id, can_vote FROM system.{} WHERE shard = ? AND group_id = ?", db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
     ::shared_ptr<cql3::untyped_result_set> cfg_rs = co_await _qp.execute_internal(load_cfg_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
 
     raft::configuration cfg;
-
     for (const cql3::untyped_result_set_row& row : *cfg_rs) {
         const auto disposition = row.get_as<sstring>("disposition");
         auto& cfg_part = disposition == "CURRENT" ? cfg.current : cfg.previous;
@@ -162,8 +187,156 @@ future<raft::snapshot_descriptor> raft_groups_storage::load_snapshot_descriptor(
     co_return s;
 }
 
+future<db::rp_handle> raft_groups_storage::add_raft_entry_to_commitlog(const raft_commit_log_entry& e) {
+    if (!_commitlog) {
+        on_internal_error(rgslog, "raft commitlog is not initialized");
+    }
+
+    const auto size = sizeof(uint8_t) + ser::get_sizeof(e);
+    auto timeout = db::timeout_clock::time_point::max();
+    auto handle = co_await _commitlog->add_mutation(_table_id, size, timeout, db::commitlog::force_sync::no,
+            [entry = e] (db::commitlog::output& out) {
+        ser::serialize(out, uint8_t(1));
+        ser::serialize(out, entry);
+    });
+    co_return handle;
+}
+
+future<> raft_groups_storage::store_log_entries_internal(const std::vector<raft::log_entry_ptr>& entries) {
+    for (const auto& eptr : entries) {
+        raft_commit_log_entry op(_group_id.id, raft::log_entry(*eptr));
+        auto h = co_await add_raft_entry_to_commitlog(op);
+        _entry_rp_handles.insert_or_assign(eptr->idx, std::move(h));
+        _log[eptr->idx] = eptr;
+        if (_replayed_truncate_idx && eptr->idx.value() >= _replayed_truncate_idx->value()) {
+            _replayed_truncate_idx.reset();
+        }
+        if (!_replayed_seen_max_idx || _replayed_seen_max_idx->value() < eptr->idx.value()) {
+            _replayed_seen_max_idx = eptr->idx;
+        }
+        if (!_replayed_max_idx || _replayed_max_idx->value() < eptr->idx.value()) {
+            _replayed_max_idx = eptr->idx;
+        }
+        co_await coroutine::maybe_yield();
+    }
+}
+
+future<> raft_groups_storage::store_log_entries(const std::vector<raft::log_entry_ptr>& entries) {
+    return execute_with_linearization_point([this, &entries] {
+        return store_log_entries_internal(entries);
+    });
+}
+
+void raft_groups_storage::apply_replayed_entry(const raft::log_entry& entry) {
+    _log[entry.idx] = make_lw_shared<const raft::log_entry>(entry);
+    if (_replayed_truncate_idx && entry.idx.value() >= _replayed_truncate_idx->value()) {
+        _replayed_truncate_idx.reset();
+    }
+    if (!_replayed_seen_max_idx || _replayed_seen_max_idx->value() < entry.idx.value()) {
+        _replayed_seen_max_idx = entry.idx;
+    }
+    if (!_replayed_max_idx || _replayed_max_idx->value() < entry.idx.value()) {
+        _replayed_max_idx = entry.idx;
+    }
+}
+
+void raft_groups_storage::apply_replayed_truncate(raft::index_t idx) {
+    _replayed_has_truncate = true;
+    _replayed_truncate_idx = idx;
+    _replayed_truncate_prefix_idx.reset();
+    if (!_replayed_seen_max_idx || _replayed_seen_max_idx->value() < idx.value()) {
+        _replayed_seen_max_idx = idx;
+    }
+    auto it = _log.lower_bound(idx);
+    _log.erase(it, _log.end());
+    auto rit = _entry_rp_handles.lower_bound(idx);
+    _entry_rp_handles.erase(rit, _entry_rp_handles.end());
+    if (_log.empty()) {
+        _replayed_max_idx.reset();
+    } else {
+        _replayed_max_idx = _log.rbegin()->first;
+    }
+}
+
+void raft_groups_storage::record_replayed_truncate_prefix(raft::index_t idx) {
+    _replayed_has_truncate = true;
+    _replayed_truncate_prefix_idx = idx;
+    _replayed_truncate_idx.reset();
+    if (!_replayed_seen_max_idx || _replayed_seen_max_idx->value() < idx.value()) {
+        _replayed_seen_max_idx = idx;
+    }
+}
+
+void raft_groups_storage::apply_replayed_truncate_prefix(raft::index_t idx) {
+    record_replayed_truncate_prefix(idx);
+    auto it = _log.upper_bound(idx);
+    _log.erase(_log.begin(), it);
+    auto rit = _entry_rp_handles.upper_bound(idx);
+    _entry_rp_handles.erase(_entry_rp_handles.begin(), rit);
+    if (_log.empty()) {
+        _replayed_max_idx.reset();
+    } else {
+        _replayed_max_idx = _log.rbegin()->first;
+    }
+}
+
+future<> raft_groups_storage::truncate_log(raft::index_t idx) {
+    return execute_with_linearization_point([this, idx] () -> future<> {
+        raft_commit_log_entry op(_group_id.id, idx, std::nullopt);
+        auto h = co_await add_raft_entry_to_commitlog(op);
+        _truncate_tail_rp_handle = std::move(h);
+        apply_replayed_truncate(idx);
+    });
+}
+
+future<> raft_groups_storage::truncate_prefix_log(raft::index_t idx) {
+    return execute_with_linearization_point([this, idx] () -> future<> {
+        co_await truncate_prefix_log_impl(idx);
+    });
+}
+
+future<> raft_groups_storage::truncate_prefix_log_impl(raft::index_t idx) {
+    raft_commit_log_entry op(_group_id.id, std::nullopt, idx);
+    auto h = co_await add_raft_entry_to_commitlog(op);
+    _truncate_prefix_rp_handle = std::move(h);
+    apply_replayed_truncate_prefix(idx);
+}
+
+future<> raft_groups_storage::abort() {
+    std::exception_ptr pending_error;
+    try {
+        co_await std::exchange(_pending_op_fut, make_ready_future<>());
+    } catch (...) {
+        pending_error = std::current_exception();
+    }
+    _entry_rp_handles.clear();
+    _truncate_tail_rp_handle.reset();
+    _truncate_prefix_rp_handle.reset();
+    if (pending_error) {
+        std::rethrow_exception(pending_error);
+    }
+}
+
+future<> raft_groups_storage::update_snapshot_and_truncate_log_tail(const raft::snapshot_descriptor &snap, size_t preserve_log_entries) {
+    static const auto store_latest_id_cql = format("INSERT INTO system.{} (shard, group_id, snapshot_id) VALUES (?, ?, ?)",
+        db::system_keyspace::RAFT_GROUPS);
+    co_await _qp.execute_internal(
+        store_latest_id_cql,
+        {int16_t(_shard), _group_id.id, snap.id.id},
+        cql3::query_processor::cache_internal::yes).discard_result();
+
+    if (preserve_log_entries >= snap.idx.value()) {
+        co_return;
+    }
+
+    raft::index_t log_tail_idx(snap.idx.value() - preserve_log_entries);
+    co_await truncate_prefix_log_impl(log_tail_idx);
+    if (_commitlog) {
+        co_await _commitlog->sync_all_segments();
+    }
+}
+
 future<> raft_groups_storage::store_snapshot_descriptor(const raft::snapshot_descriptor& snap, size_t preserve_log_entries) {
-    // TODO: check that snap.idx refers to an already persisted entry
     return execute_with_linearization_point([this, &snap, preserve_log_entries] () -> future<> {
         static const auto store_snp_cql = format("INSERT INTO system.{} (shard, group_id, snapshot_id, idx, term) VALUES (?, ?, ?, ?, ?)",
             db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
@@ -172,10 +345,8 @@ future<> raft_groups_storage::store_snapshot_descriptor(const raft::snapshot_des
             {int16_t(_shard), _group_id.id, snap.id.id, int64_t(snap.idx.value()), int64_t(snap.term.value())},
             cql3::query_processor::cache_internal::yes
         );
-        // remove old configs
         static const auto delete_raft_cfg_cql = format("DELETE FROM system.{} WHERE shard = ? AND group_id = ?", db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
         co_await _qp.execute_internal(delete_raft_cfg_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
-        // store current and previous raft configurations
         static const auto store_raft_cfg_cql = format("INSERT INTO system.{} (shard, group_id, disposition, server_id, can_vote) VALUES (?, ?, ?, ?, ?)",
             db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
         for (const raft::config_member& srv : snap.config.current) {
@@ -193,131 +364,261 @@ future<> raft_groups_storage::store_snapshot_descriptor(const raft::snapshot_des
     });
 }
 
-future<size_t> raft_groups_storage::do_store_log_entries_one_batch(const std::vector<raft::log_entry_ptr>& entries, size_t start_idx) {
-    std::vector<cql3::statements::batch_statement::single_statement> batch_stmts;
-    // statement values that can be allocated at once (one contiguous allocation)
-    std::vector<std::vector<cql3::raw_value>> stmt_values;
-    // fragmented storage for log_entries data
-    std::vector<fragmented_temporary_buffer> stmt_data_views;
-    // statement value views -- required for `query_options` to consume `fragmented_temporary_buffer::view`
-    std::vector<cql3::raw_value_view_vector_with_unset> stmt_value_views;
-    const size_t entries_size = entries.size();
-    batch_stmts.reserve(entries_size);
-    stmt_values.reserve(entries_size);
-    stmt_data_views.reserve(entries_size);
-    stmt_value_views.reserve(entries_size);
+future<> raft_groups_storage::replay_log_entries_from_file(const sstring& file) {
+    co_await db::commitlog::read_log_file(file, COMMITLOG_FILENAME_PREFIX,
+        [this] (db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+            commitlog_entry_reader reader(buf_rp.buffer, buf_rp.segment_version);
+            auto raft_entry = reader.get_raft_entry();
+            if (!raft_entry || raft_entry->group_id() != _group_id.id) {
+                co_return;
+            }
 
-    size_t size = 0;
-    size_t idx = start_idx;
-
-    for (; idx < entries_size; idx++) {
-        auto& eptr = entries[idx];
-        auto data_tmp_buf = fragmented_temporary_buffer::allocate_to_fit(ser::get_sizeof(eptr->data));
-        auto data_out_str = data_tmp_buf.get_ostream();
-        ser::serialize(data_out_str, eptr->data);
-        if (size && size + data_tmp_buf.size_bytes() > _max_mutation_size) {
-            break;
-        }
-        size += data_tmp_buf.size_bytes();
-        batch_stmts.emplace_back(cql3::statements::batch_statement::single_statement(_store_entry_stmt, false));
-
-        // don't include serialized "data" here since it will require to linearize the stream
-        std::vector<cql3::raw_value> single_stmt_values;
-        // Silly workaround for https://bugs.llvm.org/show_bug.cgi?id=51515
-        single_stmt_values.reserve(4);
-        single_stmt_values.emplace_back(cql3::raw_value::make_value(short_type->decompose(int16_t(_shard))));
-        single_stmt_values.emplace_back(cql3::raw_value::make_value(timeuuid_type->decompose(_group_id.id)));
-        single_stmt_values.emplace_back(cql3::raw_value::make_value(long_type->decompose(int64_t(eptr->term.value()))));
-        single_stmt_values.emplace_back(cql3::raw_value::make_value(long_type->decompose(int64_t(eptr->idx.value()))));
-
-        stmt_values.emplace_back(std::move(single_stmt_values));
-        stmt_data_views.emplace_back(std::move(data_tmp_buf));
-
-        // allocate value views
-        std::vector<cql3::raw_value_view> value_views;
-        value_views.reserve(5); // 5 is the number of required values for the insertion query
-        for (const cql3::raw_value& raw : stmt_values.back()) {
-            value_views.push_back(raw.view());
-        }
-        value_views.emplace_back(
-            cql3::raw_value_view::make_value(
-                fragmented_temporary_buffer::view(stmt_data_views.back())));
-        stmt_value_views.emplace_back(std::move(value_views));
-
-        co_await coroutine::maybe_yield();
-    }
-
-    auto batch_options = cql3::query_options::make_batch_options(
-        cql3::query_options(
-            cql3::default_cql_config,
-            db::consistency_level::ONE,
-            std::nullopt,
-            std::vector<cql3::raw_value>{},
-            false,
-            cql3::query_options::specific_options::DEFAULT
-            ),
-        std::move(stmt_value_views));
-
-    cql3::statements::batch_statement batch(
-        cql3::statements::batch_statement::type::UNLOGGED,
-        std::move(batch_stmts),
-        cql3::attributes::none(),
-        _qp.get_cql_stats());
-
-    co_await batch.execute(_qp, _dummy_query_state, batch_options, std::nullopt);
-
-    if (idx != entries_size) {
-        co_return idx;
-    }
-
-    co_return 0;
+            if (raft_entry->entry()) {
+                apply_replayed_entry(*raft_entry->entry());
+            } else if (raft_entry->truncate_idx()) {
+                apply_replayed_truncate(*raft_entry->truncate_idx());
+            } else if (raft_entry->truncate_prefix_idx()) {
+                apply_replayed_truncate_prefix(*raft_entry->truncate_prefix_idx());
+            }
+            co_await coroutine::maybe_yield();
+        },
+        0,
+        &_qp.db().extensions());
 }
 
-future<> raft_groups_storage::do_store_log_entries(const std::vector<raft::log_entry_ptr>& entries) {
-    if (entries.empty()) {
+future<> raft_groups_storage::replay_log_entries(std::vector<sstring> files) {
+    bool replay_had_errors = false;
+    auto replay_state = co_await replay_log_entries_for_groups(_qp, std::move(files), &replay_had_errors);
+    set_replay_had_errors(replay_had_errors);
+    if (auto it = replay_state.find(_group_id); it != replay_state.end()) {
+        set_replayed_log_state(std::move(it->second));
+    } else {
+        set_replayed_log_state({});
+    }
+}
+
+future<std::unordered_map<raft::group_id, raft_groups_storage::group_replay_state>>
+raft_groups_storage::replay_log_entries_for_groups(cql3::query_processor& qp, std::vector<sstring> files, bool* had_errors) {
+    groups_replay_state_map replay_state;
+
+    std::vector<std::pair<db::segment_id_type, sstring>> ordered_files;
+    ordered_files.reserve(files.size());
+    for (auto& file : files) {
+        try {
+            db::commitlog::descriptor d(file, COMMITLOG_FILENAME_PREFIX);
+            ordered_files.emplace_back(d.id, std::move(file));
+        } catch (const std::domain_error&) {
+            continue;
+        }
+    }
+    std::ranges::sort(ordered_files, std::less{}, &std::pair<db::segment_id_type, sstring>::first);
+
+    for (const auto& [id, file] : ordered_files) {
+        (void) id;
+        try {
+            co_await db::commitlog::read_log_file(file, COMMITLOG_FILENAME_PREFIX,
+                [&replay_state] (db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+                    commitlog_entry_reader reader(buf_rp.buffer, buf_rp.segment_version);
+                    auto raft_entry = reader.get_raft_entry();
+                    if (!raft_entry) {
+                        co_return;
+                    }
+
+                    auto gid = raft::group_id{raft_entry->group_id()};
+                    auto& group_state = replay_state[gid];
+                    if (raft_entry->entry()) {
+                        apply_group_replayed_entry(group_state, *raft_entry->entry());
+                    } else if (raft_entry->truncate_idx()) {
+                        apply_group_replayed_truncate(group_state, *raft_entry->truncate_idx());
+                    } else if (raft_entry->truncate_prefix_idx()) {
+                        auto idx = *raft_entry->truncate_prefix_idx();
+                        group_state.replayed_has_truncate = true;
+                        group_state.replayed_truncate_prefix_idx = idx;
+                        group_state.replayed_truncate_idx.reset();
+                        if (!group_state.replayed_seen_max_idx || group_state.replayed_seen_max_idx->value() < idx.value()) {
+                            group_state.replayed_seen_max_idx = idx;
+                        }
+                    }
+                    co_await coroutine::maybe_yield();
+                },
+                0,
+                &qp.db().extensions());
+        } catch (const db::commitlog::segment_truncation& e) {
+            if (had_errors) {
+                *had_errors = true;
+            }
+            rgslog.warn("Ignoring truncated raft commitlog segment {} at position {}", file, e.position());
+        } catch (const db::commitlog::segment_data_corruption_error& e) {
+            if (had_errors) {
+                *had_errors = true;
+            }
+            rgslog.warn("Ignoring corrupted raft commitlog segment {} ({} bytes)", file, e.bytes());
+        } catch (const db::commitlog::header_checksum_error&) {
+            if (had_errors) {
+                *had_errors = true;
+            }
+            rgslog.warn("Ignoring raft commitlog segment {} with broken header checksum", file);
+        }
+    }
+
+    co_return replay_state;
+}
+
+void raft_groups_storage::set_replayed_log_state(group_replay_state state) {
+    _log = std::move(state.log);
+    _entry_rp_handles.clear();
+    _truncate_tail_rp_handle.reset();
+    _truncate_prefix_rp_handle.reset();
+    _replayed_max_idx = state.replayed_max_idx;
+    _replayed_seen_max_idx = state.replayed_seen_max_idx;
+    _replayed_truncate_idx = state.replayed_truncate_idx;
+    _replayed_truncate_prefix_idx = state.replayed_truncate_prefix_idx;
+    _replayed_has_truncate = state.replayed_has_truncate;
+}
+
+void raft_groups_storage::set_replay_had_errors(bool had_errors) {
+    _replay_had_errors = had_errors;
+}
+
+future<> raft_groups_storage::filter_replayed_log_with_snapshot() {
+    if (!_replayed_truncate_prefix_idx) {
         co_return;
     }
 
-    size_t idx = 0;
-    do {
-        idx = co_await do_store_log_entries_one_batch(entries, idx);
-    } while (idx != 0);
+    auto snap = co_await load_snapshot_descriptor();
+    if (!snap.id || _replayed_truncate_prefix_idx->value() > snap.idx.value()) {
+        _replayed_truncate_prefix_idx.reset();
+        if (!_replayed_truncate_idx) {
+            _replayed_has_truncate = false;
+        }
+        co_return;
+    }
+
+    if (_replayed_truncate_prefix_idx) {
+        apply_replayed_truncate_prefix(*_replayed_truncate_prefix_idx);
+    }
+    co_return;
 }
 
-future<> raft_groups_storage::store_log_entries(const std::vector<raft::log_entry_ptr>& entries) {
-    return execute_with_linearization_point([this, &entries] {
-        return do_store_log_entries(entries);
-    });
+future<> raft_groups_storage::materialize_log_state_to_commitlog() {
+    if (_entry_rp_handles.size() == _log.size()
+            && _truncate_tail_rp_handle.has_value() == _replayed_truncate_idx.has_value()
+            && _truncate_prefix_rp_handle.has_value() == _replayed_truncate_prefix_idx.has_value()) {
+        co_return;
+    }
+
+    if (_log.empty() && !_replayed_has_truncate) {
+        co_return;
+    }
+
+    std::vector<raft::log_entry_ptr> entries;
+    entries.reserve(_log.size());
+    for (const auto& [idx, entry] : _log) {
+        (void) idx;
+        entries.push_back(entry);
+        co_await coroutine::maybe_yield();
+    }
+
+    _entry_rp_handles.clear();
+    _truncate_tail_rp_handle.reset();
+    _truncate_prefix_rp_handle.reset();
+    _log.clear();
+    _replayed_max_idx.reset();
+    _replayed_seen_max_idx.reset();
+    auto replayed_truncate_idx = _replayed_truncate_idx;
+    auto replayed_truncate_prefix_idx = _replayed_truncate_prefix_idx;
+    _replayed_truncate_idx.reset();
+    _replayed_truncate_prefix_idx.reset();
+
+    if (!entries.empty()) {
+        co_await store_log_entries_internal(entries);
+    }
+
+    if (_replayed_has_truncate) {
+        if (replayed_truncate_prefix_idx) {
+            co_await truncate_prefix_log(*replayed_truncate_prefix_idx);
+        } else if (replayed_truncate_idx) {
+            co_await truncate_log(*replayed_truncate_idx);
+        }
+    }
+
+    _replayed_has_truncate = false;
 }
 
-future<> raft_groups_storage::truncate_log(raft::index_t idx) {
-    return execute_with_linearization_point([this, idx] {
-        static const auto truncate_cql = format("DELETE FROM system.{} WHERE shard = ? AND group_id = ? AND \"index\" >= ?",
-            db::system_keyspace::RAFT_GROUPS);
-        return _qp.execute_internal(truncate_cql, {int16_t(_shard), _group_id.id, int64_t(idx.value())}, cql3::query_processor::cache_internal::yes).discard_result();
-    });
+bool raft_groups_storage::has_commitlog_log_entries() const {
+    return _replayed_max_idx.has_value() || _replayed_has_truncate;
 }
 
-future<> raft_groups_storage::abort() {
-    // wait for pending write requests to complete.
-    // TODO: should we wait for all kinds of requests?
-    return std::move(_pending_op_fut);
+bool raft_groups_storage::should_cleanup_legacy_log_entries() const {
+    return _allow_legacy_cleanup;
 }
 
-future<> raft_groups_storage::update_snapshot_and_truncate_log_tail(const raft::snapshot_descriptor &snap, size_t preserve_log_entries) {
-    // Update snapshot and truncate logs in `system.raft_groups` atomically
-    raft::index_t log_tail_idx(snap.idx.value() - preserve_log_entries);
-    static const auto store_latest_id_and_truncate_log_tail_cql = format(
-        "BEGIN UNLOGGED BATCH"
-        "   INSERT INTO system.{} (shard, group_id, snapshot_id) VALUES (?, ?, ?);"   // store latest id
-        "   DELETE FROM system.{} WHERE shard = ? AND group_id = ? AND \"index\" <= ?;"   // truncate log tail
-        "APPLY BATCH",
-        db::system_keyspace::RAFT_GROUPS, db::system_keyspace::RAFT_GROUPS);
-    return _qp.execute_internal(
-        store_latest_id_and_truncate_log_tail_cql,
-        {int16_t(_shard), _group_id.id, snap.id.id, int16_t(_shard), _group_id.id, int64_t(log_tail_idx.value())},
-        cql3::query_processor::cache_internal::yes
-    ).discard_result();
+future<bool> raft_groups_storage::import_legacy_log_entries() {
+    _allow_legacy_cleanup = has_commitlog_log_entries();
+    if (_replay_had_errors) {
+        _allow_legacy_cleanup = false;
+    }
+
+    static const auto load_cql = format("SELECT term, \"index\", data FROM system.{} WHERE shard = ? AND group_id = ?", db::system_keyspace::RAFT_GROUPS);
+    auto rs = co_await _qp.execute_internal(load_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
+
+    std::vector<raft::log_entry_ptr> to_append;
+    to_append.reserve(rs->size());
+    const auto replayed_max = _replayed_max_idx ? _replayed_max_idx->value() : 0;
+    for (const auto& row : *rs) {
+        if (!row.has("data")) {
+            continue;
+        }
+        raft::index_t idx(row.get_as<int64_t>("index"));
+        if (idx.value() <= replayed_max) {
+            continue;
+        }
+        if (_log.contains(idx)) {
+            continue;
+        }
+        if (_replayed_truncate_idx && idx.value() >= _replayed_truncate_idx->value()) {
+            continue;
+        }
+        if (_replayed_truncate_prefix_idx && idx.value() <= _replayed_truncate_prefix_idx->value()) {
+            continue;
+        }
+        auto raw_data = row.get_view("data");
+        auto in = ser::as_input_stream(raw_data);
+        using data_variant_type = decltype(raft::log_entry::data);
+        data_variant_type data = ser::deserialize(in, std::type_identity<data_variant_type>());
+        auto term = raft::term_t(row.get_as<int64_t>("term"));
+        to_append.push_back(make_lw_shared<const raft::log_entry>(raft::log_entry{.term = term, .idx = idx, .data = std::move(data)}));
+    }
+
+    std::ranges::sort(to_append, std::less{}, [] (const raft::log_entry_ptr& e) { return e->idx; });
+    if (!to_append.empty()) {
+        co_await store_log_entries_internal(to_append);
+        if (_commitlog) {
+            co_await _commitlog->sync_all_segments();
+        }
+        if (!_replay_had_errors) {
+            _allow_legacy_cleanup = true;
+        }
+        co_return true;
+    }
+
+    co_return false;
+}
+
+future<> raft_groups_storage::cleanup_legacy_log_entries() {
+    if (!_allow_legacy_cleanup) {
+        co_return;
+    }
+
+    static const auto load_idx_cql = format("SELECT \"index\" FROM system.{} WHERE shard = ? AND group_id = ?", db::system_keyspace::RAFT_GROUPS);
+    static const auto delete_idx_cql = format("DELETE FROM system.{} WHERE shard = ? AND group_id = ? AND \"index\" = ?", db::system_keyspace::RAFT_GROUPS);
+    auto rs = co_await _qp.execute_internal(load_idx_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
+    for (const auto& row : *rs) {
+        if (!row.has("index")) {
+            continue;
+        }
+        co_await _qp.execute_internal(delete_idx_cql, {int16_t(_shard), _group_id.id, row.get_as<int64_t>("index")}, cql3::query_processor::cache_internal::yes).discard_result();
+    }
 }
 
 future<> raft_groups_storage::execute_with_linearization_point(std::function<future<>()> f) {

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -88,6 +88,35 @@ raft_groups_storage::raft_groups_storage(cql3::query_processor& qp, raft::group_
     _shard = static_cast<uint16_t>(shard);
 }
 
+namespace {
+
+raft::index_t clamp_commit_idx_to_replayed_log(raft::index_t commit_idx,
+        const std::optional<raft::index_t>& replayed_max_idx,
+        raft::index_t commit_idx_floor,
+        const std::optional<raft::index_t>& replayed_truncate_prefix_idx,
+        bool replay_state_loaded) {
+    if (!replay_state_loaded) {
+        return commit_idx;
+    }
+
+    auto floor_idx = replayed_truncate_prefix_idx.value_or(raft::index_t{0});
+    if (commit_idx_floor > floor_idx) {
+        floor_idx = commit_idx_floor;
+    }
+    auto stable_idx = replayed_max_idx.value_or(floor_idx);
+
+    if (stable_idx < floor_idx) {
+        stable_idx = floor_idx;
+    }
+
+    if (commit_idx > stable_idx) {
+        return stable_idx;
+    }
+    return commit_idx;
+}
+
+}
+
 raft_groups_storage::raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard)
     : raft_groups_storage(qp, std::move(gid), std::move(server_id), shard, qp.proxy().local_db().commitlog()) {
 }
@@ -116,12 +145,20 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
 
 future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
     return execute_with_linearization_point([this, idx] {
+        static const auto load_cql = format("SELECT commit_idx FROM system.{} WHERE shard = ? AND group_id = ? LIMIT 1", db::system_keyspace::RAFT_GROUPS);
         static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?)",
             db::system_keyspace::RAFT_GROUPS);
-        return _qp.execute_internal(
+        return _qp.execute_internal(load_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes).then([this, idx] (auto rs) {
+            auto persisted_idx = raft::index_t(0);
+            if (!rs->empty()) {
+                persisted_idx = raft::index_t(rs->one().template get_or<int64_t>("commit_idx", raft::index_t{}.value()));
+            }
+            auto to_store = std::max(idx, persisted_idx);
+            return _qp.execute_internal(
             store_cql,
-            {int16_t(_shard), _group_id.id, int64_t(idx.value())},
+            {int16_t(_shard), _group_id.id, int64_t(to_store.value())},
             cql3::query_processor::cache_internal::yes).discard_result();
+        });
     });
 }
 
@@ -129,10 +166,34 @@ future<raft::index_t> raft_groups_storage::load_commit_idx() {
     static const auto load_cql = format("SELECT commit_idx FROM system.{} WHERE shard = ? AND group_id = ? LIMIT 1", db::system_keyspace::RAFT_GROUPS);
     ::shared_ptr<cql3::untyped_result_set> rs = co_await _qp.execute_internal(load_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
     if (rs->empty()) {
-        co_return raft::index_t(0);
+        co_return clamp_commit_idx_to_replayed_log(raft::index_t(0), _replayed_max_idx, _commit_idx_floor, _replayed_truncate_prefix_idx, _replay_state_loaded);
     }
     const auto& static_row = rs->one();
-    co_return raft::index_t(static_row.get_or<int64_t>("commit_idx", raft::index_t{}.value()));
+    auto persisted_commit_idx = raft::index_t(static_row.get_or<int64_t>("commit_idx", raft::index_t{}.value()));
+    auto commit_idx_floor = _commit_idx_floor;
+    if (_replay_state_loaded
+            && !_replayed_max_idx
+            && !_replayed_truncate_prefix_idx
+            && commit_idx_floor == raft::index_t{0}
+            && persisted_commit_idx > raft::index_t{0}) {
+        auto snap = co_await load_snapshot_descriptor();
+        if (snap.id && snap.idx > commit_idx_floor) {
+            commit_idx_floor = snap.idx;
+        }
+    }
+
+    auto commit_idx = clamp_commit_idx_to_replayed_log(persisted_commit_idx, _replayed_max_idx, commit_idx_floor, _replayed_truncate_prefix_idx, _replay_state_loaded);
+    if (commit_idx.value() != persisted_commit_idx.value()) {
+        const auto replayed_max_idx = _replayed_max_idx ? format("{}", *_replayed_max_idx) : sstring("none");
+        const auto replayed_truncate_prefix_idx = _replayed_truncate_prefix_idx ? format("{}", *_replayed_truncate_prefix_idx) : sstring("none");
+        rgslog.warn("Clamping commit index for group {} from {} to {} (replayed_max_idx={}, replayed_truncate_prefix_idx={})",
+            _group_id,
+            persisted_commit_idx,
+            commit_idx,
+            replayed_max_idx,
+            replayed_truncate_prefix_idx);
+    }
+    co_return commit_idx;
 }
 
 future<raft::log_entries> raft_groups_storage::load_log() {
@@ -309,6 +370,18 @@ future<> raft_groups_storage::abort() {
     } catch (...) {
         pending_error = std::current_exception();
     }
+
+    if (_commitlog && has_commitlog_log_entries()) {
+        try {
+            co_await materialize_log_state_to_commitlog();
+            co_await _commitlog->sync_all_segments();
+        } catch (...) {
+            if (!pending_error) {
+                pending_error = std::current_exception();
+            }
+        }
+    }
+
     _entry_rp_handles.clear();
     _truncate_tail_rp_handle.reset();
     _truncate_prefix_rp_handle.reset();
@@ -324,6 +397,10 @@ future<> raft_groups_storage::update_snapshot_and_truncate_log_tail(const raft::
         store_latest_id_cql,
         {int16_t(_shard), _group_id.id, snap.id.id},
         cql3::query_processor::cache_internal::yes).discard_result();
+
+    if (_commit_idx_floor < snap.idx) {
+        _commit_idx_floor = snap.idx;
+    }
 
     if (preserve_log_entries >= snap.idx.value()) {
         co_return;
@@ -405,7 +482,9 @@ raft_groups_storage::replay_log_entries_for_groups(cql3::query_processor& qp, st
     ordered_files.reserve(files.size());
     for (auto& file : files) {
         try {
-            db::commitlog::descriptor d(file, COMMITLOG_FILENAME_PREFIX);
+            const auto slash_pos = file.find_last_of('/');
+            const sstring filename = slash_pos == sstring::npos ? file : file.substr(slash_pos + 1);
+            db::commitlog::descriptor d(filename, COMMITLOG_FILENAME_PREFIX);
             ordered_files.emplace_back(d.id, std::move(file));
         } catch (const std::domain_error&) {
             continue;
@@ -474,6 +553,10 @@ void raft_groups_storage::set_replayed_log_state(group_replay_state state) {
     _replayed_truncate_idx = state.replayed_truncate_idx;
     _replayed_truncate_prefix_idx = state.replayed_truncate_prefix_idx;
     _replayed_has_truncate = state.replayed_has_truncate;
+    if (_replayed_truncate_prefix_idx && _commit_idx_floor < *_replayed_truncate_prefix_idx) {
+        _commit_idx_floor = *_replayed_truncate_prefix_idx;
+    }
+    _replay_state_loaded = true;
 }
 
 void raft_groups_storage::set_replay_had_errors(bool had_errors) {

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -11,21 +11,20 @@
 
 #include <vector>
 #include <functional>
+#include <optional>
+#include <map>
+#include <unordered_map>
 
 #include <seastar/core/future.hh>
 
 #include "service/query_state.hh"
 #include "seastarx.hh"
+#include "db/commitlog/commitlog.hh"
+#include "db/commitlog/rp_set.hh"
 
 namespace cql3 {
 
 class query_processor;
-
-namespace statements {
-
-class modification_statement;
-
-} // namespace cql3::statements
 
 } // namespace cql3
 
@@ -38,12 +37,23 @@ namespace service::strong_consistency {
 // have a (shard, group_id) composite partition key allowing data to reside
 // on the same shard as the tablet replica.
 class raft_groups_storage : public raft::persistence {
+public:
+    static inline const std::string COMMITLOG_FILENAME_PREFIX = "RaftGroupsLog-";
+
+    struct group_replay_state {
+        std::map<raft::index_t, raft::log_entry_ptr> log;
+        std::optional<raft::index_t> replayed_max_idx;
+        std::optional<raft::index_t> replayed_seen_max_idx;
+        std::optional<raft::index_t> replayed_truncate_idx;
+        std::optional<raft::index_t> replayed_truncate_prefix_idx;
+        bool replayed_has_truncate = false;
+    };
+
+private:
+
     raft::group_id _group_id;
     raft::server_id _server_id;
     uint16_t _shard;
-    // Prepared statement instance used for construction of batch statements on
-    // `store_log_entries` calls.
-    shared_ptr<cql3::statements::modification_statement> _store_entry_stmt;
     cql3::query_processor& _qp;
     service::query_state _dummy_query_state;
     // The future of the currently executing (or already finished) write operation.
@@ -52,9 +62,22 @@ class raft_groups_storage : public raft::persistence {
     // This is managed by `execute_with_linearization_point` helper function.
     future<> _pending_op_fut;
 
-    const size_t _max_mutation_size;
+    db::commitlog* _commitlog = nullptr;
+    table_id _table_id;
+    std::map<raft::index_t, raft::log_entry_ptr> _log;
+    std::map<raft::index_t, db::rp_handle> _entry_rp_handles;
+    std::optional<db::rp_handle> _truncate_tail_rp_handle;
+    std::optional<db::rp_handle> _truncate_prefix_rp_handle;
+    std::optional<raft::index_t> _replayed_max_idx;
+    std::optional<raft::index_t> _replayed_seen_max_idx;
+    std::optional<raft::index_t> _replayed_truncate_idx;
+    std::optional<raft::index_t> _replayed_truncate_prefix_idx;
+    bool _replayed_has_truncate = false;
+    bool _allow_legacy_cleanup = false;
+    bool _replay_had_errors = false;
 
 public:
+    explicit raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard, db::commitlog* commitlog);
     explicit raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard);
 
     future<> store_term_and_vote(raft::term_t term, raft::server_id vote) override;
@@ -72,19 +95,37 @@ public:
     future<> truncate_log(raft::index_t idx) override;
     future<> abort() override;
 
+    future<> replay_log_entries(std::vector<sstring> files);
+    static future<std::unordered_map<raft::group_id, group_replay_state>> replay_log_entries_for_groups(cql3::query_processor& qp, std::vector<sstring> files, bool* had_errors = nullptr);
+    void set_replayed_log_state(group_replay_state state);
+    void set_replay_had_errors(bool had_errors);
+    future<> filter_replayed_log_with_snapshot();
+    future<> materialize_log_state_to_commitlog();
+    future<bool> import_legacy_log_entries();
+    future<> cleanup_legacy_log_entries();
+
+    bool has_commitlog_log_entries() const;
+    bool should_cleanup_legacy_log_entries() const;
+
     // Persist initial configuration of a new Raft group.
     // To be called before start for the new group.
     future<> bootstrap(raft::configuration initial_configuation, bool nontrivial_snapshot);
 
 private:
-
-    future<size_t> do_store_log_entries_one_batch(const std::vector<raft::log_entry_ptr>& entries, size_t start_idx);
-    future<> do_store_log_entries(const std::vector<raft::log_entry_ptr>& entries);
     // Truncate all entries from the persisted log with indices <= idx
     // Called from the `store_snapshot` function.
     future<> update_snapshot_and_truncate_log_tail(const raft::snapshot_descriptor &snap, size_t preserve_log_entries);
 
     future<> execute_with_linearization_point(std::function<future<>()> f);
+    future<> store_log_entries_internal(const std::vector<raft::log_entry_ptr>& entries);
+    future<db::rp_handle> add_raft_entry_to_commitlog(const raft_commit_log_entry& e);
+    future<> replay_log_entries_from_file(const sstring& file);
+    void apply_replayed_entry(const raft::log_entry& entry);
+    void apply_replayed_truncate(raft::index_t idx);
+    void record_replayed_truncate_prefix(raft::index_t idx);
+    void apply_replayed_truncate_prefix(raft::index_t idx);
+    future<> truncate_prefix_log(raft::index_t idx);
+    future<> truncate_prefix_log_impl(raft::index_t idx);
 };
 
 } // namespace service::strong_consistency

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -73,6 +73,8 @@ private:
     std::optional<raft::index_t> _replayed_truncate_idx;
     std::optional<raft::index_t> _replayed_truncate_prefix_idx;
     bool _replayed_has_truncate = false;
+    bool _replay_state_loaded = false;
+    raft::index_t _commit_idx_floor = raft::index_t{0};
     bool _allow_legacy_cleanup = false;
     bool _replay_had_errors = false;
 

--- a/specs/scylladb-1111-raft-log-commitlog-persistence.md
+++ b/specs/scylladb-1111-raft-log-commitlog-persistence.md
@@ -1,0 +1,297 @@
+# Feature Specification: SCYLLADB-1111 Commitlog-Backed Raft Log Persistence for Strongly Consistent Tablet Groups
+
+## 0. Metadata
+- Ticket: SCYLLADB-1111
+- Status: done
+- Authors: Core Cluster Team (drafted by OpenCode)
+- Created: 2026-04-08
+- Updated: 2026-04-08
+
+## 1. Problem and Goals
+- Current behavior:
+  - Raft persistence for strongly consistent tablet groups uses `service/strong_consistency/raft_groups_storage.cc`, which stores Raft log entries in `system.raft_groups` table rows and stores vote/term, commit index, and snapshot metadata in `system.raft_groups*` tables.
+  - This path serializes persistence operations via `_pending_op_fut` and reloads persisted log state from tables during server startup.
+  - Group0 uses a different storage path (`service/raft/raft_sys_table_storage.cc`) and is not part of this ticket scope.
+- Problem:
+  - Persisting per-tablet Raft log entries in system tables adds avoidable write amplification and startup/query overhead for a high-cardinality set of Raft groups.
+  - The target design direction for tablet Raft groups is commitlog-backed durable log persistence/replay; table-backed log-entry storage is an interim implementation.
+  - SCYLLADB-1111 requires durable, ordered, replayable Raft log persistence across restarts/failures without introducing temporary table-storage fallback behavior.
+- Goals:
+  - Move strongly consistent tablet-group Raft **log entry** persistence from `system.raft_groups` rows to a dedicated Raft commitlog domain.
+  - Reduce write-path I/O by avoiding table-backed Raft log-entry writes and reusing commitlog append durability.
+  - Recover tablet-group Raft logs through standard commitlog replay at startup rather than table scans.
+  - Preserve existing Raft persistence ordering/linearization guarantees (`store_log_entries` vs `truncate_log`) and startup recovery correctness.
+  - Keep vote/term, commit index, and snapshot descriptor/config persistence in existing `system.raft_groups*` metadata tables for this iteration.
+  - Provide one-way upgrade safety from existing table-backed data via one-time import (migration), not long-lived fallback.
+- Non-goals:
+  - Migrating group0 (`system.raft*`) log-entry persistence in this ticket.
+  - Implementing commitlog segment compaction and advanced memory-pressure reclamation policies (tracked separately).
+  - Introducing a temporary dual-write or runtime fallback mode that keeps table-backed log-entry persistence active after cutover.
+
+## 2. Scope, Compatibility, and Lineage
+- In scope:
+  - Replace `raft_groups_storage::store_log_entries/load_log/truncate_log` log-entry backend with commitlog-based append/replay/release logic for strongly consistent tablet groups.
+  - Extend commitlog entry format handling with segment-versioned decoding:
+    - segment v4 (`legacy`): `mutation_entry` only
+    - segment v5 (`variant`): `variant<raft_commit_log_entry, mutation_entry>`
+  - Define the commitlog versioning transition explicitly:
+    - new segments are written with v5 headers (global `current_version` after this change)
+    - replay accepts both v4 and v5 segment headers and dispatches decoding by descriptor version
+  - Keep `store_term_and_vote`, `store_commit_idx`, `store_snapshot_descriptor`, and corresponding loads table-backed in `system.raft_groups*`.
+  - Introduce per-shard Raft commitlog domain lifecycle (init/start/stop/replay) for strongly consistent groups and wire it from groups-manager startup/shutdown.
+  - Add one-time import of legacy table-backed log rows (`system.raft_groups` data rows) into commitlog-backed state during node startup, then stop using table rows for log-entry persistence.
+  - Add/update tests for restart recovery, truncation ordering, and migration behavior.
+- Out of scope:
+  - Group0 persistence backend conversion.
+  - Long-term segment packing/compaction and low-memory rewriting optimizations.
+  - Bidirectional downgrade compatibility after commitlog cutover.
+- Implementation authority:
+  - `this-spec-only`
+- Compatibility impact:
+  - Protocol/API: None (no external CQL/native protocol or Raft RPC interface changes).
+  - Schema/storage format: `system.raft_groups` log-entry rows (`term/index/data`) are no longer the authoritative Raft log source for strongly consistent groups after cutover; vote/term, commit index, and snapshot metadata remain in `system.raft_groups*` tables. Commitlog introduces v5 variant payload support (`raft_commit_log_entry` + `mutation_entry`) and keeps replay compatibility with legacy v4 mutation-only segments.
+  - Configuration/flags: No new user-facing flags in this ticket. Emission of Raft variant payloads is gated by `STRONGLY_CONSISTENT_TABLES`; non-SC domains continue emitting mutation-only commitlog entries.
+  - Mixed-version behavior (upgrade/downgrade): Rolling upgrade is supported one-way via startup import from legacy table log rows into commitlog-backed state on upgraded nodes. Replay accepts v4 and v5 segments by descriptor version during transition. Downgrade to binaries that require table-backed log-entry persistence is not supported after a node has cut over.
+  - Observability/metrics/logging: Add/extend metrics and logs for Raft commitlog append/replay/import/release activity, replay filtering counters (snapshot-covered/superseded/duplicate), and startup replay/import summaries per shard.
+- Contract lineage and overlap resolution:
+  - `specs/customer-268-raft-tables-enctyption.md` -> no conflict -> encryption coverage for Raft system tables; this spec changes persistence medium for strongly consistent Raft log entries.
+  - Confluence page `228163595` (Tablet Raft Group Persistence in Tables) -> supersede -> table-backed log-entry persistence is replaced by commitlog-backed persistence for strongly consistent groups.
+  - Confluence pages `206831685` and `218169442` -> refine -> this ticket implements the first production cutover slice (durable append/replay + legacy import) without deferred compaction/reclaimer enhancements.
+
+### 2.1 Deferred Edge Cases and Out-of-Scope Constraints
+- Commitlog segment compaction for Raft-group entries -> deferred to SCYLLADB-670 to keep SCYLLADB-1111 focused on correctness/cutover.
+- Memory reclamation for commitlog-backed Raft log entries under pressure -> deferred to SCYLLADB-668; memtable-driven `rp_handle` reclamation has no equivalent for uncommitted Raft log ownership in this ticket.
+- Replay memory footprint reduction -> deferred to SCYLLADB-668/672; this ticket buffers replayed Raft entries per group before post-processing, which can be memory-heavy on large logs.
+- Replay fuzzing and negative-scenario hardening breadth expansion -> deferred to SCYLLADB-672; this ticket includes deterministic recovery/truncation regression coverage only.
+- Group0 commitlog persistence conversion -> deferred; this ticket targets strongly consistent tablet-group persistence only.
+- Downgrade-safe reverse migration from commitlog back to table rows -> deferred/not supported in this phase.
+
+### 2.2 Documentation Impact
+- User-visible behavior docs (`README.md` or equivalent): not required -> no end-user API change; behavior remains internal to strongly consistent Raft persistence.
+- Architecture docs (`docs/ARCHITECTURE.md` and topic docs): required -> update `docs/dev/strong_consistency.md` to describe commitlog-backed tablet Raft log persistence, startup replay/import flow, and table-metadata-only role of `system.raft_groups*`.
+- Other docs/tests docs: update `docs/dev/system_keyspace.md` Raft-group section to clarify that `system.raft_groups` log-entry rows are no longer the authoritative source after cutover; no separate test-doc file changes required.
+
+## 3. Design and Contracts
+- Key files/modules:
+  - `service/strong_consistency/raft_groups_storage.hh`
+  - `service/strong_consistency/raft_groups_storage.cc`
+  - `service/strong_consistency/groups_manager.hh`
+  - `service/strong_consistency/groups_manager.cc`
+  - `db/commitlog/commitlog.hh`
+  - `db/commitlog/commitlog.cc`
+  - `db/commitlog/commitlog_entry.hh`
+  - `db/commitlog/commitlog_entry.cc`
+  - `db/commitlog/commitlog_replayer.hh`
+  - `db/commitlog/commitlog_replayer.cc`
+  - `idl/commitlog.idl.hh`
+  - `replica/database.hh`
+  - `replica/database.cc`
+  - `main.cc`
+  - `test/raft/raft_sys_table_storage_test.cc`
+  - `test/cluster/test_strong_consistency.py`
+- Architecture/data flow:
+  - A dedicated Raft commitlog domain is created per shard for strongly consistent tablet groups (separate filename prefix from main/schema commitlogs).
+  - Commitlog segment format is versioned:
+    - v4 segments carry `mutation_entry` payloads only.
+    - v5 segments carry variant payloads with either `raft_commit_log_entry` or `mutation_entry`.
+  - Version transition contract:
+    - commitlog segment writer uses v5 for newly created segments after rollout,
+    - replay path accepts both v4 and v5 segment headers,
+    - decoding is strictly version-driven (no payload heuristics).
+  - Variant payload writing for strongly consistent tablet-group log persistence is enabled only when `STRONGLY_CONSISTENT_TABLES` is enabled.
+  - Schema commitlog and hints commitlog remain mutation-only payload producers in this ticket (they do not emit `raft_commit_log_entry`).
+  - `raft_groups_storage::store_log_entries` serializes and appends each Raft log entry to the shard-local Raft commitlog, retaining returned `rp_handle`s keyed by Raft index for safe release.
+  - `raft_groups_storage::truncate_log` and snapshot-tail truncation release affected handles in linearized order, allowing segment reclamation once entries are no longer needed.
+  - Startup replay for strongly consistent Raft log entries is implemented in a dedicated strong-consistency persistence path (using `db::commitlog::read_log_file` with Raft-prefix files), not in the generic mutation-applying `db::commitlog_replayer` loop.
+  - Startup replay scans Raft commitlog segments for the Raft prefix, decodes entries by segment version, buffers Raft entries per group, applies replay filtering, performs one-time import from legacy table rows when needed, and exposes the resulting log to `load_log()` before groups begin serving.
+  - Replay post-processing filters:
+    - drop entries covered by persisted snapshot index,
+    - drop superseded entries for overwritten leader epochs (term/index conflict resolution),
+    - drop duplicate entries (e.g., partial/overlapping segment replay cases).
+  - One-time import authority and idempotency:
+    - For each group, startup first computes commitlog-replayed log state and `replayed_max_idx`.
+    - Startup also computes `legacy_max_idx` from legacy `system.raft_groups` rows for that group.
+    - Legacy table-row import runs when `legacy_max_idx > replayed_max_idx` and appends only the missing legacy suffix (`idx > replayed_max_idx`) in index order.
+    - After successful import append, legacy `system.raft_groups` log rows (`term/index/data`) for the group are deleted.
+    - If crash happens during import append, the next startup recomputes both maxima and resumes from the remaining missing suffix; if crash happens after append but before cleanup, cleanup is retried opportunistically.
+  - Shard/async boundaries:
+    - Groups and persistence remain shard-local (`groups_manager` + `raft_groups_storage` per shard).
+    - No cross-shard persistence RPCs are introduced.
+    - Replay/import runs asynchronously during shard startup before strongly consistent group service readiness.
+  - Object lifetime boundaries:
+    - Raft commitlog domain lifetime is tied to strongly consistent groups-manager lifecycle on each shard.
+    - `rp_handle` ownership is tied to `raft_groups_storage` instance lifetime and is released on truncation/snapshot/abort/destruction.
+    - Replay/import caches are startup-scoped and cleared after groups are initialized.
+- Interfaces changed/added:
+  - `raft_groups_storage` constructor gains access to the shard-local Raft commitlog domain.
+  - `raft_groups_storage::store_log_entries/load_log/truncate_log` internals switch from table-row CRUD to commitlog append/replay/release behavior.
+  - `groups_manager` startup/shutdown adds initialization and teardown of the Raft commitlog domain and replay/import orchestration.
+  - Commitlog segment format handling adds v5 variant decode/encode path while keeping v4 legacy decode support.
+  - `raft_groups_storage` startup flow adds explicit legacy-import reconciliation and legacy-row cleanup logic with idempotent restart semantics.
+  - No external API or RPC signature changes.
+- Contract obligations (for changed behavior surfaces):
+  - `POST-001`: For each invocation of `raft_groups_storage::store_log_entries(entries)`, every input entry is durably appended to the shard-local Raft commitlog before the future resolves successfully.
+  - `POST-002`: `raft_groups_storage::load_log()` reconstructs an ordered, contiguous Raft log consistent with persisted append/truncate/snapshot effects and serves it to `raft::server::start()`.
+  - `POST-003`: On upgraded nodes with legacy table-backed log rows, startup imports legacy rows into commitlog-backed state when replayed log is behind legacy rows, and appends only the missing suffix (`legacy_idx > replayed_max_idx`).
+  - `POST-004`: Replay decoding is descriptor-version aware: v4 segments are parsed as legacy mutation-only entries, v5 segments are parsed as variant entries; parsing rules are deterministic and independent of runtime heuristics.
+  - `POST-005`: Replay output for each group excludes snapshot-covered entries, superseded term/index entries, and duplicates before serving `load_log()`, with deterministic precedence: commitlog records are applied in descriptor-id order and in-file order; for repeated index values in the replay stream, the last applied record is authoritative (including truncate/truncate-prefix effects).
+  - `POST-006`: After successful legacy import, legacy table log rows are cleaned up; restart after partial import append or cleanup failure resumes from the missing suffix and does not create duplicate entries.
+  - `INV-001`: Vote/term, commit index, and snapshot descriptor/config persistence semantics remain unchanged and continue using `system.raft_groups*` metadata tables.
+  - `INV-002`: After cutover for a strongly consistent group, table row writes/deletes for Raft log entries (`term/index/data` rows in `system.raft_groups`) are not part of normal persistence flow.
+  - `INV-003`: Schema and hints commitlog domains remain mutation-only entry producers in this ticket; `raft_commit_log_entry` payload usage is confined to strongly consistent tablet-group persistence path.
+  - `CONC-001`: `store_log_entries`, `truncate_log`, and snapshot-tail release operations remain linearized by invocation order for each group, preserving Raft persistence ordering guarantees from `raft::persistence` contract.
+  - `CONC-002`: `abort()` waits for in-flight linearized persistence operations and releases retained handles owned by the storage instance without leaking segment pins.
+- Simplicity and rejected alternatives:
+  - Minimal design statement: convert only the high-volume Raft log-entry path for strongly consistent groups to commitlog, keep existing table-backed metadata path unchanged, and add one-way startup import for upgrade safety.
+  - Rejected alternative: dual-write/dual-read temporary fallback to table-backed log persistence -> rejected because it materially increases correctness surface (precedence rules, rollback semantics, and mixed persistence arbitration) outside this ticket.
+  - Rejected alternative: global shared-commitlog entry-format overhaul in this ticket -> rejected due larger cross-subsystem blast radius; this ticket limits itself to strongly consistent Raft persistence cutover.
+- Concurrency/performance notes:
+  - Hot-path persistence keeps shard-local execution and existing linearization approach.
+  - Startup replay is done once per shard over Raft-prefixed segments; per-group startup consumes this replayed state, with per-group file rescan only as a fallback path when pre-replayed state is unavailable.
+  - Segment reclamation efficiency improvements beyond correctness-preserving handle release are deferred (Section 2.1).
+
+```cpp
+// Contract boundary sketch: per-group linearization is preserved.
+future<> raft_groups_storage::store_log_entries(const std::vector<raft::log_entry_ptr>& entries) {
+    return execute_with_linearization_point([this, &entries] {
+        // append to raft commitlog domain, capture rp_handles by raft index
+        return do_store_log_entries(entries);
+    });
+}
+```
+
+## 4. Acceptance Criteria
+Concrete Given/When/Then scenarios that map directly to tests and contracts.
+
+- Scenario 1: Durable append and restart recovery (covers: `POST-001`, `POST-002`, `INV-001`)
+  - Given: A strongly consistent tablet Raft group with empty persisted log on shard S.
+  - When: Commands are committed, node crashes, and node restarts.
+  - Then: `load_log()` reconstructs the committed/uncommitted Raft entries in order from Raft commitlog replay and server startup proceeds without reading table-backed log rows.
+
+- Scenario 2: Truncation ordering across conflicts (covers: `POST-002`, `CONC-001`)
+  - Given: Persisted entries at indices 1..N and a subsequent `truncate_log(K)` due to leader conflict resolution.
+  - When: New entries are appended after truncation and node restarts.
+  - Then: Recovered log contains only post-truncation authoritative entries; truncated tail entries do not reappear.
+
+- Scenario 3: Snapshot-tail release behavior (covers: `POST-002`, `CONC-001`, `CONC-002`)
+  - Given: Persisted log entries and snapshot descriptor persisted with `preserve_log_entries = P`.
+  - When: Snapshot persistence truncates eligible tail and node restarts.
+  - Then: Recovered log retains only expected trailing entries and released handles allow old segments to become reclaimable.
+
+- Scenario 4: Legacy table import once, no runtime fallback (covers: `POST-003`, `INV-002`)
+  - Given: Upgraded node with legacy `system.raft_groups` log rows for a group and no existing commitlog-backed entries for that group.
+  - When: Node starts with the new binary.
+  - Then: Startup imports legacy rows into commitlog-backed state, subsequent persistence uses commitlog only, and later restarts do not depend on table log rows.
+
+- Scenario 5: Versioned replay and filtering (covers: `POST-004`, `POST-005`)
+  - Given: Replay input contains mixed segment versions (v4 and v5) and overlapping/superseded Raft entries for a group.
+  - When: Startup replay completes.
+  - Then: Decoding follows segment version contract and final loaded log excludes snapshot-covered, superseded, and duplicate entries.
+
+- Scenario 6: Non-SC domain payload isolation (covers: `INV-003`)
+  - Given: Node starts with strongly consistent tables enabled and both schema/hints commitlogs present.
+  - When: Commitlog replay runs for all domains.
+  - Then: Schema and hints domains remain mutation-only entry domains; `raft_commit_log_entry` payloads are handled only in the strongly consistent Raft path.
+
+- Scenario 7: Import restart idempotency after partial import/cleanup failure (covers: `POST-003`, `POST-006`)
+  - Given: Startup begins importing legacy rows for a group and crashes either (a) between import batches or (b) after import append before deleting legacy table log rows.
+  - When: Node restarts and replay/import logic runs again.
+  - Then: Import resumes from the missing suffix (`legacy_max_idx > replayed_max_idx`) without duplicating already imported entries, and legacy-row cleanup is retried.
+
+## 5. Test Plan and Validation
+- Contract/scenario to test mapping:
+  - `POST-001` / Scenario 1 -> `test/raft/raft_sys_table_storage_test.cc::test_groups_store_load_log_entries`
+  - `POST-002`, `CONC-001` / Scenario 2 -> `test/raft/raft_sys_table_storage_test.cc::test_groups_truncate_log`
+  - `POST-002`, `CONC-001`, `CONC-002` / Scenario 3 -> `test/raft/raft_sys_table_storage_test.cc::test_groups_store_snapshot_truncate_log_tail`, `test/raft/raft_sys_table_storage_test.cc::test_groups_store_snapshot_preserve_tail_restart_recovery`
+  - Crash-window regression for snapshot/truncate-prefix replay filtering (supports Scenario 3, `POST-002`) -> `test/raft/raft_sys_table_storage_test.cc::test_groups_filter_replayed_truncate_prefix_without_snapshot`
+  - Underflow regression for snapshot preserve-tail math (supports Scenario 3, `POST-002`) -> `test/raft/raft_sys_table_storage_test.cc::test_groups_store_snapshot_preserve_entries_underflow_guard`
+  - `INV-001` -> `test/raft/raft_sys_table_storage_test.cc::test_groups_store_load_term_and_vote`, `test/raft/raft_sys_table_storage_test.cc::test_groups_store_load_snapshot`, `test/raft/raft_sys_table_storage_test.cc::test_groups_storage_shard_isolation`
+  - End-to-end crash/restart correctness -> `test/cluster/test_strong_consistency.py::test_sc_persistence_after_crash`
+  - End-to-end restart with shard topology changes -> `test/cluster/test_strong_consistency.py::test_sc_persistence_restart_with_smp_increase`
+  - `POST-003`, `POST-006` / Scenarios 4, 7 -> `test/raft/raft_sys_table_storage_test.cc::test_groups_storage_legacy_import_restart_idempotent` (to add)
+  - `POST-004`, `POST-005` / Scenario 5 -> `test/boost/commitlog_test.cc::test_commitlog_mixed_v4_v5_replay_for_raft_entries` (to add)
+  - `INV-002` / Scenario 4 -> `test/raft/raft_sys_table_storage_test.cc::test_groups_storage_legacy_table_import_once` (to add)
+  - `INV-003` / Scenario 6 -> `test/boost/commitlog_test.cc::test_schema_and_hints_commitlog_remain_mutation_only_under_sc_feature` (to add)
+- Unit tests (C++):
+  - Update `test/raft/raft_sys_table_storage_test.cc` to cover commitlog-backed replay, truncate ordering, snapshot-tail behavior, and crash-window/underflow regressions.
+  - Keep `test/boost/commitlog_test.cc` exercising commitlog reader/writer paths with segment-version threading (`buffer_and_replay_position.segment_version`) in existing add/read cases.
+- Integration tests (Python, if needed):
+  - Extend `test/cluster/test_strong_consistency.py` with a dedicated restart test that verifies Raft-group progress survives crash/restart with commitlog-backed persistence and that normal writes continue.
+- Stability (if needed):
+  - Run new crash/restart integration case with `--repeat 100 --max-failures 1`.
+- Validation commands:
+  ```bash
+  ./configure.py --mode=dev
+  ninja build/dev/scylla
+  ninja build/dev/test/raft/raft_sys_table_storage_test
+  ninja build/dev/test/boost/commitlog_test
+
+  ./test.py --mode=dev test/raft/raft_sys_table_storage_test.cc
+  ./test.py --mode=dev test/boost/commitlog_test.cc
+  ./test.py --mode=dev test/cluster/test_strong_consistency.py::test_sc_persistence_after_crash -v
+  ./test.py --mode=dev test/cluster/test_strong_consistency.py::test_sc_persistence_restart_with_smp_increase -v
+  ./test.py --mode=dev test/cluster/test_strong_consistency.py::test_sc_persistence_after_crash --repeat 100 --max-failures 1 -v
+  ```
+- Known uncovered paths and rationale:
+  - Dedicated automated coverage for `POST-003`/`POST-006` (legacy import once + restart-idempotent cleanup) is not yet present in this draft and must be added before moving spec status to `done`.
+  - Dedicated automated coverage for explicit mixed v4/v5 Raft payload replay (`POST-004`) and schema/hints isolation assertion (`INV-003`) is not yet present as standalone named tests in this draft and must be added before moving spec status to `done`.
+  - Extreme disk-full and long-tail segment-fragmentation behavior under sustained pressure is not fully covered here; these are addressed by deferred SCYLLADB-668/670 follow-up scopes.
+  - Replay peak-memory behavior for very large per-group buffered Raft logs is not fully stress-tested in this ticket; deferred to follow-up work in Section 2.1.
+
+## 6. Risks and Rollout (Optional - include for behavior changes or risky refactors)
+- Risks:
+  - Replay/import bugs could cause dropped or duplicated Raft entries during restart.
+  - Incorrect handle release ordering could keep segments pinned longer than expected.
+  - Replay buffering of all Raft entries per group before post-processing can cause high memory usage and potential OOM in large log windows.
+  - Startup replay/import time could increase on shards with large historical Raft commitlog volume.
+  - One-way upgrade semantics can surprise operators if downgrade is attempted after cutover.
+- Mitigations:
+  - Enforce strict contract tests for replay ordering, truncate precedence, and one-time import behavior.
+  - Enforce mixed-format v4/v5 replay tests and filtering correctness tests.
+  - Keep per-group linearization logic unchanged and explicitly test `store_log_entries` vs `truncate_log` ordering.
+  - Emit replay/import metrics and startup summary logs to support operability/debugging.
+  - Document one-way upgrade semantics in architecture docs and release notes.
+- Rollout:
+  - Immediate rollout for strongly consistent tablet groups with one-time startup import on upgraded nodes.
+  - No runtime fallback path; commitlog-backed persistence is authoritative after cutover.
+- Rollback:
+  - Binary downgrade after cutover is unsupported for affected nodes.
+  - Operational rollback requires restoring node data from pre-cutover backup/snapshot or rolling forward with a fix.
+
+## 8. Definition of Done
+- [ ] Acceptance criteria implemented
+- [ ] Tests added/updated and passing (`--repeat 100` for new tests when applicable)
+- [ ] Validation commands executed successfully
+- [ ] Compatibility impact in Section 2 verified
+- [ ] Required documentation from Section 2.2 updated
+- [ ] Spec status updated to `done`
+
+## 9. Agent Scratchpad
+<!-- Leave empty when authoring the spec. OpenCode fills this during execution. -->
+
+- Same-chat fallback gate token:
+  - `[SPEC_REVIEW_RESULT] path=specs/scylladb-1111-raft-log-commitlog-persistence.md verdict=APPROVE command=/spec-review`
+- Implementation steps:
+  - 1) Add commitlog v5 support and version-aware replay payload dispatch (v4/v5) in commitlog core readers.
+  - 2) Extend commitlog payload model with Raft entry variant and keep mutation-only producers for non-SC domains.
+  - 3) Introduce SC raft commitlog domain and replay path in strongly-consistency code.
+  - 4) Rework `raft_groups_storage` log entry persistence/truncation/load to commitlog-backed data + `rp_handle` ownership.
+  - 5) Implement legacy table import (missing suffix), cleanup, and idempotent restart semantics.
+  - 6) Update tests in `test/raft/raft_sys_table_storage_test.cc` and `test/boost/commitlog_test.cc`.
+  - 7) Update docs (`docs/dev/strong_consistency.md`, `docs/dev/system_keyspace.md`).
+- File order:
+  - `idl/commitlog.idl.hh`
+  - `db/commitlog/commitlog.hh`
+  - `db/commitlog/commitlog.cc`
+  - `db/commitlog/commitlog_entry.hh`
+  - `db/commitlog/commitlog_entry.cc`
+  - `db/commitlog/commitlog_replayer.cc`
+  - `db/hints/internal/hint_sender.cc`
+  - `service/strong_consistency/groups_manager.hh`
+  - `service/strong_consistency/groups_manager.cc`
+  - `service/strong_consistency/raft_groups_storage.hh`
+  - `service/strong_consistency/raft_groups_storage.cc`
+  - `test/raft/raft_sys_table_storage_test.cc`
+  - `test/boost/commitlog_test.cc`
+  - `docs/dev/strong_consistency.md`
+  - `docs/dev/system_keyspace.md`

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -47,6 +47,10 @@
 #include "test/lib/key_utils.hh"
 #include "test/lib/test_utils.hh"
 #include "utils/checked-file-impl.hh"
+#include "idl/commitlog.dist.hh"
+#include "idl/commitlog.dist.impl.hh"
+#include "utils/crc.hh"
+#include "db/schema_tables.hh"
 
 BOOST_AUTO_TEST_SUITE(commitlog_test)
 
@@ -80,6 +84,47 @@ static future<> cl_test(noncopyable_function<future<> (commitlog&)> f) {
 
 static table_id make_table_id() {
     return table_id(utils::UUID_gen::get_time_UUID());
+}
+
+static raft_commit_log_entry make_test_raft_entry(utils::UUID gid, raft::index_t idx) {
+    raft::command cmd;
+    ser::serialize(cmd, int32_t(idx.value()));
+    return raft_commit_log_entry(gid, raft::log_entry{.term = raft::term_t(1), .idx = idx, .data = std::move(cmd)});
+}
+
+static future<> rewrite_segment_header_version(const sstring& seg, uint32_t new_version) {
+    constexpr uint64_t ver_off = sizeof(uint32_t);
+    constexpr uint64_t id_off = 2 * sizeof(uint32_t);
+    constexpr uint64_t alignment_off = 2 * sizeof(uint32_t) + sizeof(uint64_t);
+    constexpr uint64_t checksum_off = 5 * sizeof(uint32_t);
+    constexpr uint64_t first_sector_size = 4096;
+    constexpr uint64_t first_sector_crc_off = first_sector_size - sizeof(uint32_t);
+
+    auto f = co_await open_file_dma(seg, open_flags::rw);
+    auto buf = co_await f.dma_read_exactly<char>(0, first_sector_size);
+
+    auto* p = buf.get_write();
+    const auto id = net::ntoh(*reinterpret_cast<uint64_t*>(p + id_off));
+    const auto alignment = net::ntoh(*reinterpret_cast<uint32_t*>(p + alignment_off));
+
+    auto ver_be = net::hton(new_version);
+    std::memcpy(p + ver_off, &ver_be, sizeof(ver_be));
+
+    utils::crc32 crc;
+    crc.process_be(new_version);
+    crc.process_be<int32_t>(id & 0xffffffff);
+    crc.process_be<int32_t>(id >> 32);
+    crc.process_be<uint32_t>(alignment);
+    auto checksum_be = net::hton(crc.get());
+    std::memcpy(p + checksum_off, &checksum_be, sizeof(checksum_be));
+
+    utils::crc32 sector_crc;
+    sector_crc.process(reinterpret_cast<const uint8_t*>(p), first_sector_crc_off);
+    auto sector_checksum_be = net::hton(sector_crc.get());
+    std::memcpy(p + first_sector_crc_off, &sector_checksum_be, sizeof(sector_checksum_be));
+
+    co_await f.dma_write(0, buf.get(), first_sector_size);
+    co_await f.close();
 }
 
 // just write in-memory...
@@ -362,7 +407,8 @@ SEASTAR_TEST_CASE(test_commitlog_reader){
         size_t count = 0;
         try {
             co_await db::commitlog::read_log_file(path, db::commitlog::descriptor::FILENAME_PREFIX, [&count](db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
-                auto&& [buf, rp] = buf_rp;
+                auto&& [buf, rp, segment_version] = buf_rp;
+                (void) segment_version;
                 auto linearization_buffer = bytes_ostream();
                 auto in = buf.get_istream();
                 auto str = to_string_view(in.read_bytes_view(buf.size_bytes(), linearization_buffer).value());
@@ -462,7 +508,8 @@ SEASTAR_TEST_CASE(test_commitlog_entry_corruption){
                         auto seg = segments[0];
                         return corrupt_segment(seg, rps->at(1).pos + 4, 0x451234ab).then([seg, rps] {
                             return db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, [rps](db::commitlog::buffer_and_replay_position buf_rp) {
-                                auto&& [buf, rp] = buf_rp;
+                                auto&& [buf, rp, segment_version] = buf_rp;
+                                (void) segment_version;
                                 BOOST_CHECK_EQUAL(rp, rps->at(0));
                                 return make_ready_future<>();
                             }).then_wrapped([](auto&& f) {
@@ -1021,7 +1068,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entry) {
 
                 for (auto& seg : segments) {
                     db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, [&](db::commitlog::buffer_and_replay_position buf_rp) {
-                        commitlog_entry_reader r(buf_rp.buffer);
+                        commitlog_entry_reader r(buf_rp.buffer, buf_rp.segment_version);
                         auto& rp = buf_rp.position;
                         auto i = std::find(rps.begin(), rps.end(), rp);
                         // since we are looping, we can be reading last test cases 
@@ -1083,7 +1130,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entries) {
 
                 for (auto& seg : segments) {
                     db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, [&](db::commitlog::buffer_and_replay_position buf_rp) {
-                        commitlog_entry_reader r(buf_rp.buffer);
+                        commitlog_entry_reader r(buf_rp.buffer, buf_rp.segment_version);
                         auto& rp = buf_rp.position;
                         auto i = std::find(rps.begin(), rps.end(), rp);
                         // since we are looping, we can be reading last test cases 
@@ -1896,7 +1943,7 @@ static future<> do_test_oversized_entry(size_t max_size_mb) {
                 auto&& rp = buf_rp.position;
 
                 BOOST_CHECK(rp2mut.count(rp));
-                commitlog_entry_reader cer(buf);
+                commitlog_entry_reader cer(buf, buf_rp.segment_version);
                 auto& fm = cer.mutation();
                 auto m1 = fm.unfreeze(gen.schema());
                 auto m2 = rp2mut.at(rp).unfreeze(gen.schema());
@@ -2265,7 +2312,8 @@ SEASTAR_TEST_CASE(test_commitlog_release_large_mutation_segments) {
 SEASTAR_TEST_CASE(test_segment_end_on_entry_end) {
     static auto replay_segment = [] (sstring path) -> future<> {
         co_await db::commitlog::read_log_file(path, db::commitlog::descriptor::FILENAME_PREFIX, [](db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
-            auto&& [buf, rp] = buf_rp;
+            auto&& [buf, rp, segment_version] = buf_rp;
+            (void) segment_version;
             auto linearization_buffer = bytes_ostream();
             auto in = buf.get_istream();
             auto str = to_string_view(in.read_bytes_view(buf.size_bytes(), linearization_buffer).value());
@@ -2332,6 +2380,150 @@ SEASTAR_TEST_CASE(test_segment_end_on_entry_end) {
         co_await log.sync_all_segments();
         // Without the fix, this will throw.
         co_await replay_segment(segment_path);
+    });
+}
+
+SEASTAR_TEST_CASE(test_commitlog_mixed_v4_v5_replay_for_raft_entries) {
+    commitlog::config cfg;
+    cfg.commitlog_segment_size_in_mb = 1;
+    cfg.allow_fragmented_entries = true;
+
+    return cl_test(cfg, [] (commitlog& log) -> future<> {
+        auto raft_gid = utils::UUID_gen::get_time_UUID();
+
+        random_mutation_generator gen(random_mutation_generator::generate_counters(false));
+        auto mutation = freeze(gen(1).front());
+        commitlog_entry_writer mut_writer(gen.schema(), mutation, db::commitlog::force_sync::no);
+        co_await log.add_entry(gen.schema()->id(), mut_writer, db::no_timeout);
+
+        co_await log.add_mutation(gen.schema()->id(), sizeof(uint8_t) + ser::get_sizeof(make_test_raft_entry(raft_gid, raft::index_t(11))), db::no_timeout,
+                db::commitlog::force_sync::no,
+                [raft_gid] (db::commitlog::output& out) {
+            ser::serialize(out, uint8_t(1));
+            ser::serialize(out, make_test_raft_entry(raft_gid, raft::index_t(11)));
+        });
+
+        co_await log.sync_all_segments();
+
+        std::vector<sstring> segments = log.get_active_segment_names();
+        BOOST_REQUIRE(!segments.empty());
+
+        bool saw_mutation = false;
+        bool saw_raft = false;
+        for (const auto& seg : segments) {
+            co_await db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX,
+                    [&] (db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+                commitlog_entry_reader r(buf_rp.buffer, buf_rp.segment_version);
+                if (r.get_raft_entry()) {
+                    saw_raft = true;
+                } else {
+                    saw_mutation = true;
+                }
+                co_return;
+            });
+        }
+
+        BOOST_CHECK(saw_mutation);
+        BOOST_CHECK(saw_raft);
+
+        auto downgraded_segment = segments.front();
+        co_await rewrite_segment_header_version(downgraded_segment, db::commitlog::descriptor::segment_version_4);
+
+        bool saw_v4 = false;
+        size_t entries_seen = 0;
+        co_await db::commitlog::read_log_file(downgraded_segment, db::commitlog::descriptor::FILENAME_PREFIX,
+                [&] (db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+            BOOST_CHECK_EQUAL(buf_rp.segment_version, db::commitlog::descriptor::segment_version_4);
+            saw_v4 = true;
+            ++entries_seen;
+            co_return;
+        });
+        BOOST_CHECK(saw_v4);
+        BOOST_CHECK_GT(entries_seen, 0);
+
+        auto v4_fm = freeze(gen(1).front());
+        commitlog_entry v4_entry(std::optional<column_mapping>(gen.schema()->get_column_mapping()), std::move(v4_fm));
+        auto v4_payload = ser::serialize_to_buffer<bytes>(v4_entry);
+        auto v4_buf = fragmented_temporary_buffer::allocate_to_fit(v4_payload.size());
+        auto v4_out = v4_buf.get_ostream();
+        v4_out.write(reinterpret_cast<const char*>(v4_payload.data()), v4_payload.size());
+        commitlog_entry_reader v4_reader(v4_buf, db::commitlog::descriptor::segment_version_4);
+        BOOST_CHECK(v4_reader.get_raft_entry() == nullptr);
+        (void) v4_reader.mutation();
+
+        auto v5_raft_payload = ser::serialize_to_buffer<bytes>(make_test_raft_entry(raft_gid, raft::index_t(12)));
+        auto v5_raft_buf = fragmented_temporary_buffer::allocate_to_fit(sizeof(uint8_t) + v5_raft_payload.size());
+        auto v5_raft_out = v5_raft_buf.get_ostream();
+        const uint8_t raft_tag = 1;
+        v5_raft_out.write(reinterpret_cast<const char*>(&raft_tag), sizeof(raft_tag));
+        v5_raft_out.write(reinterpret_cast<const char*>(v5_raft_payload.data()), v5_raft_payload.size());
+        commitlog_entry_reader v5_reader(v5_raft_buf, db::commitlog::descriptor::segment_version_5);
+        BOOST_REQUIRE(v5_reader.get_raft_entry());
+        BOOST_CHECK_EQUAL(v5_reader.get_raft_entry()->group_id(), raft_gid);
+    });
+}
+
+SEASTAR_TEST_CASE(test_schema_and_hints_commitlog_remain_mutation_only_under_sc_feature) {
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        random_mutation_generator gen(random_mutation_generator::generate_counters(false));
+        auto fm = freeze(gen(1).front());
+        commitlog_entry_writer cew(gen.schema(), fm, db::commitlog::force_sync::yes);
+
+        auto* schema_cl = env.local_db().schema_commitlog();
+        BOOST_REQUIRE(schema_cl);
+        auto h = schema_cl->add_entry(gen.schema()->id(), cew, db::no_timeout).get();
+        schema_cl->sync_all_segments().get();
+
+        auto paths = schema_cl->get_active_segment_names();
+        BOOST_REQUIRE(!paths.empty());
+
+        bool saw_schema_mutation = false;
+        for (const auto& p : paths) {
+            db::commitlog::read_log_file(p, db::schema_tables::COMMITLOG_FILENAME_PREFIX,
+                    [&saw_schema_mutation] (db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+                saw_schema_mutation = true;
+                commitlog_entry_reader cer(buf_rp.buffer, buf_rp.segment_version);
+                BOOST_CHECK(cer.get_raft_entry() == nullptr);
+                (void) cer.mutation();
+                co_return;
+            }).get();
+        }
+        BOOST_CHECK(saw_schema_mutation);
+
+        rp_set set;
+        set.put(std::move(h));
+    }).then([] {
+        commitlog::config cfg;
+        cfg.fname_prefix = "HintsLog-";
+        cfg.metrics_category_name = "commitlog";
+        cfg.commitlog_segment_size_in_mb = 1;
+
+        return cl_test(cfg, [] (commitlog& log) -> future<> {
+            random_mutation_generator gen(random_mutation_generator::generate_counters(false));
+            auto fm = freeze(gen(1).front());
+            commitlog_entry_writer cew(gen.schema(), fm, db::commitlog::force_sync::yes);
+            auto h = co_await log.add_entry(gen.schema()->id(), cew, db::no_timeout);
+            co_await log.sync_all_segments();
+
+            auto paths = log.get_active_segment_names();
+            BOOST_REQUIRE(!paths.empty());
+
+            bool saw_hints_mutation = false;
+            for (const auto& p : paths) {
+                co_await db::commitlog::read_log_file(p, "HintsLog-",
+                        [&saw_hints_mutation] (db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+                    saw_hints_mutation = true;
+                    commitlog_entry_reader cer(buf_rp.buffer, buf_rp.segment_version);
+                    BOOST_CHECK(cer.get_raft_entry() == nullptr);
+                    (void) cer.mutation();
+                    co_return;
+                });
+            }
+            BOOST_CHECK(saw_hints_mutation);
+
+            rp_set set;
+            set.put(std::move(h));
+        });
     });
 }
 

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -553,3 +553,70 @@ SEASTAR_TEST_CASE(test_groups_storage_shard_isolation) {
         BOOST_CHECK_EQUAL(raft::index_t(0), idx1);
     });
 }
+
+SEASTAR_TEST_CASE(test_groups_storage_load_commit_idx_clamped_to_replayed_stable_idx) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        raft::group_id clamp_gid{utils::UUID_gen::get_time_UUID()};
+
+        raft_groups_storage storage(qp, clamp_gid, raft::server_id::create_random_id(), test_shard);
+        co_await storage.store_commit_idx(raft::index_t(42));
+
+        raft_groups_storage::group_replay_state replay_state;
+        replay_state.log[raft::index_t(1)] = make_lw_shared<const raft::log_entry>(raft::log_entry{
+                .term = raft::term_t(1),
+                .idx = raft::index_t(1),
+                .data = raft::log_entry::dummy()});
+        replay_state.log[raft::index_t(2)] = make_lw_shared<const raft::log_entry>(raft::log_entry{
+                .term = raft::term_t(1),
+                .idx = raft::index_t(2),
+                .data = raft::log_entry::dummy()});
+        replay_state.log[raft::index_t(3)] = make_lw_shared<const raft::log_entry>(raft::log_entry{
+                .term = raft::term_t(1),
+                .idx = raft::index_t(3),
+                .data = raft::log_entry::dummy()});
+        replay_state.replayed_max_idx = raft::index_t(3);
+        replay_state.replayed_seen_max_idx = raft::index_t(3);
+
+        storage.set_replayed_log_state(std::move(replay_state));
+
+        auto commit_idx = co_await storage.load_commit_idx();
+        BOOST_CHECK_EQUAL(commit_idx, raft::index_t(3));
+    });
+}
+
+SEASTAR_TEST_CASE(test_groups_storage_store_commit_idx_is_monotonic) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        raft::group_id monotonic_gid{utils::UUID_gen::get_time_UUID()};
+        raft_groups_storage storage(qp, monotonic_gid, raft::server_id::create_random_id(), test_shard);
+
+        co_await storage.store_commit_idx(raft::index_t(10));
+        co_await storage.store_commit_idx(raft::index_t(2));
+
+        auto commit_idx = co_await storage.load_commit_idx();
+        BOOST_CHECK_EQUAL(commit_idx, raft::index_t(10));
+    });
+}
+
+SEASTAR_TEST_CASE(test_groups_storage_load_commit_idx_preserves_metadata_when_replay_empty_with_snapshot) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        raft::group_id preserve_gid{utils::UUID_gen::get_time_UUID()};
+
+        raft_groups_storage storage(qp, preserve_gid, raft::server_id::create_random_id(), test_shard);
+        co_await storage.store_commit_idx(raft::index_t(9));
+
+        raft::snapshot_descriptor snp{
+            .idx = raft::index_t(9),
+            .term = raft::term_t(1),
+            .id = raft::snapshot_id::create_random_id()};
+        snp.config = raft::configuration{};
+        co_await storage.store_snapshot_descriptor(snp, 9);
+
+        storage.set_replayed_log_state({});
+
+        auto commit_idx = co_await storage.load_commit_idx();
+        BOOST_CHECK_EQUAL(commit_idx, raft::index_t(9));
+    });
+}

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -10,6 +10,7 @@
 #include <seastar/core/coroutine.hh>
 
 #include "db/config.hh"
+#include "db/system_keyspace.hh"
 #include "raft/raft.hh"
 #include "utils/UUID_gen.hh"
 
@@ -19,8 +20,11 @@
 
 #include "test/lib/cql_test_env.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/values.hh"
 
 #include "gms/inet_address_serializer.hh"
+#include "idl/raft_storage.dist.hh"
+#include "idl/raft_storage.dist.impl.hh"
 
 namespace raft{
 
@@ -77,6 +81,37 @@ static std::vector<raft::log_entry_ptr> create_test_log() {
             .idx = raft::index_t(3),
             .data = raft::log_entry::dummy()})
     };
+}
+
+static future<> insert_legacy_group_rows(cql3::query_processor& qp, raft::group_id group_id, const std::vector<raft::log_entry_ptr>& entries) {
+    static const auto insert_cql = format("INSERT INTO system.{} (shard, group_id, term, \"index\", data) VALUES (?, ?, ?, ?, ?)",
+            db::system_keyspace::RAFT_GROUPS);
+    for (const auto& entry : entries) {
+        auto data = ser::serialize_to_buffer<bytes>(entry->data);
+        data_value_list values = {
+                data_value_or_unset(data_value(int16_t(test_shard))),
+                data_value_or_unset(data_value(group_id.id)),
+                data_value_or_unset(data_value(int64_t(entry->term.value()))),
+                data_value_or_unset(data_value(int64_t(entry->idx.value()))),
+                data_value_or_unset(data_value(std::move(data)))};
+        co_await qp.execute_internal(insert_cql,
+                db::consistency_level::ONE,
+                values,
+                cql3::query_processor::cache_internal::yes).discard_result();
+    }
+}
+
+static future<size_t> count_legacy_group_data_rows(cql3::query_processor& qp, raft::group_id group_id) {
+    static const auto load_cql = format("SELECT \"index\", data FROM system.{} WHERE shard = ? AND group_id = ?",
+            db::system_keyspace::RAFT_GROUPS);
+    auto rs = co_await qp.execute_internal(load_cql, {int16_t(test_shard), group_id.id}, cql3::query_processor::cache_internal::yes);
+    size_t count = 0;
+    for (const auto& row : *rs) {
+        if (row.has("data")) {
+            ++count;
+        }
+    }
+    co_return count;
 }
 
 // Factory functions to create storage instances with uniform interface
@@ -293,6 +328,168 @@ SEASTAR_TEST_CASE(test_groups_truncate_log) {
 
 SEASTAR_TEST_CASE(test_groups_store_snapshot_truncate_log_tail) {
     return test_store_snapshot_truncate_log_tail_impl(make_groups_storage);
+}
+
+SEASTAR_TEST_CASE(test_groups_store_snapshot_preserve_tail_restart_recovery) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        raft::group_id restart_gid{utils::UUID_gen::get_time_UUID()};
+
+        raft_groups_storage writer(qp, restart_gid, raft::server_id::create_random_id(), test_shard);
+        std::vector<raft::log_entry_ptr> entries = create_test_log();
+        co_await writer.store_log_entries(entries);
+
+        raft::term_t snp_term(3);
+        raft::index_t snp_idx(3);
+        raft::config_member srv{raft::server_address{
+                raft::server_id::create_random_id(),
+                ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
+            }, raft::is_voter::yes};
+        raft::configuration snp_cfg({std::move(srv)});
+        auto snp_id = raft::snapshot_id::create_random_id();
+
+        raft::snapshot_descriptor snp{
+            .idx = snp_idx,
+            .term = snp_term,
+            .config = std::move(snp_cfg),
+            .id = std::move(snp_id)};
+
+        static constexpr size_t preserve_log_entries = 2;
+        co_await writer.store_snapshot_descriptor(snp, preserve_log_entries);
+
+        raft_groups_storage reader(qp, restart_gid, raft::server_id::create_random_id(), test_shard);
+
+        raft_groups_storage::group_replay_state replay_state;
+        replay_state.log.emplace(entries[1]->idx, entries[1]);
+        replay_state.log.emplace(entries[2]->idx, entries[2]);
+        replay_state.replayed_max_idx = entries[2]->idx;
+        replay_state.replayed_seen_max_idx = entries[2]->idx;
+        replay_state.replayed_truncate_prefix_idx = raft::index_t(1);
+        replay_state.replayed_has_truncate = true;
+        reader.set_replayed_log_state(std::move(replay_state));
+
+        co_await reader.filter_replayed_log_with_snapshot();
+        auto loaded_entries = co_await reader.load_log();
+
+        BOOST_CHECK_EQUAL(loaded_entries.size(), preserve_log_entries);
+        for (size_t i = 0; i < loaded_entries.size(); ++i) {
+            BOOST_CHECK(*entries[i + 1] == *loaded_entries[i]);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_groups_store_snapshot_preserve_entries_underflow_guard) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        raft::group_id underflow_gid{utils::UUID_gen::get_time_UUID()};
+
+        raft_groups_storage storage(qp, underflow_gid, raft::server_id::create_random_id(), test_shard);
+        auto entries = create_test_log();
+        co_await storage.store_log_entries(entries);
+
+        raft::snapshot_descriptor snp{
+            .idx = raft::index_t(1),
+            .term = raft::term_t(1),
+            .id = raft::snapshot_id::create_random_id()};
+        snp.config = raft::configuration{};
+
+        static constexpr size_t preserve_log_entries = 10;
+        co_await storage.store_snapshot_descriptor(snp, preserve_log_entries);
+
+        auto loaded_entries = co_await storage.load_log();
+        BOOST_CHECK_EQUAL(loaded_entries.size(), entries.size());
+        for (size_t i = 0; i < loaded_entries.size(); ++i) {
+            BOOST_CHECK(*entries[i] == *loaded_entries[i]);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_groups_filter_replayed_truncate_prefix_without_snapshot) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        raft::group_id crash_window_gid{utils::UUID_gen::get_time_UUID()};
+
+        auto entries = create_test_log();
+        raft_groups_storage storage(qp, crash_window_gid, raft::server_id::create_random_id(), test_shard);
+
+        raft_groups_storage::group_replay_state replay_state;
+        replay_state.log.emplace(entries[1]->idx, entries[1]);
+        replay_state.log.emplace(entries[2]->idx, entries[2]);
+        replay_state.replayed_max_idx = entries[2]->idx;
+        replay_state.replayed_seen_max_idx = entries[2]->idx;
+        replay_state.replayed_truncate_prefix_idx = raft::index_t(1);
+        replay_state.replayed_has_truncate = true;
+        storage.set_replayed_log_state(std::move(replay_state));
+
+        co_await storage.filter_replayed_log_with_snapshot();
+
+        auto loaded_entries = co_await storage.load_log();
+        BOOST_CHECK_EQUAL(loaded_entries.size(), 2);
+        BOOST_CHECK(*entries[1] == *loaded_entries[0]);
+        BOOST_CHECK(*entries[2] == *loaded_entries[1]);
+    });
+}
+
+SEASTAR_TEST_CASE(test_groups_storage_legacy_table_import_once) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        raft::group_id legacy_gid{utils::UUID_gen::get_time_UUID()};
+
+        auto entries = create_test_log();
+        co_await insert_legacy_group_rows(qp, legacy_gid, entries);
+
+        raft_groups_storage storage(qp, legacy_gid, raft::server_id::create_random_id(), test_shard);
+        auto imported = co_await storage.import_legacy_log_entries();
+        BOOST_REQUIRE(imported);
+
+        auto loaded_entries = co_await storage.load_log();
+        BOOST_CHECK_EQUAL(loaded_entries.size(), entries.size());
+        for (size_t i = 0; i < loaded_entries.size(); ++i) {
+            BOOST_CHECK(*entries[i] == *loaded_entries[i]);
+        }
+
+        co_await storage.cleanup_legacy_log_entries();
+        auto legacy_rows_after_cleanup = co_await count_legacy_group_data_rows(qp, legacy_gid);
+        BOOST_CHECK_EQUAL(legacy_rows_after_cleanup, 0);
+
+        co_await storage.store_log_entries(entries);
+        co_await storage.truncate_log(raft::index_t(3));
+        auto legacy_rows_after_normal_flow = co_await count_legacy_group_data_rows(qp, legacy_gid);
+        BOOST_CHECK_EQUAL(legacy_rows_after_normal_flow, 0);
+    });
+}
+
+SEASTAR_TEST_CASE(test_groups_storage_legacy_import_restart_idempotent) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        raft::group_id legacy_gid{utils::UUID_gen::get_time_UUID()};
+
+        auto entries = create_test_log();
+        co_await insert_legacy_group_rows(qp, legacy_gid, entries);
+
+        raft_groups_storage storage1(qp, legacy_gid, raft::server_id::create_random_id(), test_shard);
+        auto imported1 = co_await storage1.import_legacy_log_entries();
+        BOOST_REQUIRE(imported1);
+
+        auto replayed_entries = co_await storage1.load_log();
+        raft_groups_storage::group_replay_state replay_state;
+        for (const auto& entry : replayed_entries) {
+            replay_state.log.emplace(entry->idx, entry);
+        }
+        replay_state.replayed_max_idx = replayed_entries.back()->idx;
+        replay_state.replayed_seen_max_idx = replayed_entries.back()->idx;
+
+        raft_groups_storage storage2(qp, legacy_gid, raft::server_id::create_random_id(), test_shard);
+        storage2.set_replayed_log_state(std::move(replay_state));
+
+        auto imported2 = co_await storage2.import_legacy_log_entries();
+        BOOST_CHECK(!imported2);
+        BOOST_CHECK(storage2.should_cleanup_legacy_log_entries());
+
+        co_await storage2.cleanup_legacy_log_entries();
+        auto legacy_rows_after_cleanup = co_await count_legacy_group_data_rows(qp, legacy_gid);
+        BOOST_CHECK_EQUAL(legacy_rows_after_cleanup, 0);
+    });
 }
 
 // Verify partitioner round-trip: token_for_shard -> shard_of returns the original shard


### PR DESCRIPTION
Move strongly consistent tablet-group Raft log entry persistence from
system table rows to a dedicated commitlog domain so startup recovery
replays append and truncate operations directly from commitlog.

Add version-aware commitlog decoding for v4 and v5 segments, keep
metadata in system.raft_groups* tables, and perform one-way legacy row
import and cleanup during startup to preserve upgrade correctness.