### PR TITLE
test: audit: use set diff to identify new audit rows

### DIFF
--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -782,14 +782,8 @@ class CQLAuditTester(AuditTester):
                 new_rows: list[AuditEntry] = []
                 for node, node_after in after_by_node.items():
                     node_before = before_by_node.get(node, [])
-                    node_new = node_after[len(node_before):]
-                    set_node_new = set(node_new)
                     set_node_diff = set(node_after) - set(node_before)
-                    assert set_node_new == set_node_diff, (
-                        f"new rows are not the last rows for node {node} in audit {mode}: "
-                        f"tail={node_new}, set_diff={set_node_diff}"
-                    )
-                    new_rows.extend(node_new)
+                    new_rows.extend(set_node_diff)
 
                 new_rows.sort(key=lambda row: (row.event_time.time, row.node))
                 new_rows_dict[mode] = new_rows


### PR DESCRIPTION
`assert_entries_were_added` asserted that new audit rows always appear at the tail of each per-node, event_time-sorted sequence. That is not a property of the audit feature. audit writes are asynchronous with respect to query completion, and on a multi-node cluster `QUORUM` reads of `audit.audit_log` can reveal a row with an older `event_time` after a row with a newer one has already been observed.

Replace the positional tail slice with a per-node set difference between the rows observed before and after the audited operation. The `wait_for` retry loop, noise filtering, and final by-value comparison against `expected_entries` are unchanged, so the test still verifies the real contract, that the expected audit entries appear, without relying on a visibility-ordering invariant that the audit log does not guarantee.

Fixes SCYLLADB-1589

This fixes the test logic in `test/cluster/test_audit.py` which is not backported to any of the previous branches, 2026.1 and earlier. There is no need for backport.