### PR TITLE
test/commitlog: reduce resource usage in test_commitlog_handle_replayed_segments

### DIFF
--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -2177,13 +2177,17 @@ SEASTAR_TEST_CASE(test_commitlog_buffer_size_counter) {
 SEASTAR_TEST_CASE(test_commitlog_handle_replayed_segments) {
     commitlog::config cfg;
 
-    constexpr uint64_t max_size_mb = 8 * 1024;
+    // Keep max_size_mb small: the test creates (4 + max_size_mb/seg_size) files
+    // of seg_size each per iteration. With a large value (e.g. 8*1024) this
+    // results in hundreds of 32 MB fallocate calls per iteration which can
+    // easily exceed the CI timeout of 15 minutes (SCYLLADB-1496).
+    constexpr uint64_t max_size_mb = 128;
 
     cfg.commitlog_total_space_in_mb = max_size_mb * smp::count;
     cfg.allow_going_over_size_limit = false;
     cfg.commitlog_sync_period_in_ms = 1;
 
-    for (size_t k = 0; k < 100; ++k) {
+    for (size_t k = 0; k < 10; ++k) {
         tmpdir tmp;
         cfg.commit_log_location = tmp.path().string();
 


### PR DESCRIPTION
The test was using max_size_mb = 8*1024 (8 GB) with 100 iterations, causing it to create up to 260 files of 32 MB each per iteration via fallocate. On a loaded CI machine this totals hundreds of GB of file operations, easily exceeding the 15-minute test timeout (SCYLLADB-1496).

The test only needs enough files to verify that delete_segments keeps the disk footprint within [shard_size, shard_size + seg_size]. Reduce max_size_mb to 128 (8 files of 32 MB per iteration) and the iteration count to 10, which is sufficient to exercise the serialized-deletion and recycle logic without imposing excessive I/O load.

Backport: test failure only seen on master, no backport for now