### PR TITLE
alternator: fix issues with stream_arn copy / move

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -97,14 +97,20 @@ namespace alternator {
 // NOTE: we're holding inside a name of cdc log table, not a user table
 class stream_arn {
     std::string _arn;
-    std::string_view _table_name;
-    std::string_view _keyspace_name;
+    size_t _table_name_offset, _table_name_size;
+    size_t _keyspace_name_offset, _keyspace_name_size;
+
+    void _initialize_offsets() {
+        auto parts = parse_arn(_arn, "StreamArn", "stream", "/stream/");
+        _table_name_offset = parts.table_name.data() - _arn.data();
+        _table_name_size = parts.table_name.size();
+        _keyspace_name_offset = parts.keyspace_name.data() - _arn.data();
+        _keyspace_name_size = parts.keyspace_name.size();
+    }
 public:
     // ARN to get table name from
     stream_arn(std::string arn) : _arn(std::move(arn)) {
-        auto parts = parse_arn(_arn, "StreamArn", "stream", "/stream/");
-        _table_name = parts.table_name;
-        _keyspace_name = parts.keyspace_name;
+        _initialize_offsets();
     }
     // NOTE: it must be a schema of a CDC log table, not a base table, because that's what we are encoding in ARN and returning to users.
     // we need base schema for creation time
@@ -114,16 +120,13 @@ public:
 
         // KCL checks for arn / aws / dynamodb and account-id being a number
         _arn = fmt::format("arn:aws:dynamodb:us-east-1:000000000000:table/{}@{}/stream/{:%FT%T}", s->ks_name(), s->cf_name(), now);
-        auto table_index = std::string_view{"arn:aws:dynamodb:us-east-1:000000000000:table/"}.size();
-        auto x1 = _arn.find("@", table_index);
-        auto x2 = _arn.find("/", x1);
-        _table_name = std::string_view{ _arn }.substr(x1 + 1, x2 - (x1 + 1));
-        _keyspace_name = std::string_view{ _arn }.substr(table_index, x1 - table_index);
+
+        _initialize_offsets();
     }
 
     std::string_view unparsed() const { return _arn; }
-    std::string_view table_name() const { return _table_name; }
-    std::string_view keyspace_name() const { return _keyspace_name; }
+    std::string_view table_name() const { return std::string_view{ _arn }.substr(_table_name_offset, _table_name_size); }
+    std::string_view keyspace_name() const { return std::string_view{ _arn }.substr(_keyspace_name_offset, _keyspace_name_size); }
     friend std::ostream& operator<<(std::ostream& os, const stream_arn& arn) {
         os << arn._arn;
         return os;


### PR DESCRIPTION
`stream_arn` object holds a full ARN as `std::string` and two `std::string_view` fields (`table_name_` and `keyspace_name_`) pointing into ARN itself. This prevents object from being safely copied (as in that case both `table_name_` and `keyspace_name_` will point into original object's ARN). Similar issue might happen with move, when ARN contains string short enough for small string optimization to kick in (although in practice this is not possible, as ARN has requirements which make it's minimal length above 15 characteres - current limit for small string optimizations in most popular string libraries).

The patch drops `std::string_view` objects in favor of integer offsets and sizes. The offset equal to 0 means beginning of ARN string. The api is preserved - both `table_name` and `keyspace_name` function will return `std::string_view` reconstructed on the fly.

Backport requirements - we should backport to 2026.1, where the code was introduced, as there's a risk of backporting other code, that might actually use copy / move for `stream_arn`.