### PR TITLE
test.py: enhance error output in case no tests were executed

### DIFF
--- a/test.py
+++ b/test.py
@@ -326,7 +326,10 @@ async def main() -> int:
     except Exception as e:
         print(palette.fail(e))
         raise
-
+    if exit_code == 5:
+        print(palette.fail("No tests were collected. Please check the test names and modes you provided, as well as"
+                           "the test markers if you used the '--markers' option."
+                           "Alternatively you can check with --list option if there any errors."))
     if 'coverage' in options.modes:
         coverage.generate_coverage_report(path_to("coverage", "tests"))
 


### PR DESCRIPTION
By default, pytest produces the error if provided file is not exists. But coupled with xdist it will produce no errors. This is due how the pytest works with xdist. test.py always uses the parameter -n, so if something will go wrong there will be no errors produced, only exit code 5 will be thrown. This PR will print warning in case pytest's exit code is 5.

No backport, test framework enhancement only.