### PR TITLE
alternator: use `stream_arn` instead of `std::string` in list_streams

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -234,7 +234,7 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
 
     auto ret = rjson::empty_object();
     auto streams = rjson::empty_array();
-    std::optional<std::string> last;
+    std::optional<stream_arn> last;
 
     for (;limit > 0 && i != e; ++i) {
         auto s = i->schema();
@@ -247,11 +247,11 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
             rjson::value new_entry = rjson::empty_object();
 
             auto arn = stream_arn{ i->schema(), cdc::get_base_table(db.real_database(), *i->schema()) };
-            last = std::string(arn.unparsed());
             rjson::add(new_entry, "StreamArn", arn);
             rjson::add(new_entry, "StreamLabel", rjson::from_string(stream_label(*s)));
             rjson::add(new_entry, "TableName", rjson::from_string(cdc::base_name(s->cf_name())));
             rjson::push_back(streams, std::move(new_entry));
+            last = std::move(arn);
             --limit;
         }
     }
@@ -263,7 +263,7 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
     // If we exhausted all tables naturally (limit > 0), there are no more
     // streams, so we must not emit a cookie.
     if (last && limit == 0) {
-        rjson::add(ret, "LastEvaluatedStreamArn", rjson::from_string(*last));
+        rjson::add(ret, "LastEvaluatedStreamArn", *last);
     }
     return make_ready_future<executor::request_return_type>(rjson::print(std::move(ret)));
 }


### PR DESCRIPTION
Use `stream_arn` object for storage of last returned to the user stream instead of raw `std::string`. `stream_arn` is used for parsing ARN incoming from the user, for returning `std::string` was used because of buggy copy / move operations of `stream_arn`. Those were fixed, so we're fixing usage as well.

Fixes: SCYLLADB-1241

Backport: let's try, as the original code was just introduced.
EDIT: no backport - some dependant PR was not backported.