### PR TITLE
Move ignore_component_digest_mismatch flag on sstables_manager

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -382,6 +382,7 @@ static auto configure_sstables_manager(const db::config& cfg, const database_con
         .memory_reclaim_threshold = cfg.components_memory_reclaim_threshold,
         .data_file_directories = cfg.data_file_directories(),
         .format = cfg.sstable_format,
+        .ignore_component_digest_mismatch = cfg.ignore_component_digest_mismatch(),
     };
 }
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -186,9 +186,6 @@ distributed_loader::process_upload_dir(sharded<replica::database>& db, sharded<d
             .need_mutate_level = true,
             .enable_dangerous_direct_import_of_cassandra_counters = db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters(),
             .allow_loading_materialized_view = false,
-            .sstable_open_config = {
-                .ignore_component_digest_mismatch = db.local().get_config().ignore_component_digest_mismatch(),
-            },
         };
         process_sstable_dir(directory, flags).get();
 
@@ -381,9 +378,6 @@ future<> table_populator::process_subdir(sharded<sstables::sstable_directory>& d
         .enable_dangerous_direct_import_of_cassandra_counters = _db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters(),
         .allow_loading_materialized_view = true,
         .garbage_collect = true,
-        .sstable_open_config = {
-            .ignore_component_digest_mismatch = _db.local().get_config().ignore_component_digest_mismatch(),
-        },
     };
     co_await distributed_loader::process_sstable_dir(directory, flags);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4873,8 +4873,7 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
     });
     rtlogger.debug("Cloned storage of tablet {} from leaving replica {}, {} sstables were found", tablet, leaving, d.size());
 
-    auto ignore_digest_mismatch = _db.local().get_config().ignore_component_digest_mismatch();
-    auto load_sstable = [leave_unsealed, ignore_digest_mismatch] (const dht::sharder& sharder, replica::table& t, sstables::entry_descriptor d) -> future<sstables::shared_sstable> {
+    auto load_sstable = [leave_unsealed] (const dht::sharder& sharder, replica::table& t, sstables::entry_descriptor d) -> future<sstables::shared_sstable> {
         auto& mng = t.get_sstables_manager();
         auto sst = mng.make_sstable(t.schema(), t.get_storage_options(), d.generation, d.state.value_or(sstables::sstable_state::normal),
                                     d.version, d.format, db_clock::now(), default_io_error_handler_gen());
@@ -4883,8 +4882,7 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
         // SSTables will be loaded at pending replica and migration is retried, so correctness
         // wise, we're good.
         auto cfg = sstables::sstable_open_config{ .current_shard_as_sstable_owner = true,
-                                                  .unsealed_sstable = leave_unsealed,
-                                                  .ignore_component_digest_mismatch = ignore_digest_mismatch };
+                                                  .unsealed_sstable = leave_unsealed };
         co_await sst->load(sharder, cfg);
         co_return sst;
     };

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -85,10 +85,6 @@ struct sstable_open_config {
     bool keep_sharding_metadata = false;
     // Allows unsealed sstable to be loaded, since it must read components from temporary TOC instead.
     bool unsealed_sstable = false;
-    // When true, log a warning instead of throwing on component digest mismatch.
-    // Useful for recovering sstables with corrupted non-vital components or
-    // working around bugs in digest calculation.
-    bool ignore_component_digest_mismatch = false;
 };
 
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2014,7 +2014,6 @@ future<> sstable::load_metadata(sstable_open_config cfg) noexcept {
 // This interface is only used during tests, snapshot loading and early initialization.
 // No need to set tunable priorities for it.
 future<> sstable::load(const dht::sharder& sharder, sstable_open_config cfg) noexcept {
-    _ignore_component_digest_mismatch = cfg.ignore_component_digest_mismatch;
     co_await load_metadata(cfg);
     validate_min_max_metadata();
     validate_max_local_deletion_time();
@@ -3887,6 +3886,7 @@ sstable::sstable(schema_ptr schema,
     , _large_data_handler(large_data_handler)
     , _corrupt_data_handler(corrupt_data_handler)
     , _manager(manager)
+    , _ignore_component_digest_mismatch(_manager.get_config().ignore_component_digest_mismatch)
 {
     manager.add(this);
 }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -639,7 +639,7 @@ private:
     // Total memory reclaimed so far from this sstable
     size_t _total_memory_reclaimed{0};
     bool _unlinked{false};
-    bool _ignore_component_digest_mismatch{false};
+    const bool _ignore_component_digest_mismatch;
 
     // The mutate semaphore is used to serialize operations like rewrite_statistics
     // with linking or moving the sstable between directories.

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -116,6 +116,7 @@ public:
         utils::updateable_value<double> memory_reclaim_threshold = utils::updateable_value<double>(0.2);
         const std::vector<sstring>& data_file_directories;
         utils::updateable_value<sstring> format = utils::updateable_value<sstring>(fmt::to_string(sstable_version_types::me));
+        bool ignore_component_digest_mismatch = false;
     };
 
 private:

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -222,7 +222,6 @@ private:
         auto units = co_await sst_manager.dir_semaphore().get_units(1);
         sstables::sstable_open_config cfg {
             .unsealed_sstable = true,
-            .ignore_component_digest_mismatch = db.get_config().ignore_component_digest_mismatch(),
         };
         co_await sst->load(table.get_effective_replication_map()->get_sharder(*table.schema()), cfg);
         co_await table.add_new_sstable_and_update_cache(sst, [&sst_manager, sst] (sstables::shared_sstable loading_sst) -> future<> {
@@ -774,7 +773,6 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
             // that might otherwise consume a significant amount of memory.
             sstables::sstable_open_config cfg {
                 .load_bloom_filter = false,
-                .ignore_component_digest_mismatch = _db.local().get_config().ignore_component_digest_mismatch(),
             };
             std::tie(table_id, sstables_on_shards) = co_await replica::distributed_loader::get_sstables_from_upload_dir(_db, ks_name, cf_name, cfg);
             co_await container().invoke_on_all([&sstables_on_shards, ks_name, cf_name, table_id, primary, scope] (sstables_loader& loader) mutable -> future<> {
@@ -901,7 +899,6 @@ future<> sstables_loader::download_task_impl::run() {
     // that might otherwise consume a significant amount of memory.
     sstables::sstable_open_config cfg {
         .load_bloom_filter = false,
-        .ignore_component_digest_mismatch = _loader.local()._db.local().get_config().ignore_component_digest_mismatch(),
     };
     llog.debug("Loading sstables from {}({}/{})", _endpoint, _bucket, _prefix);
 

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -53,8 +53,7 @@ static future<> load_sstable_for_tablet(const file_stream_id& ops_id, replica::d
         auto erm = t.get_effective_replication_map();
         auto& sstm = t.get_sstables_manager();
         auto sst = sstm.make_sstable(t.schema(), t.get_storage_options(), desc.generation, state, desc.version, desc.format);
-        sstables::sstable_open_config cfg { .unsealed_sstable = true,
-                                               .ignore_component_digest_mismatch = db.get_config().ignore_component_digest_mismatch() };
+        sstables::sstable_open_config cfg { .unsealed_sstable = true };
         co_await sst->load(erm->get_sharder(*t.schema()), cfg);
         auto on_add = [sst, &sstm] (sstables::shared_sstable loading_sst) -> future<> {
             if (loading_sst == sst) {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2972,11 +2972,14 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         sstables::directory_semaphore dir_sem(1);
         abort_source abort;
 
+        bool ignore_component_digest_mismatch = app_config.contains("ignore-component-digest-mismatch");
+
         sstables::sstables_manager::config sm_cfg {
             .available_memory = 1_GiB,
             .enable_sstable_key_validation = dbcfg.enable_sstable_key_validation(),
             .data_file_directories = dbcfg.data_file_directories(),
             .format = dbcfg.sstable_format,
+            .ignore_component_digest_mismatch = ignore_component_digest_mismatch,
         };
         sstables::storage_manager::config stm_cfg;
         stm_cfg.object_storage_clients_memory = 100_MiB;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -322,11 +322,11 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
 }
 
 const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sstables::sstables_manager& sst_man, sstables::storage_manager& sstm,
-        const std::vector<sstring>& sstable_names, bool ignore_component_digest_mismatch) {
+        const std::vector<sstring>& sstable_names) {
     std::vector<sstables::shared_sstable> sstables;
     sstables.resize(sstable_names.size());
 
-    parallel_for_each(sstable_names, [schema, &sst_man, &sstm, &sstable_names, &sstables, ignore_component_digest_mismatch] (const sstring& sst_name) -> future<> {
+    parallel_for_each(sstable_names, [schema, &sst_man, &sstm, &sstable_names, &sstables] (const sstring& sst_name) -> future<> {
         const auto i = std::distance(sstable_names.begin(), std::find(sstable_names.begin(), sstable_names.end(), sst_name));
         auto sst_path = std::filesystem::path(sst_name);
 
@@ -370,7 +370,6 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
             auto open_cfg = sstables::sstable_open_config{
                 .load_first_and_last_position_metadata = false,
                 .keep_sharding_metadata = true,
-                .ignore_component_digest_mismatch = ignore_component_digest_mismatch,
             };
             co_await sst->load(schema->get_sharder(), open_cfg);
         } catch (...) {
@@ -3015,9 +3014,8 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
                 fmt::print(std::cerr, "error processing arguments: duplicate sstable arguments found\n");
                 return 1;
             }
-            bool ignore_component_digest_mismatch = app_config.contains("ignore-component-digest-mismatch");
             try {
-                sstables = load_sstables(schema, sst_man, sstm.local(), sstable_names, ignore_component_digest_mismatch);
+                sstables = load_sstables(schema, sst_man, sstm.local(), sstable_names);
             } catch (...) {
                 fmt::print(std::cerr, "error loading sstables: {}\n", std::current_exception());
                 return 1;


### PR DESCRIPTION
The PR serves two purposes.

First, it makes the flag usage be consistent across multiple ways to load sstables components. For example, the sstable::load_metadata() doesn't set it (like .load() does) thus potentially refusing to load "corrupted" components, as the flag assumes.

Second, it removes the fanout of db.get_config().ignore_component_digest_mismatch() over the code. This thing is called pretty much everywhere to initialize the sstable_open_config, while the option in question is "scylla state" parameter, not "sstable opening" one.

Code cleanup, not backporting