### PR TITLE
S3 test storage reduction

### DIFF
--- a/test/boost/object_storage_upload_test.cc
+++ b/test/boost/object_storage_upload_test.cc
@@ -94,7 +94,9 @@ future<> test_file_upload(test_env_config cfg, size_t size) {
     }, std::move(cfg));
 }
 
-constexpr auto large_size = 256 * 1024 * 1024 + 351;
+// ~11 MiB -- enough to exercise multipart upload (>2 parts at 5 MiB minimum)
+// without writing 256 MiB to the S3 backend on every run.
+constexpr auto large_size = 11 * 1024 * 1024 + 351;
 
 SEASTAR_TEST_CASE(test_large_file_upload_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
     return test_file_upload(test_env_config{ .storage = make_test_object_storage_options("S3") }, large_size);

--- a/test/boost/object_storage_upload_test.cc
+++ b/test/boost/object_storage_upload_test.cc
@@ -91,6 +91,8 @@ future<> test_file_upload(test_env_config cfg, size_t size) {
         is1.close().get();
         is2.close().get();
 
+        client->delete_object(name).get();
+
     }, std::move(cfg));
 }
 

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -166,9 +166,12 @@ void do_test_client_multipart_upload(const client_maker_function& client_maker, 
     auto close = seastar::deferred_close(out);
 
     static constexpr unsigned chunk_size = 1000;
+    // ~11 MiB -- just above two 5 MiB minimum parts, enough to exercise
+    // multipart upload without writing 128 MiB to disk on every run.
+    static constexpr unsigned nr_chunks = 11 * 1024;
     auto rnd = tests::random::get_bytes(chunk_size);
     uint64_t object_size = 0;
-    for (unsigned ch = 0; ch < 128 * 1024; ch++) {
+    for (unsigned ch = 0; ch < nr_chunks; ch++) {
         out.write(reinterpret_cast<char*>(rnd.begin()), rnd.size()).get();
         object_size += rnd.size();
     }
@@ -634,7 +637,7 @@ SEASTAR_THREAD_TEST_CASE(test_object_reupload) {
                 jumbo ? cln->make_upload_jumbo_sink(name, 3) : cln->make_upload_sink(name));
 
             constexpr unsigned chunk_size = 1000;
-            constexpr unsigned writes = 128 * 1024;
+            constexpr unsigned writes = 11 * 1024;
             auto rnd = tests::random::get_bytes(chunk_size);
             uint64_t object_size = 0;
             for (unsigned ch = 0; ch < writes; ch++) {
@@ -686,7 +689,7 @@ void test_download_data_source(const client_maker_function& client_maker, bool i
 }
 
 SEASTAR_THREAD_TEST_CASE(test_download_data_source_minio) {
-    test_download_data_source(make_minio_client, false, 128 * 1024);
+    test_download_data_source(make_minio_client, false, 11 * 1024);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_download_data_source_proxy) {
@@ -694,7 +697,7 @@ SEASTAR_THREAD_TEST_CASE(test_download_data_source_proxy) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_minio) {
-    test_download_data_source(make_minio_client, true, 128 * 1024);
+    test_download_data_source(make_minio_client, true, 11 * 1024);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_proxy) {
@@ -770,11 +773,11 @@ void test_chunked_download_data_source(const client_maker_function& client_maker
 }
 
 SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_with_delays_minio) {
-    test_chunked_download_data_source(make_minio_client, 20_MiB);
+    test_chunked_download_data_source(make_minio_client, 6_MiB);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_with_delays_proxy) {
-    test_chunked_download_data_source(make_proxy_client, 20_MiB);
+    test_chunked_download_data_source(make_proxy_client, 6_MiB);
 }
 
 void do_test_chunked_download_data_source_memory(const client_maker_function& client_maker, size_t object_size) {
@@ -826,7 +829,7 @@ void do_test_chunked_download_data_source_memory(const client_maker_function& cl
 }
 
 SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_memory) {
-    do_test_chunked_download_data_source_memory(make_minio_client, 20_MiB);
+    do_test_chunked_download_data_source_memory(make_minio_client, 6_MiB);
 }
 
 void test_object_copy(const client_maker_function& client_maker, size_t chunk_size, size_t chunks) {

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -513,8 +513,17 @@ void client_list_objects(const client_maker_function& client_maker) {
 
     // Put extra object to check list-by-prefix filters it out
     temporary_buffer<char> data = sstring("1234567890").release();
-    client->put_object(format("/{}/extra-{}", bucket, ::getpid()), std::move(data)).get();
+    auto extra_name = format("/{}/extra-{}", bucket, ::getpid());
+    client->put_object(extra_name, std::move(data)).get();
+    auto delete_extra = deferred_delete_object(client, extra_name);
     auto names = populate_bucket(client, bucket, prefix, 12);
+
+    // Clean up all created objects when done
+    auto cleanup = seastar::defer([&] {
+        for (auto& n : names) {
+            client->delete_object(format("/{}/{}{}", bucket, prefix, n)).get();
+        }
+    });
 
     s3::client::bucket_lister lister(client, bucket, prefix, 5);
     auto close_lister = deferred_close(lister);
@@ -543,7 +552,14 @@ void client_list_objects_incomplete(const client_maker_function& client_maker) {
     auto client = client_maker(mem);
     auto close_client = deferred_close(*client);
 
-    populate_bucket(client, bucket, prefix, 8);
+    auto all_names = populate_bucket(client, bucket, prefix, 8);
+
+    // Clean up all created objects when done
+    auto cleanup = seastar::defer([&] {
+        for (auto& n : all_names) {
+            client->delete_object(format("/{}/{}{}", bucket, prefix, n)).get();
+        }
+    });
 
     s3::client::bucket_lister lister(client, bucket, prefix, 9, 2);
     auto close_lister = deferred_close(lister);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -28,6 +28,8 @@
 #include <fmt/ranges.h>
 #include <seastar/util/defer.hh>
 #include "sstables/generation_type.hh"
+#include "sstables/sstable_version.hh"
+#include "sstables/object_storage_client.hh"
 
 static const sstring some_keyspace("ks");
 static const sstring some_column_family("cf");
@@ -352,6 +354,22 @@ public:
             }
         }
     }
+
+    // Delete S3/GCS objects for all SSTables still tracked in the registry.
+    // Called during test teardown so that tests don't leak objects in the bucket.
+    void cleanup_objects(shared_ptr<sstables::object_storage_client> client, const std::string& bucket) {
+        for (auto& [key, e] : _entries) {
+            auto& gen = key.second;
+            auto& comp_map = sstable_version_constants::get_component_map(e.desc.version);
+            for (auto& [type, suffix] : comp_map) {
+                try {
+                    client->delete_object(object_name(bucket, gen, suffix)).get();
+                } catch (...) {
+                    // Ignore errors -- component may not exist (e.g., optional components)
+                }
+            }
+        }
+    }
 };
 
 future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, test_env_config cfg) {
@@ -361,13 +379,26 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
         db_cfg->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
         db_cfg->object_storage_endpoints(make_storage_options_config(cfg.storage));
         return seastar::async([func = std::move(func), cfg = std::move(cfg), db_cfg = std::move(db_cfg)] () mutable {
+            // Extract bucket and endpoint before cfg is moved into test_env
+            auto& os = std::get<data_dictionary::storage_options::object_storage>(cfg.storage.value);
+            auto bucket = os.bucket;
+            auto endpoint = os.endpoint;
+
             sharded<sstables::storage_manager> sstm;
             sstm.start(std::ref(*db_cfg), sstables::storage_manager::config{}).get();
             auto stop_sstm = defer([&] { sstm.stop().get(); });
             auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+            auto registry = std::make_unique<mock_sstables_registry>();
+            auto* registry_ptr = registry.get();
             test_env env(std::move(cfg), *scf, &sstm.local());
             auto close_env = defer([&] { env.stop().get(); });
-            env.manager().plug_sstables_registry(std::make_unique<mock_sstables_registry>());
+            env.manager().plug_sstables_registry(std::move(registry));
+            // Clean up any S3/GCS objects left behind when the test completes.
+            // Runs before close_env (defers execute in reverse order), so the
+            // S3 client and registry are still alive.
+            auto cleanup = defer([&] {
+                registry_ptr->cleanup_objects(sstm.local().get_endpoint_client(endpoint), bucket);
+            });
             func(env);
         });
     }


### PR DESCRIPTION
S3 tests write huge amounts of data (~1GB). This slows them down
and prevents moving the object storage backing store to tmpfs.

Improve this by reclaiming space after every test, and by reducing
the size of data written.

I saw about 12MB in the minio_root directory towards the end of the tests. Could
have been a leak, or tests still using object storage (can't have an exact number
since the directory is wiped at the end). Previously, I saw almost 1GB.

Test improvement, so no backport.