### PR TITLE
test/random_failures: fix gossip shadow round injection

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1964,8 +1964,6 @@ future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes, 
                 logger.debug("Got get_endpoint_states response from {}, response={}", node, response.endpoint_state_map);
                 responses.push_back(std::move(response));
                 nodes_talked.insert(node);
-
-                utils::get_local_injector().inject("stop_during_gossip_shadow_round", [] { std::raise(SIGSTOP); });
             } catch (seastar::rpc::unknown_verb_error&) {
                 auto err = format("Node {} does not support get_endpoint_states verb", node);
                 logger.error("{}", err);

--- a/test/cluster/random_failures/error_injections.py
+++ b/test/cluster/random_failures/error_injections.py
@@ -17,7 +17,8 @@ ERROR_INJECTIONS = (
     "stop_after_starting_cdc_generation_service",
     "stop_after_starting_group0_service",
     "stop_after_starting_auth_service",
-    "stop_during_gossip_shadow_round",
+    # do_shadow_round() is no longer called during fresh bootstrap since c17c4806a1
+    "REMOVED_stop_during_gossip_shadow_round",
     "stop_after_saving_tokens",
     "stop_after_starting_gossiping",
     "stop_after_sending_join_node_request",


### PR DESCRIPTION
Commit c17c4806a1f0c423dfc276b4419eec2775e570b1 removed check_for_endpoint_collision() from
the fresh bootstrap path, which was the only code path that
called do_shadow_round() for new nodes. Since the gossip shadow
round is no longer executed during bootstrap, remove the
stop_during_gossip_shadow_round error injection from the test.

The entry is marked as REMOVED_ rather than deleted to preserve
the shuffle order for seed-based test reproducibility.

The injection point in gms/gossiper.cc is also removed since it
is no longer used by any test.

Fixes: SCYLLADB-1466

No backport, as the fix is needed only on master