### PR TITLE
audit: disable caching for the audit log table

### DIFF
--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -38,7 +38,8 @@ audit_cf_storage_helper::audit_cf_storage_helper(cql3::query_processor& qp, serv
                        "source inet, "
                        "username text, "
                        "error boolean, "
-                       "PRIMARY KEY ((date, node), event_time))",
+                       "PRIMARY KEY ((date, node), event_time))"
+                       " WITH caching = {{'keys': 'NONE', 'rows_per_partition': 'NONE', 'enabled': 'false'}}",
                        KEYSPACE_NAME, TABLE_NAME),
              fmt::format("INSERT INTO {}.{} ("
                        "date,"


### PR DESCRIPTION
The audit table had caching enabled by default, which provides no value since audit data is write-heavy and rarely read back through the cache. This wastes cache space that could be used for more important user data.

Disable both key and row caching, consistent with other system tables such as system.batchlog, system.large_partitions, and CDC log tables.

Fixes: SCYLLADB-1582

Minor optimization, no need to backport.