### PR TITLE
test: filter benign shutdown errors in tests that grep logs directly

### DIFF
--- a/test/cluster/test_cdc_generation_data.py
+++ b/test/cluster/test_cdc_generation_data.py
@@ -71,4 +71,5 @@ async def test_group0_apply_while_node_is_being_shutdown(manager: ManagerClient)
         pass  # ingore errors, since we don't care
 
     errors = await log.grep_for_errors()
+    errors = await manager.filter_errors(errors)
     assert errors == []

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -2290,6 +2290,7 @@ async def test_split_stopped_on_shutdown(manager: ManagerClient):
         await shutdown_task
 
         errors = await log.grep_for_errors(from_mark=log_mark)
+        errors = await manager.filter_errors(errors)
         assert errors == []
 
         await manager.server_start(server.server_id)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -227,7 +227,7 @@ class ManagerClient:
 
         return errors
     
-    async def filter_errors(self, errors: list[str]):
+    async def filter_errors(self, errors: list[str] | list[list[str]]):
         exclude_errors_pattern = re.compile("|".join(f"{p}" for p in {
             *self.ignore_log_patterns,
             *self.ignore_cores_log_patterns,
@@ -255,7 +255,13 @@ class ManagerClient:
             # Expected Raft errors on decommission-abort or node restart with MV.
             r"raft_topology - raft_topology_cmd.*failed with: raft::request_aborted",
         }))
-        return [e for e in errors if not exclude_errors_pattern.search(e)]
+        # Support both list[str] (from distinct_errors=True) and
+        # list[list[str]] (from distinct_errors=False), matching against
+        # the first line of each error group.
+        def match_line(e):
+            line = e[0] if isinstance(e, list) else e
+            return not exclude_errors_pattern.search(line)
+        return [e for e in errors if match_line(e)]
 
     async def find_cores(self) -> dict[ServerInfo, list[str]]:
         """Find core files on all servers"""


### PR DESCRIPTION
Tests that call grep_for_errors() directly and assert no errors
can fail spuriously due to benign RPC errors during graceful
shutdown (e.g. "connection dropped: Semaphore broken"), which
are already filtered by the after_test hook via filter_errors().

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1464
Backport: no, tests fix (we may decide to backport later if it occurs on release branches)