### PR TITLE
test: use DROP KEYSPACE IF EXISTS in new_test_keyspace cleanup

### DIFF
--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -425,7 +425,9 @@ async def new_test_keyspace(manager: ManagerClient, opts, host=None):
         logger.info(f"Error happened while using keyspace '{keyspace}', the keyspace is left in place for investigation")
         raise
     else:
-        await manager.get_cql().run_async("DROP KEYSPACE " + keyspace, host=host)
+        # Use DROP KEYSPACE IF EXISTS as a workaround for
+        # https://github.com/scylladb/python-driver/issues/317
+        await manager.get_cql().run_async("DROP KEYSPACE IF EXISTS " + keyspace, host=host)
 
 previously_used_table_names = []
 @asynccontextmanager


### PR DESCRIPTION
The new_test_keyspace context manager in test/cluster/util.py uses DROP KEYSPACE without IF EXISTS during cleanup. The Python driver has a known bug (scylladb/python-driver#317) where connection pool renewal after concurrent node bootstraps causes double statement execution. The DROP succeeds server-side, but the response is lost when the old pool is closed. The driver retries on the new pool, and gets ConfigurationException message "Cannot drop non existing keyspace".

The CREATE KEYSPACE in create_new_test_keyspace already uses IF NOT EXISTS as a workaround for the same driver bug. This patch applies the same approach to fix DROP KEYSPACE.

Fixes SCYLLADB-1538

The issue is reported only once, and on master. On the other side, it is present in multiple versions, and is a CI stability fix. Backport to relevant versions.