### PR TITLE
build: drop utils/rolling_max_tracker.hh from precompiled header

### DIFF
--- a/stdafx.hh
+++ b/stdafx.hh
@@ -93,8 +93,6 @@
 #include <ctime>
 #include <deque>
 
-#include "utils/rolling_max_tracker.hh"
-
 #include <endian.h>
 #include <exception>
 #if __has_include(<execinfo.h>)


### PR DESCRIPTION
Added by mistake. Precompiled headers should only include library headers that rarely change, since any dependency change causes a full rebuild.

Minor build cleanup, not backporting.