### PR TITLE
build: cmake: fix -fno-sanitize-address-use-after-scope for CQL parser

### DIFF
--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -23,7 +23,7 @@ set_property(
       $<$<CONFIG:${unoptimized_modes}>:-O1>
       # use-after-scope sanitizer also uses large amount of stack space
       # and overflows the stack of CqlParser
-      $<$<CONFIG:${sanitized_modes}>:-fsanitize-address-use-after-scope>)
+      $<$<CONFIG:${sanitized_modes}>:-fno-sanitize-address-use-after-scope>)
 
 add_library(cql3 STATIC)
 target_sources(cql3


### PR DESCRIPTION
The CMake build had -fsanitize-address-use-after-scope (enable) when it should have been -fno-sanitize-address-use-after-scope (disable).

The comment on lines 24-25 of cql3/CMakeLists.txt explains the intent: the use-after-scope sanitizer uses too much stack space on CqlParser and overflows the stack. The Python-ninja path in configure.py:2801-2802 correctly had -fno-sanitize-address-use-after-scope.

Found by black-box comparison of compiler flags between the Python-ninja and CMake build paths (ninja -nv output, debug mode, CqlParser.o):

  Python-ninja: -fno-sanitize-address-use-after-scope  (correct: disable)
  CMake:        -fsanitize-address-use-after-scope      (wrong: enable)

Since cmake isn't used on release branches, no need to backport.