### PR TITLE
utils: avoid exceptions in disk_space_monitor polling loop

### DIFF
--- a/utils/disk_space_monitor.cc
+++ b/utils/disk_space_monitor.cc
@@ -116,10 +116,9 @@ future<> disk_space_monitor::poll() {
             auto passed = clock_type::now() - now;
             auto interval = get_polling_interval();
             if (interval > passed) {
-                try {
-                    co_await _poll_cv.wait(interval - passed);
-                } catch (const seastar::condition_variable_timed_out&) {
-                }
+                seastar::timer<clock_type> timer([this] { _poll_cv.broadcast(); });
+                timer.arm(interval - passed);
+                co_await _poll_cv.wait();
             }
         }
     } catch (const sleep_aborted&) {


### PR DESCRIPTION
The poll loop used condition_variable::wait(timeout) to sleep between iterations. On every normal timeout expiry, this threw a condition_variable_timed_out exception, which incremented the C++ exception metric and triggered false alerts for support.

Replace the timed wait with a seastar::timer that broadcasts the condition variable on expiry, combined with an untimed wait(). The timer is cancelled automatically on scope exit when the wait is woken early by trigger_poll() or abort.

Fixes SCYLLADB-1477

No backport: enhancement