### PR TITLE
cql3: keep modification statements alive while queued on modify_stage

### DIFF
--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -13,6 +13,7 @@
 #include "timeout_config.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "audit/audit.hh"
+#include <seastar/core/shared_ptr.hh>
 
 namespace service {
 
@@ -44,7 +45,7 @@ class query_options;
 // A vector of CQL warnings generated during execution of a statement.
 using cql_warnings_vec = std::vector<sstring>;
 
-class cql_statement {
+class cql_statement : public seastar::enable_shared_from_this<cql_statement> {
     timeout_config_selector _timeout_config_selector;
     audit::audit_info_ptr _audit_info;
 public:

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -237,11 +237,16 @@ modification_statement::build_partition_keys(const query_options& options, const
 }
 
 struct modification_statement_executor {
-    static auto get() { return &modification_statement::do_execute; }
+    static future<::shared_ptr<cql_transport::messages::result_message>>
+    execute(seastar::shared_ptr<const modification_statement> stmt, query_processor& qp, service::query_state& qs, const query_options& options) {
+        return stmt->do_execute(qp, qs, options).finally([stmt = std::move(stmt)] { });
+    }
+
+    static auto get() { return &modification_statement_executor::execute; }
 };
 static thread_local inheriting_concrete_execution_stage<
         future<::shared_ptr<cql_transport::messages::result_message>>,
-        const modification_statement*,
+        seastar::shared_ptr<const modification_statement>,
         query_processor&,
         service::query_state&,
         const query_options&> modify_stage{"cql3_modification", modification_statement_executor::get()};
@@ -255,7 +260,8 @@ modification_statement::execute(query_processor& qp, service::query_state& qs, c
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options, std::optional<service::group0_guard> guard) const {
     cql3::util::validate_timestamp(qp.db().get_config(), options, attrs);
-    return modify_stage(this, seastar::ref(qp), seastar::ref(qs), seastar::cref(options));
+    auto stmt = ::static_pointer_cast<const modification_statement>(shared_from_this());
+    return modify_stage(std::move(stmt), seastar::ref(qp), seastar::ref(qs), seastar::cref(options));
 }
 
 future<::shared_ptr<cql_transport::messages::result_message>>
@@ -375,7 +381,6 @@ process_forced_rebounce(unsigned shard, query_processor& qp, const query_options
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::execute_with_condition(query_processor& qp, service::query_state& qs, const query_options& options) const {
-
     auto cl_for_learn = options.get_consistency();
     utils::result_with_exception_ptr<db::consistency_level> cl_for_paxos = options.check_serial_consistency();
     if (!cl_for_paxos) [[unlikely]] {


### PR DESCRIPTION
  modify_stage queued a raw const modification_statement* and invoked
  modification_statement::do_execute() later from the execution stage.
  That left the async path dependent on external statement ownership.

  In the reported crash, do_execute() resumed and dereferenced s through
  a statement object that was no longer valid, ending in
  schema::maybe_table(this=0x0).

  Making the execution stage hold a strong reference to the
  statement object for the full lifetime of the returned future. This
  changes the queued argument from a raw pointer to
  shared_ptr<const modification_statement> and keeps that owner alive
  until do_execute() completes.

  This is a narrow ownership fix for the execution-stage boundary. It
  avoids relying on post-resume access through a raw statement pointer and
  matches the observed crash mode.

  Fixes: https://scylladb.atlassian.net/browse/CUSTOMER-310

  backport: we need to backport (or to add) this fix to all versions that are newer than 2025.4
