### PR TITLE
topology coordinator: log request cancellation only when request are …

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -325,7 +325,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             }
             // We did not find a request that has enough live node to proceed
             // Cancel all requests to let admin know that no operation can succeed
-            rtlogger.warn("topology coordinator: cancel request queue because no request can proceed. Dead nodes: {}", dead_nodes);
+            rtlogger.info("topology coordinator: no request can proceed. Dead nodes: {}", dead_nodes);
             return cancel_requests{std::move(guard), std::move(dead_nodes)};
         }
 
@@ -2655,6 +2655,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         if (_topo_sm._topology.requests.empty()) {
             co_return;
         }
+        rtlogger.warn("topology coordintator: cancel all requests because non can proceed");
         for (auto& [id, req] : _topo_sm._topology.requests) {
             auto done_msg = fmt::format("Canceled. Dead nodes: {}", dead_nodes);
             _topo_sm.generate_cancel_request_update(muts, _feature_service, guard, id, done_msg);


### PR DESCRIPTION
…really canceled

Currently cancellation is logged in get_next_task, but the function is called by tablets code as well where we do not act upon its result, only yield to the topology coordinator. But the topology coordinator will not necessary do the cancellation as well since it can be busy with tablets migration. As a result cancellation is logged, but not done which is confusing. Fix it by logging cancellation when it is actually happens.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1409

No need to backport, minor improvement.