### PR TITLE
audit: restore static_cast for batch inspect

### DIFF
--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -271,7 +271,7 @@ future<> inspect(shared_ptr<cql3::cql_statement> statement, const service::query
         return make_ready_future<>();
     }
     if (audit_info->batch()) {
-        cql3::statements::batch_statement* batch = dynamic_cast<cql3::statements::batch_statement*>(statement.get());
+        cql3::statements::batch_statement* batch = static_cast<cql3::statements::batch_statement*>(statement.get());
         return do_for_each(batch->statements().begin(), batch->statements().end(), [&query_state, &options, error] (auto&& m) {
             return inspect(m.statement, query_state, options, error);
         });


### PR DESCRIPTION
Commit 9646ee05bd ("audit/alternator: Make Alternator requests audited") reintroduced a `dynamic_cast` in `audit::inspect()` that had previously been replaced with `static_cast` in 19af46d83a ("audit: replace batch dynamic_cast with static_cast").

The cast target type is already known at that point (`audit_info->batch()` is true), so `dynamic_cast` provides no safety benefit because the result is dereferenced immediately without a null check. `static_cast` avoids RTTI overhead on this hot path.

Refs #27953