### PR TITLE
test: use uuid4 for DockerizedServer container names to avoid collisions

### DIFF
--- a/test/pylib/dockerized_service.py
+++ b/test/pylib/dockerized_service.py
@@ -6,12 +6,11 @@
 
 import logging
 import shutil
-import itertools
 import asyncio
 import pathlib
 import re
-import os
 import subprocess
+import uuid
 from typing import Callable
 
 logger = logging.getLogger("DockerizedServer")
@@ -19,8 +18,6 @@ logger = logging.getLogger("DockerizedServer")
 class DockerizedServer:
     """class for running an external dockerized service image, typically mock server"""
     # pylint: disable=too-many-instance-attributes
-
-    newid = itertools.count(start=1).__next__   # Sequential unique id
 
     def __init__(self, image, tmpdir, logfilenamebase, 
                  success_string : Callable[[str, int], bool] | str,
@@ -48,7 +45,7 @@ class DockerizedServer:
         exe = pathlib.Path(next(exe for exe in [shutil.which(path) 
                                                 for path in ["podman", "docker"]] 
                                                 if exe is not None)).resolve()
-        sid = f"{os.getpid()}-{DockerizedServer.newid()}"
+        sid = str(uuid.uuid4())
         name = f'{self.logfilenamebase}-{sid}'
         logfilename = (pathlib.Path(self.tmpdir) / name).with_suffix(".log")
         self.logfile = logfilename.open("wb")


### PR DESCRIPTION
Container names were generated as {name}-{pid}-{counter}, where the counter is a per-process itertools.count. This scheme breaks across CI runs on the same host: if a prior job was killed abruptly (SIGKILL, cancellation) its containers are left running since --rm only removes containers on exit. A subsequent run whose worker inherits the same PID (common in containerized CI with small PID namespaces) and reaches the same counter value will collide with the orphaned container.

Replace pid+counter with uuid.uuid1(), which embeds a 100ns-resolution timestamp and the host MAC address, making names unique across processes, hosts, and time without any shared state.

Fixes: SCYLLADB-1540

Backport: failure only seen on master, no backport