### PR TITLE
test/cluster/dtest: fix test_scrub_static_table flakiness

### DIFF
--- a/test/cluster/dtest/scrub_test.py
+++ b/test/cluster/dtest/scrub_test.py
@@ -234,7 +234,7 @@ class TestScrubIndexes(TestHelper):
                 "tablets_initial_scale_factor": 1,
             }
         )
-        cluster.populate(1).start(jvm_args=["--smp", "1"])
+        cluster.populate(1).start(jvm_args=["--smp", "1"], wait_for_binary_proto=True)
         node1 = cluster.nodelist()[0]
 
         session = self.patient_cql_connection(node1)
@@ -261,7 +261,7 @@ class TestScrubIndexes(TestHelper):
 
         # Restart and check data again
         cluster.stop()
-        cluster.start()
+        cluster.start(jvm_args=["--smp", "1"], wait_for_binary_proto=True)
 
         session = self.patient_cql_connection(node1)
         session.execute("USE %s" % (KEYSPACE))


### PR DESCRIPTION
## Summary

`test_scrub_static_table` was flaky because:

1. The test set `--smp 1` via `jvm_args` on the initial `start()`, but the
   subsequent `cluster.start()` after restart did not pass it, causing the node
   to restart with the default shard count. This triggered resharding of all
   sstables on startup, which is slow in debug builds.

2. The test called `cluster.start()` without `wait_for_binary_proto=True`, so
   `patient_cql_connection` started trying to connect immediately. When the
   node took too long to start up, the connection attempts timed out with
   `NoHostAvailable` / `ConnectionRefusedError`, and the test framework
   stopped the still-starting node, resulting in "Startup interrupted".

## Fix

- Pass `jvm_args=["--smp", "1"]` on both `cluster.start()` calls to ensure
  consistent shard count across restarts, avoiding resharding.
- Pass `wait_for_binary_proto=True` to both `cluster.start()` calls so the
  test waits for the CQL port to be ready before connecting.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-824

--

Backport to 2026.1: the test was introduced in d2c266eb475 which is present
since 2026.1, so the flakiness affects that branch as well.