### PR TITLE
test.py: exclude pylib_test from default test runs

### DIFF
--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -249,11 +249,11 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
     # If all tests passed, remove the log file to save space and avoid confusion with logs from failed runs.
     # We check this at the end of the session to ensure that we have the complete log available for any failed tests.
 
-    if not is_xdist_worker: # If this is not an xdist worker there is no separate xdist main process and no pytest_main.log file
-        if session.testsfailed == 0 and not session.config.getoption("--save-log-on-success"):
-            # Use missing_ok=True because the log file is only created on first write,
-            # so it may never have been written if nothing was logged.
-            pathlib.Path(_pytest_config.stash[PYTEST_LOG_FILE]).unlink(missing_ok=True)
+    if session.testsfailed == 0 and not session.config.getoption("--save-log-on-success"):
+        # Use missing_ok=True because the log file is only created on first write,
+        # so it may never have been written if nothing was logged.
+        pathlib.Path(_pytest_config.stash[PYTEST_LOG_FILE]).unlink(missing_ok=True)
+
 
     # Check if this is an xdist worker - workers should not clean up (only the main process should)
     # Check if test.py has already prepared the environment, so it should clean up

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -42,7 +42,7 @@ markers =
     skip_slow(reason): Skip because the test is too slow for regular CI.
     skip_env(reason): Skip due to a missing environment requirement.
 
-norecursedirs = manual perf lib
+norecursedirs = manual perf lib pylib_test
 # Ignore warnings about HTTPS requests without certificate verification
 # (see issue #15287). Pytest breaks urllib3.disable_warnings() in conftest.py,
 # so we need to do this here.


### PR DESCRIPTION
Add pylib_test to norecursedirs in pytest.ini so it is not collected
during ./test.py or pytest test/ runs, but can still be run directly
via 'pytest test/pylib_test'.

Also fix pytest log cleanup: worker log files (pytest_gw*) were not
being deleted on success because cleanup was restricted to the main
process only. Now each process (main and workers) cleans up its own
log file on success."
