### PR TITLE
compaction_manager: fix use-after-free in postponed_compactions_reevaluation()

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1106,7 +1106,8 @@ void compaction_manager::enable() {
 
     _compaction_submission_timer.cancel();
     _compaction_submission_timer.arm_periodic(periodic_compaction_submission_interval());
-    _waiting_reevalution = postponed_compactions_reevaluation();
+    throwing_assert(!_waiting_reevaluation);
+    _waiting_reevaluation.emplace(postponed_compactions_reevaluation());
     cmlog.info("Enabled");
 }
 
@@ -1152,6 +1153,16 @@ future<> compaction_manager::postponed_compactions_reevaluation() {
 
 void compaction_manager::reevaluate_postponed_compactions() noexcept {
     _postponed_reevaluation.signal();
+}
+
+future<> compaction_manager::stop_postponed_compactions() noexcept {
+    auto waiting_reevaluation = std::exchange(_waiting_reevaluation, std::nullopt);
+    if (!waiting_reevaluation) {
+        return make_ready_future();
+    }
+    // Trigger a signal to properly exit from postponed_compactions_reevaluation() fiber
+    reevaluate_postponed_compactions();
+    return std::move(*waiting_reevaluation);
 }
 
 void compaction_manager::postpone_compaction_for_table(compaction_group_view* t) {
@@ -1237,8 +1248,7 @@ future<> compaction_manager::drain() {
     _compaction_submission_timer.cancel();
     // Stop ongoing compactions, if the request has not been sent already and wait for them to stop.
     co_await stop_ongoing_compactions("drain");
-    // Trigger a signal to properly exit from postponed_compactions_reevaluation() fiber
-    reevaluate_postponed_compactions();
+    co_await stop_postponed_compactions();
     cmlog.info("Drained");
 }
 
@@ -1282,8 +1292,7 @@ future<> compaction_manager::really_do_stop() noexcept {
     if (!_tasks.empty()) {
         on_fatal_internal_error(cmlog, format("{} tasks still exist after being stopped", _tasks.size()));
     }
-    reevaluate_postponed_compactions();
-    co_await std::move(_waiting_reevalution);
+    co_await stop_postponed_compactions();
     co_await _sys_ks.close();
     _weight_tracker.clear();
     _compaction_submission_timer.cancel();

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -128,7 +128,7 @@ private:
     // a sstable from being compacted twice.
     std::unordered_set<sstables::shared_sstable> _compacting_sstables;
 
-    future<> _waiting_reevalution = make_ready_future<>();
+    std::optional<future<>> _waiting_reevaluation;
     condition_variable _postponed_reevaluation;
     // tables that wait for compaction but had its submission postponed due to ongoing compaction.
     std::unordered_set<compaction::compaction_group_view*> _postponed;
@@ -231,6 +231,7 @@ private:
 
     future<> postponed_compactions_reevaluation();
     void reevaluate_postponed_compactions() noexcept;
+    future<> stop_postponed_compactions() noexcept;
     // Postpone compaction for a table that couldn't be executed due to ongoing
     // similar-sized compaction.
     void postpone_compaction_for_table(compaction::compaction_group_view* t);


### PR DESCRIPTION
## Summary

- Fix use-after-free in `postponed_compactions_reevaluation()` triggered by the `enable_drained_compaction_manager` test
- `drain()` signals the reevaluation condition variable but doesn't await the coroutine's termination, so when `enable()` launches a new coroutine it orphans the old one; during shutdown the orphaned coroutine resumes and reads freed `compaction_manager` memory
- Fix by introducing `stop_postponed_compactions()`, awaiting the reevaluation coroutine in both `drain()` and `stop()` after signaling it, if `postponed_compactions_reevaluation()` is running.  It uses an `std::optional<future<>>` for `_waiting_reevalution` and `std::exchange` to leave `_waiting_reevalution` disengaged when `postponed_compactions_reevaluation()` is not running. This prevents a race between `drain()` and `stop()`.

While at it, fix typo in `_waiting_reevalution` -> `_waiting_reevaluation`.

Fixes: SCYLLADB-1463

Ref: [https://jenkins.scylladb.com/job/scylla-master/job/scylla-ci/28186/artifact/testlog/x86_64/pytest_tests_logs/boost-database_test.cc-enable_drained_compaction_manager.debug.2-call-f93b0.log](https://github.com/user-attachments/files/26655836/boost-database_test.cc-enable_drained_compaction_manager.debug.2-call-f93b0.log)

--
The bug was introduced in a9a53d917862052f27c8221c20d087baabe74b46 (compaction_manager: cancel submission timer on drain), therefore requires backport to all live branches.