### PR TITLE
compaction/twcs: Compact SSTables spanning multiple time windows

### DIFF
--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -27,6 +27,12 @@ time_window_compaction_strategy_state_ptr time_window_compaction_strategy::get_s
     return table_s.get_compaction_strategy_state().get<time_window_compaction_strategy_state_ptr>();
 }
 
+bool time_window_compaction_strategy::spans_multiple_windows(const sstables::sstable& sst) const {
+    auto min = sst.get_stats_metadata().min_timestamp;
+    auto max = sst.get_stats_metadata().max_timestamp;
+    return get_window_for(_options, min) != get_window_for(_options, max);
+}
+
 const std::unordered_map<sstring, std::chrono::seconds> time_window_compaction_strategy_options::valid_window_units = {
     { "MINUTES", 60s }, { "HOURS", 3600s }, { "DAYS", 86400s }
 };
@@ -415,6 +421,23 @@ time_window_compaction_strategy::get_next_non_expired_sstables(compaction_group_
 std::vector<sstables::shared_sstable>
 time_window_compaction_strategy::get_compaction_candidates(compaction_group_view& table_s, strategy_control& control,
     std::vector<sstables::shared_sstable> candidate_sstables, time_window_compaction_strategy_state& state) {
+    // Detect and prioritize SSTables spanning multiple time windows. These arise e.g. after
+    // switching from ICS to TWCS without running a major compaction. Compacting them causes
+    // make_interposer_consumer() to segregate their data into proper per-window SSTables.
+    std::vector<sstables::shared_sstable> multi_window;
+    std::erase_if(candidate_sstables, [&] (const sstables::shared_sstable& sst) {
+        if (spans_multiple_windows(*sst)) {
+            multi_window.push_back(sst);
+            return true;
+        }
+        return false;
+    });
+    if (!multi_window.empty()) {
+        clogger.debug("[{}] TWCS found {} multi-window sstable(s), scheduling for compaction to split into per-window sstables",
+                fmt::ptr(this), multi_window.size());
+        return trim_to_threshold(std::move(multi_window), table_s.schema()->max_compaction_threshold());
+    }
+
     auto [buckets, max_timestamp] = get_buckets(std::move(candidate_sstables), _options);
     // Update the highest window seen, if necessary
     state.highest_window_seen = std::max(state.highest_window_seen, max_timestamp);
@@ -524,9 +547,19 @@ future<int64_t> time_window_compaction_strategy::estimated_pending_compactions(c
     auto max_threshold = table_s.schema()->max_compaction_threshold();
     auto main_set = co_await table_s.main_sstable_set();
     auto candidate_sstables = *main_set->all() | std::ranges::to<std::vector>();
-    auto [buckets, max_timestamp] = get_buckets(std::move(candidate_sstables), _options);
 
     int64_t n = 0;
+    int64_t multi_window_count = 0;
+    std::erase_if(candidate_sstables, [&] (const sstables::shared_sstable& sst) {
+        if (spans_multiple_windows(*sst)) {
+            multi_window_count++;
+            return true;
+        }
+        return false;
+    });
+    n += (multi_window_count + max_threshold - 1) / max_threshold;
+
+    auto [buckets, max_timestamp] = get_buckets(std::move(candidate_sstables), _options);
     for (auto& [bucket_key, bucket] : buckets) {
         switch (compaction_mode(*state, bucket, bucket_key, max_timestamp, min_threshold)) {
         case bucket_compaction_mode::size_tiered:

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -107,6 +107,10 @@ private:
         return bucket_key >= now;
     }
 
+    // Returns true if the SSTable's data spans more than one time window.
+    // Such SSTables arise e.g. after switching from ICS to TWCS without running a major compaction.
+    bool spans_multiple_windows(const sstables::sstable& sst) const;
+
     // Returns which compaction type should be performed on a given window bucket.
     bucket_compaction_mode
     compaction_mode(const time_window_compaction_strategy_state&, const bucket_t& bucket, api::timestamp_type bucket_key, api::timestamp_type now, size_t min_threshold) const;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2170,6 +2170,88 @@ SEASTAR_FIXTURE_TEST_CASE(time_window_strategy_correctness_gcs_test, gcs_fixture
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
+// Verifies that TWCS schedules compaction for SSTables spanning multiple time windows
+// (e.g. those produced by ICS before switching to TWCS without a prior major compaction),
+// and that after all compaction rounds complete, no such multi-window SSTables remain.
+//
+// Each multi-window SSTable is given a unique max_timestamp so it lands in its own past
+// window bucket. This ensures that without the fix, normal STCS (which requires at least
+// min_threshold SSTables per bucket) would never trigger on them, and they would never
+// be compacted away.
+SEASTAR_TEST_CASE(twcs_multi_window_sstables_are_compacted_test) {
+    return test_env::do_with_async([](test_env& env) {
+        using namespace std::chrono;
+
+        // Use a 1-hour window.
+        std::map<sstring, sstring> opts_map = {
+            { compaction::time_window_compaction_strategy_options::COMPACTION_WINDOW_SIZE_KEY, "1" },
+            { compaction::time_window_compaction_strategy_options::COMPACTION_WINDOW_UNIT_KEY, "HOURS" },
+        };
+        compaction::time_window_compaction_strategy twcs(opts_map);
+        compaction::time_window_compaction_strategy_options twcs_opts(opts_map);
+
+        auto s = schema_builder("tests", "twcs_multi_window")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("value", int32_type)
+                .set_compaction_strategy(compaction::compaction_strategy_type::time_window)
+                .build();
+
+        auto cf = env.make_table_for_tests(s);
+        auto close_cf = deferred_stop(cf);
+
+        const auto keys = tests::generate_partition_keys(2, s);
+        const auto& first_key = keys.front().key();
+        const auto& last_key = keys.back().key();
+
+        // Window size in microseconds (1 hour).
+        const int64_t window_us = duration_cast<microseconds>(hours(1)).count();
+
+        auto spans_multiple_windows = [&](const shared_sstable& sst) {
+            auto min = sst->get_stats_metadata().min_timestamp;
+            auto max = sst->get_stats_metadata().max_timestamp;
+            return compaction::time_window_compaction_strategy::get_window_for(twcs_opts, min) !=
+                   compaction::time_window_compaction_strategy::get_window_for(twcs_opts, max);
+        };
+
+        // Create multi-window SSTables, each with a unique max_timestamp landing in its own
+        // past window bucket. This means without the fix, each bucket holds only one SSTable —
+        // below min_threshold — so normal STCS would never compact them.
+        // Use more than max_threshold (32) to verify multiple compaction rounds are scheduled.
+        std::vector<shared_sstable> candidates;
+        const int num_multi_window = 40;
+        for (int i = 0; i < num_multi_window; i++) {
+            // min is in window i, max is in window i+1, so the SSTable spans two windows.
+            const int64_t ts_min = window_us * i + window_us / 2;
+            const int64_t ts_max = window_us * (i + 1) + window_us / 2;
+            auto sst = env.make_sstable(s);
+            sstables::test(sst).set_values(first_key, last_key,
+                    build_stats(ts_min, ts_max, std::numeric_limits<int32_t>::max()));
+            BOOST_REQUIRE(spans_multiple_windows(sst));
+            candidates.push_back(std::move(sst));
+        }
+
+        // Simulate the compaction loop: in each round, TWCS selects multi-window SSTables.
+        // We remove them from the candidate set (simulating compaction completing with
+        // window-aligned output SSTables, which will no longer span multiple windows).
+        while (true) {
+            auto desc = get_sstables_for_compaction(twcs, cf.as_compaction_group_view(), candidates).get();
+            if (desc.sstables.empty()) {
+                break;
+            }
+            // Every SSTable selected must span multiple windows.
+            for (const auto& sst : desc.sstables) {
+                BOOST_REQUIRE(spans_multiple_windows(sst));
+            }
+            std::erase_if(candidates, [&](const shared_sstable& sst) {
+                return std::ranges::find(desc.sstables, sst) != desc.sstables.end();
+            });
+        }
+
+        // After all rounds, no multi-window SSTables should remain.
+        BOOST_REQUIRE(std::ranges::none_of(candidates, spans_multiple_windows));
+    });
+}
+
 // Check that TWCS will only perform size-tiered on the current window and also
 // the past windows that were already previously compacted into a single SSTable.
 void time_window_strategy_size_tiered_behavior_correctness_fn(test_env& env) {


### PR DESCRIPTION
When switching from ICS to TWCS without first running a major compaction, the existing ICS SSTable runs (composed of sorted fragments) are handed off to TWCS as-is. Because TWCS buckets SSTables by their max_timestamp, these multi-window SSTables land in a single bucket and are never broken apart, causing them to persist indefinitely and increasing read amplification.

Fix this by detecting SSTables whose min_timestamp and max_timestamp fall in different time windows in get_compaction_candidates() and scheduling them for compaction ahead of the normal STCS/major-per-window logic. The existing make_interposer_consumer() already handles splitting such SSTables into properly window-aligned output SSTables via segregate_by_timestamp(), so no additional output-side changes are needed.

The check runs after the fully-expired SSTable check (highest priority) but before normal window compaction (lower priority), matching the intended priority order.

estimated_pending_compactions() is updated to count the expected number of compaction rounds needed to drain multi-window SSTables, using ceil(count / max_threshold) to match how get_compaction_candidates() batches them via trim_to_threshold().

A new spans_multiple_windows() helper is extracted to the .cc file (rather than inline in the header) to avoid including the full sstable type in the header.

Not backporting since it's an enhancement.