### PR TITLE
codeowners: add owner for the test framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,6 +92,10 @@ test/boost/querier_cache_test.cc @denesb
 # PYTEST-BASED CQL TESTS
 test/cqlpy/* @nyh
 
+# TEST FRAMEWORK
+test/pylib/* @xtrey
+test.py @xtrey
+
 # RAFT
 raft/* @kbr-scylla @gleb-cloudius @kostja
 test/raft/* @kbr-scylla @gleb-cloudius @kostja


### PR DESCRIPTION
Add @xtrey as a codeowner of the test framework

No backports, codeowner change only.