### PR TITLE
test.py: fix incorrect usage of shutdown cluster

### DIFF
--- a/test/cluster/auth_cluster/test_prepared_metadata_id.py
+++ b/test/cluster/auth_cluster/test_prepared_metadata_id.py
@@ -19,6 +19,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.protocol import ResultMessage
 
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import unique_name
 
@@ -138,7 +139,7 @@ def _prepare_and_execute(host: str, query: str) -> tuple[bytes, bool, int]:
             return prepared_metadata_id, captured["metadata_changed"], len(rows)
         finally:
             session.shutdown()
-            cluster.shutdown()
+            safe_driver_shutdown(cluster)
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_describe.py
+++ b/test/cluster/test_describe.py
@@ -8,6 +8,7 @@ import asyncio
 import pytest
 from test.cluster.util import new_test_keyspace, new_test_table
 from test.pylib.manager_client import ManagerClient
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.util import wait_for
 from cassandra.connection import UnixSocketEndPoint
 from cassandra.policies import WhiteListRoundRobinPolicy
@@ -89,4 +90,4 @@ async def test_describe_cluster_sanity(manager: ManagerClient, mode: str):
         assert describe_results[0].cluster == system_local_results[0].cluster_name
     finally:
         if mode == "maintenance":
-            cluster.shutdown()
+            safe_driver_shutdown.shutdown()


### PR DESCRIPTION
Direct use of the cluster's shutdown methods leads to a lot of noise in the logs. Bug https://scylladb.atlassian.net/browse/SCYLLADB-900 that was created because of that is fixed. This PR is to fix recently added direct call to the shutdown method.

No backport, test framework usability fix.