### PR TITLE
locator, replica, schema, service: replace hot-path std::unordered_map with boost::unordered_flat_map

### DIFF
--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -11,6 +11,7 @@
 #include <memory>
 #include <functional>
 #include <unordered_map>
+#include <boost/unordered/unordered_flat_map.hpp>
 #include "gms/inet_address.hh"
 #include "locator/token_range_splitter.hh"
 #include "dht/token-sharding.hh"
@@ -62,7 +63,7 @@ struct replication_strategy_params {
         std::optional<data_dictionary::consistency_config_option> c) noexcept : options(o), initial_tablets(it), consistency(c) {}
 };
 
-using replication_map = std::unordered_map<token, host_id_vector_replica_set>;
+using replication_map = boost::unordered_flat_map<token, host_id_vector_replica_set, std::hash<token>>;
 
 using host_id_set = utils::basic_sequenced_set<locator::host_id, host_id_vector_replica_set>;
 

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -15,6 +15,7 @@
 #include <functional>
 #include <unordered_set>
 #include <unordered_map>
+#include <boost/unordered/unordered_flat_map.hpp>
 #include <iostream>
 #include <random>
 
@@ -432,7 +433,7 @@ private:
     config _cfg;
     const node* _this_node = nullptr;
     std::vector<node_holder> _nodes;
-    std::unordered_map<host_id, std::reference_wrapper<const node>> _nodes_by_host_id;
+    boost::unordered_flat_map<host_id, std::reference_wrapper<const node>, std::hash<host_id>> _nodes_by_host_id;
 
     std::unordered_map<sstring, std::unordered_set<std::reference_wrapper<const node>>> _dc_nodes;
     std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<std::reference_wrapper<const node>>>> _dc_rack_nodes;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1688,7 +1688,7 @@ future<database::created_keyspace_per_shard> database::prepare_create_keyspace_o
 
 future<>
 database::drop_caches() const {
-    std::unordered_map<table_id, lw_shared_ptr<column_family>> tables = get_tables_metadata().get_column_families_copy();
+    auto tables = get_tables_metadata().get_column_families_copy();
     for (auto&& e : tables) {
         table& t = *e.second;
         co_await t.get_row_cache().invalidate(row_cache::external_updater([] {}));
@@ -3511,7 +3511,7 @@ future<> database::tables_metadata::parallel_for_each_table(std::function<future
     });
 }
 
-const std::unordered_map<table_id, lw_shared_ptr<table>> database::tables_metadata::get_column_families_copy() const {
+const boost::unordered_flat_map<table_id, lw_shared_ptr<table>, std::hash<table_id>> database::tables_metadata::get_column_families_copy() const {
     return _column_families;
 }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -28,6 +28,7 @@
 #include <seastar/core/sharded.hh>
 #include <functional>
 #include <unordered_map>
+#include <boost/unordered/unordered_flat_map.hpp>
 #include <set>
 #include <boost/functional/hash.hpp>
 #include <optional>
@@ -1593,7 +1594,7 @@ public:
         std::unordered_map<ks_cf_t, table_id, utils::tuple_hash, string_pair_eq>;
     class tables_metadata {
         rwlock _cf_lock;
-        std::unordered_map<table_id, lw_shared_ptr<column_family>> _column_families;
+        boost::unordered_flat_map<table_id, lw_shared_ptr<column_family>, std::hash<table_id>> _column_families;
         ks_cf_to_uuid_t _ks_cf_to_uuid;
     private:
         void add_table_helper(database& db, keyspace& ks, table& cf, schema_ptr s);
@@ -1616,7 +1617,7 @@ public:
         void for_each_table_id(std::function<void(const ks_cf_t&, table_id)> f) const;
         future<> for_each_table_gently(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
         future<> parallel_for_each_table(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
-        const std::unordered_map<table_id, lw_shared_ptr<table>> get_column_families_copy() const;
+        const boost::unordered_flat_map<table_id, lw_shared_ptr<table>, std::hash<table_id>> get_column_families_copy() const;
 
         auto filter(std::function<bool(std::pair<table_id, lw_shared_ptr<table>>)> f) const {
             return _column_families | std::views::filter(std::move(f));

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <unordered_map>
+#include <boost/unordered/unordered_flat_map.hpp>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/shared_future.hh>
@@ -110,7 +110,7 @@ public:
 //
 // Schemas of views returned by this registry always have base_info set.
 class schema_registry {
-    std::unordered_map<table_schema_version, lw_shared_ptr<schema_registry_entry>> _entries;
+    boost::unordered_flat_map<table_schema_version, lw_shared_ptr<schema_registry_entry>, std::hash<table_schema_version>> _entries;
     std::unique_ptr<db::schema_ctxt> _ctxt;
 
     friend class schema_registry_entry;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3358,10 +3358,10 @@ storage_proxy::storage_proxy(sharded<replica::database>& db, storage_proxy::conf
     _hints_manager.register_metrics("hints_manager");
     _hints_for_views_manager.register_metrics("hints_for_views_manager");
     if (!_db.local().get_config().developer_mode()) {
-        // preallocate 128K pointers and set max_load_factor to 8 to support around 1M outstanding requests
-        // without re-allocations
-        _response_handlers.reserve(128*1024);
-        _response_handlers.max_load_factor(8);
+        // preallocate enough capacity to support around 1M outstanding requests
+        // without re-allocations. boost::unordered_flat_map has a fixed load
+        // factor of ~0.875, so we reserve the full target capacity directly.
+        _response_handlers.reserve(1024*1024);
     }
 }
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <variant>
+#include <boost/unordered/unordered_flat_map.hpp>
 #include "cdc/log.hh"
 #include "inet_address_vectors.hh"
 #include "replica/database_fwd.hh"
@@ -213,7 +214,7 @@ private:
         response_id_type release();
     };
     using unique_response_handler_vector = utils::small_vector<unique_response_handler, 1>;
-    using response_handlers_map = std::unordered_map<response_id_type, ::shared_ptr<abstract_write_response_handler>>;
+    using response_handlers_map = boost::unordered_flat_map<response_id_type, ::shared_ptr<abstract_write_response_handler>>;
 
 public:
     static const sstring COORDINATOR_STATS_CATEGORY;


### PR DESCRIPTION
## Motivation

Several hot-path `std::unordered_map` instances in ScyllaDB use node-based (linked-list bucket) storage, which incurs per-entry heap allocations and poor cache locality due to pointer chasing. `boost::unordered_flat_map` (available since Boost 1.81, we ship 1.83) stores entries inline in a flat open-addressing array with SIMD-accelerated probing, eliminating these overheads.

This addresses https://github.com/scylladb/scylladb/issues/29449.

## Changes

Five `std::unordered_map` instances are replaced with `boost::unordered_flat_map`:

1. **`replication_map`** (`locator/abstract_replication_strategy.hh`) — looked up once per CQL operation on vnode keyspaces via `do_get_replicas()`. Large (256 × N_nodes entries), immutable after construction.

2. **`_column_families`** (`replica/database.hh`) — looked up on every CQL operation to resolve `table_id` → `column_family`. Also updates `get_column_families_copy()` return type and its caller.

3. **`schema_registry::_entries`** (`schema/schema_registry.hh`) — consulted on schema lookups via `get_or_load()` and `get()`. Removed unused `#include <unordered_map>`.

4. **`_nodes_by_host_id`** (`locator/topology.hh`) — consulted on every topology lookup by `host_id`.

5. **`_response_handlers`** (`service/storage_proxy.hh`) — tracks in-flight write response handlers, accessed on every write. Replaced `reserve(128K) + max_load_factor(8)` with `reserve(1M)` since `boost::unordered_flat_map` has a fixed load factor of ~0.875.

### Key safety properties verified

- **No iterator/reference invalidation bugs**: All access patterns use find-then-immediate-access or find-then-erase with no intervening mutations. `boost::unordered_flat_map` invalidates all iterators on mutation, but no code holds iterators across mutations.
- **No `extract()` usage**: None of the 5 maps use `extract()` (unsupported by flat_map).
- **`clear_gently()` compatibility**: The `MapLike` overload obtains a fresh `begin()` each iteration, compatible with flat_map semantics.
- **Hash functions**: `std::hash<T>` explicitly specified for custom key types (`dht::token`, `table_id`, `table_schema_version`, `host_id`). Built-in `uint64_t` key uses default `boost::hash`.

## Testing

Build: incremental `dev` mode build via `dbuild`, verified clean compilation with no warnings after each commit.

## Performance Benchmarks

All runs: `taskset -c 0,1 build/dev/scylla perf-simple-query --smp 2 --duration 30`

| Stage | throughput median (tps) | insns/op median | cycles/op median | throughput MAD |
|-------|------------------------|-----------------|------------------|----------------|
| Baseline (origin/master) | 180,437 | 55,124 | 44,772 | 2,177 |
| +Change 1 (replication_map) | 175,713 / 169,350 | 55,108 / 55,118 | 44,799 / 45,152 | 7,499 / 9,816 |
| +Change 2 (_column_families) | 181,166 | 55,236 | 43,579 | 1,020 |
| +Change 3 (schema_registry) | 178,932 | 55,270 | 43,726 | 3,558 |
| +Change 4 (_nodes_by_host_id) | 182,454 | 55,269 | 44,499 | 2,358 |
| +All 5 changes | 180,356 | 55,311 | 44,707 | 2,347 |

### Conclusions

1. **No regression.** Final throughput (180,356 tps) is essentially identical to baseline (180,437 tps).
2. **instructions/op increased slightly** (+187, +0.34%) — expected from flat_map's different SIMD probing code path.
3. **cycles/op improved** (-65, -0.15% final; up to -2.7% after change 2) — reflects better cache locality.
4. **Change 1 runs were noisy** (machine background activity); insns/op (deterministic metric) was consistent.
5. **The dominant benefit is architectural**: this single-node perf test exercises small maps (~60 system tables). Real gains show at scale with large maps (production `replication_map`: 256×N_nodes entries; `_response_handlers`: up to 1M entries under write pressure).
6. **Memory efficiency improved**: eliminates one heap allocation per entry, reducing allocator pressure and fragmentation.