### PR TITLE
logstor: split log record to header and data

### DIFF
--- a/docs/dev/logstor.md
+++ b/docs/dev/logstor.md
@@ -188,20 +188,32 @@ A serialized form of `write_buffer::segment_header`.
 Each record within the buffer is structured as:
 
 ```
-record_header (4 bytes)
-record_data   (variable)
-zero_padding  -- to align to record_alignment (8 bytes)
+record_header        (8 bytes)
+log_record_header    (header_size bytes)
+canonical_mutation   (data_size bytes)
+zero_padding         -- to align to record_alignment (8 bytes)
 ```
 
-**Record Header:**
+**Record Header** (`write_buffer::record_header`):
 
-| Offset | Size | Field       | Description |
-|--------|------|-------------|-------------|
-| 0      | 4    | `data_size` | Size in bytes of the serialized `log_record` that follows. |
+| Offset | Size | Field         | Description |
+|--------|------|---------------|-------------|
+| 0      | 4    | `header_size` | Size in bytes of the serialized `log_record_header` that follows. |
+| 4      | 4    | `data_size`   | Size in bytes of the serialized `canonical_mutation` that follows `log_record_header`. |
 
-**Record Data:**
+**Log Record Header** (`log_record_header`):
 
-The record data is the serialized form of a `log_record`, which contains:
+The `header_size` bytes immediately following the record header are the IDL-serialized form of `log_record_header`, which contains:
 - `key`: the partition key (`primary_index_key`), including a `decorated_key` with a token and partition key bytes.
 - `generation`: a 16-bit write generation number, used during recovery to resolve conflicts when the same key appears in multiple segments.
-- `mut`: the full partition value as a `canonical_mutation`.
+- `table`: UUID of the table this record belongs to.
+
+**Mutation Data**:
+
+The `data_size` bytes immediately following the log record header are the IDL-serialized `canonical_mutation`, which holds the full partition value.
+
+**Record Location** (`log_location`):
+
+The `log_location` stored in the index for each record points to the start of the `record_header`:
+- `offset`: byte offset from the start of the segment to the `record_header`.
+- `size`: total size including `record_header` + `log_record_header` + `canonical_mutation`

--- a/idl/logstor.idl.hh
+++ b/idl/logstor.idl.hh
@@ -8,7 +8,6 @@
 
 #include "idl/frozen_schema.idl.hh"
 #include "idl/token.idl.hh"
-#include "mutation/canonical_mutation.hh"
 
 namespace replica {
 namespace logstor {
@@ -17,11 +16,10 @@ struct primary_index_key {
     dht::decorated_key dk;
 };
 
-class log_record {
+class log_record_header {
     replica::logstor::primary_index_key key;
     replica::logstor::record_generation generation;
     table_id table;
-    canonical_mutation mut;
 };
 
 }

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -80,9 +80,11 @@ future<> logstor::write(const mutation& m, compaction_group& cg, seastar::gate::
          }).value_or(record_generation(1));
 
     log_record record {
-        .key = key,
-        .generation = gen,
-        .table = table,
+        .header = {
+            .key = key,
+            .generation = gen,
+            .table = table,
+        },
         .mut = canonical_mutation(m)
     };
 

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -115,9 +115,20 @@ future<log_record> segment::read(log_location loc) {
                                              _id, loc.offset, loc.size, _max_size));
     }
 
-    // Read the serialized record
+    // Read the serialized record.
+    // the record starts with record_header that we use to find the split between log_record_header and canonical_mutation,
+    // then we read and deserialize the log_record_header and canonical_mutation that follow.
     return _file.dma_read_exactly<char>(absolute_offset(loc.offset), loc.size).then([] (seastar::temporary_buffer<char> buf) {
-        return ser::deserialize_from_buffer(buf, std::type_identity<log_record>{});
+        simple_memory_input_stream buf_stream(buf.begin(), buf.size());
+        auto rh_stream = buf_stream.read_substream(write_buffer::record_header_size);
+        auto rh = ser::deserialize(rh_stream, std::type_identity<write_buffer::record_header>{});
+        auto header_stream = buf_stream.read_substream(rh.header_size);
+        auto data_stream = buf_stream.read_substream(rh.data_size);
+
+        return log_record {
+            .header = ser::deserialize(header_stream, std::type_identity<log_record_header>{}),
+            .mut = ser::deserialize(data_stream, std::type_identity<canonical_mutation>{})
+        };
     });
 }
 
@@ -652,15 +663,23 @@ public:
 
     void free_record(log_location);
 
-    future<> for_each_record(log_segment_id,
-                            std::function<future<>(const segment_header&)>,
-                            std::function<future<>(log_location, log_record)>);
+    future<> for_each_record(log_segment_id segment_id,
+                            std::function<want_data(log_location, const log_record_header&)> on_header,
+                            std::function<future<>(log_location, log_record)> on_record)
+    {
+        return scan_segment(segment_id,
+            [] (const segment_header&) { return make_ready_future<>(); },
+            std::move(on_header), std::move(on_record));
+    }
 
-    future<> for_each_record(log_segment_id,
-                            std::function<future<>(log_location, log_record)>);
-
-    future<> for_each_record(const std::vector<log_segment_id>&,
-                            std::function<future<>(log_location, log_record)>);
+    future<> for_each_record(const std::vector<log_segment_id>& segments,
+                            std::function<want_data(log_location, const log_record_header&)> on_header,
+                            std::function<future<>(log_location, log_record)> on_record)
+    {
+        for (auto segment_id : segments) {
+            co_await for_each_record(segment_id, on_header, on_record);
+        }
+    }
 
     future<> load_segment(replica::database&, log_segment_id);
     future<> recover_segment(replica::database&, log_segment_id);
@@ -725,6 +744,19 @@ private:
 
     future<> write_to_separator(write_buffer&, segment_ref, size_t segment_seq_num);
     void write_to_separator(table&, log_location prev_loc, log_record, segment_ref);
+
+    // Sequentially scans one segment and invokes callbacks for the decoded
+    // contents.
+    //
+    // `segment_id` selects the on-disk segment to read.
+    // `header_callback` is invoked once per buffer with the decoded segment header.
+    // `on_header` is called for each record header and returns whether the record
+    // payload should be read and passed to `on_record`, or skipped.
+    // `on_record` is invoked only for records whose payload was requested.
+    future<> scan_segment(log_segment_id segment_id,
+                          std::function<future<>(const segment_header&)> header_callback,
+                          std::function<want_data(log_location, const log_record_header&)> on_header,
+                          std::function<future<>(log_location, log_record)> on_record);
 
     segment_ref make_segment_ref(log_segment_id seg_id) {
         auto& desc = get_segment_descriptor(seg_id);
@@ -1208,9 +1240,10 @@ future<> segment_manager_impl::discard_segments(segment_set& ss) {
     });
 }
 
-future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
+future<> segment_manager_impl::scan_segment(log_segment_id segment_id,
                                 std::function<future<>(const segment_header&)> header_callback,
-                                std::function<future<>(log_location, log_record)> callback) {
+                                std::function<want_data(log_location, const log_record_header&)> on_header,
+                                std::function<future<>(log_location, log_record)> on_record) {
     auto holder = _async_gate.hold();
 
     auto [file_id, file_offset] = segment_id_to_file_location(segment_id);
@@ -1274,36 +1307,48 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
         const auto buffer_data_end_position = current_position + bh.data_size;
         while (current_position < buffer_data_end_position) {
             // Read record header
+            const auto record_offset = current_position;
             auto size_buf = co_await fin.read_exactly(write_buffer::record_header_size);
             current_position += write_buffer::record_header_size;
             if (size_buf.size() < write_buffer::record_header_size) {
                 break;
             }
             auto rh = ser::deserialize_from_buffer(size_buf, std::type_identity<write_buffer::record_header>{});
-            if (rh.data_size == 0 || rh.data_size > _cfg.segment_size) {
+            if (rh.header_size == 0 || rh.header_size + rh.data_size > buffer_data_end_position - current_position) {
                 // invalid record size
                 break;
             }
 
             logstor_logger.trace("Found record of size {} bytes in segment {}",
-                                rh.data_size, segment_id);
+                                rh.header_size + rh.data_size, segment_id);
 
-            auto record_offset = current_position;
-            auto record_buf = co_await fin.read_exactly(rh.data_size);
-            current_position += rh.data_size;
-            if (record_buf.size() < rh.data_size) {
+            // Read the log_record_header bytes
+            auto header_buf = co_await fin.read_exactly(rh.header_size);
+            current_position += rh.header_size;
+            if (header_buf.size() < rh.header_size) {
                 break;
             }
-
-            auto record = ser::deserialize_from_buffer(record_buf, std::type_identity<log_record>{});
+            auto record_header = ser::deserialize_from_buffer(header_buf, std::type_identity<log_record_header>{});
 
             log_location loc {
                 .segment = segment_id,
-                .offset = record_offset,
-                .size = rh.data_size
+                .offset = static_cast<uint32_t>(record_offset),
+                .size = static_cast<uint32_t>(write_buffer::record_header_size + rh.header_size + rh.data_size)
             };
 
-            co_await callback(loc, std::move(record));
+            if (on_header(loc, record_header) == want_data::yes) {
+                auto mut_buf = co_await fin.read_exactly(rh.data_size);
+                current_position += rh.data_size;
+                if (mut_buf.size() < rh.data_size) {
+                    break;
+                }
+                auto mut = ser::deserialize_from_buffer(mut_buf, std::type_identity<canonical_mutation>{});
+                co_await on_record(loc, log_record{std::move(record_header), std::move(mut)});
+            } else {
+                // Skip the canonical_mutation bytes without reading them
+                co_await fin.skip(rh.data_size);
+                current_position += rh.data_size;
+            }
 
             // align up to next record
             auto padding = align_up(current_position, write_buffer::record_alignment) - current_position;
@@ -1327,20 +1372,6 @@ future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
     }
 
     co_await fin.close();
-}
-
-future<> segment_manager_impl::for_each_record(log_segment_id segment_id,
-                                std::function<future<>(log_location, log_record)> callback) {
-    return for_each_record(segment_id,
-        [] (const segment_header&) { return make_ready_future<>(); },
-        std::move(callback));
-}
-
-future<> segment_manager_impl::for_each_record(const std::vector<log_segment_id>& segments,
-                                        std::function<future<>(log_location, log_record)> callback) {
-    for (auto segment_id : segments) {
-        co_await for_each_record(segment_id, callback);
-    }
 }
 
 void compaction_manager_impl::submit(compaction_group& cg) {
@@ -1529,12 +1560,7 @@ struct compaction_buffer {
     // to ensure all pending updates complete.
     future<> rewrite_record(primary_index& index, log_location read_location, log_record record,
                              size_t& records_rewritten, size_t& records_skipped) {
-        if (!index.is_record_alive(record.key, read_location)) {
-            records_skipped++;
-            co_return;
-        }
-
-        auto key = record.key;
+        auto key = record.header.key;
         log_record_writer writer(std::move(record));
 
         if (!buf->can_fit(writer)) {
@@ -1570,9 +1596,17 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
     auto& index = cg.get_logstor_index();
 
     co_await _sm.for_each_record(segments,
-            [&index, &records_rewritten, &records_skipped, &cb] (log_location read_location, log_record record) -> future<> {
-        co_await cb.rewrite_record(index, read_location, std::move(record), records_rewritten, records_skipped);
-    });
+        [&index, &records_skipped] (log_location read_location, const log_record_header& record_header) -> want_data {
+            if (!index.is_record_alive(record_header.key, read_location)) {
+                records_skipped++;
+                return want_data::no;
+            }
+            return want_data::yes;
+        },
+        [&index, &records_rewritten, &records_skipped, &cb] (log_location read_location, log_record record) -> future<> {
+            co_await cb.rewrite_record(index, read_location, std::move(record), records_rewritten, records_skipped);
+        }
+    );
 
     co_await cb.close();
 
@@ -1671,10 +1705,18 @@ future<> compaction_manager_impl::split_compaction(replica::table& t, compaction
         size_t records_skipped = 0;
 
         co_await _sm.for_each_record(batch,
-                [&index, &classifier, &bufs, &records_rewritten, &records_skipped] (log_location read_location, log_record record) -> future<> {
-            auto& cb = bufs[classifier(record.key.dk.token())];
-            co_await cb.rewrite_record(index, read_location, std::move(record), records_rewritten, records_skipped);
-        });
+            [&index, &records_skipped] (log_location read_location, const log_record_header& record_header) -> want_data {
+                if (!index.is_record_alive(record_header.key, read_location)) {
+                    records_skipped++;
+                    return want_data::no;
+                }
+                return want_data::yes;
+            },
+            [&index, &records_rewritten, &records_skipped, &bufs, &classifier] (log_location read_location, log_record record) -> future<> {
+                auto& cb = bufs[classifier(record.header.key.dk.token())];
+                co_await cb.rewrite_record(index, read_location, std::move(record), records_rewritten, records_skipped);
+            }
+        );
 
         for (auto& cb : bufs) {
             co_await cb.close();
@@ -1713,7 +1755,7 @@ future<> segment_manager_impl::write_to_separator(write_buffer& wb, segment_ref 
     for (auto&& w : wb.records()) {
         co_await coroutine::maybe_yield();
 
-        auto key = w.writer.record().key;
+        auto key = w.writer.record().header.key;
         log_location prev_loc = co_await std::move(w.loc);
 
         auto* index_ptr = &w.cg->get_logstor_index();
@@ -1742,7 +1784,7 @@ future<> segment_manager_impl::write_to_separator(write_buffer& wb, segment_ref 
 }
 
 void segment_manager_impl::write_to_separator(table& t, log_location prev_loc, log_record record, segment_ref seg_ref) {
-    auto key = record.key;
+    auto key = record.header.key;
     auto* index_ptr = &t.logstor_index();
     log_record_writer writer(std::move(record));
 
@@ -1923,32 +1965,37 @@ future<> segment_manager_impl::recover_segment(replica::database& db, log_segmen
     bool is_full_segment = seg_hdr->kind == segment_kind::full;
     logstor_logger.trace("Recovering segment {} with generation {}", segment_id, desc.seg_gen);
 
-    co_await for_each_record(segment_id, [this, &desc, &db, is_full_segment] (log_location loc, log_record record) -> future<> {
-        logstor_logger.trace("Recovery: read record at {} gen {}", loc, record.generation);
+    co_await for_each_record(segment_id,
+        [this, &desc, &db, is_full_segment] (log_location loc, const log_record_header& header) -> want_data {
+            logstor_logger.trace("Recovery: read record at {} gen {}", loc, header.generation);
 
-        index_entry new_entry {
-            .location = loc,
-            .generation = record.generation
-        };
+            index_entry new_entry {
+                .location = loc,
+                .generation = header.generation
+            };
 
-        try {
-            auto& t = db.find_column_family(record.table);
-            if (!t.uses_logstor()) {
-                co_return;
-            }
-            auto [inserted, prev_entry] = t.logstor_index().insert_if_newer(record.key, new_entry, is_full_segment);
-            if (inserted) {
-                desc.on_write(loc);
-                if (prev_entry) {
-                    get_segment_descriptor(prev_entry->location).on_free(prev_entry->location);
+            try {
+                auto& t = db.find_column_family(header.table);
+                if (!t.uses_logstor()) {
+                    return want_data::no;
                 }
+                auto [inserted, prev_entry] = t.logstor_index().insert_if_newer(header.key, new_entry, is_full_segment);
+                if (inserted) {
+                    desc.on_write(loc);
+                    if (prev_entry) {
+                        get_segment_descriptor(prev_entry->location).on_free(prev_entry->location);
+                    }
+                }
+            } catch (const replica::no_such_column_family&) {
+                // ignore record
             }
-        } catch (const replica::no_such_column_family&) {
-            // ignore record
-        }
 
-        co_return;
-    });
+            return want_data::no;
+        },
+        [] (log_location, log_record) {
+            // we don't read record data, only headers.
+            return make_ready_future<>();
+        });
 }
 
 future<std::optional<segment_header>> segment_manager_impl::read_segment_header(log_segment_id segment_id) {
@@ -2013,17 +2060,25 @@ future<> segment_manager_impl::add_segment_to_compaction_group(replica::database
         auto write_to_separator_failed = defer([seg_ref] mutable {
             seg_ref.set_flush_failure();
         });
-        co_await for_each_record(seg_id, [this, seg_ref, &db] (log_location prev_loc, log_record record) -> future<> {
-            try {
-                auto& t = db.find_column_family(record.table);
-                if (t.uses_logstor() && t.logstor_index().is_record_alive(record.key, prev_loc)) {
-                    write_to_separator(t, prev_loc, std::move(record), seg_ref);
+        co_await for_each_record(seg_id,
+            [&db] (log_location prev_loc, const log_record_header& record_header) -> want_data {
+                try {
+                    auto& t = db.find_column_family(record_header.table);
+                    return t.uses_logstor() && t.logstor_index().is_record_alive(record_header.key, prev_loc)
+                            ? want_data::yes : want_data::no;
+                } catch (const replica::no_such_column_family&) {
+                    return want_data::no;
                 }
-            } catch(const replica::no_such_column_family&) {
-                // ignore record
-            }
-            return make_ready_future<>();
-        });
+            },
+            [this, seg_ref, &db] (log_location prev_loc, log_record record) -> future<> {
+                try {
+                    auto& t = db.find_column_family(record.header.table);
+                    write_to_separator(t, prev_loc, std::move(record), seg_ref);
+                } catch (const replica::no_such_column_family&) {
+                    // ignore
+                }
+                return make_ready_future<>();
+            });
         write_to_separator_failed.cancel();
     }
 }

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -16,6 +16,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/util/bool_class.hh>
 #include "bytes_fwd.hh"
 #include "mutation_writer/token_group_based_splitting_writer.hh"
 #include "replica/logstor/write_buffer.hh"
@@ -29,6 +30,8 @@ class database;
 class table;
 
 namespace logstor {
+
+using want_data = seastar::bool_class<class want_data_tag>;
 
 class compaction_manager;
 class segment_set;

--- a/replica/logstor/types.hh
+++ b/replica/logstor/types.hh
@@ -44,10 +44,14 @@ struct index_entry {
     bool operator==(const index_entry& other) const noexcept = default;
 };
 
-struct log_record {
+struct log_record_header {
     primary_index_key key;
     record_generation generation;
     table_id table;
+};
+
+struct log_record {
+    log_record_header header;
     canonical_mutation mut;
 };
 

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -23,14 +23,19 @@
 
 namespace replica::logstor {
 
-void log_record_writer::compute_size() const {
-    seastar::measuring_output_stream ms;
-    ser::serialize(ms, _record);
-    _size = ms.size();
+void log_record_writer::compute_sizes() const {
+    seastar::measuring_output_stream ms_header;
+    ser::serialize(ms_header, _record.header);
+    _header_size = ms_header.size();
+
+    seastar::measuring_output_stream ms_data;
+    ser::serialize(ms_data, _record.mut);
+    _data_size = ms_data.size();
 }
 
 void log_record_writer::write(ostream& out) const {
-    ser::serialize(out, _record);
+    ser::serialize(out, _record.header);
+    ser::serialize(out, _record.mut);
 }
 
 // write_buffer
@@ -84,50 +89,51 @@ bool write_buffer::has_data() const noexcept {
 }
 
 future<log_location_with_holder> write_buffer::write(log_record_writer writer, compaction_group* cg, seastar::gate::holder cg_holder) {
-    const auto data_size = writer.size();
+    const auto content_size = writer.size();
 
-    if (!can_fit(data_size)) {
-        throw std::runtime_error(fmt::format("Write size {} exceeds buffer size {}", data_size, _stream.size()));
+    if (!can_fit(content_size)) {
+        throw std::runtime_error(fmt::format("Write size {} exceeds buffer size {}", content_size, _stream.size()));
     }
-    if (data_size == 0) {
+    if (content_size == 0) {
         throw std::runtime_error("Cannot write empty record");
     }
 
+    size_t record_header_offset = offset_in_buffer();
     auto rh = record_header {
-        .data_size = data_size
+        .header_size = static_cast<uint32_t>(writer.header_size()),
+        .data_size = static_cast<uint32_t>(writer.data_size())
     };
     ser::serialize(_stream, rh);
 
     // Write actual data
-    size_t data_offset_in_buffer = offset_in_buffer();
-    auto data_out = _stream.write_substream(data_size);
+    auto data_out = _stream.write_substream(content_size);
     writer.write(data_out);
 
-    _net_data_size += data_size;
+    const size_t total_size = record_header_size + content_size;
+
+    _net_data_size += total_size;
     _record_count++;
-    if (!_min_token || writer.record().key.dk.token() < *_min_token) {
-        _min_token = writer.record().key.dk.token();
+    if (!_min_token || writer.record().header.key.dk.token() < *_min_token) {
+        _min_token = writer.record().header.key.dk.token();
     }
-    if (!_max_token || writer.record().key.dk.token() > *_max_token) {
-        _max_token = writer.record().key.dk.token();
+    if (!_max_token || writer.record().header.key.dk.token() > *_max_token) {
+        _max_token = writer.record().header.key.dk.token();
     }
 
     // Add padding to align record
     pad_to_alignment(record_alignment);
 
-    auto record_location = [data_offset_in_buffer, data_size] (log_location base_location) {
+    auto record_location = [record_header_offset, total_size] (log_location base_location) {
         return log_location {
             .segment = base_location.segment,
-            .offset = base_location.offset + data_offset_in_buffer,
-            .size = data_size
+            .offset = static_cast<uint32_t>(base_location.offset + record_header_offset),
+            .size = static_cast<uint32_t>(total_size)
         };
     };
 
     if (with_record_copy()) {
         _records_copy.push_back(record_in_buffer {
             .writer = std::move(writer),
-            .offset_in_buffer = data_offset_in_buffer,
-            .data_size = data_size,
             .loc = _written.get_shared_future().then(record_location),
             .cg = cg,
             .cg_holder = std::move(cg_holder)
@@ -228,8 +234,9 @@ std::vector<write_buffer::record_in_buffer>& write_buffer::records() {
 }
 
 size_t write_buffer::estimate_required_segments(size_t net_data_size, size_t record_count, size_t segment_size) {
-    // Calculate total size needed including headers and alignment padding
-    size_t total_size = record_header_size * record_count + net_data_size;
+    // Calculate total size needed including headers and alignment padding.
+    // net_data_size includes record headers.
+    size_t total_size = net_data_size;
 
     // not perfect so let's multiply by some overhead constant
     total_size = static_cast<size_t>(total_size * 1.1);

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -37,21 +37,34 @@ class log_record_writer {
     using ostream = seastar::simple_memory_output_stream;
 
     log_record _record;
-    mutable std::optional<size_t> _size;
+    mutable std::optional<size_t> _header_size;
+    mutable std::optional<size_t> _data_size;
 
-    void compute_size() const;
+    void compute_sizes() const;
 
 public:
     explicit log_record_writer(log_record record)
         : _record(std::move(record))
     {}
 
-    // Get serialized size (computed lazily)
-    size_t size() const {
-        if (!_size) {
-            compute_size();
+    // Get serialized sizes (computed lazily)
+    size_t header_size() const {
+        if (!_header_size) {
+            compute_sizes();
         }
-        return *_size;
+        return *_header_size;
+    }
+
+    size_t data_size() const {
+        if (!_data_size) {
+            compute_sizes();
+        }
+        return *_data_size;
+    }
+
+    // Total serialized content size (header + data)
+    size_t size() const {
+        return header_size() + data_size();
     }
 
     // Write the record to an output stream
@@ -128,9 +141,10 @@ public:
     static_assert(segment_header_size % record_alignment == 0, "Segment header size must be aligned by record_alignment");
 
     struct record_header {
-        uint32_t data_size; // size of the record data following the record_header
+        uint32_t header_size; // size of the serialized log_record_header
+        uint32_t data_size;   // size of the serialized canonical_mutation
     };
-    static constexpr size_t record_header_size = sizeof(uint32_t);
+    static constexpr size_t record_header_size = 2 * sizeof(uint32_t);
 
 private:
 
@@ -155,8 +169,6 @@ private:
 
     struct record_in_buffer {
         log_record_writer writer;
-        size_t offset_in_buffer;
-        size_t data_size;
         future<log_location> loc;
         compaction_group* cg;
         seastar::gate::holder cg_holder;
@@ -373,16 +385,19 @@ template <>
 struct serializer<replica::logstor::write_buffer::record_header> {
     template <typename Output>
     static void write(Output& out, const replica::logstor::write_buffer::record_header& h) {
+        serializer<uint32_t>::write(out, h.header_size);
         serializer<uint32_t>::write(out, h.data_size);
     }
     template <typename Input>
     static replica::logstor::write_buffer::record_header read(Input& in) {
         replica::logstor::write_buffer::record_header h;
+        h.header_size = serializer<uint32_t>::read(in);
         h.data_size = serializer<uint32_t>::read(in);
         return h;
     }
     template <typename Input>
     static void skip(Input& in) {
+        serializer<uint32_t>::skip(in);
         serializer<uint32_t>::skip(in);
     }
 };


### PR DESCRIPTION
Split the `log_record` to `log_record_header` type that has the record metadata fields and the mutation as a separate field which is the actual record data:

```cpp
struct log_record {
    log_record_header header;
    canonical_mutation mut;
};
```

Both the header and mutation have variable serialized size. When a record is serialized in a write_buffer, we first put a small `record_header` that has the header size and data size, then the serialized header and data follow. The `log_location` of a record points to the beginning of the `record_header`, and the size includes the `record_header`.

This allows us to read a record header without reading the data when it's not needed and avoid deserializing it:
* on recovery, when scanning all segments, we read only the record headers.
* on compaction, we read the record header first to determine if the record is alive, if yes then we read the data.

Refs https://scylladb.atlassian.net/browse/SCYLLADB-770

no backport - an enhancement