### PR TITLE
test/dtest/scrub: fix test_scrub_static_table restarting with wrong smp

### DIFF
--- a/test/cluster/dtest/scrub_test.py
+++ b/test/cluster/dtest/scrub_test.py
@@ -234,7 +234,8 @@ class TestScrubIndexes(TestHelper):
                 "tablets_initial_scale_factor": 1,
             }
         )
-        cluster.populate(1).start(jvm_args=["--smp", "1"])
+        jvm_args = ["--smp", "1"]
+        cluster.populate(1).start(jvm_args=jvm_args)
         node1 = cluster.nodelist()[0]
 
         session = self.patient_cql_connection(node1)
@@ -261,7 +262,7 @@ class TestScrubIndexes(TestHelper):
 
         # Restart and check data again
         cluster.stop()
-        cluster.start()
+        cluster.start(jvm_args=jvm_args)
 
         session = self.patient_cql_connection(node1)
         session.execute("USE %s" % (KEYSPACE))


### PR DESCRIPTION
The test starts the cluster with --smp 1 but calls cluster.start() on restart without jvm_args, causing Scylla to restart with the default --smp 2. This triggers SSTable resharding at startup which in debug mode exceeds the test framework's startup timeout, killing the process before the CQL server comes up.

Fix by extracting the jvm_args into a variable and reusing it in both the initial and post-restart cluster.start() calls.

Fixes: SCYLLADB-824

Backport: problematic test introduced in d2c266eb47 (2026.1), but the failure is rare so no backport is needed for now