### PR TITLE
test: lib: fix broken retry in start_docker_service

### DIFF
--- a/test/lib/gcs_fixture.cc
+++ b/test/lib/gcs_fixture.cc
@@ -224,7 +224,7 @@ seastar::future<> local_gcs_wrapper::setup() {
     if (!f) {
         _local = std::make_unique<gcs_fixture>();
         co_await _local->setup();
-        f = gcs_fixture::active();;
+        f = gcs_fixture::active();
     }
 
     endpoint = f->endpoint();

--- a/test/lib/gcs_fixture.cc
+++ b/test/lib/gcs_fixture.cc
@@ -44,7 +44,7 @@ static future<std::optional<google_credentials>> credentials(const std::string& 
 }
 
 static future<std::tuple<tp::process_fixture, int>> start_fake_gcs_server(const tmpdir& tmp) {
-    return tp::start_docker_service("local-kms"
+    return tp::start_docker_service("fake-gcs-server"
         , "docker.io/fsouza/fake-gcs-server:1.52.3"
         , {}
         , [](std::string_view line) {

--- a/test/lib/gcs_fixture.hh
+++ b/test/lib/gcs_fixture.hh
@@ -19,7 +19,7 @@
     Simple Google object storage endpoint provider. Uses either real or local, fake, endpoint.
 
     Note: the below text blobs are service account credentials, including private keys. 
-    _Never_ give any real priviledges to these accounts, as we are obviously exposing them here.
+    _Never_ give any real privileges to these accounts, as we are obviously exposing them here.
 
     User1 is assumed to have permissions to read/write the bucket
     User2 is assumed to only have permissions to read the bucket, but permission to 

--- a/test/lib/proc_utils.cc
+++ b/test/lib/proc_utils.cc
@@ -253,8 +253,8 @@ future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_
             return std::make_tuple(std::move(h), std::move(f));
         };
 
-        auto [out_h, out_fut] = create_handler(std::move(stdout_parse), std::cout);
-        auto [err_h, err_fut] = create_handler(std::move(stderr_parse), std::cerr);
+        auto [out_h, out_fut] = create_handler(stdout_parse, std::cout);
+        auto [err_h, err_fut] = create_handler(stderr_parse, std::cerr);
 
         auto ps = co_await process_fixture::create(exec
             , params

--- a/test/lib/proc_utils.cc
+++ b/test/lib/proc_utils.cc
@@ -205,24 +205,24 @@ future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_
     constexpr auto max_retries = 8;
 
     for (int retries = 0;; ++retries) {
-    container_name = fmt::format("{}-{}-{}", name, ::getpid(), ++counter);
+        container_name = fmt::format("{}-{}-{}", name, ::getpid(), ++counter);
 
-    // publish port ephemeral, allows parallel instances
-    std::vector<std::string> params = {
-        exec.string(),
-        "run", "--rm", 
-        "--name", container_name,
-    };
+        // publish port ephemeral, allows parallel instances
+        std::vector<std::string> params = {
+            exec.string(),
+            "run", "--rm", 
+            "--name", container_name,
+        };
 
-    if (service_port == 0) {
-        params.emplace_back("-P");
-    } else {
-        params.emplace_back("-p");
-        params.emplace_back(std::to_string(service_port));
-    }
-    params.append_range(docker_args);
-    params.emplace_back(image);
-    params.append_range(image_args);
+        if (service_port == 0) {
+            params.emplace_back("-P");
+        } else {
+            params.emplace_back("-p");
+            params.emplace_back(std::to_string(service_port));
+        }
+        params.append_range(docker_args);
+        params.emplace_back(image);
+        params.append_range(image_args);
 
         BOOST_TEST_MESSAGE(fmt::format("Will run {}", params));
 

--- a/test/lib/proc_utils.cc
+++ b/test/lib/proc_utils.cc
@@ -147,7 +147,7 @@ output_stream<char> tests::proc::process_fixture::cin() {
 namespace fs = std::filesystem;
 
 fs::path tests::proc::find_file_in_path(std::string_view name, 
-    const std::vector<fs::path>& path_preprend,
+    const std::vector<fs::path>& path_prepend,
     const std::vector<fs::path>& path_append
 ) {
     static auto get_var = [](const char* name) {
@@ -166,7 +166,7 @@ fs::path tests::proc::find_file_in_path(std::string_view name,
         return res;
     }();
 
-    for (auto& paths : { path_preprend, system_paths, path_append }) {
+    for (auto& paths : { path_prepend, system_paths, path_append }) {
         for (auto& p : paths) {
             auto test = p / name;
             if (fs::exists(test) && !fs::is_directory(test)) {
@@ -268,7 +268,7 @@ future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_
         bool retry = false;
 
         try {
-            BOOST_TEST_MESSAGE("Waiting for process to laúnch...");
+            BOOST_TEST_MESSAGE("Waiting for process to launch...");
             // arbitrary timeout of 120s for the server to make some output. Very generous.
             // but since we (maybe) run docker, and might need to pull image, this can take
             // some time if we're unlucky.

--- a/test/lib/proc_utils.cc
+++ b/test/lib/proc_utils.cc
@@ -200,6 +200,11 @@ future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_
     }
 
     static int counter = 0;
+
+    struct in_use{};
+    constexpr auto max_retries = 8;
+
+    for (int retries = 0;; ++retries) {
     container_name = fmt::format("{}-{}-{}", name, ::getpid(), ++counter);
 
     // publish port ephemeral, allows parallel instances
@@ -219,10 +224,6 @@ future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_
     params.emplace_back(image);
     params.append_range(image_args);
 
-    struct in_use{};
-    constexpr auto max_retries = 8;
-
-    for (int retries = 0;; ++retries) {
         BOOST_TEST_MESSAGE(fmt::format("Will run {}", params));
 
         std::vector<std::string> env;

--- a/test/lib/proc_utils.hh
+++ b/test/lib/proc_utils.hh
@@ -20,7 +20,7 @@ namespace tests::proc {
     using namespace seastar;
 
     std::filesystem::path find_file_in_path(std::string_view name, 
-        const std::vector<std::filesystem::path>& path_preprend = {},
+        const std::vector<std::filesystem::path>& path_prepend = {},
         const std::vector<std::filesystem::path>& path_append = {}
     );
 

--- a/test/pylib/dockerized_service.py
+++ b/test/pylib/dockerized_service.py
@@ -76,11 +76,11 @@ class DockerizedServer:
         # thus ensuring the coro runs forever, sort of... However, 
         # this currently breaks, probably due to some part of the 
         # machinery/tests that don't async fully, causing us to not
-        # process the log, and thus hand/fail, bla bla.
+        # process the log, and thus hang/fail, bla bla.
         # The solution is to make the process synced, and use a 
         # background thread (execution pool) for the processing.
         # This way we know the pipe reader will not suddenly get
-        # blocked at inconvinient times.
+        # blocked at inconvenient times.
         proc = subprocess.Popen(args, stderr=subprocess.PIPE)
         loop = asyncio.get_running_loop()
         ready_fut = loop.create_future()


### PR DESCRIPTION
The retry loop in `start_docker_service` passes the parse callbacks via `std::move` into `create_handler` on each iteration. After the first iteration, the moved-from `std::function` objects are empty. All subsequent retries skip output parsing entirely and immediately treat the service as successfully started. This defeats the entire purpose of the retry mechanism.

Fix by passing the callbacks by copy instead of move, so the original callbacks remain valid across retries.

Fixes SCYLLADB-1542

This is a CI stability issue and should be backported.