### PR TITLE
gossip: allow decommissioning nodes to announce shutdown

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2138,7 +2138,12 @@ future<> gossiper::do_stop_gossiping() {
     }
 
     auto my_ep_state = get_this_endpoint_state_ptr();
-    if (my_ep_state && _topo_sm._topology.normal_nodes.contains(raft::server_id(my_host_id().uuid()))) {
+    auto my_id = raft::server_id(my_host_id().uuid());
+    if (my_ep_state) {
+        auto it = _topo_sm._topology.find(my_id);
+        logger.info("My topology state = {}", it ? fmt::format("{}", it->second.state) : "not found");
+    }
+    if (my_ep_state && !_topo_sm._topology.left_nodes.contains(my_id)) {
         auto local_generation = my_ep_state->get_heart_beat_state().get_generation();
         logger.info("Announcing shutdown");
         co_await add_local_application_state(application_state::STATUS, versioned_value::shutdown(true));


### PR DESCRIPTION
## Summary

- Fix `do_stop_gossiping()` to allow decommissioning nodes to announce their gossip shutdown, instead of only allowing nodes in `normal_nodes`
- Change the condition from `normal_nodes.contains()` to `!left_nodes.contains()`, matching the original intent of the pre-Raft-topology `is_silent_shutdown_state()` check
- Add a log line reporting the node's topology state at shutdown time (replacing the removed `"My status = {}"` line)

## Details

The `do_stop_gossiping()` condition previously checked `normal_nodes` to decide whether to announce gossip shutdown. Decommissioning nodes are in `transition_nodes`, not `normal_nodes`, so they were silently skipping the announcement. This forced other nodes to wait for the failure detector timeout to detect the departure.

The fix checks `!left_nodes` instead — only nodes that have already left the cluster should skip the announcement. This restores the pre-Raft-topology behavior.

**Note:** A companion dtest fix is needed (separate repo/PR) to update `test_no_garbage_left_after_abort_decommission_by_kill_decommissioned_node` in `update_cluster_layout_tests.py`, which watches for the removed log line `'gossip - My status = LEFT'`. It should be changed to watch for `'storage_service - DECOMMISSIONING: done'`.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1476