### PR TITLE
doc: document asynchronous updates in MVs

### DIFF
--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -114,6 +114,7 @@ value. For example, to run the PRUNE with 100 parallel reads/writes, you can use
 ```cql
   PRUNE MATERIALIZED VIEW my_view WHERE v = 19 USING CONCURRENCY 100;
 ```
+(synchronous-materialized-views)=
 
 ## Synchronous materialized views
 

--- a/docs/features/materialized-views.rst
+++ b/docs/features/materialized-views.rst
@@ -107,8 +107,27 @@ For example:
    ALTER MATERIALIZED VIEW ks.mv
      WITH COMPACTION = {'class': 'LeveledCompactionStrategy'} ;
 
+Consistency of View Updates
+---------------------------------------
+
+By default, updates to materialized views are applied **asynchronously**.
+A write to the base table is considered successful once the required
+consistency level is reached for the base table replicas, and does not wait
+for the corresponding updates to be applied to the view. As a result, reads
+from the view may temporarily return stale data, and only achieve eventual
+consistency.
+
+If stronger consistency is required, a materialized view can be created with
+``WITH synchronous_updates = true``. In this mode, writes succeed only after
+the required consistency level is reached for both the base table and
+the view, ensuring that new data is immediately visible in the view, at
+the cost of higher write latency and reduced availability.
+
+See :ref:`Synchronous materialized views <synchronous-materialized-views>` for
+more information.
+
 More information 
-................
+-------------------
 
 * :doc:`CQL Reference for Materialized Views </cql/mv>`
 * Learn more about Materialized Views with ScyllaDB University (Free, registration required)


### PR DESCRIPTION
This PR extends the documentation for Materialized Views to clarify that asynchronous updates are the default, and to explain how to configure asynchronous updates (already covered in the CQL section, but missing from the main MV page).

Refs https://github.com/scylladb/scylla-docs/issues/3665

@nyh Please review. This is something you already added to the forum, but we've agreed it should be added to the documentation (and we need it for AI agents).